### PR TITLE
Fix the issue where run.sh deletes the container upon exit after creating it from an image each time.

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -101,7 +101,27 @@ echo "[*] XAUTHORITY=$XAUTHORITY"
 echo "[*] XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR"
 xhost +local:docker 2>/dev/null || xhost + 2>/dev/null || echo "[*] Warning: Could not set xhost permissions"
 
-docker run -it --rm \
+# Check if container already exists
+if docker ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+    echo "[*] Container ${CONTAINER_NAME} already exists"
+    
+    # Check if container is running
+    if docker ps --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+        echo "[*] Container is already running, attaching..."
+        docker exec -it $CONTAINER_NAME bash /docker-entrypoint.sh
+    else
+        echo "[*] Container exists but is stopped, starting and attaching..."
+        docker start $CONTAINER_NAME
+        sleep 2
+        docker exec -it $CONTAINER_NAME bash /docker-entrypoint.sh
+    fi
+    exit 0
+fi
+
+# If container doesn't exist, create new one
+echo "[*] Creating new container..."
+
+docker run -it \
   --name $CONTAINER_NAME \
   --hostname docker-ub \
   $NETWORK_ARGS \


### PR DESCRIPTION
## Description
This PR modifies `run.sh` to support iterative development in a local container by making two key changes:

1. **Removes the `--rm` flag** (line 104) from the `docker run` command, allowing the container to persist after exit for inspection and reuse.
2. **Adds a check for existing running containers** with the same name before creating a new one. This prevents errors and allows developers to repeatedly modify and test within the same local container environment.

These changes are especially helpful for developers who are new to the project, as they enable a stable, long-term development environment within a single container, eliminating the need to rebuild from scratch for every test.