### PR TITLE
docs: README updates post-PR-#27 merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,16 @@ It runs in two terminals: the simulator and Robonix itself.
 # T1 — simulation environment (Webots GUI; not a Robonix package — just docker compose)
 bash examples/webots/sim/start.sh
 
-# T2 — Robonix system + Tiago drivers + Nav2 wrapper
+# T2 — Robonix stack: system services + Tiago primitives + Nav2 service
 export VLM_BASE_URL=https://api.openai.com/v1   # any OpenAI-compatible endpoint
 export VLM_API_KEY=sk-...
 export VLM_MODEL=gpt-5.4-mini
 cd examples/webots
-rbnx boot                                # atlas + executor + pilot + 4 driver packages
+rbnx boot                                # whatever the manifest declares,
+                                         # in dependency order
 ```
 
-Once `rbnx boot` reports `✓ 7 component(s) up`, in a third terminal:
+Once `rbnx boot` reports the stack is up, in a third terminal:
 
 ```bash
 rbnx caps          # list registered capabilities + interfaces
@@ -54,10 +55,13 @@ rbnx tools         # tools the LLM agent sees
 rbnx chat          # interactive ratatui chat with the pilot
 ```
 
-To tear everything down:
+To tear everything down — Ctrl-C the `rbnx boot` terminal, or from
+any other shell:
 
 ```bash
-bash examples/webots/sim/stop.sh
+cd examples/webots && rbnx shutdown      # reads rbnx-boot/state.json,
+                                         # SIGTERMs each component's PGID
+bash sim/stop.sh                         # then stop the Webots container
 ```
 
 Full first-run walkthrough: [**docs/src/getting-started/quickstart.md**](https://github.com/syswonder/robonix-book/blob/main/src/getting-started/quickstart.md).

--- a/examples/webots/README.md
+++ b/examples/webots/README.md
@@ -33,16 +33,29 @@ Two terminals only:
 # T1 — sim (Ctrl-C stops):
 bash examples/webots/sim/start.sh
 
-# T2 — robonix: atlas + executor + pilot + 4 drivers + nav2:
+# T2 — robonix stack (whatever robonix_manifest.yaml declares):
 cd examples/webots
 rbnx boot
 ```
 
-Then a third terminal for `rbnx chat`. `rbnx caps` should show the
-4 driver registrations + 3 system caps (atlas / pilot / executor).
-`rbnx tools` lists every MCP tool the LLM agent sees.
+Then a third terminal for `rbnx chat`. `rbnx caps` lists the
+capabilities atlas knows about; `rbnx tools` lists the MCP tools
+the LLM agent can call.
 
-To tear everything down: `bash sim/stop.sh`.
+To tear everything down: Ctrl-C the `rbnx boot` terminal, OR from
+any other shell:
+
+```bash
+cd examples/webots && rbnx shutdown    # SIGTERM each component's PGID
+bash sim/stop.sh                       # then stop the Webots container
+```
+
+`rbnx shutdown` reads `rbnx-boot/state.json` (boot writes it
+incrementally as components come up) and tears them down in
+reverse order. Each chassis / camera / lidar / nav2 package's
+`scripts/start.sh` installs a `trap` that pkills the in-container
+python on EXIT/INT/TERM — so the docker-exec'd drivers don't
+strand the next bring-up by holding ports 50111-50113 / 50211-50213.
 
 ## Env vars
 

--- a/system/speech/README.md
+++ b/system/speech/README.md
@@ -127,7 +127,7 @@ Callers do not need to worry about audio format -- the server automatically hand
 
 Optionally registers with the Atlas control plane at startup:
 
-- **RegisterNode**: `com.robonix.services.speech`, namespace `robonix/service/speech`, kind `service`
+- **RegisterCapability** (legacy `RegisterNode` shim): `com.robonix.services.speech`, namespace `robonix/system/speech`
 - **DeclareInterface × 5**: asr, asr_stream, tts, tts_stream, dialog
 
 Automatically degrades to standalone mode when Atlas is unavailable.


### PR DESCRIPTION
## Summary

- Drop stale specifics from bring-up sections — component count and package list depend on manifest contents.
- Add `rbnx shutdown` to tear-down docs (top-level README + examples/webots/README).
- system/speech/README: `RegisterNode` → `RegisterCapability` (via legacy shim), namespace `robonix/service/speech` → `robonix/system/speech`.

## Test plan
- [ ] README renders cleanly on GitHub
- [ ] No remaining mentions of `rbnx-deploy/` or stale `4 drivers` framing in code-repo READMEs