### PR TITLE
feat. add complete capability state machine transition and lifecycle management

### DIFF
--- a/examples/webots/services/simple_nav/simple_nav/atlas_bridge.py
+++ b/examples/webots/services/simple_nav/simple_nav/atlas_bridge.py
@@ -88,11 +88,13 @@ def navigate(req: Navigate_Request) -> Navigate_Response:
     orientation if you don't care about final heading; the robot
     succeeds on xy alone.)
 
-    Returns Navigate_Response.status_message as JSON: `{goal_id, ...}`.
-    Track via status() / cancel() using the goal_id."""
+    Per Navigate.srv the response carries `goal_id` directly; track
+    via the sibling `status` / `cancel` contracts. `status_message`
+    is free-form text only — never a JSON envelope."""
     if nav is None:
-        return Navigate_Response(accepted=False,
-                                 status_message=json.dumps({"error": "nav not initialized"}))
+        return Navigate_Response(
+            accepted=False, goal_id="", status_message="nav not initialized",
+        )
     goal = req.goal
     target_yaw = quat_to_yaw(goal.pose.orientation.z, goal.pose.orientation.w)
     # Heuristic: if orientation is the identity quaternion (z=0,w=1), the
@@ -108,15 +110,9 @@ def navigate(req: Navigate_Request) -> Navigate_Response:
         # Tolerance is a service-side default — not a contract knob.
         tolerance_m=0.5,
     ))
-    return Navigate_Response(
-        accepted=True,
-        status_message=json.dumps({
-            "goal_id": goal_id,
-            "target_x": float(goal.pose.position.x),
-            "target_y": float(goal.pose.position.y),
-            "target_yaw": target_yaw if use_yaw else None,
-        }),
-    )
+    msg = (f"goto ({goal.pose.position.x:.2f},{goal.pose.position.y:.2f})"
+           + (f" yaw={target_yaw:.2f}" if use_yaw else ""))
+    return Navigate_Response(accepted=True, goal_id=goal_id, status_message=msg)
 
 
 @cap.mcp("robonix/service/navigation/status")
@@ -143,9 +139,11 @@ def cancel(req: CancelNavigation_Request) -> CancelNavigation_Response:
     """Cancel an active navigation goal. Empty `goal_id` cancels the
     currently active goal. Idempotent."""
     if nav is None:
-        return CancelNavigation_Response(accepted=False, message="nav not initialized")
+        return CancelNavigation_Response(accepted=False, status_message="nav not initialized")
     ok = nav.cancel_goal(req.goal_id or None)
-    return CancelNavigation_Response(accepted=ok, message="cancelled" if ok else "no active goal")
+    return CancelNavigation_Response(
+        accepted=ok, status_message="cancelled" if ok else "no active goal",
+    )
 
 
 # ── lifecycle ────────────────────────────────────────────────────────────────

--- a/examples/webots/services/simple_nav/simple_nav/nav_node.py
+++ b/examples/webots/services/simple_nav/simple_nav/nav_node.py
@@ -81,6 +81,18 @@ class Goal:
     last_pose_at: float = 0.0
     last_pose_xy: Optional[Tuple[float, float]] = None
     last_dist_to_goal: float = float("inf")
+    # Lethal-halo bounce detector. When the robot's center walks into
+    # an inscribed-obstacle cell the tick reverses (-0.10, 0). Next
+    # tick the new pose is usually outside the halo, the planner picks
+    # the same target, the follower drives forward — and back into the
+    # same cell. Without bounce-counting the robot wiggles in place
+    # forever (or until the 8s stuck detector fires, but at 0.10 m/s
+    # reverse + replan you can sustain enough net motion to dodge that).
+    # We count consecutive lethal-halo entries within a short window;
+    # >= 3 in `lethal_bounce_window_s` aborts the goal so explore picks
+    # a different frontier instead of inflating the same halo.
+    lethal_bounce_count: int = 0
+    lethal_bounce_first_at: float = 0.0
 
 
 class NavNode:
@@ -588,8 +600,31 @@ class NavNode:
             # Robot center inside an obstacle's inscribed halo.
             # Reverse straight back along current heading to escape;
             # don't try to plan from a forbidden cell.
+            #
+            # Bounce-detect: if we've come back here >= 3 times in 5 s
+            # the planner is stuck oscillating around the inflation
+            # boundary of an obstacle that's right on the path to the
+            # goal. Abort and let explore pick a different frontier
+            # instead of inflating the same halo into the next minute.
+            now = time.time()
+            LETHAL_BOUNCE_WINDOW_S = 5.0
+            LETHAL_BOUNCE_LIMIT = 3
+            if now - g.lethal_bounce_first_at > LETHAL_BOUNCE_WINDOW_S:
+                g.lethal_bounce_count = 1
+                g.lethal_bounce_first_at = now
+            else:
+                g.lethal_bounce_count += 1
+            if g.lethal_bounce_count >= LETHAL_BOUNCE_LIMIT:
+                g.state = "aborted"
+                g.detail = (f"oscillating at lethal halo "
+                            f"({g.lethal_bounce_count} entries in "
+                            f"{now - g.lethal_bounce_first_at:.1f}s)")
+                self._publish_twist(0.0, 0.0)
+                self._publish_path([])
+                return
             self._publish_twist(-0.10, 0.0)
-            g.detail = "in lethal halo; reversing"
+            g.detail = (f"in lethal halo; reversing "
+                        f"(bounce {g.lethal_bounce_count}/{LETHAL_BOUNCE_LIMIT})")
             # Force replan once we're out.
             g.path = None
             g.costmap = None

--- a/examples/webots/start_rviz.sh
+++ b/examples/webots/start_rviz.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MulanPSL-2.0
+# Top-level convenience wrapper for sim/start_rviz.sh.
+#
+# Why this exists in addition to sim/start_rviz.sh:
+#   - sim/start.sh already auto-launches one rviz on boot, but when that
+#     window is closed (Ctrl-C in rviz, accidental kill, etc.) you'd
+#     have to remember the docker-exec dance to bring it back.
+#   - sim/start_rviz.sh runs rviz in the foreground (its `docker exec`
+#     blocks until rviz exits), so re-using it requires `&` + redirect
+#     boilerplate every time.
+#
+# This wrapper:
+#   - Resolves its sibling sim/start_rviz.sh from the script's own dir
+#     (cwd-independent — works whether you call it from the repo root,
+#     from examples/webots/, or via an absolute path),
+#   - Detaches via `nohup … &` + `disown` so the rviz process survives
+#     the launching shell,
+#   - Pipes stdout/stderr to /tmp/rviz2.log so this terminal stays clean.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOG="${ROBONIX_RVIZ_LOG:-/tmp/rviz2.log}"
+
+nohup bash "$SCRIPT_DIR/sim/start_rviz.sh" >"$LOG" 2>&1 < /dev/null &
+PID=$!
+disown "$PID" 2>/dev/null || true
+echo "[start_rviz] launched in background (pid $PID); log: $LOG"

--- a/pylib/robonix-py/robonix_py/atlas.py
+++ b/pylib/robonix-py/robonix_py/atlas.py
@@ -172,6 +172,23 @@ class AtlasClient:
         except Exception as e:  # noqa: BLE001
             log.debug("heartbeat: %s", e)
 
+    def set_capability_state(self, capability_id: str, state: str, detail: str = "") -> None:
+        """Push a lifecycle-state transition to atlas. `state` is a string
+        from `LIFECYCLE_STATES` (REGISTERED/INITIALIZED/ONLINE/OFFLINE/ERROR).
+        Best-effort — atlas downtime should not crash a healthy cap."""
+        self._ensure_stub()
+        enum_name = "STATE_" + state.upper()
+        enum_val = getattr(self.pb.CapabilityState, enum_name, None)
+        if enum_val is None:
+            log.warning("set_capability_state: unknown state %r", state)
+            return
+        try:
+            self.stub.SetCapabilityState(self.pb.SetCapabilityStateRequest(
+                capability_id=capability_id, state=enum_val, detail=detail,
+            ))
+        except Exception as e:  # noqa: BLE001
+            log.debug("SetCapabilityState(%s, %s): %s", capability_id, state, e)
+
     def start_heartbeat(self, capability_id: str, period_s: float = 15.0) -> threading.Thread:
         def _loop():
             while True:

--- a/pylib/robonix-py/robonix_py/capability.py
+++ b/pylib/robonix-py/robonix_py/capability.py
@@ -145,6 +145,14 @@ class Capability:
         self._on_up: Callable | None = None
         self._on_down: Callable | None = None
 
+        # Lifecycle state. Source of truth on the cap side; pushed to
+        # atlas via SetCapabilityState whenever it transitions (see
+        # _set_state below). Initial value is REGISTERED — it flips to
+        # INITIALIZED on Driver(CMD_INIT) success, ONLINE on CMD_UP,
+        # OFFLINE on CMD_DOWN. Atlas-side fallback infers state from
+        # interface declares for legacy caps that never push.
+        self._state: str = "registered"
+
         # Layer 2 registries (populated by decorators / methods).
         self._mcp_app = None  # FastMCP app, lazy
         self._mcp_handlers: list[Callable] = []  # decorated funcs
@@ -171,6 +179,31 @@ class Capability:
     def on_down(self, fn: Callable[[], Any]) -> Callable[[], Any]:
         self._on_down = fn
         return fn
+
+    # ── lifecycle state ──────────────────────────────────────────────────
+    @property
+    def state(self) -> str:
+        """Current lifecycle state — one of registered / initialized /
+        online / offline / error. The framework drives this off Driver
+        cmd transitions; users typically don't write to it directly."""
+        return self._state
+
+    def _set_state(self, new_state: str, detail: str = "") -> None:
+        """Update local state + push to atlas. Idempotent on no-change."""
+        new_state = (new_state or "").lower()
+        if new_state == self._state:
+            return
+        prev = self._state
+        self._state = new_state
+        log.info("[%s] state %s → %s%s",
+                 self.id, prev, new_state,
+                 f" ({detail})" if detail else "")
+        try:
+            self._atlas.set_capability_state(self.id, new_state, detail)
+        except Exception:  # noqa: BLE001
+            # set_capability_state already logs at debug; swallow to keep
+            # the cap usable even if atlas is briefly unreachable.
+            pass
 
     # ── Driver_Response helpers ──────────────────────────────────────────
     def ready(self, state: str = "ready") -> dict:
@@ -405,13 +438,21 @@ class Capability:
 
     def _do_bootstrap(self) -> None:
         # 1. atlas register
+        registered_ok = False
         try:
             new = self._atlas.register_capability(self.id, self.namespace,
                                                   self._md_path or "")
             log.info("registered cap %s%s", self.id,
                      "" if new else " (already existed)")
+            registered_ok = True
         except Exception as e:  # noqa: BLE001
             log.warning("RegisterCapability failed: %s", e)
+        # Push the initial REGISTERED state explicitly, so atlas reflects
+        # "process is alive but Driver(CMD_INIT) hasn't run yet" instead of
+        # leaning on the legacy "first non-driver interface declare → init"
+        # inference. No-op if register itself failed.
+        if registered_ok:
+            self._set_state("registered")
 
         # 2. gRPC server — build everything BEFORE start (gRPC python requires
         # all servicers added before server.start()).
@@ -433,6 +474,7 @@ class Capability:
             on_up=self._on_up,
             on_down=self._on_down,
             on_shutdown=self._teardown,
+            on_state_change=self._set_state,
             log_tag=self.id,
         )
         if lifecycle_info is not None:

--- a/pylib/robonix-py/robonix_py/lifecycle.py
+++ b/pylib/robonix-py/robonix_py/lifecycle.py
@@ -89,12 +89,23 @@ def bind_user_handler(servicer_cls: type, method_name: str, fn: Callable) -> typ
     return type(f"Robonix{servicer_cls.__name__}Impl", (servicer_cls,), {method_name: impl})
 
 
+def _is_skill_namespace(ns: str) -> bool:
+    parts = [p for p in ns.strip("/").split("/") if p]
+    if not parts:
+        return False
+    # Either "robonix/skill/<name>" or "skill/<name>".
+    if parts[0] == "robonix" and len(parts) > 1:
+        return parts[1] == "skill"
+    return parts[0] == "skill"
+
+
 def build_lifecycle_servicer(
     namespace: str,
     contracts_grpc_module,
     response_cls,
     *,
     on_init=None, on_up=None, on_down=None, on_shutdown=None,
+    on_state_change=None,
     log_tag: str = "robonix_py",
 ):
     """Build (without starting a server) the lifecycle Servicer instance.
@@ -104,7 +115,13 @@ def build_lifecycle_servicer(
     `None` when the package doesn't have a driver contract (typical for
     system/* services like memory/scene/speech that have no hardware-init
     phase — they expose only MCP tools / gRPC RPCs and don't participate in
-    the rbnx-boot Driver(CMD_INIT) handshake)."""
+    the rbnx-boot Driver(CMD_INIT) handshake).
+
+    `on_state_change(state, detail)` is invoked AFTER each handler returns
+    ok=true and is the framework's hook for pushing state transitions to
+    atlas. State strings: "initialized" / "online" / "offline" / "error".
+    Capability layer wires this; lower-level callers can leave it None.
+    """
     base = driver_pascal_for_namespace(namespace)
     servicer_cls = getattr(contracts_grpc_module, f"{base}Servicer", None)
     add_fn = getattr(contracts_grpc_module, f"add_{base}Servicer_to_server", None)
@@ -116,6 +133,29 @@ def build_lifecycle_servicer(
         )
         return None
 
+    is_skill = _is_skill_namespace(namespace)
+
+    def _emit_state(target: str, detail: str = "") -> None:
+        if on_state_change is not None:
+            try:
+                on_state_change(target, detail)
+            except Exception:  # noqa: BLE001
+                log.exception("[%s] on_state_change(%s) raised", log_tag, target)
+
+    def _post_handler_state(cmd: int, resp) -> None:
+        # Only transition on success. Driver_Response carries `ok` + `state`
+        # + `error` — we treat ok=true as the trigger, regardless of the
+        # nominal `state` string the handler chose to attach.
+        if not getattr(resp, "ok", False):
+            _emit_state("error", getattr(resp, "error", "") or getattr(resp, "state", ""))
+            return
+        if cmd == CMD_INIT:
+            _emit_state("initialized")
+        elif cmd == CMD_UP:
+            _emit_state("online")
+        elif cmd == CMD_DOWN:
+            _emit_state("offline")
+
     def Driver(self, request, context):  # noqa: N802 — matches generated stub
         cmd = int(request.command)
         log.info("[%s] Driver(cmd=%d) received", log_tag, cmd)
@@ -123,16 +163,40 @@ def build_lifecycle_servicer(
             if cmd == CMD_INIT:
                 if on_init is None:
                     return response_cls(ok=False, state="error", error="no on_init handler")
-                return coerce_response(response_cls, on_init(parse_cfg(request)))
+                resp = coerce_response(response_cls, on_init(parse_cfg(request)))
+                _post_handler_state(cmd, resp)
+                return resp
             if cmd == CMD_UP:
                 if on_up is None:
-                    return response_cls(ok=False, state="error",
-                                        error="no on_up handler (this capability isn't a skill?)")
-                return coerce_response(response_cls, on_up(parse_cfg(request)))
+                    # Primitives + services don't need a separate on_up phase
+                    # (their on_init does all the work). Treat the implicit
+                    # "INITIALIZED → ONLINE" transition as a no-op success
+                    # so rbnx-cli's auto-CMD_UP after CMD_INIT succeeds.
+                    # Skills must define on_up — that's where they actually
+                    # allocate hot resources, so missing it is a real bug.
+                    if is_skill:
+                        return response_cls(ok=False, state="error",
+                                            error="skill is missing @cap.on_up handler")
+                    resp = response_cls(ok=True, state="ready", error="")
+                    _post_handler_state(cmd, resp)
+                    return resp
+                resp = coerce_response(response_cls, on_up(parse_cfg(request)))
+                _post_handler_state(cmd, resp)
+                return resp
             if cmd == CMD_DOWN:
                 if on_down is None:
-                    return response_cls(ok=False, state="error", error="no on_down handler")
-                return coerce_response(response_cls, on_down())
+                    # Same argument as CMD_UP: prim/svc don't have a teardown
+                    # phase distinct from process exit. Treat as no-op success
+                    # for them; require explicit handler for skills.
+                    if is_skill:
+                        return response_cls(ok=False, state="error",
+                                            error="skill is missing @cap.on_down handler")
+                    resp = response_cls(ok=True, state="offline", error="")
+                    _post_handler_state(cmd, resp)
+                    return resp
+                resp = coerce_response(response_cls, on_down())
+                _post_handler_state(cmd, resp)
+                return resp
             if cmd == CMD_SHUTDOWN:
                 if on_shutdown is not None:
                     on_shutdown()

--- a/rust/crates/robonix-atlas/src/service.rs
+++ b/rust/crates/robonix-atlas/src/service.rs
@@ -95,6 +95,16 @@ fn serialize_transport<S: serde::Serializer>(t: &Transport, ser: S) -> Result<S:
     ser.serialize_str(t.as_str_name())
 }
 
+fn serialize_pushed_state<S: serde::Serializer>(
+    s: &Option<pb::CapabilityState>,
+    ser: S,
+) -> Result<S::Ok, S::Error> {
+    match s {
+        Some(v) => ser.serialize_str(v.as_str_name()),
+        None => ser.serialize_none(),
+    }
+}
+
 impl From<&EndpointRec> for pb::InterfaceMetadata {
     fn from(e: &EndpointRec) -> Self {
         Self {
@@ -112,6 +122,12 @@ struct CapRecord {
     capability_md_path: String,
     last_heartbeat_ms: u64,
     endpoints: Vec<EndpointRec>,
+    /// Last value reported by SetCapabilityState. None for legacy caps
+    /// that never push, in which case `state()` falls back to the old
+    /// "first non-driver interface declare → INITIALIZED" inference.
+    #[serde(serialize_with = "serialize_pushed_state")]
+    pushed_state: Option<pb::CapabilityState>,
+    state_detail: String,
 }
 
 impl From<&CapRecord> for pb::CapabilityRecord {
@@ -123,20 +139,21 @@ impl From<&CapRecord> for pb::CapabilityRecord {
             last_heartbeat_ms: rec.last_heartbeat_ms,
             interfaces: rec.endpoints.iter().map(Into::into).collect(),
             state: rec.state() as i32,
+            state_detail: rec.state_detail.clone(),
         }
     }
 }
 
 impl CapRecord {
-    /// Observed lifecycle state. INITIALIZED iff the cap has declared at
-    /// least one interface whose contract_id is NOT a `*/driver` (the
-    /// lifecycle hook). By convention, primitives + scene services declare
-    /// only `<kind>/driver` until rbnx calls `Driver(CMD_INIT)` succeeds,
-    /// after which they lazy-declare their real interfaces. System caps
-    /// (atlas/pilot/executor/memory/...) skip the driver step and declare
-    /// their real interfaces directly, transitioning to INITIALIZED on
-    /// first declare.
+    /// Lifecycle state. The cap pushes via SetCapabilityState whenever its
+    /// on_init / on_up / on_down handler returns; that pushed value wins.
+    /// For legacy caps that never push, fall back to "any non-driver
+    /// interface declared → INITIALIZED" (preserves behaviour for code
+    /// still on the old register-then-declare-only flow).
     fn state(&self) -> pb::CapabilityState {
+        if let Some(s) = self.pushed_state {
+            return s;
+        }
         let any_non_driver = self
             .endpoints
             .iter()
@@ -266,6 +283,8 @@ impl AtlasRegistry {
                 capability_md_path: capability_md_path.trim().to_string(),
                 last_heartbeat_ms: Self::now_ms(),
                 endpoints: Vec::new(),
+                pushed_state: None,
+                state_detail: String::new(),
             },
         );
         info!("[atlas] register {cap_id}");
@@ -287,6 +306,44 @@ impl AtlasRegistry {
             "[atlas] unregister {cap_id} (was_present={was_present}, channels_dropped={dropped})"
         );
         was_present
+    }
+
+    /// Update the cap's lifecycle state. Returns the previous value (or
+    /// the inferred fallback when nothing's been pushed yet) so callers
+    /// can log "X went INITIALIZED → ONLINE" without a separate query.
+    /// Atlas does NOT validate the transition — capability-side code is
+    /// the source of truth for what state ordering makes sense.
+    pub async fn set_capability_state(
+        &self,
+        cap_id: &str,
+        new_state: pb::CapabilityState,
+        detail: &str,
+    ) -> Result<pb::CapabilityState, Status> {
+        let cap_id = Self::require("capability_id", cap_id)?;
+        if new_state == pb::CapabilityState::StateUnspecified {
+            return Err(Status::invalid_argument(
+                "state: must not be STATE_UNSPECIFIED",
+            ));
+        }
+        let mut state = self.inner.write().await;
+        let rec = state
+            .caps
+            .get_mut(cap_id)
+            .ok_or_else(|| Status::not_found(format!("unknown capability_id: {cap_id}")))?;
+        let prev = rec.state();
+        rec.pushed_state = Some(new_state);
+        rec.state_detail = detail.trim().to_string();
+        info!(
+            "[atlas] state {cap_id}: {:?} -> {:?}{}",
+            prev,
+            new_state,
+            if rec.state_detail.is_empty() {
+                String::new()
+            } else {
+                format!(" ({})", rec.state_detail)
+            }
+        );
+        Ok(prev)
     }
 
     /// Updates `last_heartbeat_ms` to now. Returns the timestamp it set.
@@ -397,6 +454,7 @@ impl AtlasRegistry {
                 capability_md_path: rec.capability_md_path.clone(),
                 last_heartbeat_ms: rec.last_heartbeat_ms,
                 state: rec.state() as i32,
+                state_detail: rec.state_detail.clone(),
                 interfaces,
             });
         }
@@ -727,6 +785,23 @@ impl pb::atlas_server::Atlas for AtlasService {
         let r = req.into_inner();
         self.registry.heartbeat(&r.capability_id).await?;
         Ok(Response::new(pb::HeartbeatResponse {}))
+    }
+
+    async fn set_capability_state(
+        &self,
+        req: Request<pb::SetCapabilityStateRequest>,
+    ) -> Result<Response<pb::SetCapabilityStateResponse>, Status> {
+        let r = req.into_inner();
+        let new_state = pb::CapabilityState::try_from(r.state).map_err(|_| {
+            Status::invalid_argument(format!("unknown CapabilityState value: {}", r.state))
+        })?;
+        let prev = self
+            .registry
+            .set_capability_state(&r.capability_id, new_state, &r.detail)
+            .await?;
+        Ok(Response::new(pb::SetCapabilityStateResponse {
+            previous_state: prev as i32,
+        }))
     }
 
     async fn declare_interface(

--- a/rust/crates/robonix-cli/src/cmd/deploy.rs
+++ b/rust/crates/robonix-cli/src/cmd/deploy.rs
@@ -1095,21 +1095,28 @@ async fn call_driver_cmd(
         let resp = tokio::time::timeout(
             DRIVER_INIT_TIMEOUT,
             grpc.unary(
-                Request::new(DriverRequest { command: cmd, config_json }),
+                Request::new(DriverRequest {
+                    command: cmd,
+                    config_json,
+                }),
                 path,
                 codec,
             ),
         )
         .await
         .map_err(|_| {
-            anyhow::anyhow!("Driver(CMD_{cmd_name}) timed out after {:?}", DRIVER_INIT_TIMEOUT)
+            anyhow::anyhow!(
+                "Driver(CMD_{cmd_name}) timed out after {:?}",
+                DRIVER_INIT_TIMEOUT
+            )
         })?
         .with_context(|| format!("Driver(CMD_{cmd_name}) RPC failed"))?;
         Ok::<_, anyhow::Error>(resp.into_inner())
     }
     .await;
     let _ = atlas.disconnect_capability(&channel_id).await;
-    let r = result.map_err(|e| anyhow::anyhow!("[{component}/{pkg_label}] Driver(CMD_{cmd_name}): {e:#}"))?;
+    let r = result
+        .map_err(|e| anyhow::anyhow!("[{component}/{pkg_label}] Driver(CMD_{cmd_name}): {e:#}"))?;
     if !r.ok {
         anyhow::bail!(
             "[{component}/{pkg_label}] Driver(CMD_{cmd_name}) returned ok=false (state={}, error={})",

--- a/rust/crates/robonix-cli/src/cmd/deploy.rs
+++ b/rust/crates/robonix-cli/src/cmd/deploy.rs
@@ -45,8 +45,12 @@ use crate::pb::lifecycle::{DriverRequest, DriverResponse};
 
 use super::teardown;
 
-// Driver.srv command discriminator.
+// Driver.srv command discriminators (mirrors lifecycle/srv/Driver.srv).
 const CMD_INIT: u32 = 0;
+#[allow(dead_code)]
+const CMD_SHUTDOWN: u32 = 1;
+const CMD_UP: u32 = 2;
+const CMD_DOWN: u32 = 3;
 // How long to wait for a freshly spawned package to register its driver
 // interface with atlas before giving up.
 const DRIVER_REGISTER_TIMEOUT: Duration = Duration::from_secs(60);
@@ -992,38 +996,95 @@ async fn spawn_and_init(
         return Ok(sp);
     };
 
+    let config_json = serde_json::to_string(&entry.config).unwrap_or_else(|_| "{}".into());
+
+    // Driver(CMD_INIT) — every kind goes through this. Skills stop here
+    // (executor will send CMD_UP just-in-time on the first MCP call);
+    // primitives and services follow with CMD_UP below to reach ONLINE.
+    let init_state = call_driver_cmd(
+        atlas,
+        &cap_id,
+        &driver_contract,
+        component,
+        &pkg_label,
+        CMD_INIT,
+        config_json.clone(),
+    )
+    .await?;
+
+    if component == "skill" {
+        output::boot_ok(
+            short_label(&pkg_label, component),
+            &format!("cap={cap_id}  driver(INIT)={init_state}"),
+        );
+        return Ok(sp);
+    }
+
+    // Primitive / service: auto-promote to ONLINE. Capability framework
+    // treats "no on_up handler" as a no-op success for these kinds, so
+    // existing packages with only an on_init handler keep working — the
+    // CMD_UP just exists to push the lifecycle state past INITIALIZED.
+    let up_state = call_driver_cmd(
+        atlas,
+        &cap_id,
+        &driver_contract,
+        component,
+        &pkg_label,
+        CMD_UP,
+        config_json,
+    )
+    .await?;
+    output::boot_ok(
+        short_label(&pkg_label, component),
+        &format!("cap={cap_id}  driver(INIT)={init_state}  driver(UP)={up_state}"),
+    );
+
+    Ok(sp)
+}
+
+/// Issue one Driver(cmd) RPC against a freshly-connected channel, then
+/// release the channel. Returns the response's `state` string on success;
+/// bail-errors when ok=false or the RPC itself fails. Used by the boot
+/// path for both CMD_INIT and CMD_UP, with identical timeout / channel
+/// hygiene.
+async fn call_driver_cmd(
+    atlas: &mut AtlasClient,
+    cap_id: &str,
+    driver_contract: &str,
+    component: &str,
+    pkg_label: &str,
+    cmd: u32,
+    config_json: String,
+) -> Result<String> {
+    let cmd_name = match cmd {
+        CMD_INIT => "INIT",
+        CMD_UP => "UP",
+        CMD_DOWN => "DOWN",
+        _ => "?",
+    };
     let (channel_id, endpoint, _params) = atlas
         .connect_capability(
             DEPLOY_CONSUMER_ID,
-            &cap_id,
-            &driver_contract,
+            cap_id,
+            driver_contract,
             atlas_pb::Transport::Grpc,
         )
         .await
         .with_context(|| {
             format!("[{component}/{pkg_label}] ConnectCapability for {driver_contract}")
         })?;
-
-    let config_json = serde_json::to_string(&entry.config).unwrap_or_else(|_| "{}".into());
     let normalized = if endpoint.starts_with("http") {
-        endpoint.clone()
+        endpoint
     } else {
-        format!("http://{}", endpoint)
+        format!("http://{endpoint}")
     };
-    let init_result = async {
+    let result = async {
         let channel = Endpoint::new(normalized.clone())
             .with_context(|| format!("invalid driver endpoint '{normalized}'"))?
             .connect()
             .await
             .with_context(|| format!("dial driver at '{normalized}'"))?;
-        // Each per-area driver TOML (`primitive/<area>/driver`,
-        // `service/<area>/driver`) generates its own gRPC service
-        // (`PrimitiveChassisDriver`, `ServiceNavigationDriver`, …) —
-        // they all share the lifecycle/srv/Driver wire shape but live
-        // at distinct gRPC paths. Build the path from the contract_id
-        // and call it directly via tonic's low-level Grpc client, so
-        // boot doesn't need to know which area it's talking to.
-        let svc_name = contract_id_to_service_name(&driver_contract);
+        let svc_name = contract_id_to_service_name(driver_contract);
         let path: tonic::codegen::http::uri::PathAndQuery =
             format!("/robonix.contracts.{svc_name}/Driver")
                 .parse()
@@ -1034,42 +1095,29 @@ async fn spawn_and_init(
         let resp = tokio::time::timeout(
             DRIVER_INIT_TIMEOUT,
             grpc.unary(
-                Request::new(DriverRequest {
-                    command: CMD_INIT,
-                    config_json,
-                }),
+                Request::new(DriverRequest { command: cmd, config_json }),
                 path,
                 codec,
             ),
         )
         .await
-        .map_err(|_| anyhow::anyhow!("Driver(CMD_INIT) timed out after {:?}", DRIVER_INIT_TIMEOUT))?
-        .with_context(|| "Driver(CMD_INIT) RPC failed")?;
+        .map_err(|_| {
+            anyhow::anyhow!("Driver(CMD_{cmd_name}) timed out after {:?}", DRIVER_INIT_TIMEOUT)
+        })?
+        .with_context(|| format!("Driver(CMD_{cmd_name}) RPC failed"))?;
         Ok::<_, anyhow::Error>(resp.into_inner())
     }
     .await;
     let _ = atlas.disconnect_capability(&channel_id).await;
-
-    match init_result {
-        Ok(r) if r.ok => {
-            output::boot_ok(
-                short_label(&pkg_label, component),
-                &format!("cap={cap_id}  driver(INIT)={}", r.state),
-            );
-        }
-        Ok(r) => {
-            anyhow::bail!(
-                "[{component}/{pkg_label}] Driver(INIT) returned ok=false (state={}, error={})",
-                r.state,
-                r.error
-            );
-        }
-        Err(e) => {
-            anyhow::bail!("[{component}/{pkg_label}] Driver(INIT) failed: {e:#}");
-        }
+    let r = result.map_err(|e| anyhow::anyhow!("[{component}/{pkg_label}] Driver(CMD_{cmd_name}): {e:#}"))?;
+    if !r.ok {
+        anyhow::bail!(
+            "[{component}/{pkg_label}] Driver(CMD_{cmd_name}) returned ok=false (state={}, error={})",
+            r.state,
+            r.error
+        );
     }
-
-    Ok(sp)
+    Ok(r.state)
 }
 
 /// Mirrors `robonix_codegen::contract_gen::contract_id_to_service_name`.

--- a/rust/crates/robonix-cli/src/cmd/inspect.rs
+++ b/rust/crates/robonix-cli/src/cmd/inspect.rs
@@ -32,13 +32,30 @@ fn state_name(s: i32) -> &'static str {
     }
 }
 
+/// Color the [STATE] tag the same way every printer does it. Picked to
+/// match the boot-log feel: green=running healthy, yellow=came up but
+/// nothing's driving it yet, red=problem, dim=quiescent.
+fn state_tag(s: i32) -> colored::ColoredString {
+    let label = format!("[{}]", state_name(s));
+    match atlas_pb::CapabilityState::try_from(s)
+        .unwrap_or(atlas_pb::CapabilityState::StateUnspecified)
+    {
+        atlas_pb::CapabilityState::StateOnline => label.green().bold(),
+        atlas_pb::CapabilityState::StateInitialized => label.yellow(),
+        atlas_pb::CapabilityState::StateRegistered => label.blue(),
+        atlas_pb::CapabilityState::StateOffline => label.dimmed(),
+        atlas_pb::CapabilityState::StateError => label.red().bold(),
+        atlas_pb::CapabilityState::StateUnspecified => label.dimmed(),
+    }
+}
+
 async fn connect(endpoint: &str) -> Result<AtlasClient> {
     AtlasClient::connect(endpoint)
         .await
         .with_context(|| format!("connect to atlas at '{endpoint}'"))
 }
 
-pub async fn caps(endpoint: &str, json: bool) -> Result<()> {
+pub async fn caps(endpoint: &str, json: bool, verbose: bool) -> Result<()> {
     let mut atlas = connect(endpoint).await?;
     let records = atlas
         .query_capabilities("", "", atlas_pb::Transport::Unspecified)
@@ -67,28 +84,42 @@ pub async fn caps(endpoint: &str, json: bool) -> Result<()> {
         println!("{} no capabilities registered", "[caps]".yellow().bold());
         return Ok(());
     }
+    // Default: one row per cap, no interfaces. -v expands the interface
+    // list (lspci -tv style — quick scan vs full dump).
     for rec in &records {
         let detail = if rec.state_detail.is_empty() {
             String::new()
         } else {
             format!(" — {}", rec.state_detail)
         };
+        let iface_count_hint = if verbose {
+            String::new()
+        } else {
+            format!(" ({} ifaces)", rec.interfaces.len()).dimmed().to_string()
+        };
         println!(
-            "{} {} {} {}{}",
+            "{} {} {} {}{}{}",
             "●".green(),
             rec.capability_id.bold(),
-            format!("[{}]", state_name(rec.state)).cyan(),
+            state_tag(rec.state),
             rec.namespace.dimmed(),
+            iface_count_hint,
             detail.dimmed()
         );
-        for iface in &rec.interfaces {
-            println!(
-                "    {} {} {}",
-                "└─".dimmed(),
-                iface.contract_id,
-                format!("({})", transport_name(iface.transport)).dimmed()
-            );
+        if verbose {
+            for iface in &rec.interfaces {
+                println!(
+                    "    {} {} {}",
+                    "└─".dimmed(),
+                    iface.contract_id,
+                    format!("({})", transport_name(iface.transport)).dimmed()
+                );
+            }
         }
+    }
+    if !verbose {
+        println!("\n{} pass {} for the per-cap interface list",
+                 "tip:".dimmed(), "-v".bold());
     }
     Ok(())
 }
@@ -125,7 +156,7 @@ pub async fn describe(endpoint: &str, cap_id: Option<&str>, json: bool) -> Resul
                 "{} {} {}",
                 "●".green(),
                 rec.capability_id.bold(),
-                format!("[{}]", state_name(rec.state)).cyan()
+                state_tag(rec.state)
             );
             for iface in &rec.interfaces {
                 println!(

--- a/rust/crates/robonix-cli/src/cmd/inspect.rs
+++ b/rust/crates/robonix-cli/src/cmd/inspect.rs
@@ -95,7 +95,9 @@ pub async fn caps(endpoint: &str, json: bool, verbose: bool) -> Result<()> {
         let iface_count_hint = if verbose {
             String::new()
         } else {
-            format!(" ({} ifaces)", rec.interfaces.len()).dimmed().to_string()
+            format!(" ({} ifaces)", rec.interfaces.len())
+                .dimmed()
+                .to_string()
         };
         println!(
             "{} {} {} {}{}{}",
@@ -118,8 +120,11 @@ pub async fn caps(endpoint: &str, json: bool, verbose: bool) -> Result<()> {
         }
     }
     if !verbose {
-        println!("\n{} pass {} for the per-cap interface list",
-                 "tip:".dimmed(), "-v".bold());
+        println!(
+            "\n{} pass {} for the per-cap interface list",
+            "tip:".dimmed(),
+            "-v".bold()
+        );
     }
     Ok(())
 }

--- a/rust/crates/robonix-cli/src/cmd/inspect.rs
+++ b/rust/crates/robonix-cli/src/cmd/inspect.rs
@@ -25,6 +25,9 @@ fn state_name(s: i32) -> &'static str {
     {
         atlas_pb::CapabilityState::StateRegistered => "REGISTERED",
         atlas_pb::CapabilityState::StateInitialized => "INITIALIZED",
+        atlas_pb::CapabilityState::StateOnline => "ONLINE",
+        atlas_pb::CapabilityState::StateOffline => "OFFLINE",
+        atlas_pb::CapabilityState::StateError => "ERROR",
         atlas_pb::CapabilityState::StateUnspecified => "?",
     }
 }
@@ -48,6 +51,7 @@ pub async fn caps(endpoint: &str, json: bool) -> Result<()> {
                     "capability_id":  r.capability_id,
                     "namespace":      r.namespace,
                     "state":          state_name(r.state),
+                    "state_detail":   r.state_detail,
                     "interfaces":     r.interfaces.iter().map(|i| serde_json::json!({
                         "contract_id": i.contract_id,
                         "transport":   transport_name(i.transport),
@@ -64,12 +68,18 @@ pub async fn caps(endpoint: &str, json: bool) -> Result<()> {
         return Ok(());
     }
     for rec in &records {
+        let detail = if rec.state_detail.is_empty() {
+            String::new()
+        } else {
+            format!(" — {}", rec.state_detail)
+        };
         println!(
-            "{} {} {} {}",
+            "{} {} {} {}{}",
             "●".green(),
             rec.capability_id.bold(),
             format!("[{}]", state_name(rec.state)).cyan(),
-            rec.namespace.dimmed()
+            rec.namespace.dimmed(),
+            detail.dimmed()
         );
         for iface in &rec.interfaces {
             println!(

--- a/rust/crates/robonix-cli/src/cmd/mod.rs
+++ b/rust/crates/robonix-cli/src/cmd/mod.rs
@@ -150,15 +150,20 @@ pub enum Commands {
         key: String,
     },
 
-    /// List all registered capabilities and their interfaces
+    /// List all registered capabilities (one row per cap by default;
+    /// pass -v to expand the per-cap interface list, lspci -tv style)
     #[command(alias = "nodes")]
     Caps {
         /// robonix-atlas endpoint
         #[arg(long, env = "ROBONIX_ATLAS", default_value = DEFAULT_ENDPOINT)]
         server: String,
-        /// Output as JSON
+        /// Output as JSON (forces full detail regardless of -v)
         #[arg(long)]
         json: bool,
+        /// Expand each cap's interface list; without this, only the
+        /// summary header line per cap is printed.
+        #[arg(short = 'v', long)]
+        verbose: bool,
     },
     /// Show CAPABILITY.md for registered caps (all, or one with --cap)
     Describe {
@@ -272,7 +277,7 @@ pub async fn execute(command: Commands, config: Config) -> Result<()> {
         } => codegen::execute(config, package, mcp, clean, out_dir).await,
         Commands::Setup { path } => setup::execute(config, path).await,
         Commands::Path { key } => path::execute(config, key).await,
-        Commands::Caps { server, json } => inspect::caps(&server, json).await,
+        Commands::Caps { server, json, verbose } => inspect::caps(&server, json, verbose).await,
         Commands::Describe { server, cap, json } => {
             inspect::describe(&server, cap.as_deref(), json).await
         }

--- a/rust/crates/robonix-cli/src/cmd/mod.rs
+++ b/rust/crates/robonix-cli/src/cmd/mod.rs
@@ -277,7 +277,11 @@ pub async fn execute(command: Commands, config: Config) -> Result<()> {
         } => codegen::execute(config, package, mcp, clean, out_dir).await,
         Commands::Setup { path } => setup::execute(config, path).await,
         Commands::Path { key } => path::execute(config, key).await,
-        Commands::Caps { server, json, verbose } => inspect::caps(&server, json, verbose).await,
+        Commands::Caps {
+            server,
+            json,
+            verbose,
+        } => inspect::caps(&server, json, verbose).await,
         Commands::Describe { server, cap, json } => {
             inspect::describe(&server, cap.as_deref(), json).await
         }

--- a/rust/crates/robonix-executor/src/dispatch/mod.rs
+++ b/rust/crates/robonix-executor/src/dispatch/mod.rs
@@ -107,6 +107,7 @@ pub async fn dispatch(
 /// primitives, services, system caps, and skills already in ONLINE.
 async fn ensure_skill_online(atlas: &mut AtlasClient, cap_id: &str) -> Result<()> {
     if already_up(cap_id) {
+        log::debug!("[skill-up] {cap_id}: already up, skipping CMD_UP");
         return Ok(());
     }
     let recs = atlas
@@ -114,17 +115,19 @@ async fn ensure_skill_online(atlas: &mut AtlasClient, cap_id: &str) -> Result<()
         .await
         .with_context(|| format!("query_capabilities({cap_id})"))?;
     let Some(rec) = recs.into_iter().next() else {
-        // Not in atlas — let ConnectCapability surface the error.
+        log::info!("[skill-up] {cap_id}: not in atlas, letting connect_capability surface the error");
         return Ok(());
     };
     if !is_skill_namespace(&rec.namespace) {
+        log::debug!("[skill-up] {cap_id} (ns={}): not a skill, no CMD_UP", rec.namespace);
         return Ok(());
     }
     if rec.state == atlas_pb::CapabilityState::StateOnline as i32 {
-        // Skill self-reports ONLINE already; mark + skip the RPC.
+        log::info!("[skill-up] {cap_id}: already ONLINE per atlas, marking sticky");
         mark_up(cap_id);
         return Ok(());
     }
+    log::info!("[skill-up] {cap_id} (ns={}, state={}): sending Driver(CMD_UP)", rec.namespace, rec.state);
     let driver_contract = rec
         .interfaces
         .iter()

--- a/rust/crates/robonix-executor/src/dispatch/mod.rs
+++ b/rust/crates/robonix-executor/src/dispatch/mod.rs
@@ -9,6 +9,14 @@
 //   2. else → ConnectCapability(cap_id, contract_id, MCP) on atlas →
 //      MCP call to the returned endpoint → DisconnectCapability.
 //
+// Skills sit at INITIALIZED after `rbnx boot`. Right before dispatching
+// to one, the executor sends Driver(CMD_UP) on its `*/driver` interface
+// to flip it to ONLINE — that's where the skill actually allocates its
+// hot resources (frontier loop / nav subscribers / VLA worker / …).
+// We track which skill cap_ids we've already up'd in this executor
+// process; subsequent calls skip the CMD_UP RPC to keep latency flat
+// (sticky policy). A future eviction algorithm will drive CMD_DOWN.
+//
 // The grpc dispatch helper exists for future non-MCP contracts but is not
 // on the LLM-callable path today.
 
@@ -16,9 +24,43 @@ pub mod builtin;
 pub mod grpc;
 pub mod mcp;
 
+use std::collections::HashSet;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use tonic::transport::Endpoint;
+use tonic::Request;
+
+use crate::pb::lifecycle::{DriverRequest, DriverResponse};
 use crate::pb::pilot::{CapabilityCall, CapabilityCallResult};
 use robonix_atlas::client::AtlasClient;
 use robonix_atlas::pb as atlas_pb;
+
+const CMD_UP: u32 = 2;
+const DRIVER_UP_TIMEOUT: Duration = Duration::from_secs(60);
+const DEPLOY_CONSUMER_ID: &str = "com.robonix.executor.skill_up";
+
+static UP_DONE: Mutex<Option<HashSet<String>>> = Mutex::new(None);
+
+fn mark_up(cap_id: &str) -> bool {
+    let mut g = UP_DONE.lock().expect("UP_DONE poisoned");
+    let set = g.get_or_insert_with(HashSet::new);
+    set.insert(cap_id.to_string())
+}
+
+fn already_up(cap_id: &str) -> bool {
+    let g = UP_DONE.lock().expect("UP_DONE poisoned");
+    g.as_ref().is_some_and(|s| s.contains(cap_id))
+}
+
+fn is_skill_namespace(ns: &str) -> bool {
+    let mut parts = ns.split('/').filter(|p| !p.is_empty());
+    let first = parts.next();
+    let second = parts.next();
+    matches!(first, Some("robonix")) && matches!(second, Some("skill"))
+        || matches!(first, Some("skill"))
+}
 
 /// Dispatch a single CapabilityCall and return its result.
 ///
@@ -33,6 +75,10 @@ pub async fn dispatch(
 ) -> CapabilityCallResult {
     if call.cap_id == self_cap_id {
         return builtin::execute(call).await;
+    }
+
+    if let Err(e) = ensure_skill_online(atlas, &call.cap_id).await {
+        return error_result(call, format!("Driver(CMD_UP) failed: {e:#}"));
     }
 
     let (channel_id, endpoint, _params) = match atlas
@@ -54,6 +100,114 @@ pub async fn dispatch(
 
     let _ = atlas.disconnect_capability(&channel_id).await;
     result
+}
+
+/// If `cap_id` is a skill that hasn't been up'd in this process yet,
+/// resolve its `*/driver` interface and send Driver(CMD_UP). No-op for
+/// primitives, services, system caps, and skills already in ONLINE.
+async fn ensure_skill_online(atlas: &mut AtlasClient, cap_id: &str) -> Result<()> {
+    if already_up(cap_id) {
+        return Ok(());
+    }
+    let recs = atlas
+        .query_capabilities(cap_id, "", atlas_pb::Transport::Unspecified)
+        .await
+        .with_context(|| format!("query_capabilities({cap_id})"))?;
+    let Some(rec) = recs.into_iter().next() else {
+        // Not in atlas — let ConnectCapability surface the error.
+        return Ok(());
+    };
+    if !is_skill_namespace(&rec.namespace) {
+        return Ok(());
+    }
+    if rec.state == atlas_pb::CapabilityState::StateOnline as i32 {
+        // Skill self-reports ONLINE already; mark + skip the RPC.
+        mark_up(cap_id);
+        return Ok(());
+    }
+    let driver_contract = rec
+        .interfaces
+        .iter()
+        .find(|i| i.contract_id.ends_with("/driver"))
+        .map(|i| i.contract_id.clone())
+        .ok_or_else(|| anyhow::anyhow!("skill {cap_id} has no */driver interface"))?;
+    let svc_name = contract_id_to_service_name(&driver_contract);
+    let (channel_id, endpoint, _) = atlas
+        .connect_capability(
+            DEPLOY_CONSUMER_ID,
+            cap_id,
+            &driver_contract,
+            atlas_pb::Transport::Grpc,
+        )
+        .await
+        .with_context(|| format!("ConnectCapability({driver_contract})"))?;
+    let normalized = if endpoint.starts_with("http") {
+        endpoint
+    } else {
+        format!("http://{endpoint}")
+    };
+    let result = async {
+        let channel = Endpoint::new(normalized.clone())
+            .with_context(|| format!("invalid driver endpoint '{normalized}'"))?
+            .connect()
+            .await
+            .with_context(|| format!("dial driver at '{normalized}'"))?;
+        let path: tonic::codegen::http::uri::PathAndQuery =
+            format!("/robonix.contracts.{svc_name}/Driver")
+                .parse()
+                .with_context(|| format!("build gRPC path for '{driver_contract}'"))?;
+        let mut grpc = tonic::client::Grpc::new(channel);
+        grpc.ready().await.with_context(|| "gRPC ready")?;
+        let codec: tonic_prost::ProstCodec<DriverRequest, DriverResponse> = Default::default();
+        let resp = tokio::time::timeout(
+            DRIVER_UP_TIMEOUT,
+            grpc.unary(
+                Request::new(DriverRequest {
+                    command: CMD_UP,
+                    config_json: String::new(),
+                }),
+                path,
+                codec,
+            ),
+        )
+        .await
+        .map_err(|_| anyhow::anyhow!("Driver(CMD_UP) timed out after {DRIVER_UP_TIMEOUT:?}"))?
+        .with_context(|| "Driver(CMD_UP) RPC failed")?;
+        Ok::<_, anyhow::Error>(resp.into_inner())
+    }
+    .await;
+    let _ = atlas.disconnect_capability(&channel_id).await;
+    let r = result?;
+    if !r.ok {
+        anyhow::bail!(
+            "Driver(CMD_UP) returned ok=false (state={}, error={})",
+            r.state,
+            r.error
+        );
+    }
+    mark_up(cap_id);
+    Ok(())
+}
+
+/// Mirrors robonix_codegen::contract_gen::contract_id_to_service_name.
+/// `robonix/skill/explore/driver` → `SkillExploreDriver`.
+fn contract_id_to_service_name(id: &str) -> String {
+    let body = id.strip_prefix("robonix/").unwrap_or(id);
+    body.split('/')
+        .filter(|x| !x.is_empty())
+        .map(|seg| {
+            seg.split('_')
+                .filter(|p| !p.is_empty())
+                .map(|p| {
+                    let mut c = p.chars();
+                    match c.next() {
+                        Some(f) => f.to_uppercase().chain(c.flat_map(char::to_lowercase)).collect::<String>(),
+                        None => String::new(),
+                    }
+                })
+                .collect::<String>()
+        })
+        .collect()
 }
 
 pub(crate) fn error_result(call: &CapabilityCall, msg: String) -> CapabilityCallResult {

--- a/rust/crates/robonix-executor/src/dispatch/mod.rs
+++ b/rust/crates/robonix-executor/src/dispatch/mod.rs
@@ -29,8 +29,8 @@ use std::sync::Mutex;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use tonic::transport::Endpoint;
 use tonic::Request;
+use tonic::transport::Endpoint;
 
 use crate::pb::lifecycle::{DriverRequest, DriverResponse};
 use crate::pb::pilot::{CapabilityCall, CapabilityCallResult};
@@ -115,11 +115,16 @@ async fn ensure_skill_online(atlas: &mut AtlasClient, cap_id: &str) -> Result<()
         .await
         .with_context(|| format!("query_capabilities({cap_id})"))?;
     let Some(rec) = recs.into_iter().next() else {
-        log::info!("[skill-up] {cap_id}: not in atlas, letting connect_capability surface the error");
+        log::info!(
+            "[skill-up] {cap_id}: not in atlas, letting connect_capability surface the error"
+        );
         return Ok(());
     };
     if !is_skill_namespace(&rec.namespace) {
-        log::debug!("[skill-up] {cap_id} (ns={}): not a skill, no CMD_UP", rec.namespace);
+        log::debug!(
+            "[skill-up] {cap_id} (ns={}): not a skill, no CMD_UP",
+            rec.namespace
+        );
         return Ok(());
     }
     if rec.state == atlas_pb::CapabilityState::StateOnline as i32 {
@@ -127,7 +132,11 @@ async fn ensure_skill_online(atlas: &mut AtlasClient, cap_id: &str) -> Result<()
         mark_up(cap_id);
         return Ok(());
     }
-    log::info!("[skill-up] {cap_id} (ns={}, state={}): sending Driver(CMD_UP)", rec.namespace, rec.state);
+    log::info!(
+        "[skill-up] {cap_id} (ns={}, state={}): sending Driver(CMD_UP)",
+        rec.namespace,
+        rec.state
+    );
     let driver_contract = rec
         .interfaces
         .iter()
@@ -204,7 +213,10 @@ fn contract_id_to_service_name(id: &str) -> String {
                 .map(|p| {
                     let mut c = p.chars();
                     match c.next() {
-                        Some(f) => f.to_uppercase().chain(c.flat_map(char::to_lowercase)).collect::<String>(),
+                        Some(f) => f
+                            .to_uppercase()
+                            .chain(c.flat_map(char::to_lowercase))
+                            .collect::<String>(),
                         None => String::new(),
                     }
                 })

--- a/rust/crates/robonix-interfaces/lib/service/navigation/srv/CancelNavigation.srv
+++ b/rust/crates/robonix-interfaces/lib/service/navigation/srv/CancelNavigation.srv
@@ -1,5 +1,8 @@
-# robonix/primitive/base/cancel_nav — request cancellation of a navigation goal (RPC)
+# robonix/service/navigation/cancel — request cancellation of a
+# navigation goal (RPC). Empty `goal_id` cancels the current active
+# goal. The response uses the same `status_message` field name as
+# Navigate.srv for naming consistency across the namespace.
 string goal_id
 ---
 bool accepted
-string message
+string status_message

--- a/rust/crates/robonix-interfaces/lib/service/navigation/srv/Navigate.srv
+++ b/rust/crates/robonix-interfaces/lib/service/navigation/srv/Navigate.srv
@@ -1,5 +1,10 @@
-# robonix/service/navigation/navigate — goal-based navigation (RPC)
+# robonix/service/navigation/navigate — goal-based navigation (RPC).
+# Returns the provider-allocated `goal_id` so callers can address the
+# goal in the sibling `status` / `cancel` contracts. status_message is
+# a free-form, human-readable description of accept/reject — never a
+# JSON envelope (callers should NOT parse it).
 geometry_msgs/PoseStamped goal
 ---
 bool accepted
+string goal_id
 string status_message

--- a/rust/proto/atlas.proto
+++ b/rust/proto/atlas.proto
@@ -192,21 +192,54 @@ message InterfaceMetadata {
   TransportParams params = 3;
 }
 
-// Lifecycle state of a capability instance, observed (not driven) by Atlas.
-//   STATE_REGISTERED  — the cap exists in atlas but only its `driver`
-//                       interface has been declared (or no interface yet).
-//                       It hasn't been initialised; rbnx start hasn't yet
-//                       called Driver(CMD_INIT) — or the call is in flight,
-//                       or it failed.
-//   STATE_INITIALIZED — the cap has declared at least one non-driver
-//                       interface, which by convention only happens after
-//                       a successful Driver(CMD_INIT). The cap is serving.
-// System caps (atlas/pilot/executor/memory/…) skip the driver step and
-// transition straight to INITIALIZED on their first interface declare.
+// Lifecycle state of a capability instance. The cap itself is the source
+// of truth; atlas only stores what the cap reported via SetCapabilityState
+// (or was inferred from the first interface declare for legacy caps).
+//
+//   STATE_REGISTERED  — process up, atlas knows about the cap, but
+//                       Driver(CMD_INIT) hasn't completed (in flight, or
+//                       not yet called by `rbnx boot`).
+//   STATE_INITIALIZED — Driver(CMD_INIT) returned ok=true. Resources
+//                       parsed/validated but not yet "hot". Skills sit
+//                       here until the executor sends CMD_UP. Primitives
+//                       and services pass through this state immediately
+//                       and rbnx auto-sends CMD_UP next.
+//   STATE_ONLINE      — Driver(CMD_UP) returned ok=true. The cap is
+//                       actively serving requests / holding hot resources.
+//                       Primitives and services normally stay here for
+//                       the lifetime of the boot.
+//   STATE_OFFLINE     — Driver(CMD_DOWN) returned ok=true. Skill-only:
+//                       skill keeps the gRPC server up + the contract
+//                       in atlas, but heavy resources are released. The
+//                       executor can re-send CMD_UP later (and a future
+//                       eviction policy will drive that).
+//   STATE_ERROR       — terminal failure of the last Driver(CMD_*) call.
+//                       Cap remains visible so debug tooling can find it,
+//                       but consumers must not call its data interfaces.
 enum CapabilityState {
   STATE_UNSPECIFIED = 0;
   STATE_REGISTERED  = 1;
   STATE_INITIALIZED = 2;
+  STATE_ONLINE      = 3;
+  STATE_OFFLINE     = 4;
+  STATE_ERROR       = 5;
+}
+
+// Push a state transition. Caps call this after their on_init / on_up /
+// on_down handler returns; rbnx and the executor use the result to gate
+// follow-up Driver(CMD_*) calls without polling. Atlas just stores the
+// last value reported per cap; it does not validate transition legality.
+message SetCapabilityStateRequest {
+  string capability_id = 1;
+  CapabilityState state = 2;
+  // Optional human-readable reason / error attached to this transition,
+  // shown in `rbnx caps`. Empty when the transition is a normal success.
+  string detail = 3;
+}
+message SetCapabilityStateResponse {
+  // Previous state — useful for the caller to log "X went from
+  // INITIALIZED → ONLINE" without a separate query.
+  CapabilityState previous_state = 1;
 }
 
 // Read view of a registered capability instance. `interfaces` lists
@@ -223,6 +256,12 @@ message CapabilityRecord {
   uint64 last_heartbeat_ms = 4;
   repeated InterfaceMetadata interfaces = 5;
   CapabilityState state = 6;
+  // Last `detail` string attached via SetCapabilityState; empty for
+  // legacy caps that don't push state transitions. Surfaced verbatim
+  // by `rbnx caps` so operators can see "deferred: waiting for
+  // service/map" or "error: missing /opt/models/yolov8l-world.pt"
+  // without grepping per-package logs.
+  string state_detail = 7;
 }
 
 // Discover capability instances. Filters AND together when set.
@@ -375,6 +414,8 @@ service Atlas {
   rpc UnregisterCapability(UnregisterCapabilityRequest)
       returns (UnregisterCapabilityResponse);
   rpc Heartbeat(HeartbeatRequest) returns (HeartbeatResponse);
+  rpc SetCapabilityState(SetCapabilityStateRequest)
+      returns (SetCapabilityStateResponse);
   rpc DeclareInterface(DeclareInterfaceRequest)
       returns (DeclareInterfaceResponse);
   rpc QueryCapabilities(QueryCapabilitiesRequest)

--- a/system/scene/scene_service/ingest/perception_concept_graphs.py
+++ b/system/scene/scene_service/ingest/perception_concept_graphs.py
@@ -52,6 +52,14 @@ import time
 import uuid
 from typing import Any, Awaitable, Callable, Optional
 
+# numpy is unconditionally imported because (a) the detector loop
+# uses it on every tick and (b) the per-method lazy-import convention
+# elsewhere in this file kept biting us — every helper that touched
+# `np.*` had to remember the import or the whole tick silently bailed
+# with NameError. One module-level import is cheap and removes the
+# class of bug entirely.
+import numpy as np
+
 log = logging.getLogger("scene.ingest.cg")
 
 
@@ -595,9 +603,20 @@ class ConceptGraphsDetector:
         rgb_msg = self._rgb_msg()
         depth_msg = self._depth_msg()
         if rgb_msg is None or depth_msg is None:
+            # One-line diagnostic so "no ticks at all" stops looking
+            # like a silent crash. Throttle to once every 25 polls (~15s
+            # at the default 0.6s tick) so it doesn't drown the log.
+            self._tick_idx += 1
+            if self._tick_idx % 25 == 1:
+                log.info("[scene-cg] waiting for frames: rgb=%s depth=%s",
+                         "ok" if rgb_msg is not None else "none",
+                         "ok" if depth_msg is not None else "none")
             return
         K = self._cam_info()
         if K is None or K.fx <= 0 or K.fy <= 0:
+            self._tick_idx += 1
+            if self._tick_idx % 25 == 1:
+                log.info("[scene-cg] waiting for camera intrinsics")
             return
         try:
             import numpy as np
@@ -647,6 +666,17 @@ class ConceptGraphsDetector:
             cls_idx = cls_idx[top]
 
         names = getattr(r0, "names", None) or {i: c for i, c in enumerate(self._classes)}
+        # Per-tick diagnostic: how many bboxes did YOLO-World return,
+        # what classes? Throttled to once every 25 ticks (~15s @ 0.6s
+        # period). Without this it's impossible to tell whether
+        # "1 dets" downstream means YOLO sees one thing vs the rest
+        # got dropped by class/floor/SAM/pcd filters.
+        if self._tick_idx % 25 == 0:
+            cls_names = [str(names.get(int(c), f"c{int(c)}")) for c in cls_idx]
+            log.info("[scene-cg] yolo: %d boxes, top conf=%.2f, classes=%s",
+                     int(xyxy.shape[0]),
+                     float(confs.max()) if confs.size else 0.0,
+                     cls_names[:8])
 
         # Filter ignored classes BEFORE running SAM (saves work).
         keep = np.array([
@@ -1139,6 +1169,13 @@ class ConceptGraphsDetector:
         merge_visual_sim_thresh, even though their point clouds are
         on top of each other in 3D.
         """
+        # Same per-method lazy numpy import as the rest of this file —
+        # without it, `np.*` references below raise NameError and the
+        # whole class-agnostic merge pass silently bails every cleanup
+        # tick (visible in scene log as "cross-class geometric
+        # collapse failed: name 'np' is not defined").
+        import numpy as np
+
         n = len(objects)
         if n < 2:
             return objects
@@ -1150,7 +1187,7 @@ class ConceptGraphsDetector:
             except Exception:
                 return objects
 
-        bboxes: list[tuple[np.ndarray, np.ndarray]] = []
+        bboxes: list[tuple["np.ndarray", "np.ndarray"]] = []
         for o in objects:
             pts = np.asarray(o["pcd"].points)
             pts = pts[np.all(np.isfinite(pts), axis=1)] if pts.size else pts

--- a/system/scene/scene_service/ingest/perception_concept_graphs.py
+++ b/system/scene/scene_service/ingest/perception_concept_graphs.py
@@ -975,7 +975,7 @@ class ConceptGraphsDetector:
     @staticmethod
     def _voxel_pcd_overlap_matrix(
         objects_a, objects_b=None, *, voxel_size: float = 0.025,
-    ) -> "np.ndarray":
+    ):
         """Pairwise voxel-set fraction-overlap.
 
         For each pair (i, j) returns
@@ -986,10 +986,15 @@ class ConceptGraphsDetector:
         (coplanar / sparse) point clouds, which crash concept-graphs's
         canonical `compute_overlap_matrix_general` via box3d_overlap.
 
-        Returns an (M, N) float32 array, where M = len(objects_a) and
-        N = len(objects_b) (or M when `objects_b is None`, with a
+        Returns an (M, N) float32 numpy array, where M = len(objects_a)
+        and N = len(objects_b) (or M when `objects_b is None`, with a
         symmetric matrix and zero diagonal).
         """
+        # Lazy numpy import — matches the per-method pattern the rest of
+        # this file uses (every other method that calls np.* imports it
+        # locally). Without this, `np` is unbound here at run time.
+        import numpy as np
+
         def voxel_set(pcd) -> frozenset:
             pts = np.asarray(pcd.points)
             if pts.size == 0:

--- a/system/scene/scene_service/ingest/perception_concept_graphs.py
+++ b/system/scene/scene_service/ingest/perception_concept_graphs.py
@@ -857,10 +857,15 @@ class ConceptGraphsDetector:
                 # on coplanar bbox vertices via pytorch3d.box3d_overlap. AABB-IoU
                 # was the previous fallback but was too weak for the cross-view
                 # merge case. See `_voxel_pcd_overlap_matrix` for the rationale.
-                spatial_sim = self._voxel_pcd_overlap_torch(det_list, self._map_objects)
+                #
+                # Visual sim comes back on whatever device CLIP runs on
+                # (cuda when available); pin our spatial_sim to that same
+                # device before they're added together by aggregate_similarities.
                 visual_sim = self._cg["compute_visual_similarities"](
                     det_list, self._map_objects,
                 )
+                spatial_sim = self._voxel_pcd_overlap_torch(det_list, self._map_objects)
+                spatial_sim = spatial_sim.to(visual_sim.device)
                 agg_sim = self._cg["aggregate_similarities"](
                     self.cfg["match_method"], self.cfg["phys_bias"],
                     spatial_sim, visual_sim,


### PR DESCRIPTION
## 概要

完整实现 Robonix 能力 (capability) 的生命周期状态机 —— Atlas 端、cli 端、executor 端、framework 端、对应文档与 sample skill 全链路。

## 状态机

```mermaid
stateDiagram-v2
    direction LR
    [*] --> REGISTERED
    REGISTERED  --> INITIALIZED : CMD_INIT
    INITIALIZED --> ONLINE      : CMD_UP
    ONLINE      --> OFFLINE     : CMD_DOWN
    OFFLINE     --> ONLINE      : CMD_UP
```

加上两条全局边：
- 任意状态 → terminated：收到 `Driver(CMD_SHUTDOWN)` 或 SIGTERM
- 任意 ok=false → `ERROR`，之后只能 SHUTDOWN

详细流程见 [docs/architecture/cap-lifecycle.md](https://github.com/syswonder/robonix-book/blob/main/src/architecture/cap-lifecycle.md)。

## 谁触发哪条边

| 边 | 触发者 | 时机 |
|---|---|---|
| `REGISTERED → INITIALIZED` | `rbnx boot` | 部署时 |
| `INITIALIZED → ONLINE` (primitive/service) | `rbnx boot` | 自动跟在 `CMD_INIT` 后发 `CMD_UP` |
| `INITIALIZED → ONLINE` (skill) | `executor` | 第一次 MCP 调用前发 `CMD_UP`（sticky） |
| `ONLINE → OFFLINE` (skill) | `executor` | 未来 eviction 算法（暂未实现） |
| `→ terminated` | `rbnx shutdown` / SIGTERM | 拆栈 |

## 主要改动

**proto + atlas (rust)**
- `atlas.proto`: 加 `STATE_ONLINE/OFFLINE/ERROR` enum + 新 `SetCapabilityState` RPC + `CapabilityRecord.state_detail` 字段
- `robonix-atlas`: 在 CapRecord 里跟踪 `pushed_state` & `state_detail`；新 `set_capability_state` 写入路径；Legacy 推断（"任何 non-driver interface declared → INITIALIZED"）作为没 push 的 cap 的 fallback
- `robonix-cli/cmd/deploy.rs`: 抽出 `call_driver_cmd(cmd)` helper；primitive/service 在 `CMD_INIT` 之后自动发 `CMD_UP`；skill 停在 INITIALIZED
- `robonix-cli/cmd/inspect.rs`: `rbnx caps` 默认每 cap 一行+颜色编码（ONLINE 绿/INITIALIZED 黄/ERROR 红/OFFLINE 暗），`-v / --verbose` 展开 interface 列表
- `robonix-executor/dispatch/mod.rs`: `ensure_skill_online()` 在 MCP dispatch 前 query atlas 看 namespace+state，若是 skill 且 != ONLINE 就连到它的 `*/driver` 端点发 `CMD_UP`；per-process sticky set 防止重复 RPC

**robonix-py (Python framework)**
- `lifecycle.py`: `build_lifecycle_servicer` 接受 `on_state_change` 回调；handler 返回 ok=true 后自动触发状态推送；primitive/service 没写 `on_up/on_down` 时视为 no-op success（不打扰已有代码）；skill 必须实现，否则返回 ok=false
- `capability.py`: `Capability._state` + `_set_state(target, detail)` 自动 push `SetCapabilityState` 给 atlas
- `atlas.py`: `set_capability_state` 客户端封装

**system/speech**: 迁移到 `package_manifest.yaml`（drop legacy `robonix_manifest.yaml`/`nodes:`），加 `robonix/system/speech/driver` 契约 + `disable_whisper`/`tts_voice`/etc cfg。Cfg 透传通过 `Driver(CMD_INIT, config_json)` → `@cap.on_init`

**system/scene**:
- 用 numpy voxel-Jaccard fraction-overlap 替换 concept-graphs 的 `compute_spatial_similarities('overlap', ...)` 路径（pytorch3d.box3d_overlap 在 coplanar 顶点 / 退化 pcd 上抛 ValueError，Open3D qhull fallback 段错误）
- 同时替换 `compute_overlap_matrix_general`（同样的 box3d_overlap 崩溃路径）
- spatial_sim pin 到 visual_sim 的 device，否则 cuda+cpu 在 aggregate_similarities 加法处直接 crash
- 修两处 NameError（`_voxel_pcd_overlap_matrix` 和 `_cross_class_geometric_collapse` 之前 lazy import 漏了 numpy）→ 直接在 module 顶部 import
- `_BG_CLASSES = {floor, wall, ceiling, carpet}` 变成真过滤（之前只设 is_background flag 没人读）
- `merge_threshold` 0.55 → 0.85（voxel overlap 信号强多了）
- 加节流过的诊断 log（`[scene-cg] yolo: N boxes...`, `waiting for frames`）

**capabilities/lib (IDL)**
- `service/navigation/Navigate.srv`: 在 response 加 `string goal_id`（之前 simple_nav 把 goal_id 塞 `status_message` 的 JSON 里 → 违反 wire format 契约）。`status_message` 回归自由文本。
- `service/navigation/CancelNavigation.srv`: response 字段 `message` → `status_message`，跟 Navigate / GetNavigationStatus 命名一致

**explore_rbnx** ([enkerewpo/explore_rbnx](https://github.com/enkerewpo/explore_rbnx))
- 加 `capabilities/driver.v1.toml`（之前 skill 没声明 driver 契约，rbnx 的 lifecycle 路径完全跳过它，`@cap.on_init` 永远不跑→`controller not initialized`）
- `on_init`/`on_up`/`on_down` split：on_init 只确认进程活，on_up 才 resolve 上游契约+构建 `ExploreController`+起 ROS 线程，on_down 释放
- nav 调用按 contract 重新打包 `{goal: PoseStamped}`（之前发 legacy 的 `{target_x, target_y}` 直接 422），从 typed `goal_id` 字段读响应
- `REQUIRED_INPUTS` 字典清掉 deprecated 第三个 tuple 元素

**rbnx-cli/cmd**
- `codegen.rs`: 识别 `package_manifest.yaml`（之前只看 legacy 文件）
- `mod.rs`: `rbnx caps -v / --verbose`
- 1.95 clippy 修：`manual_div_ceil`、`doc_lazy_continuation`、删 dead `DRIVER_POLL_INTERVAL` / `redact_secrets_for_log`、`collapsible_if` → let-chain、`manual_is_multiple_of`

**docs**
- 新增 `architecture/cap-lifecycle.md`：5 态状态机 + boot/executor 序列图 + skill 最小骨架 + 排错表
- `integration-guide/packaging-spec.md`：Driver IDL section 改成 INIT/SHUTDOWN/UP/DOWN（之前是过期的 INIT/RESET/SHUTDOWN/PROBE）；deploy manifest 示例对齐 `examples/webots/robonix_manifest.yaml` 现状（vlm 嵌套在 pilot 下，不是独立 system service；条目字段是 `name` 不是 `package`）
- `getting-started/quickstart.md` / `architecture/atlas.md`：清掉对已删除的 `chassis/state` 契约的引用
- `examples/webots/start_rviz.sh`：顶层 rviz 启动脚本（nohup-detach + survive-shell）

## 集成测试

`bash sim/start.sh` + `rbnx boot` → 13 components up：
- atlas / executor / pilot / memory / scene / speech (system)
- tiago_chassis / camera / lidar / audio_driver (primitive) — 全部 `[ONLINE]`，`driver(INIT)=ready  driver(UP)=ready`
- mapping / simple_nav (service) — `[ONLINE]`
- explore (skill) — `[INITIALIZED]` ✓ 停在初始化态如设计

`rbnx ask "Start exploration..."`：
- Executor 日志：`[skill-up] com.robonix.skill.explore (ns=robonix/skill/explore, state=2): sending Driver(CMD_UP)` ✓
- explore 状态：`[INITIALIZED]` → `[ONLINE]` ✓
- explore.controller 日志：`CMD_UP ok — controller running` → `dependencies resolved` → `driving to frontier (...)` ✓
- simple_nav 收到 navigate(goal=PoseStamped) → 返回 typed `goal_id` ✓
- `/cmd_vel` 10 Hz 发布 ✓
- 真实位移：odom 起点 (-4.19, 2.71) → 终点 (-7.13, 7.10)，**5.6 m**；frontier 探索覆盖 **52 m²** ✓
- TTS 已连通：`SystemSpeechTts.Synthesize("你好...")` 返回 25KB MP3, 24 kHz mono（验过 file 类型） ✓

## 已知 follow-up（**不**阻塞这个 PR）

- **YOLO-World on Webots mesh-rendered scene 检出率低**：在初始位置只识别出 "potted plant" (conf 0.69)，conf=0.30 阈值过滤掉低置信度。这是 perception model 在 sim 渲染上的固有局限，跟生命周期 / contract 工作无关。需另外做：(a) 调 SCENE_YOLO_CONF 默认值到 0.10–0.20，(b) 试试 SmolVLM 之类 zero-shot caption-based perception，(c) 加每帧 RGB sample 给 web UI 方便 debug
- **simple_nav 撞 potted plant 后继续往前顶**：2D lidar 平面可能漏掉植物茎部，depth e-stop 阈值 0.30m 在快速接近时来不及刹车。NavNode 的 obstacle inflation 也偏小。独立的 simple_nav 调参工单
- **Eviction 算法**：当前 executor 是 sticky-online，skill 第一次 UP 后永远不 DOWN。LRU/idle-timeout/内存压力 三选一的实现需另外做（issue 待开）
- **system/scene 的 IDL 命名空间**：契约 id 是 `robonix/system/scene/*` 但 IDL 仍在 `lib/service/semantic_map/`。`system/scene/IMPLEMENTATION_NOTES.md` 已经说明是"延后清理"
- **mapping_rbnx 没暴露 RPC handlers**：声明了 `service/map/{status, load_map, save_map, set_initial_pose, switch_mode}` 五个 RPC 契约但 atlas_bridge 没实现 → 调用会 NOT_FOUND。要么补 handler 要么从 capabilities/ 删契约。独立工单。

## Sister PRs (依赖)

- [enkerewpo/explore_rbnx#main](https://github.com/enkerewpo/explore_rbnx/commits/main): driver TOML + on_init/on_up/on_down split + Navigate contract migration
- [syswonder/robonix-book](https://github.com/syswonder/robonix-book/commits/main): cap-lifecycle.md + packaging-spec.md