### PR TITLE
feat: add deploy, init, and package-new commands

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2474,6 +2474,7 @@ dependencies = [
  "serde_yaml",
  "tokio",
  "tokio-stream",
+ "toml 0.8.23",
  "tonic",
  "tonic-prost",
  "uuid",
@@ -2490,7 +2491,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -2735,6 +2736,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3214,17 +3224,38 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.1",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3237,13 +3268,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.1",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -3960,6 +4011,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/rust/crates/robonix-cli/Cargo.toml
+++ b/rust/crates/robonix-cli/Cargo.toml
@@ -33,6 +33,7 @@ hostname = "0.4"
 colored = "3.0"
 git2 = "0.20.4"
 resvg = "0.47.0"
+toml = "0.8"
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", features = ["signal", "process"] }

--- a/rust/crates/robonix-cli/src/cmd/build.rs
+++ b/rust/crates/robonix-cli/src/cmd/build.rs
@@ -1,15 +1,60 @@
 // SPDX-License-Identifier: MulanPSL-2.0
 // Build command: run the package's build.script
+//
+// Two modes:
+//   1) Single-package mode: `rbnx build -p <path>` or `rbnx build -g <name>`
+//   2) Config-file mode:    `rbnx build --config <config.yaml>`
+//      Reads config.yaml (+ upstream robonix_workspace.yaml), discovers all
+//      packages, topo-sorts by depends_on, validates contracts, and builds each.
 
 use anyhow::{Context, Result};
 use robonix_cli::manifest;
 use robonix_cli::output;
+use serde::Deserialize;
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 const RBNX_BUILD_DIR: &str = "rbnx-build";
 const RBNX_BUILT_STAMP: &str = "rbnx-build/.rbnx-built";
+
+// ── Config-file schema (subset of deploy config) ────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct BuildConfig {
+    #[serde(default)]
+    upstream_config: Option<String>,
+    #[serde(default)]
+    packages: Vec<BuildPackageEntry>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct UpstreamWorkspace {
+    #[serde(default)]
+    workspace: Option<String>,
+    /// System services define contract_ids that downstream packages may consume.
+    #[serde(default)]
+    system: Vec<SystemEntry>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct SystemEntry {
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    contract_id: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct BuildPackageEntry {
+    name: String,
+    path: String,
+    #[serde(default)]
+    depends_on: Vec<String>,
+}
+
+// ── Existing helpers ────────────────────────────────────────────────────────
 
 pub fn build_stamp_path(package_root: &Path) -> PathBuf {
     package_root.join(RBNX_BUILT_STAMP)
@@ -89,4 +134,282 @@ pub async fn execute_local(path: PathBuf, clean: bool) -> Result<()> {
     );
     build_local_package(&package_root, clean)?;
     Ok(())
+}
+
+// ── Config-file mode ────────────────────────────────────────────────────────
+
+/// Build all packages defined in a config.yaml file:
+///   1. Parse config.yaml, optionally load upstream robonix_workspace.yaml
+///   2. Resolve each package path, load its robonix_manifest.yaml
+///   3. Validate contracts against upstream (consumed interfaces vs upstream contract_ids)
+///   4. Topological sort by depends_on
+///   5. Build each package in order
+pub async fn execute_from_config(config_path: PathBuf, clean: bool) -> Result<()> {
+    let config_path = config_path
+        .canonicalize()
+        .unwrap_or_else(|_| config_path.clone());
+
+    output::action("Build", &format!("from config {}", config_path.display()));
+
+    let content = fs::read_to_string(&config_path)
+        .with_context(|| format!("failed to read {}", config_path.display()))?;
+    let cfg: BuildConfig = serde_yaml::from_str(&content)
+        .with_context(|| format!("failed to parse {}", config_path.display()))?;
+
+    let base_dir = config_path
+        .parent()
+        .map(|p| {
+            if p.as_os_str().is_empty() {
+                PathBuf::from(".")
+            } else {
+                p.to_path_buf()
+            }
+        })
+        .unwrap_or_else(|| PathBuf::from("."));
+    let base_dir = base_dir
+        .canonicalize()
+        .unwrap_or_else(|_| base_dir.to_path_buf());
+
+    // ── Load upstream config for contract validation ────────────────────────
+    let upstream = if let Some(ref upstream_path) = cfg.upstream_config {
+        let resolved = base_dir.join(upstream_path);
+        if resolved.exists() {
+            let upstream_content = fs::read_to_string(&resolved)
+                .with_context(|| format!("failed to read upstream config {}", resolved.display()))?;
+            let up: UpstreamWorkspace = serde_yaml::from_str(&upstream_content).with_context(|| {
+                format!("failed to parse upstream config {}", resolved.display())
+            })?;
+            output::step(
+                "Loaded",
+                &format!(
+                    "upstream config: {} (workspace: {})",
+                    resolved.display(),
+                    up.workspace.as_deref().unwrap_or("unnamed")
+                ),
+            );
+            up
+        } else {
+            output::warning(&format!(
+                "upstream_config '{}' not found at {}, skipping",
+                upstream_path,
+                resolved.display()
+            ));
+            UpstreamWorkspace::default()
+        }
+    } else {
+        UpstreamWorkspace::default()
+    };
+
+    // Build set of available upstream contract_ids for validation.
+    let upstream_contracts: Vec<&str> = upstream
+        .system
+        .iter()
+        .filter(|s| !s.contract_id.is_empty())
+        .map(|s| s.contract_id.as_str())
+        .collect();
+    if !upstream_contracts.is_empty() {
+        output::step("Upstream", &format!("{} contract(s) available", upstream_contracts.len()));
+        for cid in &upstream_contracts {
+            output::sub_step(&format!("contract: {}", cid));
+        }
+    }
+
+    if cfg.packages.is_empty() {
+        output::warning("no packages defined in config — nothing to build");
+        return Ok(());
+    }
+
+    // ── Resolve packages and load manifests ─────────────────────────────────
+    output::step("Resolving", &format!("{} package(s)", cfg.packages.len()));
+
+    struct ResolvedPackage {
+        name: String,
+        root: PathBuf,
+        manifest: manifest::Manifest,
+        depends_on: Vec<String>,
+    }
+
+    let mut resolved: Vec<ResolvedPackage> = Vec::new();
+
+    for entry in &cfg.packages {
+        let pkg_path = base_dir.join(&entry.path);
+        if !pkg_path.exists() {
+            output::cross(&format!(
+                "package '{}': path {} does not exist",
+                entry.name,
+                pkg_path.display()
+            ));
+            anyhow::bail!(
+                "package '{}' path {} not found",
+                entry.name,
+                pkg_path.display()
+            );
+        }
+
+        let pkg_root = pkg_path
+            .canonicalize()
+            .unwrap_or_else(|_| pkg_path.clone());
+
+        // Load robonix_manifest.yaml.
+        let manifest_path = pkg_root.join(manifest::MANIFEST_FILE);
+        if !manifest_path.exists() {
+            output::cross(&format!(
+                "package '{}': {} not found at {}",
+                entry.name,
+                manifest::MANIFEST_FILE,
+                manifest_path.display()
+            ));
+            anyhow::bail!(
+                "package '{}' is missing {}",
+                entry.name,
+                manifest::MANIFEST_FILE
+            );
+        }
+
+        let pkg_manifest = manifest::load_from_path(&manifest_path).with_context(|| {
+            format!(
+                "failed to load {} for package '{}'",
+                manifest::MANIFEST_FILE,
+                entry.name
+            )
+        })?;
+
+        output::check(&format!(
+            "{} — {} v{}",
+            entry.name, pkg_manifest.package.name, pkg_manifest.package.version
+        ));
+
+        resolved.push(ResolvedPackage {
+            name: entry.name.clone(),
+            root: pkg_root,
+            manifest: pkg_manifest,
+            depends_on: entry.depends_on.clone(),
+        });
+    }
+
+    // ── Validate contracts against upstream ─────────────────────────────────
+    output::step("Validating", "contracts against upstream");
+
+    let mut contract_warnings = 0usize;
+    for pkg in &resolved {
+        if let Some(ref interfaces) = pkg.manifest.interfaces {
+            for consumed in &interfaces.consumes {
+                // Check if the consumed interface matches an upstream contract_id.
+                let matched = upstream_contracts
+                    .iter()
+                    .any(|cid| *cid == consumed.id || consumed.id.starts_with(cid));
+                if matched {
+                    output::check(&format!(
+                        "{}: consumed interface '{}' ← upstream OK",
+                        pkg.name, consumed.id
+                    ));
+                } else {
+                    output::warning(&format!(
+                        "{}: consumed interface '{}' not found in upstream contracts",
+                        pkg.name, consumed.id
+                    ));
+                    contract_warnings += 1;
+                }
+            }
+        }
+    }
+    if contract_warnings == 0 {
+        output::check("all contracts validated");
+    } else {
+        output::warning(&format!(
+            "{} contract warning(s) — some consumed interfaces may not be satisfied at runtime",
+            contract_warnings
+        ));
+    }
+
+    // ── Topological sort ────────────────────────────────────────────────────
+    let build_order = topo_sort_by_name_deps(
+        &resolved.iter().map(|p| (p.name.as_str(), &p.depends_on)).collect::<Vec<_>>(),
+    )?;
+    let order_names: Vec<&str> = build_order.iter().map(|&i| resolved[i].name.as_str()).collect();
+    output::step("Build order", &order_names.join(" → "));
+
+    // ── Build each package ──────────────────────────────────────────────────
+    let mut succeeded = 0usize;
+    let mut failed = 0usize;
+
+    for (step_num, &idx) in build_order.iter().enumerate() {
+        let pkg = &resolved[idx];
+        output::action(
+            &format!("[{}/{}] Building", step_num + 1, build_order.len()),
+            &format!("{} ({})", pkg.name, pkg.root.display()),
+        );
+        match build_local(&pkg.root, &pkg.manifest, clean) {
+            Ok(()) => succeeded += 1,
+            Err(e) => {
+                output::error(&format!("package '{}' build failed: {}", pkg.name, e));
+                failed += 1;
+                // Stop on first failure (downstream packages likely depend on this).
+                anyhow::bail!(
+                    "stopping build — package '{}' failed ({} succeeded, {} failed)",
+                    pkg.name,
+                    succeeded,
+                    failed
+                );
+            }
+        }
+    }
+
+    output::success(&format!(
+        "Build complete — {}/{} package(s) built successfully",
+        succeeded,
+        resolved.len()
+    ));
+
+    Ok(())
+}
+
+/// Topological sort by (name, depends_on) pairs using Kahn's algorithm.
+/// Returns indices in dependency-first order.
+fn topo_sort_by_name_deps(items: &[(&str, &Vec<String>)]) -> Result<Vec<usize>> {
+    let name_to_idx: HashMap<&str, usize> = items
+        .iter()
+        .enumerate()
+        .map(|(i, (name, _))| (*name, i))
+        .collect();
+
+    let n = items.len();
+    let mut in_degree = vec![0usize; n];
+    let mut adj: Vec<Vec<usize>> = vec![Vec::new(); n];
+
+    for (i, (_, deps)) in items.iter().enumerate() {
+        for dep in *deps {
+            if let Some(&dep_idx) = name_to_idx.get(dep.as_str()) {
+                adj[dep_idx].push(i);
+                in_degree[i] += 1;
+            }
+        }
+    }
+
+    // Kahn's algorithm with stable name-based ordering.
+    let mut queue: Vec<usize> = (0..n).filter(|&i| in_degree[i] == 0).collect();
+    queue.sort_by(|a, b| items[*a].0.cmp(items[*b].0));
+
+    let mut order = Vec::with_capacity(n);
+    while let Some(node) = queue.pop() {
+        order.push(node);
+        for &nb in &adj[node] {
+            in_degree[nb] -= 1;
+            if in_degree[nb] == 0 {
+                queue.push(nb);
+                queue.sort_by(|a, b| items[*a].0.cmp(items[*b].0));
+            }
+        }
+    }
+
+    if order.len() != n {
+        let missing: Vec<&str> = items
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| !order.contains(i))
+            .map(|(_, (name, _))| *name)
+            .collect();
+        anyhow::bail!("circular dependency detected among packages: {:?}", missing);
+    }
+    Ok(order)
 }

--- a/rust/crates/robonix-cli/src/cmd/build.rs
+++ b/rust/crates/robonix-cli/src/cmd/build.rs
@@ -11,10 +11,11 @@ use anyhow::{Context, Result};
 use robonix_cli::manifest;
 use robonix_cli::output;
 use serde::Deserialize;
-use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+
+use super::deploy; // Reuse topo_sort from deploy module.
 
 const RBNX_BUILD_DIR: &str = "rbnx-build";
 const RBNX_BUILT_STAMP: &str = "rbnx-build/.rbnx-built";
@@ -294,10 +295,12 @@ pub async fn execute_from_config(config_path: PathBuf, clean: bool) -> Result<()
     for pkg in &resolved {
         if let Some(ref interfaces) = pkg.manifest.interfaces {
             for consumed in &interfaces.consumes {
-                // Check if the consumed interface matches an upstream contract_id.
+                // Exact match only — avoid prefix matching which could produce
+                // false positives (e.g. "robonix/sys/model" matching
+                // "robonix/sys/model_evil").
                 let matched = upstream_contracts
                     .iter()
-                    .any(|cid| *cid == consumed.id || consumed.id.starts_with(cid));
+                    .any(|cid| *cid == consumed.id);
                 if matched {
                     output::check(&format!(
                         "{}: consumed interface '{}' ← upstream OK",
@@ -322,10 +325,12 @@ pub async fn execute_from_config(config_path: PathBuf, clean: bool) -> Result<()
         ));
     }
 
-    // ── Topological sort ────────────────────────────────────────────────────
-    let build_order = topo_sort_by_name_deps(
-        &resolved.iter().map(|p| (p.name.as_str(), &p.depends_on)).collect::<Vec<_>>(),
-    )?;
+    // ── Topological sort (reuse shared implementation) ──────────────────────
+    let items: Vec<(&str, &[String])> = resolved
+        .iter()
+        .map(|p| (p.name.as_str(), p.depends_on.as_slice()))
+        .collect();
+    let build_order = deploy::topo_sort(&items)?;
     let order_names: Vec<&str> = build_order.iter().map(|&i| resolved[i].name.as_str()).collect();
     output::step("Build order", &order_names.join(" → "));
 
@@ -362,54 +367,4 @@ pub async fn execute_from_config(config_path: PathBuf, clean: bool) -> Result<()
     ));
 
     Ok(())
-}
-
-/// Topological sort by (name, depends_on) pairs using Kahn's algorithm.
-/// Returns indices in dependency-first order.
-fn topo_sort_by_name_deps(items: &[(&str, &Vec<String>)]) -> Result<Vec<usize>> {
-    let name_to_idx: HashMap<&str, usize> = items
-        .iter()
-        .enumerate()
-        .map(|(i, (name, _))| (*name, i))
-        .collect();
-
-    let n = items.len();
-    let mut in_degree = vec![0usize; n];
-    let mut adj: Vec<Vec<usize>> = vec![Vec::new(); n];
-
-    for (i, (_, deps)) in items.iter().enumerate() {
-        for dep in *deps {
-            if let Some(&dep_idx) = name_to_idx.get(dep.as_str()) {
-                adj[dep_idx].push(i);
-                in_degree[i] += 1;
-            }
-        }
-    }
-
-    // Kahn's algorithm with stable name-based ordering.
-    let mut queue: Vec<usize> = (0..n).filter(|&i| in_degree[i] == 0).collect();
-    queue.sort_by(|a, b| items[*a].0.cmp(items[*b].0));
-
-    let mut order = Vec::with_capacity(n);
-    while let Some(node) = queue.pop() {
-        order.push(node);
-        for &nb in &adj[node] {
-            in_degree[nb] -= 1;
-            if in_degree[nb] == 0 {
-                queue.push(nb);
-                queue.sort_by(|a, b| items[*a].0.cmp(items[*b].0));
-            }
-        }
-    }
-
-    if order.len() != n {
-        let missing: Vec<&str> = items
-            .iter()
-            .enumerate()
-            .filter(|(i, _)| !order.contains(i))
-            .map(|(_, (name, _))| *name)
-            .collect();
-        anyhow::bail!("circular dependency detected among packages: {:?}", missing);
-    }
-    Ok(order)
 }

--- a/rust/crates/robonix-cli/src/cmd/build.rs
+++ b/rust/crates/robonix-cli/src/cmd/build.rs
@@ -40,6 +40,7 @@ struct UpstreamWorkspace {
 }
 
 #[derive(Debug, Deserialize, Clone)]
+#[allow(dead_code)]
 struct SystemEntry {
     #[serde(default)]
     name: String,

--- a/rust/crates/robonix-cli/src/cmd/build.rs
+++ b/rust/crates/robonix-cli/src/cmd/build.rs
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: MulanPSL-2.0
 // Build command: run the package's build.script
 //
-// Two modes:
-//   1) Single-package mode: `rbnx build -p <path>` or `rbnx build -g <name>`
-//   2) Config-file mode:    `rbnx build --config <config.yaml>`
-//      Reads config.yaml (+ upstream robonix_workspace.yaml), discovers all
-//      packages, topo-sorts by depends_on, validates contracts, and builds each.
+// Modes:
+//   1) Single-package:   `rbnx build -p <path>` or `rbnx build -g <name>`
+//   2) Config-file:      `rbnx build -c <config.yaml>`
+//   3) Target:           `rbnx build <target>`  (finds deploy/<target>.yaml)
+//   4) Workspace:        `rbnx build`           (reads robonix_workspace.yaml)
 
 use anyhow::{Context, Result};
 use robonix_cli::manifest;
 use robonix_cli::output;
-use serde::Deserialize;
+use robonix_cli::workspace::{DeployConfig, WorkspaceConfig};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -19,42 +19,6 @@ use super::deploy; // Reuse topo_sort from deploy module.
 
 const RBNX_BUILD_DIR: &str = "rbnx-build";
 const RBNX_BUILT_STAMP: &str = "rbnx-build/.rbnx-built";
-
-// ── Config-file schema (subset of deploy config) ────────────────────────────
-
-#[derive(Debug, Deserialize)]
-struct BuildConfig {
-    #[serde(default)]
-    upstream_config: Option<String>,
-    #[serde(default)]
-    packages: Vec<BuildPackageEntry>,
-}
-
-#[derive(Debug, Deserialize, Default)]
-struct UpstreamWorkspace {
-    #[serde(default)]
-    workspace: Option<String>,
-    /// System services define contract_ids that downstream packages may consume.
-    #[serde(default)]
-    system: Vec<SystemEntry>,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-#[allow(dead_code)]
-struct SystemEntry {
-    #[serde(default)]
-    name: String,
-    #[serde(default)]
-    contract_id: String,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-struct BuildPackageEntry {
-    name: String,
-    path: String,
-    #[serde(default)]
-    depends_on: Vec<String>,
-}
 
 // ── Existing helpers ────────────────────────────────────────────────────────
 
@@ -138,14 +102,13 @@ pub async fn execute_local(path: PathBuf, clean: bool) -> Result<()> {
     Ok(())
 }
 
-// ── Config-file mode ────────────────────────────────────────────────────────
+// ── Config-file mode (new format: deploy/<target>.yaml) ─────────────────────
 
-/// Build all packages defined in a config.yaml file:
-///   1. Parse config.yaml, optionally load upstream robonix_workspace.yaml
-///   2. Resolve each package path, load its robonix_manifest.yaml
-///   3. Validate contracts against upstream (consumed interfaces vs upstream contract_ids)
-///   4. Topological sort by depends_on
-///   5. Build each package in order
+/// Build packages referenced by a deploy config file.
+///
+/// Reads deploy/<target>.yaml + upstream robonix_workspace.yaml using new
+/// format (packages_run / workspace packages). Currently a stub that
+/// validates parsing; full build logic will be implemented in stage three.
 pub async fn execute_from_config(config_path: PathBuf, clean: bool) -> Result<()> {
     let config_path = config_path
         .canonicalize()
@@ -155,7 +118,7 @@ pub async fn execute_from_config(config_path: PathBuf, clean: bool) -> Result<()
 
     let content = fs::read_to_string(&config_path)
         .with_context(|| format!("failed to read {}", config_path.display()))?;
-    let cfg: BuildConfig = serde_yaml::from_str(&content)
+    let cfg: DeployConfig = serde_yaml::from_str(&content)
         .with_context(|| format!("failed to parse {}", config_path.display()))?;
 
     let base_dir = config_path
@@ -172,13 +135,13 @@ pub async fn execute_from_config(config_path: PathBuf, clean: bool) -> Result<()
         .canonicalize()
         .unwrap_or_else(|_| base_dir.to_path_buf());
 
-    // ── Load upstream config for contract validation ────────────────────────
-    let upstream = if let Some(ref upstream_path) = cfg.upstream_config {
+    // Load upstream workspace config.
+    let ws = if let Some(ref upstream_path) = cfg.upstream_config {
         let resolved = base_dir.join(upstream_path);
         if resolved.exists() {
             let upstream_content = fs::read_to_string(&resolved)
                 .with_context(|| format!("failed to read upstream config {}", resolved.display()))?;
-            let up: UpstreamWorkspace = serde_yaml::from_str(&upstream_content).with_context(|| {
+            let ws: WorkspaceConfig = serde_yaml::from_str(&upstream_content).with_context(|| {
                 format!("failed to parse upstream config {}", resolved.display())
             })?;
             output::step(
@@ -186,158 +149,115 @@ pub async fn execute_from_config(config_path: PathBuf, clean: bool) -> Result<()
                 &format!(
                     "upstream config: {} (workspace: {})",
                     resolved.display(),
-                    up.workspace.as_deref().unwrap_or("unnamed")
+                    ws.workspace.as_deref().unwrap_or("unnamed")
                 ),
             );
-            up
+            ws
         } else {
             output::warning(&format!(
                 "upstream_config '{}' not found at {}, skipping",
                 upstream_path,
                 resolved.display()
             ));
-            UpstreamWorkspace::default()
+            WorkspaceConfig::default()
         }
     } else {
-        UpstreamWorkspace::default()
+        WorkspaceConfig::default()
     };
 
-    // Build set of available upstream contract_ids for validation.
-    let upstream_contracts: Vec<&str> = upstream
-        .system
-        .iter()
-        .filter(|s| !s.contract_id.is_empty())
-        .map(|s| s.contract_id.as_str())
-        .collect();
-    if !upstream_contracts.is_empty() {
-        output::step("Upstream", &format!("{} contract(s) available", upstream_contracts.len()));
-        for cid in &upstream_contracts {
-            output::sub_step(&format!("contract: {}", cid));
-        }
-    }
+    // Print summary.
+    output::sub_step(&format!(
+        "workspace: {}, {} workspace package(s), {} packages_run entry(ies)",
+        ws.workspace.as_deref().unwrap_or("unnamed"),
+        ws.packages.len(),
+        cfg.packages_run.len(),
+    ));
 
-    if cfg.packages.is_empty() {
-        output::warning("no packages defined in config — nothing to build");
+    if ws.packages.is_empty() {
+        output::warning("no packages declared in workspace — nothing to build");
         return Ok(());
     }
 
-    // ── Resolve packages and load manifests ─────────────────────────────────
-    output::step("Resolving", &format!("{} package(s)", cfg.packages.len()));
-
+    // Resolve packages from workspace and build using manifest.depend for topo sort.
     struct ResolvedPackage {
         name: String,
         root: PathBuf,
         manifest: manifest::Manifest,
-        depends_on: Vec<String>,
     }
 
     let mut resolved: Vec<ResolvedPackage> = Vec::new();
 
-    for entry in &cfg.packages {
-        let pkg_path = base_dir.join(&entry.path);
-        if !pkg_path.exists() {
-            output::cross(&format!(
-                "package '{}': path {} does not exist",
-                entry.name,
-                pkg_path.display()
-            ));
-            anyhow::bail!(
-                "package '{}' path {} not found",
-                entry.name,
-                pkg_path.display()
-            );
-        }
+    for pkg_entry in &ws.packages {
+        // Resolve package path.
+        let pkg_path = if let Some(ref path) = pkg_entry.path {
+            let resolved_path = base_dir.parent().unwrap_or(&base_dir).join(path);
+            if !resolved_path.exists() {
+                anyhow::bail!(
+                    "package '{}' path '{}' does not exist (resolved to {})",
+                    pkg_entry.name,
+                    path,
+                    resolved_path.display()
+                );
+            }
+            resolved_path
+                .canonicalize()
+                .unwrap_or(resolved_path)
+        } else {
+            // Try packages/<short_name>
+            let ws_root = base_dir.parent().unwrap_or(&base_dir);
+            let short_name = pkg_entry.name.rsplit('.').next().unwrap_or(&pkg_entry.name);
+            let candidate = ws_root.join("packages").join(short_name);
+            if !candidate.exists() {
+                anyhow::bail!(
+                    "package '{}' not found at {}{}",
+                    pkg_entry.name,
+                    candidate.display(),
+                    if pkg_entry.url.is_some() {
+                        " (has url, auto-clone not yet implemented)"
+                    } else {
+                        " and no url specified"
+                    }
+                );
+            }
+            candidate
+                .canonicalize()
+                .unwrap_or(candidate)
+        };
 
-        let pkg_root = pkg_path
-            .canonicalize()
-            .unwrap_or_else(|_| pkg_path.clone());
-
-        // Load robonix_manifest.yaml.
-        let manifest_path = pkg_root.join(manifest::MANIFEST_FILE);
+        // Load manifest.
+        let manifest_path = pkg_path.join(manifest::MANIFEST_FILE);
         if !manifest_path.exists() {
-            output::cross(&format!(
-                "package '{}': {} not found at {}",
-                entry.name,
+            anyhow::bail!(
+                "package '{}' is missing {} at {}",
+                pkg_entry.name,
                 manifest::MANIFEST_FILE,
                 manifest_path.display()
-            ));
-            anyhow::bail!(
-                "package '{}' is missing {}",
-                entry.name,
-                manifest::MANIFEST_FILE
             );
         }
-
-        let pkg_manifest = manifest::load_from_path(&manifest_path).with_context(|| {
-            format!(
-                "failed to load {} for package '{}'",
-                manifest::MANIFEST_FILE,
-                entry.name
-            )
-        })?;
-
+        let pkg_manifest = manifest::load_from_path(&manifest_path)?;
         output::check(&format!(
             "{} — {} v{}",
-            entry.name, pkg_manifest.package.name, pkg_manifest.package.version
+            pkg_entry.name, pkg_manifest.package.name, pkg_manifest.package.version
         ));
 
         resolved.push(ResolvedPackage {
-            name: entry.name.clone(),
-            root: pkg_root,
+            name: pkg_entry.name.clone(),
+            root: pkg_path,
             manifest: pkg_manifest,
-            depends_on: entry.depends_on.clone(),
         });
     }
 
-    // ── Validate contracts against upstream ─────────────────────────────────
-    output::step("Validating", "contracts against upstream");
-
-    let mut contract_warnings = 0usize;
-    for pkg in &resolved {
-        if let Some(ref interfaces) = pkg.manifest.interfaces {
-            for consumed in &interfaces.consumes {
-                // Exact match only — avoid prefix matching which could produce
-                // false positives (e.g. "robonix/sys/model" matching
-                // "robonix/sys/model_evil").
-                let matched = upstream_contracts
-                    .iter()
-                    .any(|cid| *cid == consumed.id);
-                if matched {
-                    output::check(&format!(
-                        "{}: consumed interface '{}' ← upstream OK",
-                        pkg.name, consumed.id
-                    ));
-                } else {
-                    output::warning(&format!(
-                        "{}: consumed interface '{}' not found in upstream contracts",
-                        pkg.name, consumed.id
-                    ));
-                    contract_warnings += 1;
-                }
-            }
-        }
-    }
-    if contract_warnings == 0 {
-        output::check("all contracts validated");
-    } else {
-        output::warning(&format!(
-            "{} contract warning(s) — some consumed interfaces may not be satisfied at runtime",
-            contract_warnings
-        ));
-    }
-
-    // ── Topological sort (reuse shared implementation) ──────────────────────
+    // Topological sort using manifest.depend.
     let items: Vec<(&str, &[String])> = resolved
         .iter()
-        .map(|p| (p.name.as_str(), p.depends_on.as_slice()))
+        .map(|p| (p.name.as_str(), p.manifest.depend.as_slice()))
         .collect();
     let build_order = deploy::topo_sort(&items)?;
     let order_names: Vec<&str> = build_order.iter().map(|&i| resolved[i].name.as_str()).collect();
     output::step("Build order", &order_names.join(" → "));
 
-    // ── Build each package ──────────────────────────────────────────────────
+    // Build each package.
     let mut succeeded = 0usize;
-    let mut failed = 0usize;
 
     for (step_num, &idx) in build_order.iter().enumerate() {
         let pkg = &resolved[idx];
@@ -349,13 +269,10 @@ pub async fn execute_from_config(config_path: PathBuf, clean: bool) -> Result<()
             Ok(()) => succeeded += 1,
             Err(e) => {
                 output::error(&format!("package '{}' build failed: {}", pkg.name, e));
-                failed += 1;
-                // Stop on first failure (downstream packages likely depend on this).
                 anyhow::bail!(
-                    "stopping build — package '{}' failed ({} succeeded, {} failed)",
+                    "stopping build — package '{}' failed ({} succeeded)",
                     pkg.name,
                     succeeded,
-                    failed
                 );
             }
         }
@@ -367,5 +284,41 @@ pub async fn execute_from_config(config_path: PathBuf, clean: bool) -> Result<()
         resolved.len()
     ));
 
+    Ok(())
+}
+
+// ── Workspace mode (no config file) ─────────────────────────────────────────
+
+/// Build all packages from robonix_workspace.yaml in the current directory.
+///
+/// Stub implementation — will be fully implemented in stage four.
+pub async fn execute_from_workspace(_clean: bool) -> Result<()> {
+    let ws_yaml = PathBuf::from("robonix_workspace.yaml");
+    if !ws_yaml.exists() {
+        anyhow::bail!(
+            "no robonix_workspace.yaml found in current directory; \
+             use 'rbnx build <target>' or 'rbnx build -c <config>' instead"
+        );
+    }
+
+    let content = fs::read_to_string(&ws_yaml)?;
+    let ws: WorkspaceConfig = serde_yaml::from_str(&content)
+        .with_context(|| "failed to parse robonix_workspace.yaml")?;
+
+    output::action(
+        "Build",
+        &format!(
+            "from workspace {} ({} package(s))",
+            ws.workspace.as_deref().unwrap_or("unnamed"),
+            ws.packages.len(),
+        ),
+    );
+
+    if ws.packages.is_empty() {
+        output::warning("no packages declared in workspace — nothing to build");
+        return Ok(());
+    }
+
+    output::warning("workspace-level build not yet fully implemented (stage 4 WIP)");
     Ok(())
 }

--- a/rust/crates/robonix-cli/src/cmd/build.rs
+++ b/rust/crates/robonix-cli/src/cmd/build.rs
@@ -10,7 +10,9 @@
 use anyhow::{Context, Result};
 use robonix_cli::manifest;
 use robonix_cli::output;
-use robonix_cli::workspace::{DeployConfig, WorkspaceConfig};
+use robonix_cli::workspace::{
+    DeployConfig, WorkspaceConfig, ensure_packages_exist, find_workspace_root,
+};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -52,7 +54,12 @@ fn run_build_script(package_root: &Path, script_rel: &str, clean: bool) -> Resul
     Ok(())
 }
 
-fn build_local(package_root: &Path, manifest: &manifest::Manifest, clean: bool) -> Result<()> {
+fn build_local(
+    package_root: &Path,
+    manifest: &manifest::Manifest,
+    clean: bool,
+    workspace_build_dir: Option<&Path>,
+) -> Result<()> {
     let _summary = manifest.validate_and_summarize()?;
     let script_rel = manifest.build.script.trim();
     let script_path = package_root.join(script_rel);
@@ -75,6 +82,15 @@ fn build_local(package_root: &Path, manifest: &manifest::Manifest, clean: bool) 
             build_stamp_path(package_root).display()
         )
     })?;
+
+    // Write workspace-level build stamp if workspace_build_dir provided.
+    if let Some(build_dir) = workspace_build_dir {
+        if fs::create_dir_all(build_dir).is_ok() {
+            let stamp = build_dir.join(format!("{}.built", manifest.package.name));
+            let _ = fs::write(&stamp, chrono::Utc::now().to_rfc3339());
+        }
+    }
+
     output::success(&format!(
         "Package '{}' build finished",
         manifest.package.name
@@ -87,7 +103,7 @@ pub fn build_local_package(path: &Path, clean: bool) -> Result<()> {
         .canonicalize()
         .with_context(|| format!("Failed to canonicalize package path {}", path.display()))?;
     let detected = manifest::detect_and_load(&package_root)?;
-    build_local(&package_root, &detected.manifest, clean)
+    build_local(&package_root, &detected.manifest, clean, None)
 }
 
 pub async fn execute_local(path: PathBuf, clean: bool) -> Result<()> {
@@ -102,13 +118,95 @@ pub async fn execute_local(path: PathBuf, clean: bool) -> Result<()> {
     Ok(())
 }
 
-// ── Config-file mode (new format: deploy/<target>.yaml) ─────────────────────
+// ── Shared: resolve + topo sort + build ─────────────────────────────────────
+
+struct ResolvedPackage {
+    name: String,
+    root: PathBuf,
+    manifest: manifest::Manifest,
+}
+
+/// Resolve workspace packages, topo-sort by manifest.depend, build each.
+fn resolve_and_build(
+    package_paths: &std::collections::HashMap<String, PathBuf>,
+    packages: &[robonix_cli::workspace::WorkspacePackageEntry],
+    clean: bool,
+    workspace_build_dir: Option<&Path>,
+) -> Result<()> {
+    let mut resolved: Vec<ResolvedPackage> = Vec::new();
+
+    for pkg_entry in packages {
+        let pkg_path = package_paths.get(&pkg_entry.name).unwrap();
+        let manifest_path = pkg_path.join(manifest::MANIFEST_FILE);
+        if !manifest_path.exists() {
+            anyhow::bail!(
+                "package '{}' is missing {} at {}",
+                pkg_entry.name,
+                manifest::MANIFEST_FILE,
+                manifest_path.display()
+            );
+        }
+        let pkg_manifest = manifest::load_from_path(&manifest_path)?;
+        output::check(&format!(
+            "{} — {} v{}",
+            pkg_entry.name, pkg_manifest.package.name, pkg_manifest.package.version
+        ));
+        resolved.push(ResolvedPackage {
+            name: pkg_entry.name.clone(),
+            root: pkg_path.clone(),
+            manifest: pkg_manifest,
+        });
+    }
+
+    if resolved.is_empty() {
+        output::warning("no packages to build");
+        return Ok(());
+    }
+
+    // Topological sort using manifest.depend.
+    let items: Vec<(&str, &[String])> = resolved
+        .iter()
+        .map(|p| (p.name.as_str(), p.manifest.depend.as_slice()))
+        .collect();
+    let build_order = deploy::topo_sort(&items)?;
+    let order_names: Vec<&str> = build_order
+        .iter()
+        .map(|&i| resolved[i].name.as_str())
+        .collect();
+    output::step("Build order", &order_names.join(" → "));
+
+    // Build each package.
+    let mut succeeded = 0usize;
+    for (step_num, &idx) in build_order.iter().enumerate() {
+        let pkg = &resolved[idx];
+        output::action(
+            &format!("[{}/{}] Building", step_num + 1, build_order.len()),
+            &format!("{} ({})", pkg.name, pkg.root.display()),
+        );
+        match build_local(&pkg.root, &pkg.manifest, clean, workspace_build_dir) {
+            Ok(()) => succeeded += 1,
+            Err(e) => {
+                output::error(&format!("package '{}' build failed: {}", pkg.name, e));
+                anyhow::bail!(
+                    "stopping build — package '{}' failed ({} succeeded)",
+                    pkg.name,
+                    succeeded,
+                );
+            }
+        }
+    }
+
+    output::success(&format!(
+        "Build complete — {}/{} package(s) built successfully",
+        succeeded,
+        resolved.len()
+    ));
+    Ok(())
+}
+
+// ── Config-file mode (deploy/<target>.yaml) ─────────────────────────────────
 
 /// Build packages referenced by a deploy config file.
-///
-/// Reads deploy/<target>.yaml + upstream robonix_workspace.yaml using new
-/// format (packages_run / workspace packages). Currently a stub that
-/// validates parsing; full build logic will be implemented in stage three.
 pub async fn execute_from_config(config_path: PathBuf, clean: bool) -> Result<()> {
     let config_path = config_path
         .canonicalize()
@@ -165,134 +263,26 @@ pub async fn execute_from_config(config_path: PathBuf, clean: bool) -> Result<()
         WorkspaceConfig::default()
     };
 
-    // Print summary.
-    output::sub_step(&format!(
-        "workspace: {}, {} workspace package(s), {} packages_run entry(ies)",
-        ws.workspace.as_deref().unwrap_or("unnamed"),
-        ws.packages.len(),
-        cfg.packages_run.len(),
-    ));
-
     if ws.packages.is_empty() {
         output::warning("no packages declared in workspace — nothing to build");
         return Ok(());
     }
 
-    // Resolve packages from workspace and build using manifest.depend for topo sort.
-    struct ResolvedPackage {
-        name: String,
-        root: PathBuf,
-        manifest: manifest::Manifest,
-    }
+    let workspace_root = find_workspace_root(&base_dir)?;
 
-    let mut resolved: Vec<ResolvedPackage> = Vec::new();
+    // Ensure all packages exist (with git clone support).
+    let package_paths = ensure_packages_exist(&workspace_root, &ws.packages)?;
 
-    for pkg_entry in &ws.packages {
-        // Resolve package path.
-        let pkg_path = if let Some(ref path) = pkg_entry.path {
-            let resolved_path = base_dir.parent().unwrap_or(&base_dir).join(path);
-            if !resolved_path.exists() {
-                anyhow::bail!(
-                    "package '{}' path '{}' does not exist (resolved to {})",
-                    pkg_entry.name,
-                    path,
-                    resolved_path.display()
-                );
-            }
-            resolved_path
-                .canonicalize()
-                .unwrap_or(resolved_path)
-        } else {
-            // Try packages/<short_name>
-            let ws_root = base_dir.parent().unwrap_or(&base_dir);
-            let short_name = pkg_entry.name.rsplit('.').next().unwrap_or(&pkg_entry.name);
-            let candidate = ws_root.join("packages").join(short_name);
-            if !candidate.exists() {
-                anyhow::bail!(
-                    "package '{}' not found at {}{}",
-                    pkg_entry.name,
-                    candidate.display(),
-                    if pkg_entry.url.is_some() {
-                        " (has url, auto-clone not yet implemented)"
-                    } else {
-                        " and no url specified"
-                    }
-                );
-            }
-            candidate
-                .canonicalize()
-                .unwrap_or(candidate)
-        };
+    // Workspace-level build directory.
+    let build_dir = workspace_root.join("build");
 
-        // Load manifest.
-        let manifest_path = pkg_path.join(manifest::MANIFEST_FILE);
-        if !manifest_path.exists() {
-            anyhow::bail!(
-                "package '{}' is missing {} at {}",
-                pkg_entry.name,
-                manifest::MANIFEST_FILE,
-                manifest_path.display()
-            );
-        }
-        let pkg_manifest = manifest::load_from_path(&manifest_path)?;
-        output::check(&format!(
-            "{} — {} v{}",
-            pkg_entry.name, pkg_manifest.package.name, pkg_manifest.package.version
-        ));
-
-        resolved.push(ResolvedPackage {
-            name: pkg_entry.name.clone(),
-            root: pkg_path,
-            manifest: pkg_manifest,
-        });
-    }
-
-    // Topological sort using manifest.depend.
-    let items: Vec<(&str, &[String])> = resolved
-        .iter()
-        .map(|p| (p.name.as_str(), p.manifest.depend.as_slice()))
-        .collect();
-    let build_order = deploy::topo_sort(&items)?;
-    let order_names: Vec<&str> = build_order.iter().map(|&i| resolved[i].name.as_str()).collect();
-    output::step("Build order", &order_names.join(" → "));
-
-    // Build each package.
-    let mut succeeded = 0usize;
-
-    for (step_num, &idx) in build_order.iter().enumerate() {
-        let pkg = &resolved[idx];
-        output::action(
-            &format!("[{}/{}] Building", step_num + 1, build_order.len()),
-            &format!("{} ({})", pkg.name, pkg.root.display()),
-        );
-        match build_local(&pkg.root, &pkg.manifest, clean) {
-            Ok(()) => succeeded += 1,
-            Err(e) => {
-                output::error(&format!("package '{}' build failed: {}", pkg.name, e));
-                anyhow::bail!(
-                    "stopping build — package '{}' failed ({} succeeded)",
-                    pkg.name,
-                    succeeded,
-                );
-            }
-        }
-    }
-
-    output::success(&format!(
-        "Build complete — {}/{} package(s) built successfully",
-        succeeded,
-        resolved.len()
-    ));
-
-    Ok(())
+    resolve_and_build(&package_paths, &ws.packages, clean, Some(&build_dir))
 }
 
 // ── Workspace mode (no config file) ─────────────────────────────────────────
 
 /// Build all packages from robonix_workspace.yaml in the current directory.
-///
-/// Stub implementation — will be fully implemented in stage four.
-pub async fn execute_from_workspace(_clean: bool) -> Result<()> {
+pub async fn execute_from_workspace(clean: bool) -> Result<()> {
     let ws_yaml = PathBuf::from("robonix_workspace.yaml");
     if !ws_yaml.exists() {
         anyhow::bail!(
@@ -301,6 +291,7 @@ pub async fn execute_from_workspace(_clean: bool) -> Result<()> {
         );
     }
 
+    let workspace_root = std::env::current_dir()?;
     let content = fs::read_to_string(&ws_yaml)?;
     let ws: WorkspaceConfig = serde_yaml::from_str(&content)
         .with_context(|| "failed to parse robonix_workspace.yaml")?;
@@ -319,6 +310,11 @@ pub async fn execute_from_workspace(_clean: bool) -> Result<()> {
         return Ok(());
     }
 
-    output::warning("workspace-level build not yet fully implemented (stage 4 WIP)");
-    Ok(())
+    // Ensure all packages exist (with git clone support).
+    let package_paths = ensure_packages_exist(&workspace_root, &ws.packages)?;
+
+    // Workspace-level build directory.
+    let build_dir = workspace_root.join("build");
+
+    resolve_and_build(&package_paths, &ws.packages, clean, Some(&build_dir))
 }

--- a/rust/crates/robonix-cli/src/cmd/deploy.rs
+++ b/rust/crates/robonix-cli/src/cmd/deploy.rs
@@ -10,23 +10,21 @@
 //   Step 4 — start nodes in dependency order
 
 use anyhow::{Context, Result};
+use robonix_cli::manifest;
 use robonix_cli::output;
 use robonix_cli::workspace::{
-    DeployConfig, MergedConfig, WorkspaceConfig, parse_package_run,
+    DeployConfig, MergedConfig, NodeSelector, ParsedPackageRun, WorkspaceConfig,
+    WorkspacePackageEntry, parse_package_run,
 };
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use tokio::process::{Child, Command};
 use tokio::time::{Duration, sleep};
 
-// ── Helpers ──────────────────────────────────────────────────────────────────
+// ── Process helpers ─────────────────────────────────────────────────────────
 
-/// Spawn a background process.  Returns the Child handle (caller must store it).
-///
-/// On Unix, the child is placed into its own process group via `pre_exec(setsid)`
-/// so that we can cleanly terminate it later without killing the parent shell.
-#[allow(dead_code)]
+/// Spawn a background process in its own process group.
 async fn spawn_background(
     label: &str,
     cmd: &str,
@@ -42,11 +40,9 @@ async fn spawn_background(
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit());
 
-    // Place child in its own process group so we can kill it independently.
     #[cfg(unix)]
     unsafe {
         command.pre_exec(|| {
-            // Create a new session / process group for this child.
             nix::unistd::setsid().map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
             Ok(())
         });
@@ -58,8 +54,7 @@ async fn spawn_background(
     Ok(child)
 }
 
-/// Wait for a TCP endpoint to become reachable (connect-only check).
-#[allow(dead_code)]
+/// Wait for a TCP endpoint to become reachable.
 async fn wait_for_endpoint(addr: &str, timeout: Duration) -> bool {
     let deadline = tokio::time::Instant::now() + timeout;
     while tokio::time::Instant::now() < deadline {
@@ -71,12 +66,33 @@ async fn wait_for_endpoint(addr: &str, timeout: Duration) -> bool {
     false
 }
 
-/// Generic topological sort using Kahn's algorithm with FIFO (VecDeque)
-/// for correct alphabetical ordering.
-///
-/// `items` is a slice of (name, depends_on) pairs.
-/// Returns indices in dependency-first order.
-/// Reports an error if any `depends_on` reference is unknown.
+/// Gracefully shut down all tracked child processes.
+#[cfg(unix)]
+async fn shutdown_children(children: &mut Vec<Child>) {
+    use nix::sys::signal::{Signal, kill};
+    use nix::unistd::Pid;
+
+    for child in children.iter_mut() {
+        if let Some(pid) = child.id() {
+            let _ = kill(Pid::from_raw(-(pid as i32)), Signal::SIGTERM);
+        }
+    }
+    sleep(Duration::from_secs(2)).await;
+    for child in children.iter_mut() {
+        let _ = child.kill().await;
+    }
+}
+
+#[cfg(not(unix))]
+async fn shutdown_children(children: &mut Vec<Child>) {
+    for child in children.iter_mut() {
+        let _ = child.kill().await;
+    }
+}
+
+// ── Topological sort ────────────────────────────────────────────────────────
+
+/// Generic topological sort using Kahn's algorithm.
 pub(crate) fn topo_sort(items: &[(&str, &[String])]) -> Result<Vec<usize>> {
     let name_to_idx: HashMap<&str, usize> = items
         .iter()
@@ -104,7 +120,6 @@ pub(crate) fn topo_sort(items: &[(&str, &[String])]) -> Result<Vec<usize>> {
         }
     }
 
-    // Kahn's algorithm with a VecDeque (FIFO) for stable alphabetical order.
     let mut ready: Vec<usize> = (0..n).filter(|&i| in_degree[i] == 0).collect();
     ready.sort_by(|a, b| items[*a].0.cmp(items[*b].0));
     let mut queue: VecDeque<usize> = ready.into_iter().collect();
@@ -112,7 +127,6 @@ pub(crate) fn topo_sort(items: &[(&str, &[String])]) -> Result<Vec<usize>> {
     let mut order = Vec::with_capacity(n);
     while let Some(node) = queue.pop_front() {
         order.push(node);
-        // Collect newly-ready neighbors, sort alphabetically, then enqueue.
         let mut newly_ready = Vec::new();
         for &nb in &adj[node] {
             in_degree[nb] -= 1;
@@ -140,16 +154,13 @@ pub(crate) fn topo_sort(items: &[(&str, &[String])]) -> Result<Vec<usize>> {
 
 // ── Config loading & merging ────────────────────────────────────────────────
 
-/// Load and merge configs: read deploy/<target>.yaml, optionally load upstream
-/// robonix_workspace.yaml, merge env (upstream defaults, local overrides),
-/// parse packages_run entries.
+/// Load deploy config + upstream workspace config, merge env, parse packages_run.
 fn load_and_merge(config_path: &Path) -> Result<(MergedConfig, PathBuf)> {
     let content = std::fs::read_to_string(config_path)
         .with_context(|| format!("failed to read {}", config_path.display()))?;
     let cfg: DeployConfig = serde_yaml::from_str(&content)
         .with_context(|| format!("failed to parse {}", config_path.display()))?;
 
-    // Resolve base directory (config file's parent).
     let base_dir = config_path
         .parent()
         .map(|p| {
@@ -164,7 +175,6 @@ fn load_and_merge(config_path: &Path) -> Result<(MergedConfig, PathBuf)> {
         .canonicalize()
         .unwrap_or_else(|_| base_dir.to_path_buf());
 
-    // Load upstream workspace config if specified.
     let upstream = if let Some(ref upstream_path) = cfg.upstream_config {
         let resolved = base_dir.join(upstream_path);
         if resolved.exists() {
@@ -191,13 +201,11 @@ fn load_and_merge(config_path: &Path) -> Result<(MergedConfig, PathBuf)> {
         WorkspaceConfig::default()
     };
 
-    // Merge env: upstream provides defaults, local config overrides.
     let mut merged_env = upstream.env.clone();
     for (k, v) in &cfg.env {
         merged_env.insert(k.clone(), v.clone());
     }
 
-    // Parse packages_run entries.
     let packages_run = cfg
         .packages_run
         .iter()
@@ -216,40 +224,9 @@ fn load_and_merge(config_path: &Path) -> Result<(MergedConfig, PathBuf)> {
     ))
 }
 
-/// Gracefully shut down all tracked child processes by sending SIGTERM
-/// to each child's process group, then waiting for them.
-#[cfg(unix)]
-#[allow(dead_code)]
-async fn shutdown_children(children: &mut Vec<Child>) {
-    use nix::sys::signal::{Signal, kill};
-    use nix::unistd::Pid;
-
-    for child in children.iter_mut() {
-        if let Some(pid) = child.id() {
-            // Send SIGTERM to the child's process group (negative PID).
-            let _ = kill(Pid::from_raw(-(pid as i32)), Signal::SIGTERM);
-        }
-    }
-    // Give children a moment to exit gracefully.
-    sleep(Duration::from_secs(2)).await;
-    for child in children.iter_mut() {
-        // Force kill any remaining.
-        let _ = child.kill().await;
-    }
-}
-
-#[cfg(not(unix))]
-#[allow(dead_code)]
-async fn shutdown_children(children: &mut Vec<Child>) {
-    for child in children.iter_mut() {
-        let _ = child.kill().await;
-    }
-}
-
-// ── Discovery helpers ────────────────────────────────────────────────────────
+// ── Discovery helpers ───────────────────────────────────────────────────────
 
 /// Walk up from `base` looking for a Cargo workspace containing robonix crates.
-#[allow(dead_code)]
 fn detect_rust_root(base: &Path) -> Option<PathBuf> {
     let mut dir = base.to_path_buf();
     for _ in 0..10 {
@@ -276,56 +253,328 @@ fn detect_rust_root(base: &Path) -> Option<PathBuf> {
     None
 }
 
+/// Find the workspace root by searching upward for `robonix_workspace.yaml`.
+fn find_workspace_root(base_dir: &Path) -> Result<PathBuf> {
+    let mut dir = base_dir.to_path_buf();
+    for _ in 0..10 {
+        if dir.join("robonix_workspace.yaml").exists() {
+            return Ok(dir);
+        }
+        if !dir.pop() {
+            break;
+        }
+    }
+    anyhow::bail!(
+        "robonix_workspace.yaml not found (searched from {} upward)",
+        base_dir.display()
+    );
+}
+
+// ── Step 1: Start upstream system ───────────────────────────────────────────
+
+/// Start the fixed system components (atlas, executor, pilot, liaison).
+async fn start_upstream_system(
+    workspace_root: &Path,
+    env: &HashMap<String, String>,
+    children: &mut Vec<Child>,
+) -> Result<()> {
+    let system_components = [
+        ("robonix-atlas", "127.0.0.1:50051"),
+        ("robonix-executor", "127.0.0.1:50061"),
+        ("robonix-pilot", "127.0.0.1:50071"),
+        ("robonix-liaison", "127.0.0.1:50081"),
+    ];
+
+    let rust_root = detect_rust_root(workspace_root);
+    let cwd = rust_root.as_deref().unwrap_or(workspace_root);
+
+    for (name, endpoint) in &system_components {
+        output::step("Starting", &format!("{} (system)", name));
+
+        // Check if already running.
+        if wait_for_endpoint(endpoint, Duration::from_millis(500)).await {
+            output::check(&format!("{} already running at {}", name, endpoint));
+            continue;
+        }
+
+        let child = spawn_background(name, "cargo", &["run", "-p", name], cwd, env).await?;
+        let pid = child.id().unwrap_or(0);
+        output::sub_step(&format!("PID {}", pid));
+        children.push(child);
+
+        output::sub_step(&format!("waiting for {} ...", endpoint));
+        if wait_for_endpoint(endpoint, Duration::from_secs(15)).await {
+            output::check(&format!("{} ready at {}", name, endpoint));
+        } else {
+            output::warning(&format!(
+                "{} started but {} not reachable after 15s — continuing",
+                name, endpoint
+            ));
+        }
+    }
+    Ok(())
+}
+
+// ── Step 2: Ensure packages exist ───────────────────────────────────────────
+
+/// Check that all workspace-declared packages exist locally.
+/// Returns a map of package_name → local path.
+fn ensure_packages_exist(
+    workspace_root: &Path,
+    packages: &[WorkspacePackageEntry],
+) -> Result<HashMap<String, PathBuf>> {
+    let mut package_paths: HashMap<String, PathBuf> = HashMap::new();
+
+    for pkg in packages {
+        let local_path = if let Some(ref path) = pkg.path {
+            let resolved = workspace_root.join(path);
+            if !resolved.exists() {
+                anyhow::bail!(
+                    "package '{}' path '{}' does not exist (resolved to {})",
+                    pkg.name,
+                    path,
+                    resolved.display()
+                );
+            }
+            resolved.canonicalize().unwrap_or(resolved)
+        } else {
+            // No path specified — check packages/<short_name>
+            let pkg_dir_name = pkg.name.rsplit('.').next().unwrap_or(&pkg.name);
+            let candidate = workspace_root.join("packages").join(pkg_dir_name);
+            if !candidate.exists() {
+                // Git clone will be implemented in stage four.
+                anyhow::bail!(
+                    "package '{}' not found at {}{}",
+                    pkg.name,
+                    candidate.display(),
+                    if pkg.url.is_some() {
+                        " (has url, auto-clone will be available in a future update)"
+                    } else {
+                        " and no url specified"
+                    }
+                );
+            }
+            candidate.canonicalize().unwrap_or(candidate)
+        };
+        output::check(&format!("{} → {}", pkg.name, local_path.display()));
+        package_paths.insert(pkg.name.clone(), local_path);
+    }
+    Ok(package_paths)
+}
+
+// ── Step 3: Validate packages_run ───────────────────────────────────────────
+
+/// A validated package run entry with resolved manifest and nodes.
+struct ValidatedPackageRun {
+    package_name: String,
+    pkg_path: PathBuf,
+    manifest: manifest::Manifest,
+    nodes_to_start: Vec<manifest::Node>,
+}
+
+/// Validate packages_run entries against workspace declarations and manifests.
+fn validate_packages_run(
+    packages_run: &[ParsedPackageRun],
+    workspace_packages: &[WorkspacePackageEntry],
+    package_paths: &HashMap<String, PathBuf>,
+) -> Result<Vec<ValidatedPackageRun>> {
+    let ws_pkg_names: HashSet<&str> = workspace_packages.iter().map(|p| p.name.as_str()).collect();
+    let mut validated = Vec::new();
+
+    for run in packages_run {
+        // 1. Check package is declared in workspace.
+        if !ws_pkg_names.contains(run.package_name.as_str()) {
+            anyhow::bail!(
+                "packages_run references '{}' but it is not declared in workspace packages",
+                run.package_name
+            );
+        }
+
+        // 2. Get path and load manifest.
+        let pkg_path = package_paths
+            .get(&run.package_name)
+            .ok_or_else(|| anyhow::anyhow!("package '{}' path not resolved", run.package_name))?;
+        let manifest_path = pkg_path.join(manifest::MANIFEST_FILE);
+        let pkg_manifest = manifest::load_from_path(&manifest_path).with_context(|| {
+            format!(
+                "failed to load {} for package '{}'",
+                manifest::MANIFEST_FILE,
+                run.package_name
+            )
+        })?;
+
+        // 3. Validate node selector.
+        let nodes_to_start: Vec<manifest::Node> = match &run.node_selector {
+            NodeSelector::All => {
+                if pkg_manifest.nodes.is_empty() {
+                    output::warning(&format!(
+                        "package '{}' has no nodes defined",
+                        run.package_name
+                    ));
+                }
+                pkg_manifest.nodes.clone()
+            }
+            NodeSelector::Single(node_id) => {
+                let node = pkg_manifest
+                    .nodes
+                    .iter()
+                    .find(|n| n.id == *node_id)
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "package '{}' has no node '{}'. Available: {:?}",
+                            run.package_name,
+                            node_id,
+                            pkg_manifest
+                                .nodes
+                                .iter()
+                                .map(|n| &n.id)
+                                .collect::<Vec<_>>()
+                        )
+                    })?;
+                vec![node.clone()]
+            }
+        };
+
+        let node_ids: Vec<&str> = nodes_to_start.iter().map(|n| n.id.as_str()).collect();
+        output::check(&format!(
+            "{} — {} v{}, nodes: [{}]",
+            run.package_name,
+            pkg_manifest.package.name,
+            pkg_manifest.package.version,
+            node_ids.join(", ")
+        ));
+
+        validated.push(ValidatedPackageRun {
+            package_name: run.package_name.clone(),
+            pkg_path: pkg_path.clone(),
+            manifest: pkg_manifest,
+            nodes_to_start,
+        });
+    }
+    Ok(validated)
+}
+
 // ── Core deploy logic ────────────────────────────────────────────────────────
 
 /// Deploy from a config file (deploy/<target>.yaml).
-///
-/// Phase 1 (stage one): loads and validates config, prints summary.
-/// Full execution logic (system startup, node launching) will be
-/// implemented in stage three.
 pub async fn execute(config_path: &Path) -> Result<()> {
     output::action("Deploy", &format!("from {}", config_path.display()));
 
-    let (merged, _base_dir) = load_and_merge(config_path)?;
+    let (merged, base_dir) = load_and_merge(config_path)?;
 
-    // Print summary of loaded configuration.
+    // Build global env (current process env + merged config env).
+    let mut global_env: HashMap<String, String> = std::env::vars().collect();
+    for (k, v) in &merged.env {
+        global_env.insert(k.clone(), v.clone());
+    }
+
     if let Some(ref target) = merged.target {
         output::sub_step(&format!("target: {}", target));
     }
-    output::sub_step(&format!(
-        "workspace: {}, {} workspace package(s), {} packages_run entry(ies)",
-        merged.workspace_name.as_deref().unwrap_or("unnamed"),
-        merged.workspace_packages.len(),
-        merged.packages_run.len(),
+
+    let workspace_root = find_workspace_root(&base_dir)?;
+    let mut children: Vec<Child> = Vec::new();
+
+    // ── Step 1: Start upstream system (fixed components) ────────────────────
+    output::action("Step 1", "Starting upstream system");
+    start_upstream_system(&workspace_root, &global_env, &mut children).await?;
+
+    // ── Step 2: Check packages existence ────────────────────────────────────
+    output::action("Step 2", "Checking packages existence");
+    let package_paths = ensure_packages_exist(&workspace_root, &merged.workspace_packages)?;
+
+    // ── Step 3: Validate packages_run declarations ──────────────────────────
+    output::action("Step 3", "Validating packages_run");
+    let validated = validate_packages_run(
+        &merged.packages_run,
+        &merged.workspace_packages,
+        &package_paths,
+    )?;
+
+    if validated.is_empty() {
+        output::warning("no packages_run entries — nothing to deploy");
+        output::info("Press Ctrl+C to shut down system components.");
+        tokio::signal::ctrl_c().await?;
+        shutdown_children(&mut children).await;
+        return Ok(());
+    }
+
+    // ── Step 4: Start nodes in dependency order ─────────────────────────────
+    output::action("Step 4", "Starting nodes in dependency order");
+
+    // Build check (warning only).
+    let build_dir = workspace_root.join("build");
+    if !build_dir.exists() {
+        output::warning("build/ directory not found; packages may not have been built yet");
+    }
+
+    // Topological sort based on manifest.depend.
+    let items: Vec<(&str, &[String])> = validated
+        .iter()
+        .map(|v| (v.package_name.as_str(), v.manifest.depend.as_slice()))
+        .collect();
+    let order = topo_sort(&items)?;
+
+    let order_names: Vec<&str> = order
+        .iter()
+        .map(|&i| validated[i].package_name.as_str())
+        .collect();
+    output::sub_step(&format!("launch order: {}", order_names.join(" → ")));
+
+    // Launch nodes in topo order.
+    for &idx in &order {
+        let vp = &validated[idx];
+        for node in &vp.nodes_to_start {
+            let start_cmd = node.start.trim();
+            if start_cmd.is_empty() {
+                output::warning(&format!(
+                    "{}:{} has empty start command, skipping",
+                    vp.package_name, node.id
+                ));
+                continue;
+            }
+
+            output::step("Starting", &format!("{}:{}", vp.package_name, node.id));
+            output::sub_step(&format!("cmd: {}", start_cmd));
+
+            let child = spawn_background(
+                &format!("{}:{}", vp.package_name, node.id),
+                "bash",
+                &["-c", start_cmd],
+                &vp.pkg_path,
+                &global_env,
+            )
+            .await?;
+            let pid = child.id().unwrap_or(0);
+            output::sub_step(&format!("PID {}", pid));
+            children.push(child);
+
+            sleep(Duration::from_secs(2)).await;
+            output::check(&format!("{}:{} launched", vp.package_name, node.id));
+        }
+    }
+
+    // ── Summary + wait for Ctrl+C ───────────────────────────────────────────
+    let node_count: usize = validated.iter().map(|v| v.nodes_to_start.len()).sum();
+    output::success(&format!(
+        "Deploy complete — {} node(s) from {} package(s) started",
+        node_count,
+        validated.len(),
     ));
+    output::info("Press Ctrl+C to shut down all deployed components.");
 
-    for pkg in &merged.workspace_packages {
-        let source = if let Some(ref url) = pkg.url {
-            format!("url={}", url)
-        } else if let Some(ref path) = pkg.path {
-            format!("path={}", path)
-        } else {
-            "no source".to_string()
-        };
-        output::sub_step(&format!("  package: {} ({})", pkg.name, source));
-    }
+    tokio::signal::ctrl_c()
+        .await
+        .context("failed to listen for Ctrl+C")?;
 
-    for run in &merged.packages_run {
-        let selector = match &run.node_selector {
-            robonix_cli::workspace::NodeSelector::All => "all".to_string(),
-            robonix_cli::workspace::NodeSelector::Single(id) => id.clone(),
-        };
-        output::sub_step(&format!("  run: {}:{}", run.package_name, selector));
-    }
-
-    output::warning("deploy execution logic not yet implemented (stage 3 WIP)");
+    output::action("Shutdown", "stopping deployed components...");
+    shutdown_children(&mut children).await;
 
     Ok(())
 }
 
-/// Deploy from the workspace-level config (no explicit config file).
-///
-/// Stub implementation — will be completed in stage three.
+/// Deploy from workspace-level config (no explicit config file).
+/// Reads robonix_workspace.yaml and starts all packages with all nodes.
 pub async fn execute_from_workspace() -> Result<()> {
     let ws_yaml = PathBuf::from("robonix_workspace.yaml");
     if !ws_yaml.exists() {
@@ -334,6 +583,119 @@ pub async fn execute_from_workspace() -> Result<()> {
              use 'rbnx deploy <target>' or 'rbnx deploy -c <config>' instead"
         );
     }
-    output::warning("workspace-level deploy not yet implemented (stage 3 WIP)");
+
+    let workspace_root = std::env::current_dir()?;
+    let content = std::fs::read_to_string(&ws_yaml)?;
+    let ws: WorkspaceConfig = serde_yaml::from_str(&content)
+        .with_context(|| "failed to parse robonix_workspace.yaml")?;
+
+    output::action(
+        "Deploy",
+        &format!(
+            "from workspace {} ({} package(s))",
+            ws.workspace.as_deref().unwrap_or("unnamed"),
+            ws.packages.len(),
+        ),
+    );
+
+    if ws.packages.is_empty() {
+        output::warning("no packages declared in workspace — nothing to deploy");
+        return Ok(());
+    }
+
+    // Build global env.
+    let mut global_env: HashMap<String, String> = std::env::vars().collect();
+    for (k, v) in &ws.env {
+        global_env.insert(k.clone(), v.clone());
+    }
+
+    let mut children: Vec<Child> = Vec::new();
+
+    // Step 1: Start upstream system.
+    output::action("Step 1", "Starting upstream system");
+    start_upstream_system(&workspace_root, &global_env, &mut children).await?;
+
+    // Step 2: Check packages existence.
+    output::action("Step 2", "Checking packages existence");
+    let package_paths = ensure_packages_exist(&workspace_root, &ws.packages)?;
+
+    // Step 3: Build "all nodes" run entries for every package.
+    output::action("Step 3", "Loading manifests");
+    let mut validated = Vec::new();
+    for pkg_entry in &ws.packages {
+        let pkg_path = package_paths.get(&pkg_entry.name).unwrap();
+        let manifest_path = pkg_path.join(manifest::MANIFEST_FILE);
+        let pkg_manifest = manifest::load_from_path(&manifest_path)?;
+        let nodes = pkg_manifest.nodes.clone();
+        let node_ids: Vec<&str> = nodes.iter().map(|n| n.id.as_str()).collect();
+        output::check(&format!(
+            "{} — {} v{}, nodes: [{}]",
+            pkg_entry.name,
+            pkg_manifest.package.name,
+            pkg_manifest.package.version,
+            node_ids.join(", ")
+        ));
+        validated.push(ValidatedPackageRun {
+            package_name: pkg_entry.name.clone(),
+            pkg_path: pkg_path.clone(),
+            manifest: pkg_manifest,
+            nodes_to_start: nodes,
+        });
+    }
+
+    if validated.is_empty() {
+        output::warning("no packages to deploy");
+        return Ok(());
+    }
+
+    // Step 4: Start nodes in dependency order.
+    output::action("Step 4", "Starting nodes in dependency order");
+
+    let items: Vec<(&str, &[String])> = validated
+        .iter()
+        .map(|v| (v.package_name.as_str(), v.manifest.depend.as_slice()))
+        .collect();
+    let order = topo_sort(&items)?;
+
+    let order_names: Vec<&str> = order
+        .iter()
+        .map(|&i| validated[i].package_name.as_str())
+        .collect();
+    output::sub_step(&format!("launch order: {}", order_names.join(" → ")));
+
+    for &idx in &order {
+        let vp = &validated[idx];
+        for node in &vp.nodes_to_start {
+            let start_cmd = node.start.trim();
+            if start_cmd.is_empty() {
+                continue;
+            }
+            output::step("Starting", &format!("{}:{}", vp.package_name, node.id));
+            let child = spawn_background(
+                &format!("{}:{}", vp.package_name, node.id),
+                "bash",
+                &["-c", start_cmd],
+                &vp.pkg_path,
+                &global_env,
+            )
+            .await?;
+            children.push(child);
+            sleep(Duration::from_secs(2)).await;
+            output::check(&format!("{}:{} launched", vp.package_name, node.id));
+        }
+    }
+
+    let node_count: usize = validated.iter().map(|v| v.nodes_to_start.len()).sum();
+    output::success(&format!(
+        "Deploy complete — {} node(s) from {} package(s) started",
+        node_count,
+        validated.len(),
+    ));
+    output::info("Press Ctrl+C to shut down all deployed components.");
+
+    tokio::signal::ctrl_c().await?;
+    output::action("Shutdown", "stopping deployed components...");
+    shutdown_children(&mut children).await;
+
     Ok(())
 }

--- a/rust/crates/robonix-cli/src/cmd/deploy.rs
+++ b/rust/crates/robonix-cli/src/cmd/deploy.rs
@@ -14,10 +14,10 @@ use anyhow::{Context, Result};
 use robonix_cli::manifest;
 use robonix_cli::output;
 use serde::Deserialize;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use tokio::process::Command;
+use tokio::process::{Child, Command};
 use tokio::time::{Duration, sleep};
 
 // ── YAML schema ─────────────────────────────────────────────────────────────
@@ -137,14 +137,17 @@ fn runtime_cargo_package(name: &str) -> Option<&'static str> {
     }
 }
 
-/// Spawn a background process.  Returns its PID on success.
+/// Spawn a background process.  Returns the Child handle (caller must store it).
+///
+/// On Unix, the child is placed into its own process group via `pre_exec(setsid)`
+/// so that we can cleanly terminate it later without killing the parent shell.
 async fn spawn_background(
     label: &str,
     cmd: &str,
     args: &[&str],
     cwd: &Path,
     env: &HashMap<String, String>,
-) -> Result<u32> {
+) -> Result<Child> {
     let mut command = Command::new(cmd);
     command
         .args(args)
@@ -153,16 +156,20 @@ async fn spawn_background(
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit());
 
+    // Place child in its own process group so we can kill it independently.
+    #[cfg(unix)]
+    unsafe {
+        command.pre_exec(|| {
+            // Create a new session / process group for this child.
+            nix::unistd::setsid().map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+            Ok(())
+        });
+    }
+
     let child = command
         .spawn()
         .with_context(|| format!("failed to spawn {label}"))?;
-    let pid = child
-        .id()
-        .ok_or_else(|| anyhow::anyhow!("failed to get PID for {label}"))?;
-    // Don't await — let it run in the background.
-    // Leak the child handle so it doesn't get killed when dropped.
-    std::mem::forget(child);
-    Ok(pid)
+    Ok(child)
 }
 
 /// Wait for a TCP endpoint to become reachable (connect-only check).
@@ -177,102 +184,69 @@ async fn wait_for_endpoint(addr: &str, timeout: Duration) -> bool {
     false
 }
 
-/// Topological sort of packages by depends_on (works on Vec<PackageEntry>).
-fn topo_sort_packages(packages: &[PackageEntry]) -> Result<Vec<usize>> {
-    let name_to_idx: HashMap<&str, usize> = packages
+/// Generic topological sort using Kahn's algorithm with FIFO (VecDeque)
+/// for correct alphabetical ordering.
+///
+/// `items` is a slice of (name, depends_on) pairs.
+/// Returns indices in dependency-first order.
+/// Reports an error if any `depends_on` reference is unknown.
+pub(crate) fn topo_sort(items: &[(&str, &[String])]) -> Result<Vec<usize>> {
+    let name_to_idx: HashMap<&str, usize> = items
         .iter()
         .enumerate()
-        .map(|(i, p)| (p.name.as_str(), i))
+        .map(|(i, (name, _))| (*name, i))
         .collect();
 
-    let n = packages.len();
+    let n = items.len();
     let mut in_degree = vec![0usize; n];
     let mut adj: Vec<Vec<usize>> = vec![Vec::new(); n];
 
-    for (i, pkg) in packages.iter().enumerate() {
-        for dep in &pkg.depends_on {
+    for (i, (item_name, deps)) in items.iter().enumerate() {
+        for dep in *deps {
             if let Some(&dep_idx) = name_to_idx.get(dep.as_str()) {
                 adj[dep_idx].push(i);
                 in_degree[i] += 1;
+            } else {
+                anyhow::bail!(
+                    "'{}' depends on '{}', but '{}' is not defined",
+                    item_name,
+                    dep,
+                    dep
+                );
             }
         }
     }
 
-    // Kahn's algorithm.
-    let mut queue: Vec<usize> = (0..n).filter(|&i| in_degree[i] == 0).collect();
-    queue.sort_by(|a, b| packages[*a].name.cmp(&packages[*b].name));
+    // Kahn's algorithm with a VecDeque (FIFO) for stable alphabetical order.
+    let mut ready: Vec<usize> = (0..n).filter(|&i| in_degree[i] == 0).collect();
+    ready.sort_by(|a, b| items[*a].0.cmp(items[*b].0));
+    let mut queue: VecDeque<usize> = ready.into_iter().collect();
 
     let mut order = Vec::with_capacity(n);
-    while let Some(node) = queue.pop() {
+    while let Some(node) = queue.pop_front() {
         order.push(node);
+        // Collect newly-ready neighbors, sort alphabetically, then enqueue.
+        let mut newly_ready = Vec::new();
         for &nb in &adj[node] {
             in_degree[nb] -= 1;
             if in_degree[nb] == 0 {
-                queue.push(nb);
-                queue.sort_by(|a, b| packages[*a].name.cmp(&packages[*b].name));
+                newly_ready.push(nb);
             }
+        }
+        newly_ready.sort_by(|a, b| items[*a].0.cmp(items[*b].0));
+        for idx in newly_ready {
+            queue.push_back(idx);
         }
     }
 
     if order.len() != n {
-        let missing: Vec<&str> = packages
+        let missing: Vec<&str> = items
             .iter()
             .enumerate()
             .filter(|(i, _)| !order.contains(i))
-            .map(|(_, p)| p.name.as_str())
+            .map(|(_, (name, _))| *name)
             .collect();
-        anyhow::bail!("circular dependency detected among packages: {:?}", missing);
-    }
-    Ok(order)
-}
-
-/// Topological sort of runtime entries by depends_on.
-fn topo_sort_runtime(entries: &[RuntimeEntry]) -> Result<Vec<usize>> {
-    let name_to_idx: HashMap<&str, usize> = entries
-        .iter()
-        .enumerate()
-        .map(|(i, e)| (e.name.as_str(), i))
-        .collect();
-
-    let n = entries.len();
-    let mut in_degree = vec![0usize; n];
-    let mut adj: Vec<Vec<usize>> = vec![Vec::new(); n];
-
-    for (i, entry) in entries.iter().enumerate() {
-        for dep in &entry.depends_on {
-            if let Some(&dep_idx) = name_to_idx.get(dep.as_str()) {
-                adj[dep_idx].push(i);
-                in_degree[i] += 1;
-            }
-        }
-    }
-
-    let mut queue: Vec<usize> = (0..n).filter(|&i| in_degree[i] == 0).collect();
-    queue.sort_by(|a, b| entries[*a].name.cmp(&entries[*b].name));
-
-    let mut order = Vec::with_capacity(n);
-    while let Some(node) = queue.pop() {
-        order.push(node);
-        for &nb in &adj[node] {
-            in_degree[nb] -= 1;
-            if in_degree[nb] == 0 {
-                queue.push(nb);
-                queue.sort_by(|a, b| entries[*a].name.cmp(&entries[*b].name));
-            }
-        }
-    }
-
-    if order.len() != n {
-        let missing: Vec<&str> = entries
-            .iter()
-            .enumerate()
-            .filter(|(i, _)| !order.contains(i))
-            .map(|(_, e)| e.name.as_str())
-            .collect();
-        anyhow::bail!(
-            "circular dependency detected among runtime entries: {:?}",
-            missing
-        );
+        anyhow::bail!("circular dependency detected: {:?}", missing);
     }
     Ok(order)
 }
@@ -347,6 +321,34 @@ fn load_and_merge(config_path: &Path) -> Result<(MergedConfig, PathBuf)> {
     ))
 }
 
+/// Gracefully shut down all tracked child processes by sending SIGTERM
+/// to each child's process group, then waiting for them.
+#[cfg(unix)]
+async fn shutdown_children(children: &mut Vec<Child>) {
+    use nix::sys::signal::{Signal, kill};
+    use nix::unistd::Pid;
+
+    for child in children.iter_mut() {
+        if let Some(pid) = child.id() {
+            // Send SIGTERM to the child's process group (negative PID).
+            let _ = kill(Pid::from_raw(-(pid as i32)), Signal::SIGTERM);
+        }
+    }
+    // Give children a moment to exit gracefully.
+    sleep(Duration::from_secs(2)).await;
+    for child in children.iter_mut() {
+        // Force kill any remaining.
+        let _ = child.kill().await;
+    }
+}
+
+#[cfg(not(unix))]
+async fn shutdown_children(children: &mut Vec<Child>) {
+    for child in children.iter_mut() {
+        let _ = child.kill().await;
+    }
+}
+
 // ── Core deploy logic ────────────────────────────────────────────────────────
 
 pub async fn execute(config_path: &Path) -> Result<()> {
@@ -355,9 +357,10 @@ pub async fn execute(config_path: &Path) -> Result<()> {
     let (merged, base_dir) = load_and_merge(config_path)?;
 
     // Build global env map (merged config env + current process env).
-    let mut global_env: HashMap<String, String> = merged.env.clone();
-    for (k, v) in std::env::vars() {
-        global_env.entry(k).or_insert(v);
+    // Config env takes priority over inherited process env.
+    let mut global_env: HashMap<String, String> = std::env::vars().collect();
+    for (k, v) in &merged.env {
+        global_env.insert(k.clone(), v.clone());
     }
 
     // Inject runtime endpoints into env so packages can discover them.
@@ -382,11 +385,19 @@ pub async fn execute(config_path: &Path) -> Result<()> {
     // Detect Rust workspace root for cargo run.
     let rust_root = detect_rust_root(&base_dir);
 
+    // Track all spawned child processes for graceful shutdown.
+    let mut children: Vec<Child> = Vec::new();
+
     // ── Phase 1: Start runtime components ────────────────────────────────────
     if !merged.runtime.is_empty() {
         output::action("Phase 1", "Starting runtime components");
 
-        let runtime_order = topo_sort_runtime(&merged.runtime)?;
+        let items: Vec<(&str, &[String])> = merged
+            .runtime
+            .iter()
+            .map(|e| (e.name.as_str(), e.depends_on.as_slice()))
+            .collect();
+        let runtime_order = topo_sort(&items)?;
         let runtime_names: Vec<&str> = runtime_order
             .iter()
             .map(|&i| merged.runtime[i].name.as_str())
@@ -415,10 +426,12 @@ pub async fn execute(config_path: &Path) -> Result<()> {
 
                 let cwd = rust_root.as_deref().unwrap_or(&base_dir);
 
-                let pid =
+                let child =
                     spawn_background(&entry.name, "cargo", &["run", "-p", pkg], cwd, &global_env)
                         .await?;
+                let pid = child.id().unwrap_or(0);
                 output::sub_step(&format!("PID {}", pid));
+                children.push(child);
 
                 // Wait for the endpoint to become reachable.
                 if !entry.endpoint.is_empty() {
@@ -464,7 +477,7 @@ pub async fn execute(config_path: &Path) -> Result<()> {
                 if let Some(pkg_path) = service_pkg_path {
                     let cwd = rust_root.as_deref().unwrap_or(&base_dir);
                     let pkg_str = pkg_path.to_string_lossy().to_string();
-                    let pid = spawn_background(
+                    let child = spawn_background(
                         &entry.name,
                         "cargo",
                         &[
@@ -484,7 +497,9 @@ pub async fn execute(config_path: &Path) -> Result<()> {
                         &global_env,
                     )
                     .await?;
+                    let pid = child.id().unwrap_or(0);
                     output::sub_step(&format!("PID {} (rbnx start {})", pid, entry.node_id));
+                    children.push(child);
                     sleep(Duration::from_secs(2)).await;
                     output::check(&format!("{} started", entry.name));
                 } else {
@@ -506,7 +521,12 @@ pub async fn execute(config_path: &Path) -> Result<()> {
     if !merged.packages.is_empty() {
         output::action("Phase 3", "Starting packages");
 
-        let launch_order = topo_sort_packages(&merged.packages)?;
+        let items: Vec<(&str, &[String])> = merged
+            .packages
+            .iter()
+            .map(|p| (p.name.as_str(), p.depends_on.as_slice()))
+            .collect();
+        let launch_order = topo_sort(&items)?;
         let pkg_names: Vec<&str> = launch_order
             .iter()
             .map(|&i| merged.packages[i].name.as_str())
@@ -568,6 +588,8 @@ pub async fn execute(config_path: &Path) -> Result<()> {
                 continue;
             }
 
+            // ── Validate manifest start command (security) ──────────────────
+            // Log the command being executed for auditability.
             output::sub_step(&format!(
                 "manifest: {} v{} — node '{}' ({})",
                 pkg_manifest.package.name,
@@ -575,17 +597,19 @@ pub async fn execute(config_path: &Path) -> Result<()> {
                 node.id,
                 node.node_type.as_deref().unwrap_or("unknown")
             ));
+            output::sub_step(&format!("executing start command: {}", start_cmd));
 
-            // Build the full launch command with optional params.
-            let mut full_cmd = String::new();
+            // Build per-package env: inject params via environment variables
+            // instead of shell string interpolation (prevents command injection).
+            let mut pkg_env = global_env.clone();
 
             // Inject params_file if specified in config.yaml.
             if let Some(ref params_file) = entry.params_file {
                 let params_abs = pkg_path.join(params_file);
-                full_cmd.push_str(&format!(
-                    "export RBNX_PARAMS_FILE={}; ",
-                    params_abs.display()
-                ));
+                pkg_env.insert(
+                    "RBNX_PARAMS_FILE".to_string(),
+                    params_abs.display().to_string(),
+                );
             }
 
             // Inject inline params as environment variables.
@@ -602,21 +626,23 @@ pub async fn execute(config_path: &Path) -> Result<()> {
                         "RBNX_PARAM_{}",
                         k.to_uppercase().replace('.', "_").replace('-', "_")
                     );
-                    full_cmd.push_str(&format!("export {}={}; ", env_key, val_str));
+                    pkg_env.insert(env_key, val_str);
                 }
             }
 
-            full_cmd.push_str(start_cmd);
-
-            let pid = spawn_background(
+            // Launch via bash -c with the start command; params are in env,
+            // not interpolated into the shell string.
+            let child = spawn_background(
                 &entry.name,
                 "bash",
-                &["-c", &full_cmd],
+                &["-c", start_cmd],
                 &pkg_path,
-                &global_env,
+                &pkg_env,
             )
             .await?;
+            let pid = child.id().unwrap_or(0);
             output::sub_step(&format!("PID {} — {}", pid, start_cmd));
+            children.push(child);
 
             // If this package has robonix integration, log it.
             if let Some(ref rbnx) = entry.robonix {
@@ -652,13 +678,7 @@ pub async fn execute(config_path: &Path) -> Result<()> {
         .context("failed to listen for Ctrl+C")?;
 
     output::action("Shutdown", "stopping deployed components...");
-    #[cfg(unix)]
-    {
-        use nix::sys::signal::{Signal, killpg};
-        use nix::unistd::getpgrp;
-        let pgid = getpgrp();
-        let _ = killpg(pgid, Signal::SIGTERM);
-    }
+    shutdown_children(&mut children).await;
 
     Ok(())
 }

--- a/rust/crates/robonix-cli/src/cmd/deploy.rs
+++ b/rust/crates/robonix-cli/src/cmd/deploy.rs
@@ -1,0 +1,729 @@
+// SPDX-License-Identifier: MulanPSL-2.0
+// Deploy command: read a config.yaml and bring up the full stack
+// (runtime components, services, and packages) in dependency order.
+//
+// The config.yaml may reference an `upstream_config` (e.g. robonix_workspace.yaml)
+// which provides runtime components, system services, and global env.
+// The deploy command merges both configs, then:
+//   Phase 1 — start runtime components (from upstream)
+//   Phase 2 — start system services (from upstream)
+//   Phase 3 — start packages (from local config), reading each package's
+//             `robonix_manifest.yaml` to discover the actual start command.
+
+use anyhow::{Context, Result};
+use robonix_cli::manifest;
+use robonix_cli::output;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use tokio::process::Command;
+use tokio::time::{Duration, sleep};
+
+// ── YAML schema ─────────────────────────────────────────────────────────────
+
+/// Top-level config.yaml (the user's project-level config).
+#[derive(Debug, Deserialize)]
+struct DeployConfig {
+    /// Path to upstream workspace config (e.g. "robonix_workspace.yaml"),
+    /// resolved relative to this config file's directory.
+    #[serde(default)]
+    upstream_config: Option<String>,
+    /// Target platform hint (e.g. "jetson-orin-agx", "sim").
+    #[serde(default)]
+    target: Option<String>,
+    /// Global environment variables exported to every child process.
+    #[serde(default)]
+    env: HashMap<String, String>,
+    /// Packages to launch.
+    #[serde(default)]
+    packages: Vec<PackageEntry>,
+}
+
+/// Upstream workspace config (robonix_workspace.yaml).
+#[derive(Debug, Deserialize, Default)]
+struct UpstreamConfig {
+    /// Workspace name.
+    #[serde(default)]
+    workspace: Option<String>,
+    /// Global environment variables (merged with local, local wins).
+    #[serde(default)]
+    env: HashMap<String, String>,
+    /// Runtime components (atlas, executor, pilot, liaison).
+    #[serde(default)]
+    runtime: Vec<RuntimeEntry>,
+    /// System services (VLM, MemSearch, …).
+    #[serde(default)]
+    system: Vec<SystemEntry>,
+}
+
+/// A runtime component entry (from upstream_config).
+#[derive(Debug, Deserialize, Clone)]
+struct RuntimeEntry {
+    name: String,
+    #[serde(default)]
+    endpoint: String,
+    #[serde(default)]
+    depends_on: Vec<String>,
+    #[serde(default)]
+    description: Option<String>,
+}
+
+/// A system service entry (from upstream_config).
+#[derive(Debug, Deserialize, Clone)]
+struct SystemEntry {
+    name: String,
+    #[serde(default)]
+    contract_id: String,
+    #[serde(default)]
+    node_id: String,
+    #[serde(default)]
+    depends_on: Vec<String>,
+    #[serde(default)]
+    description: Option<String>,
+}
+
+/// A package entry (from the user's config.yaml).
+#[derive(Debug, Deserialize, Clone)]
+struct PackageEntry {
+    name: String,
+    path: String,
+    #[serde(default)]
+    params_file: Option<String>,
+    #[serde(default)]
+    params: Option<HashMap<String, serde_yaml::Value>>,
+    #[serde(default)]
+    depends_on: Vec<String>,
+    #[serde(default)]
+    transport: Option<String>,
+    #[serde(default)]
+    robonix: Option<RobonixIntegration>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct RobonixIntegration {
+    #[serde(default)]
+    namespace: String,
+    #[serde(default)]
+    kind: String,
+    #[serde(default)]
+    interfaces: Vec<String>,
+    #[serde(default)]
+    skills_dir: String,
+    #[serde(default)]
+    tools: Vec<String>,
+}
+
+/// The merged view used during deployment.
+struct MergedConfig {
+    env: HashMap<String, String>,
+    runtime: Vec<RuntimeEntry>,
+    system: Vec<SystemEntry>,
+    packages: Vec<PackageEntry>,
+    #[allow(dead_code)]
+    target: Option<String>,
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Cargo binary names for known runtime components.
+fn runtime_cargo_package(name: &str) -> Option<&'static str> {
+    match name {
+        "robonix-atlas" => Some("robonix-atlas"),
+        "robonix-executor" => Some("robonix-executor"),
+        "robonix-pilot" => Some("robonix-pilot"),
+        "robonix-liaison" => Some("robonix-liaison"),
+        _ => None,
+    }
+}
+
+/// Spawn a background process.  Returns its PID on success.
+async fn spawn_background(
+    label: &str,
+    cmd: &str,
+    args: &[&str],
+    cwd: &Path,
+    env: &HashMap<String, String>,
+) -> Result<u32> {
+    let mut command = Command::new(cmd);
+    command
+        .args(args)
+        .current_dir(cwd)
+        .envs(env)
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+
+    let child = command
+        .spawn()
+        .with_context(|| format!("failed to spawn {label}"))?;
+    let pid = child
+        .id()
+        .ok_or_else(|| anyhow::anyhow!("failed to get PID for {label}"))?;
+    // Don't await — let it run in the background.
+    // Leak the child handle so it doesn't get killed when dropped.
+    std::mem::forget(child);
+    Ok(pid)
+}
+
+/// Wait for a TCP endpoint to become reachable (connect-only check).
+async fn wait_for_endpoint(addr: &str, timeout: Duration) -> bool {
+    let deadline = tokio::time::Instant::now() + timeout;
+    while tokio::time::Instant::now() < deadline {
+        if tokio::net::TcpStream::connect(addr).await.is_ok() {
+            return true;
+        }
+        sleep(Duration::from_millis(300)).await;
+    }
+    false
+}
+
+/// Topological sort of packages by depends_on (works on Vec<PackageEntry>).
+fn topo_sort_packages(packages: &[PackageEntry]) -> Result<Vec<usize>> {
+    let name_to_idx: HashMap<&str, usize> = packages
+        .iter()
+        .enumerate()
+        .map(|(i, p)| (p.name.as_str(), i))
+        .collect();
+
+    let n = packages.len();
+    let mut in_degree = vec![0usize; n];
+    let mut adj: Vec<Vec<usize>> = vec![Vec::new(); n];
+
+    for (i, pkg) in packages.iter().enumerate() {
+        for dep in &pkg.depends_on {
+            if let Some(&dep_idx) = name_to_idx.get(dep.as_str()) {
+                adj[dep_idx].push(i);
+                in_degree[i] += 1;
+            }
+        }
+    }
+
+    // Kahn's algorithm.
+    let mut queue: Vec<usize> = (0..n).filter(|&i| in_degree[i] == 0).collect();
+    queue.sort_by(|a, b| packages[*a].name.cmp(&packages[*b].name));
+
+    let mut order = Vec::with_capacity(n);
+    while let Some(node) = queue.pop() {
+        order.push(node);
+        for &nb in &adj[node] {
+            in_degree[nb] -= 1;
+            if in_degree[nb] == 0 {
+                queue.push(nb);
+                queue.sort_by(|a, b| packages[*a].name.cmp(&packages[*b].name));
+            }
+        }
+    }
+
+    if order.len() != n {
+        let missing: Vec<&str> = packages
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| !order.contains(i))
+            .map(|(_, p)| p.name.as_str())
+            .collect();
+        anyhow::bail!("circular dependency detected among packages: {:?}", missing);
+    }
+    Ok(order)
+}
+
+/// Topological sort of runtime entries by depends_on.
+fn topo_sort_runtime(entries: &[RuntimeEntry]) -> Result<Vec<usize>> {
+    let name_to_idx: HashMap<&str, usize> = entries
+        .iter()
+        .enumerate()
+        .map(|(i, e)| (e.name.as_str(), i))
+        .collect();
+
+    let n = entries.len();
+    let mut in_degree = vec![0usize; n];
+    let mut adj: Vec<Vec<usize>> = vec![Vec::new(); n];
+
+    for (i, entry) in entries.iter().enumerate() {
+        for dep in &entry.depends_on {
+            if let Some(&dep_idx) = name_to_idx.get(dep.as_str()) {
+                adj[dep_idx].push(i);
+                in_degree[i] += 1;
+            }
+        }
+    }
+
+    let mut queue: Vec<usize> = (0..n).filter(|&i| in_degree[i] == 0).collect();
+    queue.sort_by(|a, b| entries[*a].name.cmp(&entries[*b].name));
+
+    let mut order = Vec::with_capacity(n);
+    while let Some(node) = queue.pop() {
+        order.push(node);
+        for &nb in &adj[node] {
+            in_degree[nb] -= 1;
+            if in_degree[nb] == 0 {
+                queue.push(nb);
+                queue.sort_by(|a, b| entries[*a].name.cmp(&entries[*b].name));
+            }
+        }
+    }
+
+    if order.len() != n {
+        let missing: Vec<&str> = entries
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| !order.contains(i))
+            .map(|(_, e)| e.name.as_str())
+            .collect();
+        anyhow::bail!(
+            "circular dependency detected among runtime entries: {:?}",
+            missing
+        );
+    }
+    Ok(order)
+}
+
+// ── Config loading & merging ────────────────────────────────────────────────
+
+/// Load and merge configs: read config.yaml, optionally load upstream_config,
+/// merge env (upstream defaults, local overrides), collect runtime + system + packages.
+fn load_and_merge(config_path: &Path) -> Result<(MergedConfig, PathBuf)> {
+    let content = std::fs::read_to_string(config_path)
+        .with_context(|| format!("failed to read {}", config_path.display()))?;
+    let cfg: DeployConfig = serde_yaml::from_str(&content)
+        .with_context(|| format!("failed to parse {}", config_path.display()))?;
+
+    // Resolve base directory (config.yaml's parent).
+    let base_dir = config_path
+        .parent()
+        .map(|p| {
+            if p.as_os_str().is_empty() {
+                PathBuf::from(".")
+            } else {
+                p.to_path_buf()
+            }
+        })
+        .unwrap_or_else(|| PathBuf::from("."));
+    let base_dir = base_dir
+        .canonicalize()
+        .unwrap_or_else(|_| base_dir.to_path_buf());
+
+    // Load upstream config if specified.
+    let upstream = if let Some(ref upstream_path) = cfg.upstream_config {
+        let resolved = base_dir.join(upstream_path);
+        if resolved.exists() {
+            let upstream_content = std::fs::read_to_string(&resolved)
+                .with_context(|| format!("failed to read upstream config {}", resolved.display()))?;
+            let up: UpstreamConfig = serde_yaml::from_str(&upstream_content).with_context(|| {
+                format!("failed to parse upstream config {}", resolved.display())
+            })?;
+            output::sub_step(&format!(
+                "loaded upstream config: {} (workspace: {})",
+                resolved.display(),
+                up.workspace.as_deref().unwrap_or("unnamed")
+            ));
+            up
+        } else {
+            output::warning(&format!(
+                "upstream_config '{}' not found at {}, skipping",
+                upstream_path,
+                resolved.display()
+            ));
+            UpstreamConfig::default()
+        }
+    } else {
+        UpstreamConfig::default()
+    };
+
+    // Merge env: upstream provides defaults, local config overrides.
+    let mut merged_env = upstream.env.clone();
+    for (k, v) in &cfg.env {
+        merged_env.insert(k.clone(), v.clone());
+    }
+
+    Ok((
+        MergedConfig {
+            env: merged_env,
+            runtime: upstream.runtime,
+            system: upstream.system,
+            packages: cfg.packages,
+            target: cfg.target,
+        },
+        base_dir,
+    ))
+}
+
+// ── Core deploy logic ────────────────────────────────────────────────────────
+
+pub async fn execute(config_path: &Path) -> Result<()> {
+    output::action("Deploy", &format!("from {}", config_path.display()));
+
+    let (merged, base_dir) = load_and_merge(config_path)?;
+
+    // Build global env map (merged config env + current process env).
+    let mut global_env: HashMap<String, String> = merged.env.clone();
+    for (k, v) in std::env::vars() {
+        global_env.entry(k).or_insert(v);
+    }
+
+    // Inject runtime endpoints into env so packages can discover them.
+    for rt in &merged.runtime {
+        if !rt.endpoint.is_empty() {
+            let env_key = rt.name.to_uppercase().replace('-', "_");
+            global_env
+                .entry(env_key)
+                .or_insert_with(|| rt.endpoint.clone());
+            // Also set _ENDPOINT variant.
+            let env_key_ep = format!("{}_ENDPOINT", rt.name.to_uppercase().replace('-', "_"));
+            global_env
+                .entry(env_key_ep)
+                .or_insert_with(|| format!("http://{}", rt.endpoint));
+        }
+    }
+
+    if let Some(ref target) = merged.target {
+        output::sub_step(&format!("target: {}", target));
+    }
+
+    // Detect Rust workspace root for cargo run.
+    let rust_root = detect_rust_root(&base_dir);
+
+    // ── Phase 1: Start runtime components ────────────────────────────────────
+    if !merged.runtime.is_empty() {
+        output::action("Phase 1", "Starting runtime components");
+
+        let runtime_order = topo_sort_runtime(&merged.runtime)?;
+        let runtime_names: Vec<&str> = runtime_order
+            .iter()
+            .map(|&i| merged.runtime[i].name.as_str())
+            .collect();
+        output::sub_step(&format!("boot order: {}", runtime_names.join(" → ")));
+
+        for &idx in &runtime_order {
+            let entry = &merged.runtime[idx];
+            let cargo_pkg = runtime_cargo_package(&entry.name);
+            if let Some(pkg) = cargo_pkg {
+                output::step("Starting", &format!("{} (runtime)", entry.name));
+                if let Some(desc) = &entry.description {
+                    output::sub_step(&format!("  {}", desc));
+                }
+
+                // Check if already running.
+                if !entry.endpoint.is_empty()
+                    && wait_for_endpoint(&entry.endpoint, Duration::from_millis(500)).await
+                {
+                    output::check(&format!(
+                        "{} already running at {}",
+                        entry.name, entry.endpoint
+                    ));
+                    continue;
+                }
+
+                let cwd = rust_root.as_deref().unwrap_or(&base_dir);
+
+                let pid =
+                    spawn_background(&entry.name, "cargo", &["run", "-p", pkg], cwd, &global_env)
+                        .await?;
+                output::sub_step(&format!("PID {}", pid));
+
+                // Wait for the endpoint to become reachable.
+                if !entry.endpoint.is_empty() {
+                    output::sub_step(&format!("waiting for {} ...", entry.endpoint));
+                    if wait_for_endpoint(&entry.endpoint, Duration::from_secs(15)).await {
+                        output::check(&format!("{} ready at {}", entry.name, entry.endpoint));
+                    } else {
+                        output::warning(&format!(
+                            "{} started but endpoint {} not reachable after 15s — continuing",
+                            entry.name, entry.endpoint
+                        ));
+                    }
+                } else {
+                    sleep(Duration::from_secs(2)).await;
+                    output::check(&format!("{} started", entry.name));
+                }
+            } else {
+                output::warning(&format!("unknown runtime '{}', skipping", entry.name));
+            }
+        }
+    }
+
+    // ── Phase 2: Start system services ───────────────────────────────────────
+    if !merged.system.is_empty() {
+        output::action("Phase 2", "Starting system services");
+
+        let atlas_endpoint = merged
+            .runtime
+            .iter()
+            .find(|r| r.name == "robonix-atlas")
+            .map(|r| r.endpoint.clone())
+            .unwrap_or_else(|| "127.0.0.1:50051".to_string());
+
+        for entry in &merged.system {
+            output::step("Starting", &format!("{} (service)", entry.name));
+            if let Some(desc) = &entry.description {
+                output::sub_step(&format!("  {}", desc));
+            }
+
+            if !entry.node_id.is_empty() {
+                // Try to find the service package under robonix examples.
+                let service_pkg_path = find_service_package(rust_root.as_deref(), &entry.name);
+                if let Some(pkg_path) = service_pkg_path {
+                    let cwd = rust_root.as_deref().unwrap_or(&base_dir);
+                    let pkg_str = pkg_path.to_string_lossy().to_string();
+                    let pid = spawn_background(
+                        &entry.name,
+                        "cargo",
+                        &[
+                            "run",
+                            "-p",
+                            "robonix-cli",
+                            "--",
+                            "start",
+                            "--endpoint",
+                            &atlas_endpoint,
+                            "-p",
+                            &pkg_str,
+                            "-n",
+                            &entry.node_id,
+                        ],
+                        cwd,
+                        &global_env,
+                    )
+                    .await?;
+                    output::sub_step(&format!("PID {} (rbnx start {})", pid, entry.node_id));
+                    sleep(Duration::from_secs(2)).await;
+                    output::check(&format!("{} started", entry.name));
+                } else {
+                    output::warning(&format!(
+                        "service '{}' (node_id={}) — no package found; ensure it is started externally",
+                        entry.name, entry.node_id
+                    ));
+                }
+            } else {
+                output::warning(&format!(
+                    "service '{}' has no node_id — ensure it is started externally",
+                    entry.name
+                ));
+            }
+        }
+    }
+
+    // ── Phase 3: Start packages (topological order) ──────────────────────────
+    if !merged.packages.is_empty() {
+        output::action("Phase 3", "Starting packages");
+
+        let launch_order = topo_sort_packages(&merged.packages)?;
+        let pkg_names: Vec<&str> = launch_order
+            .iter()
+            .map(|&i| merged.packages[i].name.as_str())
+            .collect();
+        output::sub_step(&format!("launch order: {}", pkg_names.join(" → ")));
+
+        for &idx in &launch_order {
+            let entry = &merged.packages[idx];
+            let pkg_path = base_dir.join(&entry.path);
+
+            if !pkg_path.exists() {
+                output::warning(&format!(
+                    "package '{}' path {} does not exist, skipping",
+                    entry.name,
+                    pkg_path.display()
+                ));
+                continue;
+            }
+
+            output::step("Launching", &format!("{} ({})", entry.name, entry.path));
+
+            // ── Read robonix_manifest.yaml from the package directory ────────
+            let manifest_path = pkg_path.join(manifest::MANIFEST_FILE);
+            if !manifest_path.exists() {
+                output::warning(&format!(
+                    "package '{}': {} not found at {}, skipping",
+                    entry.name,
+                    manifest::MANIFEST_FILE,
+                    manifest_path.display()
+                ));
+                continue;
+            }
+
+            let pkg_manifest = manifest::load_from_path(&manifest_path).with_context(|| {
+                format!(
+                    "failed to load {} for package '{}'",
+                    manifest::MANIFEST_FILE,
+                    entry.name
+                )
+            })?;
+
+            // Pick the first node's start command (or the only one).
+            if pkg_manifest.nodes.is_empty() {
+                output::warning(&format!(
+                    "package '{}': {} has no nodes defined, skipping",
+                    entry.name,
+                    manifest::MANIFEST_FILE
+                ));
+                continue;
+            }
+
+            let node = &pkg_manifest.nodes[0];
+            let start_cmd = node.start.trim();
+            if start_cmd.is_empty() {
+                output::warning(&format!(
+                    "package '{}': node '{}' has empty start command, skipping",
+                    entry.name, node.id
+                ));
+                continue;
+            }
+
+            output::sub_step(&format!(
+                "manifest: {} v{} — node '{}' ({})",
+                pkg_manifest.package.name,
+                pkg_manifest.package.version,
+                node.id,
+                node.node_type.as_deref().unwrap_or("unknown")
+            ));
+
+            // Build the full launch command with optional params.
+            let mut full_cmd = String::new();
+
+            // Inject params_file if specified in config.yaml.
+            if let Some(ref params_file) = entry.params_file {
+                let params_abs = pkg_path.join(params_file);
+                full_cmd.push_str(&format!(
+                    "export RBNX_PARAMS_FILE={}; ",
+                    params_abs.display()
+                ));
+            }
+
+            // Inject inline params as environment variables.
+            if let Some(ref params) = entry.params {
+                for (k, v) in params {
+                    let val_str = match v {
+                        serde_yaml::Value::String(s) => s.clone(),
+                        serde_yaml::Value::Bool(b) => b.to_string(),
+                        serde_yaml::Value::Number(n) => n.to_string(),
+                        other => format!("{:?}", other),
+                    };
+                    // Export as RBNX_PARAM_<KEY>=<VALUE>.
+                    let env_key = format!(
+                        "RBNX_PARAM_{}",
+                        k.to_uppercase().replace('.', "_").replace('-', "_")
+                    );
+                    full_cmd.push_str(&format!("export {}={}; ", env_key, val_str));
+                }
+            }
+
+            full_cmd.push_str(start_cmd);
+
+            let pid = spawn_background(
+                &entry.name,
+                "bash",
+                &["-c", &full_cmd],
+                &pkg_path,
+                &global_env,
+            )
+            .await?;
+            output::sub_step(&format!("PID {} — {}", pid, start_cmd));
+
+            // If this package has robonix integration, log it.
+            if let Some(ref rbnx) = entry.robonix {
+                output::sub_step(&format!(
+                    "robonix integration: ns={}, kind={}, tools=[{}]",
+                    rbnx.namespace,
+                    rbnx.kind,
+                    rbnx.tools.join(", ")
+                ));
+            }
+
+            // Brief pause between launches for service discovery.
+            sleep(Duration::from_secs(2)).await;
+            output::check(&format!("{} launched", entry.name));
+        }
+    }
+
+    // ── Summary ──────────────────────────────────────────────────────────────
+    let total = merged.runtime.len() + merged.system.len() + merged.packages.len();
+    output::success(&format!(
+        "Deploy complete — {} component(s) started ({} runtime, {} service, {} package)",
+        total,
+        merged.runtime.len(),
+        merged.system.len(),
+        merged.packages.len(),
+    ));
+    output::info("Use 'rbnx chat' to interact with the system, or Ctrl+C to stop.");
+
+    // Keep the main process alive so background children keep running.
+    output::info("Press Ctrl+C to shut down all deployed components.");
+    tokio::signal::ctrl_c()
+        .await
+        .context("failed to listen for Ctrl+C")?;
+
+    output::action("Shutdown", "stopping deployed components...");
+    #[cfg(unix)]
+    {
+        use nix::sys::signal::{Signal, killpg};
+        use nix::unistd::getpgrp;
+        let pgid = getpgrp();
+        let _ = killpg(pgid, Signal::SIGTERM);
+    }
+
+    Ok(())
+}
+
+// ── Discovery helpers ────────────────────────────────────────────────────────
+
+/// Walk up from `base` looking for a Cargo workspace containing robonix crates.
+fn detect_rust_root(base: &Path) -> Option<PathBuf> {
+    let mut dir = base.to_path_buf();
+    for _ in 0..10 {
+        let candidate = dir.join("Cargo.toml");
+        if candidate.exists() {
+            if let Ok(content) = std::fs::read_to_string(&candidate) {
+                if content.contains("[workspace]") && content.contains("robonix") {
+                    return Some(dir);
+                }
+            }
+        }
+        let rust_candidate = dir.join("rust").join("Cargo.toml");
+        if rust_candidate.exists() {
+            if let Ok(content) = std::fs::read_to_string(&rust_candidate) {
+                if content.contains("[workspace]") && content.contains("robonix") {
+                    return Some(dir.join("rust"));
+                }
+            }
+        }
+        if !dir.pop() {
+            break;
+        }
+    }
+    None
+}
+
+/// Try to find the service package under the robonix examples directory.
+/// Supports both dotted names (robonix.sys.model.vlm → vlm_service)
+/// and short names (vlm → vlm_service).
+fn find_service_package(rust_root: Option<&Path>, service_name: &str) -> Option<PathBuf> {
+    let root = rust_root?;
+    let packages_dir = root.join("examples").join("packages");
+
+    // Extract the short name from dotted notation:
+    //   "robonix.sys.model.vlm" → "vlm"
+    //   "robonix.sys.memory.search" → "memsearch" (special case)
+    let short_name = service_name
+        .rsplit('.')
+        .next()
+        .unwrap_or(service_name);
+
+    let dir_name = match short_name {
+        "vlm" => "vlm_service",
+        "search" | "memsearch" => "memsearch_service",
+        other => {
+            // Try <name>_service as a fallback.
+            let candidate = packages_dir.join(format!("{}_service", other));
+            if candidate.exists() {
+                return Some(candidate);
+            }
+            return None;
+        }
+    };
+
+    let candidate = packages_dir.join(dir_name);
+    if candidate.exists() {
+        Some(candidate)
+    } else {
+        None
+    }
+}

--- a/rust/crates/robonix-cli/src/cmd/deploy.rs
+++ b/rust/crates/robonix-cli/src/cmd/deploy.rs
@@ -1,149 +1,32 @@
 // SPDX-License-Identifier: MulanPSL-2.0
-// Deploy command: read a config.yaml and bring up the full stack
-// (runtime components, services, and packages) in dependency order.
+// Deploy command: read a deploy/<target>.yaml and bring up the full stack.
 //
-// The config.yaml may reference an `upstream_config` (e.g. robonix_workspace.yaml)
-// which provides runtime components, system services, and global env.
+// The config file references an `upstream_config` (robonix_workspace.yaml)
+// which provides workspace-level env and package declarations.
 // The deploy command merges both configs, then:
-//   Phase 1 — start runtime components (from upstream)
-//   Phase 2 — start system services (from upstream)
-//   Phase 3 — start packages (from local config), reading each package's
-//             `robonix_manifest.yaml` to discover the actual start command.
+//   Step 1 — start upstream system (fixed components)
+//   Step 2 — check packages existence
+//   Step 3 — validate packages_run declarations
+//   Step 4 — start nodes in dependency order
 
 use anyhow::{Context, Result};
-use robonix_cli::manifest;
 use robonix_cli::output;
-use serde::Deserialize;
+use robonix_cli::workspace::{
+    DeployConfig, MergedConfig, WorkspaceConfig, parse_package_run,
+};
 use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use tokio::process::{Child, Command};
 use tokio::time::{Duration, sleep};
 
-// ── YAML schema ─────────────────────────────────────────────────────────────
-
-/// Top-level config.yaml (the user's project-level config).
-#[derive(Debug, Deserialize)]
-struct DeployConfig {
-    /// Path to upstream workspace config (e.g. "robonix_workspace.yaml"),
-    /// resolved relative to this config file's directory.
-    #[serde(default)]
-    upstream_config: Option<String>,
-    /// Target platform hint (e.g. "jetson-orin-agx", "sim").
-    #[serde(default)]
-    target: Option<String>,
-    /// Global environment variables exported to every child process.
-    #[serde(default)]
-    env: HashMap<String, String>,
-    /// Packages to launch.
-    #[serde(default)]
-    packages: Vec<PackageEntry>,
-}
-
-/// Upstream workspace config (robonix_workspace.yaml).
-#[derive(Debug, Deserialize, Default)]
-struct UpstreamConfig {
-    /// Workspace name.
-    #[serde(default)]
-    workspace: Option<String>,
-    /// Global environment variables (merged with local, local wins).
-    #[serde(default)]
-    env: HashMap<String, String>,
-    /// Runtime components (atlas, executor, pilot, liaison).
-    #[serde(default)]
-    runtime: Vec<RuntimeEntry>,
-    /// System services (VLM, MemSearch, …).
-    #[serde(default)]
-    system: Vec<SystemEntry>,
-}
-
-/// A runtime component entry (from upstream_config).
-#[derive(Debug, Deserialize, Clone)]
-struct RuntimeEntry {
-    name: String,
-    #[serde(default)]
-    endpoint: String,
-    #[serde(default)]
-    depends_on: Vec<String>,
-    #[serde(default)]
-    description: Option<String>,
-}
-
-/// A system service entry (from upstream_config).
-#[derive(Debug, Deserialize, Clone)]
-#[allow(dead_code)]
-struct SystemEntry {
-    name: String,
-    #[serde(default)]
-    contract_id: String,
-    #[serde(default)]
-    node_id: String,
-    #[serde(default)]
-    depends_on: Vec<String>,
-    #[serde(default)]
-    description: Option<String>,
-}
-
-/// A package entry (from the user's config.yaml).
-#[derive(Debug, Deserialize, Clone)]
-#[allow(dead_code)]
-struct PackageEntry {
-    name: String,
-    path: String,
-    #[serde(default)]
-    params_file: Option<String>,
-    #[serde(default)]
-    params: Option<HashMap<String, serde_yaml::Value>>,
-    #[serde(default)]
-    depends_on: Vec<String>,
-    #[serde(default)]
-    transport: Option<String>,
-    #[serde(default)]
-    robonix: Option<RobonixIntegration>,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-#[allow(dead_code)]
-struct RobonixIntegration {
-    #[serde(default)]
-    namespace: String,
-    #[serde(default)]
-    kind: String,
-    #[serde(default)]
-    interfaces: Vec<String>,
-    #[serde(default)]
-    skills_dir: String,
-    #[serde(default)]
-    tools: Vec<String>,
-}
-
-/// The merged view used during deployment.
-struct MergedConfig {
-    env: HashMap<String, String>,
-    runtime: Vec<RuntimeEntry>,
-    system: Vec<SystemEntry>,
-    packages: Vec<PackageEntry>,
-    #[allow(dead_code)]
-    target: Option<String>,
-}
-
 // ── Helpers ──────────────────────────────────────────────────────────────────
-
-/// Cargo binary names for known runtime components.
-fn runtime_cargo_package(name: &str) -> Option<&'static str> {
-    match name {
-        "robonix-atlas" => Some("robonix-atlas"),
-        "robonix-executor" => Some("robonix-executor"),
-        "robonix-pilot" => Some("robonix-pilot"),
-        "robonix-liaison" => Some("robonix-liaison"),
-        _ => None,
-    }
-}
 
 /// Spawn a background process.  Returns the Child handle (caller must store it).
 ///
 /// On Unix, the child is placed into its own process group via `pre_exec(setsid)`
 /// so that we can cleanly terminate it later without killing the parent shell.
+#[allow(dead_code)]
 async fn spawn_background(
     label: &str,
     cmd: &str,
@@ -176,6 +59,7 @@ async fn spawn_background(
 }
 
 /// Wait for a TCP endpoint to become reachable (connect-only check).
+#[allow(dead_code)]
 async fn wait_for_endpoint(addr: &str, timeout: Duration) -> bool {
     let deadline = tokio::time::Instant::now() + timeout;
     while tokio::time::Instant::now() < deadline {
@@ -256,15 +140,16 @@ pub(crate) fn topo_sort(items: &[(&str, &[String])]) -> Result<Vec<usize>> {
 
 // ── Config loading & merging ────────────────────────────────────────────────
 
-/// Load and merge configs: read config.yaml, optionally load upstream_config,
-/// merge env (upstream defaults, local overrides), collect runtime + system + packages.
+/// Load and merge configs: read deploy/<target>.yaml, optionally load upstream
+/// robonix_workspace.yaml, merge env (upstream defaults, local overrides),
+/// parse packages_run entries.
 fn load_and_merge(config_path: &Path) -> Result<(MergedConfig, PathBuf)> {
     let content = std::fs::read_to_string(config_path)
         .with_context(|| format!("failed to read {}", config_path.display()))?;
     let cfg: DeployConfig = serde_yaml::from_str(&content)
         .with_context(|| format!("failed to parse {}", config_path.display()))?;
 
-    // Resolve base directory (config.yaml's parent).
+    // Resolve base directory (config file's parent).
     let base_dir = config_path
         .parent()
         .map(|p| {
@@ -279,31 +164,31 @@ fn load_and_merge(config_path: &Path) -> Result<(MergedConfig, PathBuf)> {
         .canonicalize()
         .unwrap_or_else(|_| base_dir.to_path_buf());
 
-    // Load upstream config if specified.
+    // Load upstream workspace config if specified.
     let upstream = if let Some(ref upstream_path) = cfg.upstream_config {
         let resolved = base_dir.join(upstream_path);
         if resolved.exists() {
             let upstream_content = std::fs::read_to_string(&resolved)
                 .with_context(|| format!("failed to read upstream config {}", resolved.display()))?;
-            let up: UpstreamConfig = serde_yaml::from_str(&upstream_content).with_context(|| {
+            let ws: WorkspaceConfig = serde_yaml::from_str(&upstream_content).with_context(|| {
                 format!("failed to parse upstream config {}", resolved.display())
             })?;
             output::sub_step(&format!(
                 "loaded upstream config: {} (workspace: {})",
                 resolved.display(),
-                up.workspace.as_deref().unwrap_or("unnamed")
+                ws.workspace.as_deref().unwrap_or("unnamed")
             ));
-            up
+            ws
         } else {
             output::warning(&format!(
                 "upstream_config '{}' not found at {}, skipping",
                 upstream_path,
                 resolved.display()
             ));
-            UpstreamConfig::default()
+            WorkspaceConfig::default()
         }
     } else {
-        UpstreamConfig::default()
+        WorkspaceConfig::default()
     };
 
     // Merge env: upstream provides defaults, local config overrides.
@@ -312,12 +197,19 @@ fn load_and_merge(config_path: &Path) -> Result<(MergedConfig, PathBuf)> {
         merged_env.insert(k.clone(), v.clone());
     }
 
+    // Parse packages_run entries.
+    let packages_run = cfg
+        .packages_run
+        .iter()
+        .map(|e| parse_package_run(e))
+        .collect::<Result<Vec<_>>>()?;
+
     Ok((
         MergedConfig {
             env: merged_env,
-            runtime: upstream.runtime,
-            system: upstream.system,
-            packages: cfg.packages,
+            workspace_name: upstream.workspace,
+            workspace_packages: upstream.packages,
+            packages_run,
             target: cfg.target,
         },
         base_dir,
@@ -327,6 +219,7 @@ fn load_and_merge(config_path: &Path) -> Result<(MergedConfig, PathBuf)> {
 /// Gracefully shut down all tracked child processes by sending SIGTERM
 /// to each child's process group, then waiting for them.
 #[cfg(unix)]
+#[allow(dead_code)]
 async fn shutdown_children(children: &mut Vec<Child>) {
     use nix::sys::signal::{Signal, kill};
     use nix::unistd::Pid;
@@ -346,349 +239,17 @@ async fn shutdown_children(children: &mut Vec<Child>) {
 }
 
 #[cfg(not(unix))]
+#[allow(dead_code)]
 async fn shutdown_children(children: &mut Vec<Child>) {
     for child in children.iter_mut() {
         let _ = child.kill().await;
     }
 }
 
-// ── Core deploy logic ────────────────────────────────────────────────────────
-
-pub async fn execute(config_path: &Path) -> Result<()> {
-    output::action("Deploy", &format!("from {}", config_path.display()));
-
-    let (merged, base_dir) = load_and_merge(config_path)?;
-
-    // Build global env map (merged config env + current process env).
-    // Config env takes priority over inherited process env.
-    let mut global_env: HashMap<String, String> = std::env::vars().collect();
-    for (k, v) in &merged.env {
-        global_env.insert(k.clone(), v.clone());
-    }
-
-    // Inject runtime endpoints into env so packages can discover them.
-    for rt in &merged.runtime {
-        if !rt.endpoint.is_empty() {
-            let env_key = rt.name.to_uppercase().replace('-', "_");
-            global_env
-                .entry(env_key)
-                .or_insert_with(|| rt.endpoint.clone());
-            // Also set _ENDPOINT variant.
-            let env_key_ep = format!("{}_ENDPOINT", rt.name.to_uppercase().replace('-', "_"));
-            global_env
-                .entry(env_key_ep)
-                .or_insert_with(|| format!("http://{}", rt.endpoint));
-        }
-    }
-
-    if let Some(ref target) = merged.target {
-        output::sub_step(&format!("target: {}", target));
-    }
-
-    // Detect Rust workspace root for cargo run.
-    let rust_root = detect_rust_root(&base_dir);
-
-    // Track all spawned child processes for graceful shutdown.
-    let mut children: Vec<Child> = Vec::new();
-
-    // ── Phase 1: Start runtime components ────────────────────────────────────
-    if !merged.runtime.is_empty() {
-        output::action("Phase 1", "Starting runtime components");
-
-        let items: Vec<(&str, &[String])> = merged
-            .runtime
-            .iter()
-            .map(|e| (e.name.as_str(), e.depends_on.as_slice()))
-            .collect();
-        let runtime_order = topo_sort(&items)?;
-        let runtime_names: Vec<&str> = runtime_order
-            .iter()
-            .map(|&i| merged.runtime[i].name.as_str())
-            .collect();
-        output::sub_step(&format!("boot order: {}", runtime_names.join(" → ")));
-
-        for &idx in &runtime_order {
-            let entry = &merged.runtime[idx];
-            let cargo_pkg = runtime_cargo_package(&entry.name);
-            if let Some(pkg) = cargo_pkg {
-                output::step("Starting", &format!("{} (runtime)", entry.name));
-                if let Some(desc) = &entry.description {
-                    output::sub_step(&format!("  {}", desc));
-                }
-
-                // Check if already running.
-                if !entry.endpoint.is_empty()
-                    && wait_for_endpoint(&entry.endpoint, Duration::from_millis(500)).await
-                {
-                    output::check(&format!(
-                        "{} already running at {}",
-                        entry.name, entry.endpoint
-                    ));
-                    continue;
-                }
-
-                let cwd = rust_root.as_deref().unwrap_or(&base_dir);
-
-                let child =
-                    spawn_background(&entry.name, "cargo", &["run", "-p", pkg], cwd, &global_env)
-                        .await?;
-                let pid = child.id().unwrap_or(0);
-                output::sub_step(&format!("PID {}", pid));
-                children.push(child);
-
-                // Wait for the endpoint to become reachable.
-                if !entry.endpoint.is_empty() {
-                    output::sub_step(&format!("waiting for {} ...", entry.endpoint));
-                    if wait_for_endpoint(&entry.endpoint, Duration::from_secs(15)).await {
-                        output::check(&format!("{} ready at {}", entry.name, entry.endpoint));
-                    } else {
-                        output::warning(&format!(
-                            "{} started but endpoint {} not reachable after 15s — continuing",
-                            entry.name, entry.endpoint
-                        ));
-                    }
-                } else {
-                    sleep(Duration::from_secs(2)).await;
-                    output::check(&format!("{} started", entry.name));
-                }
-            } else {
-                output::warning(&format!("unknown runtime '{}', skipping", entry.name));
-            }
-        }
-    }
-
-    // ── Phase 2: Start system services ───────────────────────────────────────
-    if !merged.system.is_empty() {
-        output::action("Phase 2", "Starting system services");
-
-        let atlas_endpoint = merged
-            .runtime
-            .iter()
-            .find(|r| r.name == "robonix-atlas")
-            .map(|r| r.endpoint.clone())
-            .unwrap_or_else(|| "127.0.0.1:50051".to_string());
-
-        for entry in &merged.system {
-            output::step("Starting", &format!("{} (service)", entry.name));
-            if let Some(desc) = &entry.description {
-                output::sub_step(&format!("  {}", desc));
-            }
-
-            if !entry.node_id.is_empty() {
-                // Try to find the service package under robonix examples.
-                let service_pkg_path = find_service_package(rust_root.as_deref(), &entry.name);
-                if let Some(pkg_path) = service_pkg_path {
-                    let cwd = rust_root.as_deref().unwrap_or(&base_dir);
-                    let pkg_str = pkg_path.to_string_lossy().to_string();
-                    let child = spawn_background(
-                        &entry.name,
-                        "cargo",
-                        &[
-                            "run",
-                            "-p",
-                            "robonix-cli",
-                            "--",
-                            "start",
-                            "--endpoint",
-                            &atlas_endpoint,
-                            "-p",
-                            &pkg_str,
-                            "-n",
-                            &entry.node_id,
-                        ],
-                        cwd,
-                        &global_env,
-                    )
-                    .await?;
-                    let pid = child.id().unwrap_or(0);
-                    output::sub_step(&format!("PID {} (rbnx start {})", pid, entry.node_id));
-                    children.push(child);
-                    sleep(Duration::from_secs(2)).await;
-                    output::check(&format!("{} started", entry.name));
-                } else {
-                    output::warning(&format!(
-                        "service '{}' (node_id={}) — no package found; ensure it is started externally",
-                        entry.name, entry.node_id
-                    ));
-                }
-            } else {
-                output::warning(&format!(
-                    "service '{}' has no node_id — ensure it is started externally",
-                    entry.name
-                ));
-            }
-        }
-    }
-
-    // ── Phase 3: Start packages (topological order) ──────────────────────────
-    if !merged.packages.is_empty() {
-        output::action("Phase 3", "Starting packages");
-
-        let items: Vec<(&str, &[String])> = merged
-            .packages
-            .iter()
-            .map(|p| (p.name.as_str(), p.depends_on.as_slice()))
-            .collect();
-        let launch_order = topo_sort(&items)?;
-        let pkg_names: Vec<&str> = launch_order
-            .iter()
-            .map(|&i| merged.packages[i].name.as_str())
-            .collect();
-        output::sub_step(&format!("launch order: {}", pkg_names.join(" → ")));
-
-        for &idx in &launch_order {
-            let entry = &merged.packages[idx];
-            let pkg_path = base_dir.join(&entry.path);
-
-            if !pkg_path.exists() {
-                output::warning(&format!(
-                    "package '{}' path {} does not exist, skipping",
-                    entry.name,
-                    pkg_path.display()
-                ));
-                continue;
-            }
-
-            output::step("Launching", &format!("{} ({})", entry.name, entry.path));
-
-            // ── Read robonix_manifest.yaml from the package directory ────────
-            let manifest_path = pkg_path.join(manifest::MANIFEST_FILE);
-            if !manifest_path.exists() {
-                output::warning(&format!(
-                    "package '{}': {} not found at {}, skipping",
-                    entry.name,
-                    manifest::MANIFEST_FILE,
-                    manifest_path.display()
-                ));
-                continue;
-            }
-
-            let pkg_manifest = manifest::load_from_path(&manifest_path).with_context(|| {
-                format!(
-                    "failed to load {} for package '{}'",
-                    manifest::MANIFEST_FILE,
-                    entry.name
-                )
-            })?;
-
-            // Pick the first node's start command (or the only one).
-            if pkg_manifest.nodes.is_empty() {
-                output::warning(&format!(
-                    "package '{}': {} has no nodes defined, skipping",
-                    entry.name,
-                    manifest::MANIFEST_FILE
-                ));
-                continue;
-            }
-
-            let node = &pkg_manifest.nodes[0];
-            let start_cmd = node.start.trim();
-            if start_cmd.is_empty() {
-                output::warning(&format!(
-                    "package '{}': node '{}' has empty start command, skipping",
-                    entry.name, node.id
-                ));
-                continue;
-            }
-
-            // ── Validate manifest start command (security) ──────────────────
-            // Log the command being executed for auditability.
-            output::sub_step(&format!(
-                "manifest: {} v{} — node '{}' ({})",
-                pkg_manifest.package.name,
-                pkg_manifest.package.version,
-                node.id,
-                node.node_type.as_deref().unwrap_or("unknown")
-            ));
-            output::sub_step(&format!("executing start command: {}", start_cmd));
-
-            // Build per-package env: inject params via environment variables
-            // instead of shell string interpolation (prevents command injection).
-            let mut pkg_env = global_env.clone();
-
-            // Inject params_file if specified in config.yaml.
-            if let Some(ref params_file) = entry.params_file {
-                let params_abs = pkg_path.join(params_file);
-                pkg_env.insert(
-                    "RBNX_PARAMS_FILE".to_string(),
-                    params_abs.display().to_string(),
-                );
-            }
-
-            // Inject inline params as environment variables.
-            if let Some(ref params) = entry.params {
-                for (k, v) in params {
-                    let val_str = match v {
-                        serde_yaml::Value::String(s) => s.clone(),
-                        serde_yaml::Value::Bool(b) => b.to_string(),
-                        serde_yaml::Value::Number(n) => n.to_string(),
-                        other => format!("{:?}", other),
-                    };
-                    // Export as RBNX_PARAM_<KEY>=<VALUE>.
-                    let env_key = format!(
-                        "RBNX_PARAM_{}",
-                        k.to_uppercase().replace('.', "_").replace('-', "_")
-                    );
-                    pkg_env.insert(env_key, val_str);
-                }
-            }
-
-            // Launch via bash -c with the start command; params are in env,
-            // not interpolated into the shell string.
-            let child = spawn_background(
-                &entry.name,
-                "bash",
-                &["-c", start_cmd],
-                &pkg_path,
-                &pkg_env,
-            )
-            .await?;
-            let pid = child.id().unwrap_or(0);
-            output::sub_step(&format!("PID {} — {}", pid, start_cmd));
-            children.push(child);
-
-            // If this package has robonix integration, log it.
-            if let Some(ref rbnx) = entry.robonix {
-                output::sub_step(&format!(
-                    "robonix integration: ns={}, kind={}, tools=[{}]",
-                    rbnx.namespace,
-                    rbnx.kind,
-                    rbnx.tools.join(", ")
-                ));
-            }
-
-            // Brief pause between launches for service discovery.
-            sleep(Duration::from_secs(2)).await;
-            output::check(&format!("{} launched", entry.name));
-        }
-    }
-
-    // ── Summary ──────────────────────────────────────────────────────────────
-    let total = merged.runtime.len() + merged.system.len() + merged.packages.len();
-    output::success(&format!(
-        "Deploy complete — {} component(s) started ({} runtime, {} service, {} package)",
-        total,
-        merged.runtime.len(),
-        merged.system.len(),
-        merged.packages.len(),
-    ));
-    output::info("Use 'rbnx chat' to interact with the system, or Ctrl+C to stop.");
-
-    // Keep the main process alive so background children keep running.
-    output::info("Press Ctrl+C to shut down all deployed components.");
-    tokio::signal::ctrl_c()
-        .await
-        .context("failed to listen for Ctrl+C")?;
-
-    output::action("Shutdown", "stopping deployed components...");
-    shutdown_children(&mut children).await;
-
-    Ok(())
-}
-
 // ── Discovery helpers ────────────────────────────────────────────────────────
 
 /// Walk up from `base` looking for a Cargo workspace containing robonix crates.
+#[allow(dead_code)]
 fn detect_rust_root(base: &Path) -> Option<PathBuf> {
     let mut dir = base.to_path_buf();
     for _ in 0..10 {
@@ -715,38 +276,64 @@ fn detect_rust_root(base: &Path) -> Option<PathBuf> {
     None
 }
 
-/// Try to find the service package under the robonix examples directory.
-/// Supports both dotted names (robonix.sys.model.vlm → vlm_service)
-/// and short names (vlm → vlm_service).
-fn find_service_package(rust_root: Option<&Path>, service_name: &str) -> Option<PathBuf> {
-    let root = rust_root?;
-    let packages_dir = root.join("examples").join("packages");
+// ── Core deploy logic ────────────────────────────────────────────────────────
 
-    // Extract the short name from dotted notation:
-    //   "robonix.sys.model.vlm" → "vlm"
-    //   "robonix.sys.memory.search" → "memsearch" (special case)
-    let short_name = service_name
-        .rsplit('.')
-        .next()
-        .unwrap_or(service_name);
+/// Deploy from a config file (deploy/<target>.yaml).
+///
+/// Phase 1 (stage one): loads and validates config, prints summary.
+/// Full execution logic (system startup, node launching) will be
+/// implemented in stage three.
+pub async fn execute(config_path: &Path) -> Result<()> {
+    output::action("Deploy", &format!("from {}", config_path.display()));
 
-    let dir_name = match short_name {
-        "vlm" => "vlm_service",
-        "search" | "memsearch" => "memsearch_service",
-        other => {
-            // Try <name>_service as a fallback.
-            let candidate = packages_dir.join(format!("{}_service", other));
-            if candidate.exists() {
-                return Some(candidate);
-            }
-            return None;
-        }
-    };
+    let (merged, _base_dir) = load_and_merge(config_path)?;
 
-    let candidate = packages_dir.join(dir_name);
-    if candidate.exists() {
-        Some(candidate)
-    } else {
-        None
+    // Print summary of loaded configuration.
+    if let Some(ref target) = merged.target {
+        output::sub_step(&format!("target: {}", target));
     }
+    output::sub_step(&format!(
+        "workspace: {}, {} workspace package(s), {} packages_run entry(ies)",
+        merged.workspace_name.as_deref().unwrap_or("unnamed"),
+        merged.workspace_packages.len(),
+        merged.packages_run.len(),
+    ));
+
+    for pkg in &merged.workspace_packages {
+        let source = if let Some(ref url) = pkg.url {
+            format!("url={}", url)
+        } else if let Some(ref path) = pkg.path {
+            format!("path={}", path)
+        } else {
+            "no source".to_string()
+        };
+        output::sub_step(&format!("  package: {} ({})", pkg.name, source));
+    }
+
+    for run in &merged.packages_run {
+        let selector = match &run.node_selector {
+            robonix_cli::workspace::NodeSelector::All => "all".to_string(),
+            robonix_cli::workspace::NodeSelector::Single(id) => id.clone(),
+        };
+        output::sub_step(&format!("  run: {}:{}", run.package_name, selector));
+    }
+
+    output::warning("deploy execution logic not yet implemented (stage 3 WIP)");
+
+    Ok(())
+}
+
+/// Deploy from the workspace-level config (no explicit config file).
+///
+/// Stub implementation — will be completed in stage three.
+pub async fn execute_from_workspace() -> Result<()> {
+    let ws_yaml = PathBuf::from("robonix_workspace.yaml");
+    if !ws_yaml.exists() {
+        anyhow::bail!(
+            "no robonix_workspace.yaml found in current directory; \
+             use 'rbnx deploy <target>' or 'rbnx deploy -c <config>' instead"
+        );
+    }
+    output::warning("workspace-level deploy not yet implemented (stage 3 WIP)");
+    Ok(())
 }

--- a/rust/crates/robonix-cli/src/cmd/deploy.rs
+++ b/rust/crates/robonix-cli/src/cmd/deploy.rs
@@ -71,6 +71,7 @@ struct RuntimeEntry {
 
 /// A system service entry (from upstream_config).
 #[derive(Debug, Deserialize, Clone)]
+#[allow(dead_code)]
 struct SystemEntry {
     name: String,
     #[serde(default)]
@@ -85,6 +86,7 @@ struct SystemEntry {
 
 /// A package entry (from the user's config.yaml).
 #[derive(Debug, Deserialize, Clone)]
+#[allow(dead_code)]
 struct PackageEntry {
     name: String,
     path: String,
@@ -101,6 +103,7 @@ struct PackageEntry {
 }
 
 #[derive(Debug, Deserialize, Clone)]
+#[allow(dead_code)]
 struct RobonixIntegration {
     #[serde(default)]
     namespace: String,

--- a/rust/crates/robonix-cli/src/cmd/deploy.rs
+++ b/rust/crates/robonix-cli/src/cmd/deploy.rs
@@ -14,7 +14,7 @@ use robonix_cli::manifest;
 use robonix_cli::output;
 use robonix_cli::workspace::{
     DeployConfig, MergedConfig, NodeSelector, ParsedPackageRun, WorkspaceConfig,
-    WorkspacePackageEntry, parse_package_run,
+    WorkspacePackageEntry, parse_package_run, find_workspace_root, ensure_packages_exist,
 };
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
@@ -253,23 +253,6 @@ fn detect_rust_root(base: &Path) -> Option<PathBuf> {
     None
 }
 
-/// Find the workspace root by searching upward for `robonix_workspace.yaml`.
-fn find_workspace_root(base_dir: &Path) -> Result<PathBuf> {
-    let mut dir = base_dir.to_path_buf();
-    for _ in 0..10 {
-        if dir.join("robonix_workspace.yaml").exists() {
-            return Ok(dir);
-        }
-        if !dir.pop() {
-            break;
-        }
-    }
-    anyhow::bail!(
-        "robonix_workspace.yaml not found (searched from {} upward)",
-        base_dir.display()
-    );
-}
-
 // ── Step 1: Start upstream system ───────────────────────────────────────────
 
 /// Start the fixed system components (atlas, executor, pilot, liaison).
@@ -313,53 +296,6 @@ async fn start_upstream_system(
         }
     }
     Ok(())
-}
-
-// ── Step 2: Ensure packages exist ───────────────────────────────────────────
-
-/// Check that all workspace-declared packages exist locally.
-/// Returns a map of package_name → local path.
-fn ensure_packages_exist(
-    workspace_root: &Path,
-    packages: &[WorkspacePackageEntry],
-) -> Result<HashMap<String, PathBuf>> {
-    let mut package_paths: HashMap<String, PathBuf> = HashMap::new();
-
-    for pkg in packages {
-        let local_path = if let Some(ref path) = pkg.path {
-            let resolved = workspace_root.join(path);
-            if !resolved.exists() {
-                anyhow::bail!(
-                    "package '{}' path '{}' does not exist (resolved to {})",
-                    pkg.name,
-                    path,
-                    resolved.display()
-                );
-            }
-            resolved.canonicalize().unwrap_or(resolved)
-        } else {
-            // No path specified — check packages/<short_name>
-            let pkg_dir_name = pkg.name.rsplit('.').next().unwrap_or(&pkg.name);
-            let candidate = workspace_root.join("packages").join(pkg_dir_name);
-            if !candidate.exists() {
-                // Git clone will be implemented in stage four.
-                anyhow::bail!(
-                    "package '{}' not found at {}{}",
-                    pkg.name,
-                    candidate.display(),
-                    if pkg.url.is_some() {
-                        " (has url, auto-clone will be available in a future update)"
-                    } else {
-                        " and no url specified"
-                    }
-                );
-            }
-            candidate.canonicalize().unwrap_or(candidate)
-        };
-        output::check(&format!("{} → {}", pkg.name, local_path.display()));
-        package_paths.insert(pkg.name.clone(), local_path);
-    }
-    Ok(package_paths)
 }
 
 // ── Step 3: Validate packages_run ───────────────────────────────────────────
@@ -475,16 +411,12 @@ pub async fn execute(config_path: &Path) -> Result<()> {
     let workspace_root = find_workspace_root(&base_dir)?;
     let mut children: Vec<Child> = Vec::new();
 
-    // ── Step 1: Start upstream system (fixed components) ────────────────────
-    output::action("Step 1", "Starting upstream system");
-    start_upstream_system(&workspace_root, &global_env, &mut children).await?;
-
-    // ── Step 2: Check packages existence ────────────────────────────────────
-    output::action("Step 2", "Checking packages existence");
+    // ── Step 1: Check packages existence (fast-fail before heavy system startup) ─
+    output::action("Step 1", "Checking packages existence");
     let package_paths = ensure_packages_exist(&workspace_root, &merged.workspace_packages)?;
 
-    // ── Step 3: Validate packages_run declarations ──────────────────────────
-    output::action("Step 3", "Validating packages_run");
+    // ── Step 2: Validate packages_run declarations ──────────────────────────
+    output::action("Step 2", "Validating packages_run");
     let validated = validate_packages_run(
         &merged.packages_run,
         &merged.workspace_packages,
@@ -493,20 +425,21 @@ pub async fn execute(config_path: &Path) -> Result<()> {
 
     if validated.is_empty() {
         output::warning("no packages_run entries — nothing to deploy");
-        output::info("Press Ctrl+C to shut down system components.");
-        tokio::signal::ctrl_c().await?;
-        shutdown_children(&mut children).await;
         return Ok(());
     }
-
-    // ── Step 4: Start nodes in dependency order ─────────────────────────────
-    output::action("Step 4", "Starting nodes in dependency order");
 
     // Build check (warning only).
     let build_dir = workspace_root.join("build");
     if !build_dir.exists() {
         output::warning("build/ directory not found; packages may not have been built yet");
     }
+
+    // ── Step 3: Start upstream system (fixed components) ────────────────────
+    output::action("Step 3", "Starting upstream system");
+    start_upstream_system(&workspace_root, &global_env, &mut children).await?;
+
+    // ── Step 4: Start nodes in dependency order ─────────────────────────────
+    output::action("Step 4", "Starting nodes in dependency order");
 
     // Topological sort based on manifest.depend.
     let items: Vec<(&str, &[String])> = validated
@@ -611,16 +544,12 @@ pub async fn execute_from_workspace() -> Result<()> {
 
     let mut children: Vec<Child> = Vec::new();
 
-    // Step 1: Start upstream system.
-    output::action("Step 1", "Starting upstream system");
-    start_upstream_system(&workspace_root, &global_env, &mut children).await?;
-
-    // Step 2: Check packages existence.
-    output::action("Step 2", "Checking packages existence");
+    // Step 1: Check packages existence (fast-fail).
+    output::action("Step 1", "Checking packages existence");
     let package_paths = ensure_packages_exist(&workspace_root, &ws.packages)?;
 
-    // Step 3: Build "all nodes" run entries for every package.
-    output::action("Step 3", "Loading manifests");
+    // Step 2: Load manifests for all packages.
+    output::action("Step 2", "Loading manifests");
     let mut validated = Vec::new();
     for pkg_entry in &ws.packages {
         let pkg_path = package_paths.get(&pkg_entry.name).unwrap();
@@ -647,6 +576,10 @@ pub async fn execute_from_workspace() -> Result<()> {
         output::warning("no packages to deploy");
         return Ok(());
     }
+
+    // Step 3: Start upstream system.
+    output::action("Step 3", "Starting upstream system");
+    start_upstream_system(&workspace_root, &global_env, &mut children).await?;
 
     // Step 4: Start nodes in dependency order.
     output::action("Step 4", "Starting nodes in dependency order");

--- a/rust/crates/robonix-cli/src/cmd/init.rs
+++ b/rust/crates/robonix-cli/src/cmd/init.rs
@@ -94,6 +94,23 @@ log/
 pub async fn execute(name: &str, path: Option<&Path>) -> Result<()> {
     output::action("Init", &format!("creating workspace '{}'", name));
 
+    // Validate workspace name to prevent path traversal and invalid names.
+    if name.is_empty() {
+        anyhow::bail!("workspace name must not be empty");
+    }
+    if name.contains('/') || name.contains('\\') || name == "." || name == ".." || name.starts_with('.') {
+        anyhow::bail!(
+            "invalid workspace name '{}': must not contain path separators or start with '.'",
+            name
+        );
+    }
+    if !name.chars().all(|c| c.is_alphanumeric() || c == '_' || c == '-') {
+        anyhow::bail!(
+            "invalid workspace name '{}': only alphanumeric characters, hyphens and underscores are allowed",
+            name
+        );
+    }
+
     let base_dir = path.unwrap_or_else(|| Path::new("."));
     let workspace_dir = base_dir.join(name);
 

--- a/rust/crates/robonix-cli/src/cmd/init.rs
+++ b/rust/crates/robonix-cli/src/cmd/init.rs
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: MulanPSL-2.0
+// Init command: generate a new robonix workspace skeleton.
+//
+// Usage:  rbnx init <name>
+// Creates:
+//   <name>/
+//   ├── robonix_workspace.yaml   (upstream workspace config template)
+//   ├── config.yaml              (project-level deploy config)
+//   ├── packages/                (empty directory for user packages)
+//   └── .gitignore
+
+use anyhow::{Context, Result};
+use robonix_cli::output;
+use std::fs;
+use std::path::Path;
+
+const WORKSPACE_YAML_TEMPLATE: &str = r#"workspace: {name}
+
+# Global environment variables (injected into all child processes)
+env:
+  VLM_API_KEY: ""
+  VLM_BASE_URL: ""
+  VLM_MODEL: ""
+
+# ── Robonix runtime core components (started in dependency order) ──────────
+runtime:
+  - name: robonix-atlas
+    endpoint: "127.0.0.1:50051"
+    description: Service registry and discovery
+
+  - name: robonix-executor
+    endpoint: "127.0.0.1:50061"
+    depends_on:
+      - robonix-atlas
+    description: Task scheduling and execution engine
+
+  - name: robonix-pilot
+    endpoint: "127.0.0.1:50071"
+    depends_on:
+      - robonix-atlas
+      - robonix-executor
+    description: Autonomous decision making and planner
+
+  - name: robonix-liaison
+    endpoint: "127.0.0.1:50081"
+    depends_on:
+      - robonix-atlas
+    description: External communication and bridge gateway
+
+# ── Upstream system services (started after runtime is ready) ──────────────
+system: []
+  # Example:
+  # - name: robonix.sys.model.vlm
+  #   contract_id: robonix/sys/model/vlm/chat
+  #   node_id: com.robonix.services.vlm
+  #   depends_on:
+  #     - robonix-atlas
+  #     - robonix-executor
+  #   description: VLM vision-language model
+"#;
+
+const CONFIG_YAML_TEMPLATE: &str = r#"upstream_config: robonix_workspace.yaml
+target: default
+
+# Downstream packages
+packages: []
+  # Example:
+  # - name: my-package
+  #   path: ./packages/my_package
+  #   depends_on: []
+"#;
+
+const GITIGNORE_TEMPLATE: &str = r#"# Build artifacts
+rbnx-build/
+.rbnx-built
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# ROS 2 build artifacts
+build/
+install/
+log/
+"#;
+
+pub async fn execute(name: &str) -> Result<()> {
+    output::action("Init", &format!("creating workspace '{}'", name));
+
+    let workspace_dir = Path::new(name);
+
+    // Check if directory already exists.
+    if workspace_dir.exists() {
+        anyhow::bail!(
+            "directory '{}' already exists — choose a different name or remove it first",
+            name
+        );
+    }
+
+    // Create directory structure.
+    output::step("Creating", "workspace directory structure");
+
+    fs::create_dir_all(workspace_dir.join("packages"))
+        .with_context(|| format!("failed to create {}/packages", name))?;
+    output::check("packages/");
+
+    // Write robonix_workspace.yaml.
+    let workspace_yaml = WORKSPACE_YAML_TEMPLATE.replace("{name}", name);
+    let workspace_yaml_path = workspace_dir.join("robonix_workspace.yaml");
+    fs::write(&workspace_yaml_path, &workspace_yaml).with_context(|| {
+        format!(
+            "failed to write {}",
+            workspace_yaml_path.display()
+        )
+    })?;
+    output::check("robonix_workspace.yaml");
+
+    // Write config.yaml.
+    let config_yaml_path = workspace_dir.join("config.yaml");
+    fs::write(&config_yaml_path, CONFIG_YAML_TEMPLATE).with_context(|| {
+        format!("failed to write {}", config_yaml_path.display())
+    })?;
+    output::check("config.yaml");
+
+    // Write .gitignore.
+    let gitignore_path = workspace_dir.join(".gitignore");
+    fs::write(&gitignore_path, GITIGNORE_TEMPLATE)
+        .with_context(|| format!("failed to write {}", gitignore_path.display()))?;
+    output::check(".gitignore");
+
+    // Summary.
+    output::success(&format!("Workspace '{}' created successfully", name));
+    output::info("");
+    output::info("Next steps:");
+    output::info(&format!(
+        "  cd {}",
+        name
+    ));
+    output::info("  rbnx package new my_package    # create a new package");
+    output::info("  rbnx build --config config.yaml # build all packages");
+    output::info("  rbnx deploy config.yaml         # deploy the full stack");
+
+    Ok(())
+}

--- a/rust/crates/robonix-cli/src/cmd/init.rs
+++ b/rust/crates/robonix-cli/src/cmd/init.rs
@@ -4,9 +4,9 @@
 // Usage:  rbnx init <name> [--path <dir>]
 // Creates:
 //   <name>/
-//   ├── robonix_workspace.yaml   (upstream workspace config template)
+//   ├── robonix_workspace.yaml   (workspace config: env + packages list)
 //   ├── deploy/
-//   │   └── config.yaml          (project-level deploy config)
+//   │   └── init.yaml            (deploy profile: target, env overrides, packages_run)
 //   ├── packages/                (empty directory for user packages)
 //   └── .gitignore
 
@@ -19,56 +19,34 @@ const WORKSPACE_YAML_TEMPLATE: &str = r#"workspace: {name}
 
 # Global environment variables (injected into all child processes)
 env:
-  VLM_API_KEY: ""
-  VLM_BASE_URL: ""
-  VLM_MODEL: ""
+  ROBONIX_ATLAS: "127.0.0.1:50051"
+  ROBONIX_META_GRPC_ENDPOINT: "127.0.0.1:50051"
+  ROBONIX_ATLAS_ENDPOINT: "http://127.0.0.1:50051"
+  ROBONIX_EXECUTOR_ENDPOINT: "http://127.0.0.1:50061"
+  ROBONIX_PILOT_ENDPOINT: "http://127.0.0.1:50071"
+  RUST_LOG: "robonix_atlas=info,robonix_pilot=info,robonix_executor=info,robonix_liaison=warn"
 
-# ── Robonix runtime core components (started in dependency order) ──────────
-runtime:
-  - name: robonix-atlas
-    endpoint: "127.0.0.1:50051"
-    description: Service registry and discovery
-
-  - name: robonix-executor
-    endpoint: "127.0.0.1:50061"
-    depends_on:
-      - robonix-atlas
-    description: Task scheduling and execution engine
-
-  - name: robonix-pilot
-    endpoint: "127.0.0.1:50071"
-    depends_on:
-      - robonix-atlas
-      - robonix-executor
-    description: Autonomous decision making and planner
-
-  - name: robonix-liaison
-    endpoint: "127.0.0.1:50081"
-    depends_on:
-      - robonix-atlas
-    description: External communication and bridge gateway
-
-# ── Upstream system services (started after runtime is ready) ──────────────
-system: []
-  # Example:
-  # - name: robonix.sys.model.vlm
-  #   contract_id: robonix/sys/model/vlm/chat
-  #   node_id: com.robonix.services.vlm
-  #   depends_on:
-  #     - robonix-atlas
-  #     - robonix-executor
-  #   description: VLM vision-language model
+# Packages in this workspace (url or path, at least one required per entry)
+packages: []
+  # Examples:
+  # - name: com.robonix.pkg.memory
+  #   url: https://github.com/xxx
+  #
+  # - name: my.local.pkg
+  #   path: ./packages/my_local_pkg
 "#;
 
 const CONFIG_YAML_TEMPLATE: &str = r#"upstream_config: ../robonix_workspace.yaml
-target: default
+target: init
 
-# Downstream packages
-packages: []
-  # Example:
-  # - name: my-package
-  #   path: ./packages/my_package
-  #   depends_on: []
+# Environment variable overrides (merged with workspace env, local wins)
+env: {}
+
+# Packages and nodes to run (format: "package_name:node_id" or "package_name:all")
+packages_run: []
+  # Examples:
+  # - name: com.robonix.pkg.mapping:all
+  # - name: com.robonix.pkg.memory:node_xx
 "#;
 
 const GITIGNORE_TEMPLATE: &str = r#"# Build artifacts
@@ -146,14 +124,14 @@ pub async fn execute(name: &str, path: Option<&Path>) -> Result<()> {
     })?;
     output::check("robonix_workspace.yaml");
 
-    // Create deploy/ directory and write config.yaml.
+    // Create deploy/ directory and write init.yaml.
     fs::create_dir_all(workspace_dir.join("deploy"))
         .with_context(|| format!("failed to create {}/deploy", workspace_dir.display()))?;
-    let config_yaml_path = workspace_dir.join("deploy").join("config.yaml");
+    let config_yaml_path = workspace_dir.join("deploy").join("init.yaml");
     fs::write(&config_yaml_path, CONFIG_YAML_TEMPLATE).with_context(|| {
         format!("failed to write {}", config_yaml_path.display())
     })?;
-    output::check("deploy/config.yaml");
+    output::check("deploy/init.yaml");
 
     // Write .gitignore.
     let gitignore_path = workspace_dir.join(".gitignore");
@@ -162,16 +140,16 @@ pub async fn execute(name: &str, path: Option<&Path>) -> Result<()> {
     output::check(".gitignore");
 
     // Summary.
-    output::success(&format!("Workspace '{}' created at {}", name, workspace_dir.display()));
+    let ws_abs = workspace_dir.canonicalize().unwrap_or_else(|_| workspace_dir.clone());
+    output::success(&format!("Workspace '{}' created at {}", name, ws_abs.display()));
     output::info("");
     output::info("Next steps:");
-    output::info(&format!(
-        "  cd {}",
-        workspace_dir.display()
-    ));
-    output::info("  rbnx package new my_package    # create a new package");
-    output::info("  rbnx build --config deploy/config.yaml # build all packages");
-    output::info("  rbnx deploy deploy/config.yaml         # deploy the full stack");
+    output::info(&format!("  cd {}", ws_abs.display()));
+    output::info("  rbnx package-new my_package        # create a new package");
+    output::info("  rbnx build                          # build all workspace packages");
+    output::info("  rbnx deploy                         # deploy using workspace config");
+    output::info("  rbnx build init                     # build by deploy target 'init'");
+    output::info("  rbnx deploy init                    # deploy by target 'init'");
 
     Ok(())
 }

--- a/rust/crates/robonix-cli/src/cmd/init.rs
+++ b/rust/crates/robonix-cli/src/cmd/init.rs
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MulanPSL-2.0
 // Init command: generate a new robonix workspace skeleton.
 //
-// Usage:  rbnx init <name>
+// Usage:  rbnx init <name> [--path <dir>]
 // Creates:
 //   <name>/
 //   ├── robonix_workspace.yaml   (upstream workspace config template)
-//   ├── config.yaml              (project-level deploy config)
+//   ├── deploy/
+//   │   └── config.yaml          (project-level deploy config)
 //   ├── packages/                (empty directory for user packages)
 //   └── .gitignore
 
@@ -59,7 +60,7 @@ system: []
   #   description: VLM vision-language model
 "#;
 
-const CONFIG_YAML_TEMPLATE: &str = r#"upstream_config: robonix_workspace.yaml
+const CONFIG_YAML_TEMPLATE: &str = r#"upstream_config: ../robonix_workspace.yaml
 target: default
 
 # Downstream packages
@@ -90,24 +91,31 @@ install/
 log/
 "#;
 
-pub async fn execute(name: &str) -> Result<()> {
+pub async fn execute(name: &str, path: Option<&Path>) -> Result<()> {
     output::action("Init", &format!("creating workspace '{}'", name));
 
-    let workspace_dir = Path::new(name);
+    let base_dir = path.unwrap_or_else(|| Path::new("."));
+    let workspace_dir = base_dir.join(name);
 
     // Check if directory already exists.
     if workspace_dir.exists() {
         anyhow::bail!(
             "directory '{}' already exists — choose a different name or remove it first",
-            name
+            workspace_dir.display()
         );
+    }
+
+    // Ensure the parent directory exists.
+    if !base_dir.exists() {
+        fs::create_dir_all(base_dir)
+            .with_context(|| format!("failed to create parent directory '{}'", base_dir.display()))?;
     }
 
     // Create directory structure.
     output::step("Creating", "workspace directory structure");
 
     fs::create_dir_all(workspace_dir.join("packages"))
-        .with_context(|| format!("failed to create {}/packages", name))?;
+        .with_context(|| format!("failed to create {}/packages", workspace_dir.display()))?;
     output::check("packages/");
 
     // Write robonix_workspace.yaml.
@@ -121,12 +129,14 @@ pub async fn execute(name: &str) -> Result<()> {
     })?;
     output::check("robonix_workspace.yaml");
 
-    // Write config.yaml.
-    let config_yaml_path = workspace_dir.join("config.yaml");
+    // Create deploy/ directory and write config.yaml.
+    fs::create_dir_all(workspace_dir.join("deploy"))
+        .with_context(|| format!("failed to create {}/deploy", workspace_dir.display()))?;
+    let config_yaml_path = workspace_dir.join("deploy").join("config.yaml");
     fs::write(&config_yaml_path, CONFIG_YAML_TEMPLATE).with_context(|| {
         format!("failed to write {}", config_yaml_path.display())
     })?;
-    output::check("config.yaml");
+    output::check("deploy/config.yaml");
 
     // Write .gitignore.
     let gitignore_path = workspace_dir.join(".gitignore");
@@ -135,16 +145,16 @@ pub async fn execute(name: &str) -> Result<()> {
     output::check(".gitignore");
 
     // Summary.
-    output::success(&format!("Workspace '{}' created successfully", name));
+    output::success(&format!("Workspace '{}' created at {}", name, workspace_dir.display()));
     output::info("");
     output::info("Next steps:");
     output::info(&format!(
         "  cd {}",
-        name
+        workspace_dir.display()
     ));
     output::info("  rbnx package new my_package    # create a new package");
-    output::info("  rbnx build --config config.yaml # build all packages");
-    output::info("  rbnx deploy config.yaml         # deploy the full stack");
+    output::info("  rbnx build --config deploy/config.yaml # build all packages");
+    output::info("  rbnx deploy deploy/config.yaml         # deploy the full stack");
 
     Ok(())
 }

--- a/rust/crates/robonix-cli/src/cmd/mod.rs
+++ b/rust/crates/robonix-cli/src/cmd/mod.rs
@@ -64,16 +64,19 @@ pub enum Commands {
         #[arg(short = 'p', long)]
         path: Option<PathBuf>,
     },
-    /// Build a package (local path or system-installed) or all packages from a config
+    /// Build packages: single package, by target, by config, or entire workspace
     Build {
-        /// Build by local path (e.g. examples/skill_demo)
-        #[arg(short = 'p', long, conflicts_with = "config")]
+        /// Target name: find matching config in deploy/ directory
+        #[arg(value_name = "TARGET", conflicts_with_all = ["path", "global", "config"])]
+        target: Option<String>,
+        /// Build by local path (e.g. packages/my_pkg)
+        #[arg(short = 'p', long, conflicts_with_all = ["target", "config"])]
         path: Option<PathBuf>,
         /// Build by system-installed package name
-        #[arg(short = 'g', long, conflicts_with = "config")]
+        #[arg(short = 'g', long, conflicts_with_all = ["target", "config"])]
         global: Option<String>,
-        /// Build all packages from a config.yaml file
-        #[arg(short = 'c', long = "config", conflicts_with_all = ["path", "global"])]
+        /// Build from a specific config file
+        #[arg(short = 'c', long = "config", conflicts_with_all = ["target", "path", "global"])]
         config: Option<PathBuf>,
         /// Clean build (remove rbnx-build before building). Default: incremental.
         #[arg(long)]
@@ -216,11 +219,14 @@ pub enum Commands {
         args: GraphArgs,
     },
 
-    /// Deploy a full stack from a config.yaml file (runtime + services + packages)
+    /// Deploy a full stack: by target name, by config file, or from workspace
     Deploy {
-        /// Path to config.yaml
-        #[arg(required = true)]
-        config: PathBuf,
+        /// Target name: find matching config in deploy/ directory
+        #[arg(value_name = "TARGET", conflicts_with = "config")]
+        target: Option<String>,
+        /// Deploy from a specific config file
+        #[arg(short = 'c', long = "config", conflicts_with = "target")]
+        config: Option<PathBuf>,
     },
 }
 
@@ -229,15 +235,28 @@ pub async fn execute(command: Commands, config: Config) -> Result<()> {
         Commands::Init { name, path } => init::execute(&name, path.as_deref()).await,
         Commands::PackageNew { name, path } => package_new::execute(&name, path.as_deref()).await,
         Commands::Build {
+            target,
             path,
             global,
             config: config_file,
             clean,
         } => {
-            if let Some(cfg_path) = config_file {
+            if let Some(p) = path {
+                // -p mode: single-package build (preserved)
+                build::execute_local(p, clean).await
+            } else if let Some(ref g) = global {
+                // -g mode: global package build (preserved)
+                run_package::execute_build(config, None, Some(g.clone()), clean).await
+            } else if let Some(cfg_path) = config_file {
+                // -c mode: build from specified config file
+                build::execute_from_config(cfg_path, clean).await
+            } else if let Some(target_name) = target {
+                // <target> mode: find deploy/<target>.yaml
+                let cfg_path = find_deploy_config_by_target(&target_name)?;
                 build::execute_from_config(cfg_path, clean).await
             } else {
-                run_package::execute_build(config, path, global, clean).await
+                // No args: workspace-level build from robonix_workspace.yaml
+                build::execute_from_workspace(clean).await
             }
         }
         Commands::Start {
@@ -277,11 +296,68 @@ pub async fn execute(command: Commands, config: Config) -> Result<()> {
         Commands::Graph { args } => {
             graph::execute(&args.server, args.output, args.format, args.test_mode).await
         }
-        Commands::Deploy { config } => {
-            let config_path = config
-                .canonicalize()
-                .unwrap_or_else(|_| config.clone());
-            deploy::execute(&config_path).await
+        Commands::Deploy { target, config } => {
+            if let Some(cfg_path) = config {
+                let cfg_path = cfg_path.canonicalize().unwrap_or(cfg_path);
+                deploy::execute(&cfg_path).await
+            } else if let Some(target_name) = target {
+                let cfg_path = find_deploy_config_by_target(&target_name)?;
+                deploy::execute(&cfg_path).await
+            } else {
+                // No args: workspace-level deploy from robonix_workspace.yaml
+                deploy::execute_from_workspace().await
+            }
         }
     }
+}
+
+/// Find a deploy config file by target name.
+/// Searches `deploy/` directory for `<target>.yaml` or a file with `target: <name>`.
+fn find_deploy_config_by_target(target: &str) -> Result<PathBuf> {
+    let deploy_dir = PathBuf::from("deploy");
+    if !deploy_dir.is_dir() {
+        anyhow::bail!(
+            "deploy/ directory not found in current directory; \
+             use '-c <path>' to specify a config file directly"
+        );
+    }
+
+    // Strategy 1: direct filename match deploy/<target>.yaml
+    let direct = deploy_dir.join(format!("{}.yaml", target));
+    if direct.exists() {
+        return Ok(direct.canonicalize()?);
+    }
+
+    // Strategy 2: scan deploy/*.yaml for matching `target` field
+    use serde::Deserialize;
+    #[derive(Deserialize)]
+    struct Peek {
+        target: Option<String>,
+    }
+
+    for entry in std::fs::read_dir(&deploy_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path
+            .extension()
+            .map(|e| e == "yaml" || e == "yml")
+            .unwrap_or(false)
+        {
+            if let Ok(content) = std::fs::read_to_string(&path) {
+                if let Ok(peek) = serde_yaml::from_str::<Peek>(&content) {
+                    if peek.target.as_deref() == Some(target) {
+                        return Ok(path.canonicalize()?);
+                    }
+                }
+            }
+        }
+    }
+
+    anyhow::bail!(
+        "no deploy config found for target '{}' in deploy/ directory.\n\
+         Expected deploy/{}.yaml or a file with 'target: {}' field.",
+        target,
+        target,
+        target
+    );
 }

--- a/rust/crates/robonix-cli/src/cmd/mod.rs
+++ b/rust/crates/robonix-cli/src/cmd/mod.rs
@@ -13,11 +13,14 @@ mod build;
 mod chat;
 mod codegen;
 mod config;
+mod deploy;
 mod graph;
 mod info;
+mod init;
 mod install;
 mod launch_helpers;
 mod list;
+mod package_new;
 mod path;
 mod run_package;
 mod runtime;
@@ -44,7 +47,18 @@ pub struct GraphArgs {
 
 #[derive(Subcommand)]
 pub enum Commands {
-    /// Build a package (local path or system-installed)
+    /// Initialize a new robonix workspace
+    Init {
+        /// Workspace name (creates a directory with this name)
+        name: String,
+    },
+    /// Create a new package under packages/
+    #[command(name = "package-new")]
+    PackageNew {
+        /// Package name
+        name: String,
+    },
+    /// Build a package (local path or system-installed) or all packages from a config
     Build {
         /// Local package path (relative to $RBNX_INVOCATION_CWD, else process cwd)
         #[arg(short = 'p', long)]
@@ -52,6 +66,9 @@ pub enum Commands {
         /// Build by system-installed package name
         #[arg(short = 'g', long)]
         global: Option<String>,
+        /// Build all packages from a config.yaml file
+        #[arg(short = 'c', long = "config")]
+        config: Option<PathBuf>,
         /// Clean build (remove rbnx-build before building). Default: incremental.
         #[arg(long)]
         clean: bool,
@@ -192,15 +209,31 @@ pub enum Commands {
         #[command(flatten)]
         args: GraphArgs,
     },
+
+    /// Deploy a full stack from a config.yaml file (runtime + services + packages)
+    Deploy {
+        /// Path to config.yaml
+        #[arg(required = true)]
+        config: PathBuf,
+    },
 }
 
 pub async fn execute(command: Commands, config: Config) -> Result<()> {
     match command {
+        Commands::Init { name } => init::execute(&name).await,
+        Commands::PackageNew { name } => package_new::execute(&name).await,
         Commands::Build {
             path,
             global,
+            config: config_file,
             clean,
-        } => run_package::execute_build(config, path, global, clean).await,
+        } => {
+            if let Some(cfg_path) = config_file {
+                build::execute_from_config(cfg_path, clean).await
+            } else {
+                run_package::execute_build(config, path, global, clean).await
+            }
+        }
         Commands::Start {
             package,
             node,
@@ -237,6 +270,12 @@ pub async fn execute(command: Commands, config: Config) -> Result<()> {
         Commands::Chat { server } => chat::execute(&server).await,
         Commands::Graph { args } => {
             graph::execute(&args.server, args.output, args.format, args.test_mode).await
+        }
+        Commands::Deploy { config } => {
+            let config_path = config
+                .canonicalize()
+                .unwrap_or_else(|_| config.clone());
+            deploy::execute(&config_path).await
         }
     }
 }

--- a/rust/crates/robonix-cli/src/cmd/mod.rs
+++ b/rust/crates/robonix-cli/src/cmd/mod.rs
@@ -51,12 +51,18 @@ pub enum Commands {
     Init {
         /// Workspace name (creates a directory with this name)
         name: String,
+        /// Parent directory where the workspace will be created (default: current directory)
+        #[arg(short = 'p', long)]
+        path: Option<PathBuf>,
     },
     /// Create a new package under packages/
     #[command(name = "package-new")]
     PackageNew {
         /// Package name
         name: String,
+        /// Parent directory where the package will be created (default: current directory)
+        #[arg(short = 'p', long)]
+        path: Option<PathBuf>,
     },
     /// Build a package (local path or system-installed) or all packages from a config
     Build {
@@ -220,8 +226,8 @@ pub enum Commands {
 
 pub async fn execute(command: Commands, config: Config) -> Result<()> {
     match command {
-        Commands::Init { name } => init::execute(&name).await,
-        Commands::PackageNew { name } => package_new::execute(&name).await,
+        Commands::Init { name, path } => init::execute(&name, path.as_deref()).await,
+        Commands::PackageNew { name, path } => package_new::execute(&name, path.as_deref()).await,
         Commands::Build {
             path,
             global,

--- a/rust/crates/robonix-cli/src/cmd/mod.rs
+++ b/rust/crates/robonix-cli/src/cmd/mod.rs
@@ -66,14 +66,14 @@ pub enum Commands {
     },
     /// Build a package (local path or system-installed) or all packages from a config
     Build {
-        /// Local package path (relative to $RBNX_INVOCATION_CWD, else process cwd)
-        #[arg(short = 'p', long)]
+        /// Build by local path (e.g. examples/skill_demo)
+        #[arg(short = 'p', long, conflicts_with = "config")]
         path: Option<PathBuf>,
         /// Build by system-installed package name
-        #[arg(short = 'g', long)]
+        #[arg(short = 'g', long, conflicts_with = "config")]
         global: Option<String>,
         /// Build all packages from a config.yaml file
-        #[arg(short = 'c', long = "config")]
+        #[arg(short = 'c', long = "config", conflicts_with_all = ["path", "global"])]
         config: Option<PathBuf>,
         /// Clean build (remove rbnx-build before building). Default: incremental.
         #[arg(long)]

--- a/rust/crates/robonix-cli/src/cmd/package_new.rs
+++ b/rust/crates/robonix-cli/src/cmd/package_new.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MulanPSL-2.0
 // Package-new command: create a new package under packages/ with scaffolding.
 //
-// Usage:  rbnx package new <name>
+// Usage:  rbnx package new <name> [--path <dir>]
 // Creates:
 //   packages/<name>/
 //   ├── robonix_manifest.yaml
@@ -80,7 +80,7 @@ echo "Starting {name} ..."
 #   exec ./rbnx-build/{name}
 "#;
 
-pub async fn execute(name: &str) -> Result<()> {
+pub async fn execute(name: &str, path: Option<&Path>) -> Result<()> {
     output::action("Package", &format!("creating new package '{}'", name));
 
     // Validate package name: must be non-empty, alphanumeric + underscores.
@@ -94,14 +94,25 @@ pub async fn execute(name: &str) -> Result<()> {
         );
     }
 
-    // Determine where to create: if `packages/` exists (inside a workspace), use it.
-    // Otherwise, create in the current directory.
-    let packages_dir = Path::new("packages");
-    let pkg_root = if packages_dir.is_dir() {
-        packages_dir.join(name)
+    // Determine where to create:
+    // 1. If --path is given, create under that directory.
+    // 2. Else if `packages/` exists (inside a workspace), use it.
+    // 3. Otherwise, create in the current directory.
+    let pkg_root = if let Some(base) = path {
+        // Ensure the parent directory exists.
+        if !base.exists() {
+            fs::create_dir_all(base)
+                .with_context(|| format!("failed to create directory '{}'", base.display()))?;
+        }
+        base.join(name)
     } else {
-        output::warning("'packages/' directory not found — creating package in current directory");
-        Path::new(name).to_path_buf()
+        let packages_dir = Path::new("packages");
+        if packages_dir.is_dir() {
+            packages_dir.join(name)
+        } else {
+            output::warning("'packages/' directory not found — creating package in current directory");
+            Path::new(name).to_path_buf()
+        }
     };
 
     if pkg_root.exists() {

--- a/rust/crates/robonix-cli/src/cmd/package_new.rs
+++ b/rust/crates/robonix-cli/src/cmd/package_new.rs
@@ -34,6 +34,16 @@ nodes:
     type: python
     start: >
       bash scripts/start.sh
+
+interfaces:
+  provides: []
+    # - id: robonix/prm/camera/rgb
+  consumes: []
+    # - id: robonix/sys/perception/yolo/gpu_tensor
+
+# Package-level dependencies (other package names this package depends on)
+depend: []
+  # - com.robonix.pkg.memory
 "#;
 
 const BUILD_SH_TEMPLATE: &str = r#"#!/usr/bin/env bash
@@ -159,18 +169,22 @@ pub async fn execute(name: &str, path: Option<&Path>) -> Result<()> {
     output::check("src/");
 
     // Summary.
+    let pkg_abs = pkg_root.canonicalize().unwrap_or_else(|_| pkg_root.clone());
     output::success(&format!(
         "Package '{}' created at {}",
         name,
-        pkg_root.display()
+        pkg_abs.display()
     ));
     output::info("");
     output::info("Next steps:");
-    output::info(&format!("  cd {}", pkg_root.display()));
-    output::info("  # Edit robonix_manifest.yaml to describe your package");
-    output::info("  # Edit scripts/build.sh with your build commands");
-    output::info("  # Edit scripts/start.sh with your start commands");
-    output::info("  # Add your package to config.yaml under 'packages:'");
+    output::info("  1. Edit robonix_manifest.yaml to describe your package");
+    output::info("  2. Edit scripts/build.sh with your build commands");
+    output::info("  3. Edit scripts/start.sh with your start commands");
+    output::info("  4. Add your package to robonix_workspace.yaml under 'packages:'");
+    output::info(&format!("     e.g.  - name: com.vendor.{}", name));
+    output::info(&format!("            path: ./packages/{}", name));
+    output::info("  5. Add your package:node to deploy/<target>.yaml under 'packages_run:'");
+    output::info(&format!("     e.g.  - name: com.vendor.{}:all", name));
 
     Ok(())
 }

--- a/rust/crates/robonix-cli/src/cmd/package_new.rs
+++ b/rust/crates/robonix-cli/src/cmd/package_new.rs
@@ -176,12 +176,13 @@ pub async fn execute(name: &str, path: Option<&Path>) -> Result<()> {
 }
 
 /// Make a file executable (chmod +x) on Unix systems.
+/// Only adds the execute bit for user/group/other — does not alter read/write bits.
 #[cfg(unix)]
 fn make_executable(path: &Path) -> Result<()> {
     use std::os::unix::fs::PermissionsExt;
     let metadata = fs::metadata(path)?;
     let mut perms = metadata.permissions();
-    perms.set_mode(perms.mode() | 0o755);
+    perms.set_mode(perms.mode() | 0o111);
     fs::set_permissions(path, perms)?;
     Ok(())
 }

--- a/rust/crates/robonix-cli/src/cmd/package_new.rs
+++ b/rust/crates/robonix-cli/src/cmd/package_new.rs
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: MulanPSL-2.0
+// Package-new command: create a new package under packages/ with scaffolding.
+//
+// Usage:  rbnx package new <name>
+// Creates:
+//   packages/<name>/
+//   ├── robonix_manifest.yaml
+//   ├── scripts/
+//   │   ├── build.sh
+//   │   └── start.sh
+//   └── src/
+//       └── .gitkeep
+
+use anyhow::{Context, Result};
+use robonix_cli::output;
+use std::fs;
+use std::path::Path;
+
+const MANIFEST_TEMPLATE: &str = r#"manifestVersion: 1
+
+build:
+  script: scripts/build.sh
+
+package:
+  id: com.vendor.{name}
+  name: {name}
+  version: 0.0.1
+  vendor: vendor
+  description: TODO — describe your package
+  license: Apache-2.0
+
+nodes:
+  - id: com.vendor.{name}.main
+    type: python
+    start: >
+      bash scripts/start.sh
+"#;
+
+const BUILD_SH_TEMPLATE: &str = r#"#!/usr/bin/env bash
+# Build script for {name}
+# Called by: rbnx build
+# Working directory: package root
+# Environment:
+#   RBNX_PACKAGE_ROOT — absolute path to this package
+#   RBNX_BUILD_CLEAN  — set to "1" when --clean is passed
+
+set -euo pipefail
+
+echo "Building {name} ..."
+
+if [ "${RBNX_BUILD_CLEAN:-}" = "1" ]; then
+    echo "Clean build requested — removing rbnx-build/"
+    rm -rf rbnx-build
+fi
+
+mkdir -p rbnx-build
+
+# TODO: Add your build steps here.
+# Examples:
+#   colcon build --packages-select {name}
+#   pip install -e .
+#   cargo build --release
+
+echo "Build complete."
+"#;
+
+const START_SH_TEMPLATE: &str = r#"#!/usr/bin/env bash
+# Start script for {name}
+# Called by: rbnx start -p <package> -n <node>
+# Working directory: package root
+
+set -euo pipefail
+
+echo "Starting {name} ..."
+
+# TODO: Add your start command here.
+# Examples:
+#   source /opt/ros/humble/setup.bash && ros2 launch {name} launch.py
+#   python3 -m {name}.main
+#   exec ./rbnx-build/{name}
+"#;
+
+pub async fn execute(name: &str) -> Result<()> {
+    output::action("Package", &format!("creating new package '{}'", name));
+
+    // Validate package name: must be non-empty, alphanumeric + underscores.
+    if name.is_empty() {
+        anyhow::bail!("package name must not be empty");
+    }
+    if !name.chars().all(|c| c.is_alphanumeric() || c == '_' || c == '-') {
+        anyhow::bail!(
+            "invalid package name '{}': only alphanumeric characters, hyphens and underscores are allowed",
+            name
+        );
+    }
+
+    // Determine where to create: if `packages/` exists (inside a workspace), use it.
+    // Otherwise, create in the current directory.
+    let packages_dir = Path::new("packages");
+    let pkg_root = if packages_dir.is_dir() {
+        packages_dir.join(name)
+    } else {
+        output::warning("'packages/' directory not found — creating package in current directory");
+        Path::new(name).to_path_buf()
+    };
+
+    if pkg_root.exists() {
+        anyhow::bail!(
+            "directory '{}' already exists — choose a different name or remove it first",
+            pkg_root.display()
+        );
+    }
+
+    // Create directory structure.
+    output::step("Creating", &format!("{}", pkg_root.display()));
+
+    fs::create_dir_all(pkg_root.join("scripts"))
+        .with_context(|| format!("failed to create {}/scripts", pkg_root.display()))?;
+    fs::create_dir_all(pkg_root.join("src"))
+        .with_context(|| format!("failed to create {}/src", pkg_root.display()))?;
+
+    // Write robonix_manifest.yaml.
+    let manifest_content = MANIFEST_TEMPLATE.replace("{name}", name);
+    let manifest_path = pkg_root.join("robonix_manifest.yaml");
+    fs::write(&manifest_path, &manifest_content)
+        .with_context(|| format!("failed to write {}", manifest_path.display()))?;
+    output::check("robonix_manifest.yaml");
+
+    // Write scripts/build.sh.
+    let build_sh = BUILD_SH_TEMPLATE.replace("{name}", name);
+    let build_sh_path = pkg_root.join("scripts").join("build.sh");
+    fs::write(&build_sh_path, &build_sh)
+        .with_context(|| format!("failed to write {}", build_sh_path.display()))?;
+    make_executable(&build_sh_path)?;
+    output::check("scripts/build.sh");
+
+    // Write scripts/start.sh.
+    let start_sh = START_SH_TEMPLATE.replace("{name}", name);
+    let start_sh_path = pkg_root.join("scripts").join("start.sh");
+    fs::write(&start_sh_path, &start_sh)
+        .with_context(|| format!("failed to write {}", start_sh_path.display()))?;
+    make_executable(&start_sh_path)?;
+    output::check("scripts/start.sh");
+
+    // Write src/.gitkeep (placeholder so git tracks the directory).
+    fs::write(pkg_root.join("src").join(".gitkeep"), "")
+        .with_context(|| "failed to write src/.gitkeep")?;
+    output::check("src/");
+
+    // Summary.
+    output::success(&format!(
+        "Package '{}' created at {}",
+        name,
+        pkg_root.display()
+    ));
+    output::info("");
+    output::info("Next steps:");
+    output::info(&format!("  cd {}", pkg_root.display()));
+    output::info("  # Edit robonix_manifest.yaml to describe your package");
+    output::info("  # Edit scripts/build.sh with your build commands");
+    output::info("  # Edit scripts/start.sh with your start commands");
+    output::info("  # Add your package to config.yaml under 'packages:'");
+
+    Ok(())
+}
+
+/// Make a file executable (chmod +x) on Unix systems.
+#[cfg(unix)]
+fn make_executable(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let metadata = fs::metadata(path)?;
+    let mut perms = metadata.permissions();
+    perms.set_mode(perms.mode() | 0o755);
+    fs::set_permissions(path, perms)?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn make_executable(_path: &Path) -> Result<()> {
+    // No-op on non-Unix platforms.
+    Ok(())
+}

--- a/rust/crates/robonix-cli/src/lib.rs
+++ b/rust/crates/robonix-cli/src/lib.rs
@@ -9,6 +9,7 @@ pub mod install;
 pub mod manifest;
 pub mod output;
 pub mod process;
+pub mod workspace;
 
 pub use config::{Config, SourcePathKey};
 pub use database::{PackageDatabase, PackageInfo, PackageSource};

--- a/rust/crates/robonix-cli/src/manifest.rs
+++ b/rust/crates/robonix-cli/src/manifest.rs
@@ -22,6 +22,8 @@ pub struct PackageSummary {
     pub provided_interfaces: Vec<String>,
     pub consumed_interfaces: Vec<String>,
     pub nodes: Vec<String>,
+    /// Package-level dependencies (other package names this package depends on).
+    pub depend: Vec<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -37,6 +39,9 @@ pub struct Manifest {
     /// How this package is built: `rbnx build` runs `bash <script>` from the package root.
     #[serde(default)]
     pub build: BuildConfig,
+    /// Package-level dependencies: names of other packages this package depends on.
+    #[serde(default)]
+    pub depend: Vec<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
@@ -153,6 +158,7 @@ impl Manifest {
             provided_interfaces: interfaces.provides.into_iter().map(|i| i.id).collect(),
             consumed_interfaces: interfaces.consumes.into_iter().map(|i| i.id).collect(),
             nodes: self.nodes.iter().map(|n| n.id.clone()).collect(),
+            depend: self.depend.clone(),
         })
     }
 }

--- a/rust/crates/robonix-cli/src/workspace.rs
+++ b/rust/crates/robonix-cli/src/workspace.rs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MulanPSL-2.0
+// Workspace configuration types shared by deploy and build commands.
+//
+// Defines the Rust structs that map to:
+//   - robonix_workspace.yaml  (WorkspaceConfig)
+//   - deploy/<target>.yaml    (DeployConfig)
+
+use anyhow::Result;
+use serde::Deserialize;
+use std::collections::HashMap;
+
+// ── robonix_workspace.yaml ──────────────────────────────────────────────────
+
+/// Top-level structure of `robonix_workspace.yaml`.
+#[derive(Debug, Deserialize, Default, Clone)]
+pub struct WorkspaceConfig {
+    /// Workspace name.
+    #[serde(default)]
+    pub workspace: Option<String>,
+    /// Global environment variables (injected into all child processes).
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+    /// Packages declared in this workspace (url or path, at least one required).
+    #[serde(default)]
+    pub packages: Vec<WorkspacePackageEntry>,
+}
+
+/// A package entry inside `robonix_workspace.yaml`.
+#[derive(Debug, Deserialize, Clone)]
+pub struct WorkspacePackageEntry {
+    /// Fully-qualified package name (e.g. `com.robonix.pkg.memory`).
+    pub name: String,
+    /// Git URL to clone from (optional).
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Local path relative to workspace root (optional).
+    #[serde(default)]
+    pub path: Option<String>,
+}
+
+// ── deploy/<target>.yaml ────────────────────────────────────────────────────
+
+/// Top-level structure of a deploy config file (`deploy/<target>.yaml`).
+#[derive(Debug, Deserialize)]
+pub struct DeployConfig {
+    /// Path to upstream workspace config (e.g. `../robonix_workspace.yaml`),
+    /// resolved relative to this config file's directory.
+    #[serde(default)]
+    pub upstream_config: Option<String>,
+    /// Target platform / profile name (e.g. `sim`, `jetson`).
+    #[serde(default)]
+    pub target: Option<String>,
+    /// Environment variable overrides (merged with workspace env, local wins).
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+    /// Packages and nodes to run.
+    /// Format: `"package_name:node_id"` or `"package_name:all"`.
+    #[serde(default)]
+    pub packages_run: Vec<PackageRunEntry>,
+}
+
+/// A single entry in `packages_run`.
+#[derive(Debug, Deserialize, Clone)]
+pub struct PackageRunEntry {
+    /// Format: `<package_name>:<node_id>` or `<package_name>:all`.
+    pub name: String,
+}
+
+// ── Parsed / resolved types ─────────────────────────────────────────────────
+
+/// Parsed representation of a `PackageRunEntry`.
+#[derive(Debug, Clone)]
+pub struct ParsedPackageRun {
+    pub package_name: String,
+    pub node_selector: NodeSelector,
+}
+
+/// Which node(s) to start for a given package.
+#[derive(Debug, Clone)]
+pub enum NodeSelector {
+    /// Start every node declared in the manifest.
+    All,
+    /// Start a single node by id.
+    Single(String),
+}
+
+/// The merged view produced after loading deploy config + workspace config.
+#[derive(Debug)]
+pub struct MergedConfig {
+    /// Merged environment variables (workspace defaults + deploy overrides).
+    pub env: HashMap<String, String>,
+    /// Workspace name from `robonix_workspace.yaml`.
+    pub workspace_name: Option<String>,
+    /// Package declarations from `robonix_workspace.yaml`.
+    pub workspace_packages: Vec<WorkspacePackageEntry>,
+    /// Parsed `packages_run` from the deploy config.
+    pub packages_run: Vec<ParsedPackageRun>,
+    /// Target name from the deploy config.
+    pub target: Option<String>,
+}
+
+// ── Parsing helpers ─────────────────────────────────────────────────────────
+
+/// Parse a raw `PackageRunEntry` (e.g. `"com.pkg:all"`) into a `ParsedPackageRun`.
+pub fn parse_package_run(entry: &PackageRunEntry) -> Result<ParsedPackageRun> {
+    // Use rsplitn so that the *last* colon is the delimiter.
+    // This handles package names that might theoretically contain colons
+    // (unlikely, but defensive).
+    let parts: Vec<&str> = entry.name.rsplitn(2, ':').collect();
+    if parts.len() != 2 {
+        anyhow::bail!(
+            "invalid packages_run entry '{}': expected format 'package_name:node_id' or 'package_name:all'",
+            entry.name
+        );
+    }
+    let node_part = parts[0];
+    let pkg_name = parts[1];
+    let node_selector = if node_part == "all" {
+        NodeSelector::All
+    } else {
+        NodeSelector::Single(node_part.to_string())
+    };
+    Ok(ParsedPackageRun {
+        package_name: pkg_name.to_string(),
+        node_selector,
+    })
+}

--- a/rust/crates/robonix-cli/src/workspace.rs
+++ b/rust/crates/robonix-cli/src/workspace.rs
@@ -5,9 +5,12 @@
 //   - robonix_workspace.yaml  (WorkspaceConfig)
 //   - deploy/<target>.yaml    (DeployConfig)
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use serde::Deserialize;
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use crate::output;
 
 // ── robonix_workspace.yaml ──────────────────────────────────────────────────
 
@@ -124,4 +127,99 @@ pub fn parse_package_run(entry: &PackageRunEntry) -> Result<ParsedPackageRun> {
         package_name: pkg_name.to_string(),
         node_selector,
     })
+}
+
+// ── Workspace discovery ─────────────────────────────────────────────────────
+
+/// Find the workspace root by searching upward for `robonix_workspace.yaml`.
+pub fn find_workspace_root(base_dir: &Path) -> Result<PathBuf> {
+    let mut dir = base_dir.to_path_buf();
+    for _ in 0..10 {
+        if dir.join("robonix_workspace.yaml").exists() {
+            return Ok(dir);
+        }
+        if !dir.pop() {
+            break;
+        }
+    }
+    anyhow::bail!(
+        "robonix_workspace.yaml not found (searched from {} upward)",
+        base_dir.display()
+    );
+}
+
+// ── Package resolution (with git clone support) ─────────────────────────────
+
+/// Ensure all workspace-declared packages exist locally.
+/// If a package has a `url` but is not found locally, it will be cloned via git.
+/// Returns a map of package_name → resolved local path.
+pub fn ensure_packages_exist(
+    workspace_root: &Path,
+    packages: &[WorkspacePackageEntry],
+) -> Result<HashMap<String, PathBuf>> {
+    let mut package_paths: HashMap<String, PathBuf> = HashMap::new();
+
+    for pkg in packages {
+        let local_path = if let Some(ref path) = pkg.path {
+            // Explicit path specified — resolve relative to workspace root.
+            let resolved = workspace_root.join(path);
+            if !resolved.exists() {
+                anyhow::bail!(
+                    "package '{}' path '{}' does not exist (resolved to {})",
+                    pkg.name,
+                    path,
+                    resolved.display()
+                );
+            }
+            resolved.canonicalize().unwrap_or(resolved)
+        } else {
+            // No path — check packages/<short_name>, auto-clone if url is set.
+            let pkg_dir_name = pkg.name.rsplit('.').next().unwrap_or(&pkg.name);
+            let candidate = workspace_root.join("packages").join(pkg_dir_name);
+            if !candidate.exists() {
+                if let Some(ref url) = pkg.url {
+                    output::step("Cloning", &format!("{} from {}", pkg.name, url));
+                    // Ensure packages/ directory exists.
+                    let packages_dir = workspace_root.join("packages");
+                    std::fs::create_dir_all(&packages_dir).with_context(|| {
+                        format!("failed to create {}", packages_dir.display())
+                    })?;
+                    clone_package_to_workspace(url, &candidate)?;
+                    output::check(&format!("{} cloned to {}", pkg.name, candidate.display()));
+                } else {
+                    anyhow::bail!(
+                        "package '{}' not found at {} and no url specified",
+                        pkg.name,
+                        candidate.display()
+                    );
+                }
+            }
+            candidate.canonicalize().unwrap_or(candidate)
+        };
+        output::check(&format!("{} → {}", pkg.name, local_path.display()));
+        package_paths.insert(pkg.name.clone(), local_path);
+    }
+    Ok(package_paths)
+}
+
+/// Normalize a git URL: handle short forms like `user/repo`.
+fn normalize_git_url(url: &str) -> String {
+    let s = url.trim().trim_end_matches('/');
+    if s.starts_with("http://") || s.starts_with("https://") || s.starts_with("git@") {
+        return s.to_string();
+    }
+    // Short form: user/repo → https://github.com/user/repo.git
+    if s.contains('/') && !s.contains(' ') {
+        return format!("https://github.com/{}.git", s.trim_end_matches(".git"));
+    }
+    s.to_string()
+}
+
+/// Clone a git repository to the target directory.
+fn clone_package_to_workspace(url: &str, target: &Path) -> Result<()> {
+    let clone_url = normalize_git_url(url);
+    git2::build::RepoBuilder::new()
+        .clone(&clone_url, target)
+        .with_context(|| format!("failed to clone {} to {}", url, target.display()))?;
+    Ok(())
 }

--- a/rust/crates/robonix-pilot/src/session.rs
+++ b/rust/crates/robonix-pilot/src/session.rs
@@ -19,7 +19,9 @@ pub struct Session {
     pub history: Vec<Message>,
     /// Current turn count (incremented on each SubmitTask call).
     pub turn_count: u32,
+    #[allow(dead_code)]
     pub state: SessionState,
+    #[allow(dead_code)]
     pub created_at_ms: u64,
 }
 
@@ -55,10 +57,12 @@ impl SessionManager {
             .clone()
     }
 
+    #[allow(dead_code)]
     pub async fn get(&self, session_id: &str) -> Option<Arc<Mutex<Session>>> {
         self.sessions.lock().await.get(session_id).cloned()
     }
 
+    #[allow(dead_code)]
     pub async fn list(&self) -> Vec<(String, SessionState, u64, u32)> {
         let map = self.sessions.lock().await;
         let mut out = Vec::new();

--- a/rust/crates/robonix-pilot/src/session_state.rs
+++ b/rust/crates/robonix-pilot/src/session_state.rs
@@ -9,5 +9,6 @@ pub enum SessionState {
     Active = 0,
     Completed = 1,
     Failed = 2,
+    #[allow(dead_code)]
     WaitingInput = 3,
 }

--- a/rust/crates/robonix-pilot/src/vlm.rs
+++ b/rust/crates/robonix-pilot/src/vlm.rs
@@ -272,11 +272,52 @@ pub struct VlmClient {
 
 impl VlmClient {
     /// Discover a VLM/LLM service via robonix-atlas and negotiate a gRPC channel.
+    ///
+    /// The entire flow (query → negotiate → connect) is retried up to 30 times
+    /// (2s interval, ~60s total) to tolerate services that haven't registered yet
+    /// or stale registrations from a previous run.
     pub async fn discover(
         sdk: &mut robonix_sdk::RobonixClient,
         agent_node_id: &str,
     ) -> Result<Self> {
+        const MAX_RETRIES: u32 = 30;
+        const RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+
         let contract_id = vlm_contract_id_for_query();
+        let mut last_err: Option<anyhow::Error> = None;
+
+        for attempt in 1..=MAX_RETRIES {
+            match Self::try_discover(sdk, agent_node_id, &contract_id).await {
+                Ok(client) => return Ok(client),
+                Err(e) => {
+                    if attempt < MAX_RETRIES {
+                        log::info!(
+                            "VLM discovery attempt {}/{} failed: {}. Retrying in {}s...",
+                            attempt,
+                            MAX_RETRIES,
+                            e,
+                            RETRY_INTERVAL.as_secs()
+                        );
+                        last_err = Some(e);
+                        tokio::time::sleep(RETRY_INTERVAL).await;
+                    } else {
+                        last_err = Some(e);
+                    }
+                }
+            }
+        }
+
+        Err(last_err.unwrap_or_else(|| {
+            anyhow::anyhow!("VLM discovery failed after {} attempts", MAX_RETRIES)
+        }))
+    }
+
+    /// Single attempt: query nodes → negotiate channel → connect.
+    async fn try_discover(
+        sdk: &mut robonix_sdk::RobonixClient,
+        agent_node_id: &str,
+        contract_id: &str,
+    ) -> Result<Self> {
         let mut nodes = if contract_id.is_empty() {
             let ns_prefix = vlm_query_namespace_prefix();
             let iface_leaf = vlm_interface_leaf();
@@ -285,13 +326,24 @@ impl VlmClient {
                 .with_context(|| "failed to query nodes (legacy split namespace + name)")?
         } else {
             sdk.query_nodes_opts(QueryNodesOpts {
-                contract_id: contract_id.clone(),
+                contract_id: contract_id.to_string(),
                 transport: "grpc".into(),
                 ..Default::default()
             })
             .await
             .with_context(|| format!("failed to query nodes for contract_id={contract_id}"))?
         };
+
+        if nodes.is_empty() {
+            anyhow::bail!(
+                "no VLM node for contract {} (grpc)",
+                if contract_id.is_empty() {
+                    format!("{}+{}", vlm_query_namespace_prefix(), vlm_interface_leaf())
+                } else {
+                    contract_id.to_string()
+                }
+            );
+        }
 
         if nodes.len() > 1 {
             nodes.sort_by(|a, b| b.namespace.len().cmp(&a.namespace.len()));
@@ -302,17 +354,7 @@ impl VlmClient {
             );
         }
 
-        let vlm_node = nodes.first().ok_or_else(|| {
-            anyhow::anyhow!(
-                "no VLM node for contract {} (grpc). See rust/docs/NAMESPACE.md; \
-                 set ROBONIX_VLM_CONTRACT_ID or use legacy empty contract + ROBONIX_VLM_NAMESPACE_PREFIX.",
-                if contract_id.is_empty() {
-                    format!("{}+{}", vlm_query_namespace_prefix(), vlm_interface_leaf())
-                } else {
-                    contract_id.clone()
-                }
-            )
-        })?;
+        let vlm_node = &nodes[0];
 
         log::info!(
             "discovered VLM service: node_id='{}' namespace='{}'",

--- a/rust/examples/packages/clawhub_skills/run.sh
+++ b/rust/examples/packages/clawhub_skills/run.sh
@@ -65,7 +65,7 @@ export START_LIAISON="${START_LIAISON:-1}"
 export PYTHONPATH="${PACKAGES}/vlm_service:${PACKAGES}/memsearch_service${PYTHONPATH:+:$PYTHONPATH}"
 
 rbnx() {
-  (cd "$RUST_ROOT" && cargo run -p robonix-cli -- "$@")
+  cargo run --manifest-path "$RUST_ROOT/Cargo.toml" -p robonix-cli -- "$@"
 }
 
 rbnx_validate_build() {
@@ -96,7 +96,7 @@ sleep 0.3
 # ── 1. Atlas (control plane) ─────────────────────────────────────────────────
 if [[ "${SMOKE_USE_EXISTING_ATLAS:-0}" != "1" ]]; then
   echo "[clawhub] starting robonix-atlas (control plane, :50051)..."
-  (cd "$RUST_ROOT" && cargo run -p robonix-atlas) &
+  cargo run --manifest-path "$RUST_ROOT/Cargo.toml" -p robonix-atlas &
   sleep 2
 fi
 
@@ -106,8 +106,8 @@ RBNX_START_OPTS=(start --endpoint "$ROBONIX_ATLAS")
 if [ "$START_VLM_SERVICE" = "1" ]; then
   rbnx_validate_build "$PACKAGES/vlm_service"
   echo "[clawhub] starting vlm_service..."
-  (cd "$RUST_ROOT" && cargo run -p robonix-cli -- "${RBNX_START_OPTS[@]}" \
-    -p "$PACKAGES/vlm_service" -n com.robonix.services.vlm) &
+  cargo run --manifest-path "$RUST_ROOT/Cargo.toml" -p robonix-cli -- "${RBNX_START_OPTS[@]}" \
+    -p "$PACKAGES/vlm_service" -n com.robonix.services.vlm &
   sleep 1
 fi
 
@@ -115,28 +115,28 @@ fi
 rbnx_validate_build "$SCRIPT_DIR"
 
 echo "[clawhub] starting clawhub_skills bridge node..."
-(cd "$RUST_ROOT" && cargo run -p robonix-cli -- "${RBNX_START_OPTS[@]}" \
-  -p "$SCRIPT_DIR" -n com.robonix.skills.clawhub) &
+cargo run --manifest-path "$RUST_ROOT/Cargo.toml" -p robonix-cli -- "${RBNX_START_OPTS[@]}" \
+  -p "$SCRIPT_DIR" -n com.robonix.skills.clawhub &
 sleep 2
 
 # ── 4. Executor (tool dispatch runtime) ──────────────────────────────────────
 if [ "$START_EXECUTOR" = "1" ]; then
   echo "[clawhub] starting robonix-executor (:50061)..."
-  (cd "$RUST_ROOT" && cargo run -p robonix-executor) &
+  cargo run --manifest-path "$RUST_ROOT/Cargo.toml" -p robonix-executor &
   sleep 1
 fi
 
 # ── 5. Pilot (VLM reasoning service) ─────────────────────────────────────────
 if [ "$START_PILOT" = "1" ]; then
   echo "[clawhub] starting robonix-pilot (:50071)..."
-  (cd "$RUST_ROOT" && cargo run -p robonix-pilot) &
+  cargo run --manifest-path "$RUST_ROOT/Cargo.toml" -p robonix-pilot &
   sleep 2
 fi
 
 # ── 6. Liaison (user-facing gRPC server) ─────────────────────────────────────
 if [ "$START_LIAISON" = "1" ]; then
   echo "[clawhub] starting robonix-liaison (:50081)..."
-  (cd "$RUST_ROOT" && cargo run -p robonix-liaison) &
+  cargo run --manifest-path "$RUST_ROOT/Cargo.toml" -p robonix-liaison &
   sleep 2
 fi
 

--- a/rust/examples/packages/maniskill_vla_demo/run.sh
+++ b/rust/examples/packages/maniskill_vla_demo/run.sh
@@ -103,7 +103,7 @@ fi
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 rbnx() {
-  (cd "$RUST_ROOT" && cargo run -p robonix-cli -- "$@")
+  cargo run --manifest-path "$RUST_ROOT/Cargo.toml" -p robonix-cli -- "$@"
 }
 
 rbnx_validate_build() {

--- a/rust/examples/packages/zero_copy_demo/run.sh
+++ b/rust/examples/packages/zero_copy_demo/run.sh
@@ -20,7 +20,7 @@ fi
 
 _build_rust() {
     echo "[+] Building robonix-buffer (Rust)..."
-    (cd "$RUST_ROOT" && cargo build -p robonix-buffer --release)
+    cargo build --manifest-path "$RUST_ROOT/Cargo.toml" -p robonix-buffer --release
     echo "    librobonix_buffer.so -> $RUST_ROOT/target/release/"
 }
 

--- a/rust/examples/packages/zero_copy_demo/scripts/build.sh
+++ b/rust/examples/packages/zero_copy_demo/scripts/build.sh
@@ -9,8 +9,8 @@ RUST_ROOT="$(rbnx path rust)"
 FLAGS=()
 [[ "${RBNX_BUILD_CLEAN:-}" == "1" ]] && FLAGS+=(--clean)
 
-echo "[build] building librobonix_buffer.so..."
-(cd "$RUST_ROOT" && cargo build -p robonix-buffer --release)
+echo "[build] Building librobonix_buffer.so..."
+cargo build --manifest-path "$RUST_ROOT/Cargo.toml" -p robonix-buffer --release
 
 echo "[build] installing Python package (editable)..."
 if command -v uv >/dev/null 2>&1; then

--- a/rust/examples/run.sh
+++ b/rust/examples/run.sh
@@ -46,7 +46,7 @@ export START_MEMSEARCH="${START_MEMSEARCH:-1}"
 export PYTHONPATH="${PACKAGES}/vlm_service:${PACKAGES}/memsearch_service${PYTHONPATH:+:$PYTHONPATH}"
 
 rbnx() {
-  (cd "$RUST_ROOT" && cargo run -p robonix-cli -- "$@")
+  cargo run --manifest-path "$RUST_ROOT/Cargo.toml" -p robonix-cli -- "$@"
 }
 
 rbnx_validate_build() {
@@ -136,50 +136,50 @@ fi
 
 # ── 1. Atlas (control plane) ──────────────────────────────────────────────────
 if [[ "${SMOKE_USE_EXISTING_ATLAS:-0}" != "1" ]]; then
-  echo "[example] starting robonix-atlas (control plane)..."
-  (cd "$RUST_ROOT" && cargo run -p robonix-atlas) &
+  echo "[e2e] starting robonix-atlas (control plane)..."
+  cargo run --manifest-path "$RUST_ROOT/Cargo.toml" -p robonix-atlas &
   sleep 2
 fi
 
 RBNX_START_OPTS=(start --endpoint "$ROBONIX_ATLAS")
 
 if [ "$START_VLM_SERVICE" = "1" ]; then
-  echo "[example] rbnx start vlm_service (background)..."
-  (cd "$RUST_ROOT" && cargo run -p robonix-cli -- "${RBNX_START_OPTS[@]}" -p "$PACKAGES/vlm_service" -n com.robonix.services.vlm) &
+  echo "[e2e] rbnx start vlm_service (background)..."
+  cargo run --manifest-path "$RUST_ROOT/Cargo.toml" -p robonix-cli -- "${RBNX_START_OPTS[@]}" -p "$PACKAGES/vlm_service" -n com.robonix.services.vlm &
   sleep 1
 fi
 
 if [ "$START_MEMSEARCH" = "1" ]; then
   echo "[example] rbnx start memsearch_service (background)..."
   rbnx_validate_build "$PACKAGES/memsearch_service"
-  (cd "$RUST_ROOT" && cargo run -p robonix-cli -- "${RBNX_START_OPTS[@]}" -p "$PACKAGES/memsearch_service" -n com.robonix.services.memsearch) &
+  cargo run --manifest-path "$RUST_ROOT/Cargo.toml" -p robonix-cli -- "${RBNX_START_OPTS[@]}" -p "$PACKAGES/memsearch_service" -n com.robonix.services.memsearch &
   sleep 1
 fi
 
 if [ "$START_SIM_STACK" = "1" ]; then
-  echo "[example] rbnx start tiago_sim_stack (background, docker compose)..."
-  (cd "$RUST_ROOT" && cargo run -p robonix-cli -- "${RBNX_START_OPTS[@]}" -p "$PACKAGES/tiago_sim_stack" -n com.robonix.prm.tiago) &
+  echo "[e2e] rbnx start tiago_sim_stack (background, docker compose)..."
+  cargo run --manifest-path "$RUST_ROOT/Cargo.toml" -p robonix-cli -- "${RBNX_START_OPTS[@]}" -p "$PACKAGES/tiago_sim_stack" -n com.robonix.prm.tiago &
   sleep 4
 fi
 
 # ── 2. Executor (tool dispatch runtime) ──────────────────────────────────────
 if [ "$START_EXECUTOR" = "1" ]; then
-  echo "[example] starting robonix-executor (background)..."
-  (cd "$RUST_ROOT" && cargo run -p robonix-executor) &
+  echo "[e2e] starting robonix-executor (background)..."
+  cargo run --manifest-path "$RUST_ROOT/Cargo.toml" -p robonix-executor &
   sleep 1
 fi
 
 # ── 3. Pilot (VLM reasoning service) ─────────────────────────────────────────
 if [ "$START_PILOT" = "1" ]; then
-  echo "[example] starting robonix-pilot (background)..."
-  (cd "$RUST_ROOT" && cargo run -p robonix-pilot) &
+  echo "[e2e] starting robonix-pilot (background)..."
+  cargo run --manifest-path "$RUST_ROOT/Cargo.toml" -p robonix-pilot &
   sleep 2
 fi
 
 # ── 4. Liaison (user-facing gRPC server) ─────────────────────────────────────
 if [ "$START_LIAISON" = "1" ]; then
-  echo "[example] starting robonix-liaison (background, gRPC on :50081)..."
-  (cd "$RUST_ROOT" && cargo run -p robonix-liaison) &
+  echo "[e2e] starting robonix-liaison (background, gRPC on :50081)..."
+  cargo run --manifest-path "$RUST_ROOT/Cargo.toml" -p robonix-liaison &
   sleep 2
 fi
 

--- a/rust/examples/scripts/smoke_minimal.sh
+++ b/rust/examples/scripts/smoke_minimal.sh
@@ -3,7 +3,6 @@
 set -euo pipefail
 
 RUST_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-cd "$RUST_ROOT"
 
 if ! command -v python3 >/dev/null 2>&1; then
   echo "[smoke] python3 required"
@@ -17,7 +16,7 @@ export ROBONIX_ATLAS="${ROBONIX_ATLAS:-127.0.0.1:50051}"
 ATLAS_PID=""
 if [[ "${SMOKE_USE_EXISTING_ATLAS:-0}" != "1" ]]; then
   echo "[smoke] starting robonix-atlas..."
-  cargo run -p robonix-atlas &
+  cargo run --manifest-path "$RUST_ROOT/Cargo.toml" -p robonix-atlas &
   ATLAS_PID=$!
   sleep 2
 fi
@@ -29,7 +28,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-python3 examples/scripts/smoke_control_plane.py
+python3 "$RUST_ROOT/examples/scripts/smoke_control_plane.py"
 EC=$?
 echo "[smoke] exit=$EC"
 exit "$EC"

--- a/rust/examples/scripts/test_examples_packages.sh
+++ b/rust/examples/scripts/test_examples_packages.sh
@@ -3,21 +3,20 @@
 set -euo pipefail
 
 RUST_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-cd "$RUST_ROOT"
 
 echo "[test] rbnx validate vlm_service"
-cargo run -p robonix-cli -- validate "$RUST_ROOT/examples/packages/vlm_service"
+cargo run --manifest-path "$RUST_ROOT/Cargo.toml" -p robonix-cli -- validate "$RUST_ROOT/examples/packages/vlm_service"
 
 echo "[test] rbnx validate tiago_sim_stack"
-cargo run -p robonix-cli -- validate "$RUST_ROOT/examples/packages/tiago_sim_stack"
+cargo run --manifest-path "$RUST_ROOT/Cargo.toml" -p robonix-cli -- validate "$RUST_ROOT/examples/packages/tiago_sim_stack"
 
 echo "[test] rbnx validate memsearch_service"
-cargo run -p robonix-cli -- validate "$RUST_ROOT/examples/packages/memsearch_service"
+cargo run --manifest-path "$RUST_ROOT/Cargo.toml" -p robonix-cli -- validate "$RUST_ROOT/examples/packages/memsearch_service"
 
 echo "[test] rbnx validate zero_copy_demo"
-cargo run -p robonix-cli -- validate "$RUST_ROOT/examples/packages/zero_copy_demo"
+cargo run --manifest-path "$RUST_ROOT/Cargo.toml" -p robonix-cli -- validate "$RUST_ROOT/examples/packages/zero_copy_demo"
 
 echo "[test] rbnx validate maniskill_vla_demo"
-cargo run -p robonix-cli -- validate "$RUST_ROOT/examples/packages/maniskill_vla_demo"
+cargo run --manifest-path "$RUST_ROOT/Cargo.toml" -p robonix-cli -- validate "$RUST_ROOT/examples/packages/maniskill_vla_demo"
 
 echo "[test] done"

--- a/rust/start_server
+++ b/rust/start_server
@@ -11,43 +11,66 @@ export RUST_LOG="${RUST_LOG:-robonix_atlas=info}"
 
 LISTEN_PORT="${LISTEN_ADDR##*:}"
 
-# Kill any existing process on the listen port
+# Kill any existing process on the listen port (cross-platform: Linux + macOS)
 python3 - "$LISTEN_PORT" <<'PY'
-import os, signal, sys, time
+import os, signal, subprocess, sys, time, platform
 
 port = int(sys.argv[1])
-hex_port = format(port, "04X")
-inodes = set()
-for path in ("/proc/net/tcp", "/proc/net/tcp6"):
-    try:
-        with open(path) as f:
-            next(f)
-            for line in f:
-                parts = line.split()
-                local, state, inode = parts[1], parts[3], parts[9]
-                if local.split(":")[1].upper() == hex_port and state == "0A":
-                    inodes.add(inode)
-    except FileNotFoundError:
-        pass
 
-pids = []
-for pid in os.listdir("/proc"):
-    if not pid.isdigit():
-        continue
-    fd_dir = f"/proc/{pid}/fd"
+def find_pids_lsof(port):
+    """Use lsof to find PIDs listening on the given port (works on macOS and Linux)."""
     try:
-        for fd in os.listdir(fd_dir):
-            try:
-                target = os.readlink(os.path.join(fd_dir, fd))
-            except OSError:
-                continue
-            if target.startswith("socket:[") and target[8:-1] in inodes:
-                pids.append(int(pid))
-                break
-    except OSError:
-        continue
+        out = subprocess.check_output(
+            ["lsof", "-iTCP:" + str(port), "-sTCP:LISTEN", "-t"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        return sorted(set(int(p) for p in out.strip().splitlines() if p.strip()))
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return []
 
-pids = sorted(set(pids))
+def find_pids_proc(port):
+    """Use /proc (Linux) to find PIDs listening on the given port."""
+    hex_port = format(port, "04X")
+    inodes = set()
+    for path in ("/proc/net/tcp", "/proc/net/tcp6"):
+        try:
+            with open(path) as f:
+                next(f)
+                for line in f:
+                    parts = line.split()
+                    local, state, inode = parts[1], parts[3], parts[9]
+                    if local.split(":")[1].upper() == hex_port and state == "0A":
+                        inodes.add(inode)
+        except FileNotFoundError:
+            pass
+    if not inodes:
+        return []
+
+    pids = []
+    for pid in os.listdir("/proc"):
+        if not pid.isdigit():
+            continue
+        fd_dir = f"/proc/{pid}/fd"
+        try:
+            for fd in os.listdir(fd_dir):
+                try:
+                    target = os.readlink(os.path.join(fd_dir, fd))
+                except OSError:
+                    continue
+                if target.startswith("socket:[") and target[8:-1] in inodes:
+                    pids.append(int(pid))
+                    break
+        except OSError:
+            continue
+    return sorted(set(pids))
+
+# Prefer /proc on Linux, fall back to lsof everywhere else
+if platform.system() == "Linux" and os.path.isdir("/proc"):
+    pids = find_pids_proc(port)
+else:
+    pids = find_pids_lsof(port)
+
 if not pids:
     raise SystemExit(0)
 

--- a/test/workspace_test/.gitignore
+++ b/test/workspace_test/.gitignore
@@ -1,0 +1,20 @@
+# Build artifacts
+rbnx-build/
+.rbnx-built
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# ROS 2 build artifacts
+build/
+install/
+log/
+
+proto_gen/

--- a/test/workspace_test/deploy/init.yaml
+++ b/test/workspace_test/deploy/init.yaml
@@ -1,0 +1,14 @@
+upstream_config: ../robonix_workspace.yaml
+target: init
+
+# Environment variable overrides (merged with workspace env, local wins)
+env: {}
+
+# Packages and nodes to run (format: "package_name:node_id" or "package_name:all")
+packages_run: 
+  # Examples:
+  - name: com.vendor.test_pkg_local:all
+  - name: com.vendor.test_pkg_remote:com.vendor.test_pkg_remote.main
+  - name: com.robonix.example.vlm_service:all
+  # - name: nonexistent.pkg:all
+  # - name: com.vendor.test_pkg_local:nonexistent

--- a/test/workspace_test/packages/test_pkg_local/robonix_manifest.yaml
+++ b/test/workspace_test/packages/test_pkg_local/robonix_manifest.yaml
@@ -1,0 +1,28 @@
+manifestVersion: 1
+
+build:
+  script: scripts/build.sh
+
+package:
+  id: com.vendor.test_pkg_local
+  name: test_pkg_local
+  version: 0.0.1
+  vendor: vendor
+  description: TODO — describe your package
+  license: Apache-2.0
+
+nodes:
+  - id: com.vendor.test_pkg_local.main
+    type: python
+    start: >
+      bash scripts/start.sh
+
+interfaces:
+  provides: []
+    # - id: robonix/prm/camera/rgb
+  consumes: []
+    # - id: robonix/sys/perception/yolo/gpu_tensor
+
+# Package-level dependencies (other package names this package depends on)
+depend:
+  - com.vendor.test_pkg_remote

--- a/test/workspace_test/packages/test_pkg_local/scripts/build.sh
+++ b/test/workspace_test/packages/test_pkg_local/scripts/build.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Build script for test_pkg_local
+# Called by: rbnx build
+# Working directory: package root
+# Environment:
+#   RBNX_PACKAGE_ROOT — absolute path to this package
+#   RBNX_BUILD_CLEAN  — set to "1" when --clean is passed
+
+set -euo pipefail
+
+echo "Building test_pkg_local ..."
+
+if [ "${RBNX_BUILD_CLEAN:-}" = "1" ]; then
+    echo "Clean build requested — removing rbnx-build/"
+    rm -rf rbnx-build
+fi
+
+mkdir -p rbnx-build
+
+# TODO: Add your build steps here.
+# Examples:
+#   colcon build --packages-select test_pkg_local
+#   pip install -e .
+#   cargo build --release
+
+echo "Build complete."

--- a/test/workspace_test/packages/test_pkg_local/scripts/start.sh
+++ b/test/workspace_test/packages/test_pkg_local/scripts/start.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Start script for test_pkg_local
+# Called by: rbnx start -p <package> -n <node>
+# Working directory: package root
+
+set -euo pipefail
+
+echo "Starting test_pkg_local ..."
+
+# TODO: Add your start command here.
+# Examples:
+#   source /opt/ros/humble/setup.bash && ros2 launch test_pkg_local launch.py
+#   python3 -m test_pkg_local.main
+#   exec ./rbnx-build/test_pkg_local

--- a/test/workspace_test/packages/vlm_service/.gitignore
+++ b/test/workspace_test/packages/vlm_service/.gitignore
@@ -1,0 +1,2 @@
+rbnx-build
+proto_gen

--- a/test/workspace_test/packages/vlm_service/robonix_manifest.yaml
+++ b/test/workspace_test/packages/vlm_service/robonix_manifest.yaml
@@ -1,0 +1,22 @@
+# RFC002: VLM chat completions over gRPC (OpenAI-compatible backend).
+# Data plane: SysModelVlmChat.Stream (robonix_contracts.proto); stubs in package-local proto_gen/.
+# Host build: scripts/build.sh runs robonix-codegen --lang proto then grpc_tools.protoc.
+manifestVersion: 1
+
+build:
+  script: scripts/build.sh
+
+package:
+  id: com.robonix.example.vlm_service
+  name: vlm_service
+  version: 0.1.0
+  vendor: robonix
+  description: VLM service registered under robonix/sys/model/vlm
+  license: MulanPSL-2.0
+
+nodes:
+  - id: com.robonix.services.vlm
+    type: python
+    start: |
+      export PYTHONPATH="$(pwd)/proto_gen:${PYTHONPATH:-}"
+      exec python -m vlm_service.service

--- a/test/workspace_test/packages/vlm_service/scripts/build.sh
+++ b/test/workspace_test/packages/vlm_service/scripts/build.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MulanPSL-2.0
+set -euo pipefail
+PKG="${RBNX_PACKAGE_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+EXAMPLES="$(cd "$PKG/../.." && pwd)"
+RUST_ROOT_PRE="$(cd "$EXAMPLES/.." && pwd)"
+RUST_ROOT="${RUST_ROOT:-$(cd "$RUST_ROOT_PRE/../rust" && pwd)}"
+PROTO_GEN="$PKG/proto_gen"
+
+if [[ "${RBNX_BUILD_CLEAN:-}" == "1" ]]; then
+  rm -rf "$PKG/rbnx-build"
+  rm -rf "$PROTO_GEN"
+fi
+
+INTERFACES_LIB="$RUST_ROOT/crates/robonix-interfaces/lib"
+CONTRACTS_DIR="$RUST_ROOT/contracts"
+INTERFACES_DIR="$RUST_ROOT/crates/robonix-interfaces/robonix_proto"
+if [[ -x /usr/bin/cargo ]]; then
+  CARGO_BIN=/usr/bin/cargo
+else
+  CARGO_BIN="${CARGO:-cargo}"
+fi
+
+echo "[build] regenerating crates/robonix-interfaces/robonix_proto (robonix-codegen --lang proto)..."
+"$CARGO_BIN" run -p robonix-codegen --manifest-path "$RUST_ROOT/Cargo.toml" -- \
+  --lang proto \
+  -I "$INTERFACES_LIB" \
+  --contracts "$CONTRACTS_DIR" \
+  -o "$INTERFACES_DIR"
+
+# Package-local proto_gen (robonix_contracts_pb2_grpc.SysModelVlmChat, etc.).
+if python3 -m grpc_tools.protoc --version >/dev/null 2>&1; then
+  echo "[build] generating proto_gen stubs..."
+  mkdir -p "$PROTO_GEN"
+  RUNTIME_DIR="$RUST_ROOT/proto"
+  python3 -m grpc_tools.protoc \
+    -I "$RUNTIME_DIR" \
+    -I "$INTERFACES_DIR" \
+    --python_out="$PROTO_GEN" \
+    --grpc_python_out="$PROTO_GEN" \
+    "$RUNTIME_DIR"/*.proto \
+    "$INTERFACES_DIR"/*.proto 2>/dev/null || true
+else
+  echo "[build] grpcio-tools not found — leaving existing package-local proto_gen/"
+fi
+
+mkdir -p "$PKG/rbnx-build/ws/install"
+cat >"$PKG/rbnx-build/ws/install/setup.bash" <<EOF
+#!/usr/bin/env bash
+export PYTHONPATH="$PKG:$PROTO_GEN:\${PYTHONPATH:-}"
+EOF
+
+echo "[build] done."

--- a/test/workspace_test/packages/vlm_service/vlm_service/__init__.py
+++ b/test/workspace_test/packages/vlm_service/vlm_service/__init__.py
@@ -1,0 +1,2 @@
+# RFC002 package vlm_service: serves contract SysModelVlmChat (robonix_contracts_pb2_grpc).
+# Message types live in vlm.proto; gRPC service definitions only in robonix_contracts.proto.

--- a/test/workspace_test/packages/vlm_service/vlm_service/service.py
+++ b/test/workspace_test/packages/vlm_service/vlm_service/service.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python3
+# pyright: reportArgumentType=false
+"""VLM service: registers with robonix-atlas, serves chat completions over gRPC.
+
+The agent discovers this service via the control plane, negotiates a channel,
+then calls contract `SysModelVlmChat.Stream` (server streaming). Wire types live in
+`vlm.proto`; the gRPC service is only in `robonix_contracts.proto` (see
+`rust/contracts` + codegen).
+
+Required environment variables:
+  VLM_API_KEY       API key for the VLM/LLM provider
+
+Optional environment variables:
+  VLM_BASE_URL      OpenAI-compatible API base URL (default: Qwen DashScope)
+  VLM_MODEL         Model name (default: qwen3-vl-plus)
+  VLM_MESSAGE_FORMAT  Request message format: "openai" or "gemini" (default: openai)
+  ROBONIX_ATLAS    Control-plane address (default: localhost:50051)
+  VLM_BIND_ADDR     If set, try this host first when binding the data-plane (default: try 127.0.0.1 then 0.0.0.0).
+                    The service picks a free TCP port (DeclareInterface listen_port) so it does not collide with host services on 50100+.
+
+Control plane (must match robonix-pilot discovery):
+  Registers under `robonix/sys/model/vlm` with interface `chat` (contract id
+  `robonix/sys/model/vlm/chat`). The agent uses `QueryNodes.contract_id`
+  by default; override with `ROBONIX_VLM_CONTRACT_ID`, or empty contract
+  + `ROBONIX_VLM_NAMESPACE_PREFIX` for legacy split queries. See `rust/docs/NAMESPACE.md`.
+"""
+import json
+import os
+import sys
+from concurrent import futures
+from pathlib import Path
+
+
+def _ensure_proto_gen() -> None:
+    d = Path(__file__).resolve().parent
+    while d.parent != d:
+        pg = d / "proto_gen"
+        if pg.is_dir() and (pg / "robonix_runtime_pb2.py").exists():
+            sys.path.insert(0, str(pg))
+            return
+        d = d.parent
+
+
+_ensure_proto_gen()
+import grpc
+import robonix_runtime_pb2 as pb
+import robonix_runtime_pb2_grpc as pb_grpc
+import robonix_contracts_pb2_grpc
+import robonix_msg_pb2
+import vlm_pb2
+
+_HELP = """\
+ERROR: VLM_API_KEY environment variable is not set.
+
+vlm_service.py requires an OpenAI-compatible VLM/LLM API endpoint.
+Set the following environment variables before running:
+
+  export VLM_API_KEY="your-api-key"
+  export VLM_BASE_URL="https://api-endpoint/v1"   # optional
+  export VLM_MODEL="model-name"                   # optional
+  export VLM_MESSAGE_FORMAT="openai"              # optional
+
+Examples for common providers:
+
+  # Qwen (Alibaba DashScope) — default
+  export VLM_API_KEY="sk-xxx"
+  export VLM_BASE_URL="https://dashscope.aliyuncs.com/compatible-mode/v1"
+  export VLM_MODEL="qwen3-vl-plus"
+
+  # DeepSeek
+  export VLM_API_KEY="sk-xxx"
+  export VLM_BASE_URL="https://api.deepseek.com/v1"
+  export VLM_MODEL="deepseek-chat"
+"""
+
+
+def _load_skill_md() -> str:
+    p = Path(__file__).with_name("SKILL.md")
+    if p.is_file():
+        return p.read_text(encoding="utf-8")
+    return "# VLM\nVision-language chat service.\n"
+
+
+def _iface_meta() -> str:
+    return json.dumps(
+        {
+            "transport": "grpc",
+            "contract": {
+                "idl_type": "protobuf",
+                "proto_file": "robonix-interfaces/robonix_proto/robonix_contracts.proto",
+                "service": "robonix.contracts.SysModelVlmChat",
+                "streaming_rpc_method": "/robonix.contracts.SysModelVlmChat/Stream",
+                "stream_request_type": "robonix.vlm.ChatStream_Request",
+                "stream_event_type": "robonix.vlm.ChatStreamEvent",
+            },
+        }
+    )
+
+
+def main() -> None:
+    if "VLM_API_KEY" not in os.environ:
+        print(_HELP, file=sys.stderr)
+        sys.exit(1)
+
+    channel = grpc.insecure_channel(os.environ.get("ROBONIX_ATLAS", "localhost:50051"))
+    stub = pb_grpc.RobonixRuntimeStub(channel)
+
+    stub.RegisterNode(
+        pb.RegisterNodeRequest(
+            node_id="com.robonix.services.vlm",
+            namespace="robonix/sys/model/vlm",
+            kind="service",
+            skill_md=_load_skill_md(),
+        )
+    )
+
+    from openai import OpenAI
+
+    client = OpenAI(
+        api_key=os.environ["VLM_API_KEY"],
+        base_url=os.environ.get(
+            "VLM_BASE_URL", "https://dashscope.aliyuncs.com/compatible-mode/v1"
+        ),
+    )
+    model = os.environ.get("VLM_MODEL", "qwen3-vl-plus")
+    message_format = os.environ.get("VLM_MESSAGE_FORMAT", "openai").strip().lower()
+
+    def _openai_chat(messages, tools=None, tool_choice=None, max_tokens=0, stream=False):
+        kwargs: dict = {"model": model, "messages": messages, "stream": stream}
+        if tools:
+            kwargs["tools"] = tools
+        if tool_choice:
+            kwargs["tool_choice"] = tool_choice
+        if max_tokens:
+            kwargs["max_tokens"] = max_tokens
+        try:
+            out = client.chat.completions.create(**kwargs)
+        except Exception as e:
+            print(f"[vlm-debug] OpenAI API error: {e}", flush=True)
+            # Dump the messages that caused the error (without full base64)
+            for i, m in enumerate(messages):
+                c = m.get("content", "")
+                if isinstance(c, list):
+                    summary = []
+                    for p in c:
+                        if isinstance(p, dict) and p.get("type") == "image_url":
+                            url = p.get("image_url", {}).get("url", "")
+                            summary.append(f"image_url(len={len(url)}, first60={url[:60]!r})")
+                        else:
+                            summary.append(str(p)[:100])
+                    print(f"[vlm-debug] err msg[{i}]: role={m.get('role')}, parts={summary}", flush=True)
+                else:
+                    print(f"[vlm-debug] err msg[{i}]: role={m.get('role')}, content_len={len(str(c))}", flush=True)
+            raise
+        if stream:
+            return out
+        return out.choices[0]
+
+    def _part_to_openai(part):
+        kind = getattr(part, "kind", "")
+        if kind == "text":
+            text = getattr(part, "text", "")
+            return {"type": "text", "text": text} if text else None
+        if kind in {"image_url", "inline_data"}:
+            uri = getattr(part, "uri", "")
+            data_b64 = getattr(part, "data_base64", "")
+            mime = getattr(part, "mime_type", "") or "image/jpeg"
+            if uri:
+                return {"type": "image_url", "image_url": {"url": uri}}
+            if data_b64:
+                return {
+                    "type": "image_url",
+                    "image_url": {"url": f"data:{mime};base64,{data_b64}"},
+                }
+        return None
+
+    def _build_openai_messages(request):
+        req_messages = []
+
+        for m in request.messages:
+            openai_parts = []
+            for part in getattr(m, "parts", []) or []:
+                mapped = _part_to_openai(part)
+                if mapped:
+                    openai_parts.append(mapped)
+
+            if not openai_parts and m.image_base64:
+                print(
+                    f"[vlm-debug] FALLBACK to image_base64! role={m.role}, "
+                    f"parts_count={len(getattr(m, 'parts', []) or [])}, "
+                    f"image_base64_len={len(m.image_base64)}, "
+                    f"image_base64_first40={m.image_base64[:40]!r}",
+                    flush=True,
+                )
+                # Dump each part for diagnosis
+                for j, part in enumerate(getattr(m, "parts", []) or []):
+                    print(
+                        f"[vlm-debug]   part[{j}]: kind={getattr(part, 'kind', '?')}, "
+                        f"text_len={len(getattr(part, 'text', '') or '')}, "
+                        f"data_base64_len={len(getattr(part, 'data_base64', '') or '')}, "
+                        f"uri={getattr(part, 'uri', '')!r}",
+                        flush=True,
+                    )
+                if m.content:
+                    openai_parts.append({"type": "text", "text": m.content})
+                openai_parts.append({
+                    "type": "image_url",
+                    "image_url": {"url": f"data:image/jpeg;base64,{m.image_base64}"},
+                })
+
+            if not openai_parts and m.content:
+                content = m.content
+            else:
+                content = openai_parts
+
+            msg = {"role": m.role, "content": content}
+
+            tool_calls = []
+            for tc in getattr(m, "tool_calls", []) or []:
+                tool_calls.append({
+                    "id": tc.id,
+                    "type": "function",
+                    "function": {
+                        "name": tc.name,
+                        "arguments": tc.arguments_json,
+                    },
+                })
+            if tool_calls:
+                msg["tool_calls"] = tool_calls
+
+            tool_call_id = getattr(m, "tool_call_id", "")
+            if tool_call_id:
+                msg["tool_call_id"] = tool_call_id
+
+            name = getattr(m, "name", "")
+            if name:
+                msg["name"] = name
+
+            # Legacy fallback: old wire format cannot express valid OpenAI tool linkage.
+            if m.role == "tool" and not tool_call_id:
+                text = m.content or "[tool returned output]"
+                if openai_parts:
+                    text_parts = [{"type": "text", "text": f"Tool result:\n{text}"}]
+                    text_parts.extend(openai_parts)
+                    req_messages.append({"role": "user", "content": text_parts})
+                else:
+                    req_messages.append({"role": "user", "content": f"Tool result:\n{text}"})
+                continue
+
+            req_messages.append(msg)
+        return req_messages
+
+    def _build_gemini_contents(request):
+        contents = []
+        for m in request.messages:
+            role = "model" if m.role == "assistant" else "user"
+            parts = []
+
+            for part in getattr(m, "parts", []) or []:
+                kind = getattr(part, "kind", "")
+                if kind == "text" and getattr(part, "text", ""):
+                    parts.append({"text": part.text})
+                elif kind in {"image_url", "inline_data"} and getattr(part, "data_base64", ""):
+                    parts.append({
+                        "inline_data": {
+                            "mime_type": getattr(part, "mime_type", "") or "image/jpeg",
+                            "data": part.data_base64,
+                        }
+                    })
+                elif kind == "function_call":
+                    parts.append({
+                        "function_call": {
+                            "name": getattr(part, "tool_name", ""),
+                            "args": json.loads(getattr(part, "tool_arguments_json", "") or "{}"),
+                        }
+                    })
+                elif kind == "function_response":
+                    parts.append({
+                        "function_response": {
+                            "name": getattr(part, "tool_call_id", ""),
+                            "response": json.loads(getattr(part, "tool_result_json", "") or "{}"),
+                        }
+                    })
+
+            if not parts and getattr(m, "content", ""):
+                parts.append({"text": m.content})
+            if getattr(m, "image_base64", "") and not any("inline_data" in p for p in parts):
+                parts.append({
+                    "inline_data": {
+                        "mime_type": "image/jpeg",
+                        "data": m.image_base64,
+                    }
+                })
+            if parts:
+                contents.append({"role": role, "parts": parts})
+        return contents
+
+    def _build_openai_tools(request):
+        if not request.tools:
+            return None
+        tools_list = []
+        for t in request.tools:
+            schema = json.loads(t.input_schema_json) if t.input_schema_json else {}
+            tools_list.append({
+                "type": "function",
+                "function": {
+                    "name": t.name,
+                    "description": t.description,
+                    "parameters": schema,
+                },
+            })
+        return tools_list
+
+    def handle_chat_stream(request, context):
+        """Server-streaming chat: yields text deltas, then tool calls, then finish."""
+        if message_format == "gemini":
+            raise NotImplementedError(
+                "VLM_MESSAGE_FORMAT=gemini is defined in the wire model, but vlm_service "
+                "stream transport is still wired to OpenAI-compatible chat.completions. "
+                "Use openai for now or implement a Gemini transport adapter."
+            )
+
+        req_messages = _build_openai_messages(request)
+        tools_list = _build_openai_tools(request)
+        tc_mode = request.tool_choice if request.tool_choice else None
+        print(f"[vlm-debug] req_messages: {req_messages}")
+
+        # Debug: log messages being sent to OpenAI API
+        for i, msg in enumerate(req_messages):
+            role = msg.get("role", "?")
+            content = msg.get("content", "")
+            has_tool_calls = bool(msg.get("tool_calls"))
+            tool_call_id = msg.get("tool_call_id", "")
+            if isinstance(content, str):
+                preview = content[:120] + ("..." if len(content) > 120 else "")
+                has_image = False
+            elif isinstance(content, list):
+                has_image = any(
+                    p.get("type") == "image_url" for p in content if isinstance(p, dict)
+                )
+                text_parts = [
+                    p.get("text", "")[:80] for p in content
+                    if isinstance(p, dict) and p.get("type") == "text"
+                ]
+                preview = "; ".join(text_parts)
+                if has_image:
+                    for p in content:
+                        if isinstance(p, dict) and p.get("type") == "image_url":
+                            url = p.get("image_url", {}).get("url", "")
+                            print(
+                                f"[vlm-debug] msg[{i}] image_url len={len(url)}, "
+                                f"first_60={url[:60]!r}",
+                                flush=True,
+                            )
+            else:
+                preview = str(content)[:120]
+                has_image = False
+            print(
+                f"[vlm-debug] msg[{i}]: role={role}, has_image={has_image}, "
+                f"tool_calls={has_tool_calls}, tool_call_id={tool_call_id!r}, "
+                f"content_preview={preview!r}",
+                flush=True,
+            )
+
+        print(
+            f"[vlm-debug] total {len(req_messages)} messages, "
+            f"{len(tools_list) if tools_list else 0} tools, tool_choice={tc_mode}",
+            flush=True,
+        )
+
+        stream_iter = _openai_chat(
+            req_messages,
+            tools=tools_list,
+            tool_choice=tc_mode,
+            max_tokens=request.max_tokens,
+            stream=True,
+        )
+
+        # Accumulate tool call deltas: index → {id, name, arguments}
+        tc_acc: dict[int, dict] = {}
+        finish = "stop"
+
+        for chunk in stream_iter:
+            if not chunk.choices:
+                continue
+            delta = chunk.choices[0].delta
+            fr = chunk.choices[0].finish_reason
+
+            if delta and delta.content:
+                yield vlm_pb2.ChatStreamEvent(text_delta=delta.content)
+
+            if delta and delta.tool_calls:
+                for tc_delta in delta.tool_calls:
+                    idx = tc_delta.index
+                    if idx not in tc_acc:
+                        tc_acc[idx] = {"id": "", "name": "", "arguments": ""}
+                    if tc_delta.id:
+                        tc_acc[idx]["id"] = tc_delta.id
+                    if tc_delta.function and tc_delta.function.name:
+                        tc_acc[idx]["name"] += tc_delta.function.name
+                    if tc_delta.function and tc_delta.function.arguments:
+                        tc_acc[idx]["arguments"] += tc_delta.function.arguments
+
+            if fr:
+                finish = fr
+
+        for idx in sorted(tc_acc.keys()):
+            tc = tc_acc[idx]
+            yield vlm_pb2.ChatStreamEvent(
+                tool_call=robonix_msg_pb2.ToolCall(
+                    id=tc["id"],
+                    name=tc["name"],
+                    arguments_json=tc["arguments"],
+                )
+            )
+
+        yield vlm_pb2.ChatStreamEvent(finish_reason=finish)
+
+    class VlmHandler(robonix_contracts_pb2_grpc.SysModelVlmChatServicer):
+        def Stream(self, request, context):
+            return handle_chat_stream(request, context)
+
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=4))
+    robonix_contracts_pb2_grpc.add_SysModelVlmChatServicer_to_server(
+        VlmHandler(), server
+    )
+
+    bind_candidates: list[str] = []
+    if os.environ.get("VLM_BIND_ADDR", "").strip():
+        bind_candidates.append(os.environ["VLM_BIND_ADDR"].strip())
+    bind_candidates.extend(["127.0.0.1", "0.0.0.0"])
+
+    bound_port: int | None = None
+    last_err: BaseException | None = None
+    for bind in bind_candidates:
+        try:
+            p = server.add_insecure_port(f"{bind}:0")
+            if p > 0:
+                bound_port = p
+                break
+        except RuntimeError as e:
+            last_err = e
+
+    if bound_port is None:
+        raise RuntimeError(
+            f"Failed to bind VLM gRPC data plane (tried {bind_candidates}): {last_err}"
+        )
+
+    resp = stub.DeclareInterface(
+        pb.DeclareInterfaceRequest(
+            node_id="com.robonix.services.vlm",
+            name="chat",
+            supported_transports=["grpc"],
+            metadata_json=_iface_meta(),
+            listen_port=bound_port,
+            contract_id="robonix/sys/model/vlm/chat",
+        )
+    )
+    data_endpoint = resp.allocated_endpoint
+    print(f"[vlm-service] using model={model}, data-plane at {data_endpoint}")
+
+    _, ep_port_str = data_endpoint.rsplit(":", 1)
+    if int(ep_port_str) != bound_port:
+        print(
+            f"[vlm-service] warning: control plane endpoint port {ep_port_str} != bound port {bound_port}",
+            file=sys.stderr,
+        )
+
+    server.start()
+    print(f"[vlm-service] gRPC listening on port {bound_port}")
+    server.wait_for_termination()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/workspace_test/robonix_workspace.yaml
+++ b/test/workspace_test/robonix_workspace.yaml
@@ -1,0 +1,29 @@
+workspace: workspace_test
+
+# Global environment variables (injected into all child processes)
+env:
+  ROBONIX_ATLAS: "127.0.0.1:50051"
+  ROBONIX_META_GRPC_ENDPOINT: "127.0.0.1:50051"
+  ROBONIX_ATLAS_ENDPOINT: "http://127.0.0.1:50051"
+  ROBONIX_EXECUTOR_ENDPOINT: "http://127.0.0.1:50061"
+  ROBONIX_PILOT_ENDPOINT: "http://127.0.0.1:50071"
+  RUST_LOG: "robonix_atlas=info,robonix_pilot=info,robonix_executor=info,robonix_liaison=warn"
+  VLM_API_KEY: "sk-e5b6865a506746139e04e119202ba2ce"
+  VLM_BASE_URL: "https://dashscope.aliyuncs.com/compatible-mode/v1"
+  VLM_MODEL: "qwen3-vl-plus"
+  VLM_MESSAGE_FORMAT: "openai"
+
+# Packages in this workspace (url or path, at least one required per entry)
+packages:
+  - name: com.vendor.test_pkg_remote
+    url: https://github.com/lhw2002426/test_pkg_remote.git
+  
+  - name: com.vendor.test_pkg_local
+    path: ./packages/test_pkg_local
+  
+  - name: com.robonix.example.vlm_service
+    path: ./packages/vlm_service
+  
+  # - name: com.bad.pkg
+  #   url: https://github.com/nonexistent/doesnotexist.git
+  # - name: com.missing.pkg


### PR DESCRIPTION
## Description:
Add three new workspace management subcommands to rbnx CLI and enhance the build command:

rbnx init <name> — Scaffold a new robonix workspace with robonix_workspace.yaml, packages/, contracts/, generated/, and deploy/ directories.
rbnx package-new <name> — Create a new package under packages/ with robonix_manifest.yaml and src/ boilerplate.
rbnx deploy <config> — Deploy a full stack (runtime + services + packages) from a config file.
rbnx build -c <config> — Add --config flag to batch-build all packages defined in a config file.

## Changes:

New modules: init.rs, package_new.rs, deploy.rs, build.rs
Updated mod.rs to register and route new commands
Added dependency in Cargo.toml