### PR TITLE
Update RTDL plan structure and add parallel operation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,9 +67,7 @@ types, and crate names matching `robonix-*`. Python targets 3.10+, uses
 files follow `<interface>.v1.toml` naming, grouped by domain, for example
 `capabilities/primitive/camera/rgb.v1.toml`.
 
-For each non-trivial function or method, add a standard comment block. Keep
-comments concise and focused on behavior, invariants, side effects, or
-non-obvious constraints.
+If one function/method body exceeds five lines, treat documentation as mandatory: The comment block must state behavior at minimum; add side effects, or constraints when they are not obvious from the signature.
 
 ## Testing Guidelines
 

--- a/rust/crates/robonix-cli/src/cmd/ask.rs
+++ b/rust/crates/robonix-cli/src/cmd/ask.rs
@@ -22,7 +22,7 @@ use tonic::Request;
 use uuid::Uuid;
 
 use crate::pb::contracts::robonix_system_pilot_client::RobonixSystemPilotClient;
-use crate::pb::pilot::Task;
+use crate::pb::pilot::{CapabilityCall, Plan, Task};
 
 // PilotEvent.event_kind discriminants — must mirror service.rs / .msg.
 const EVT_TEXT_CHUNK: u32 = 0;
@@ -80,7 +80,8 @@ pub async fn execute(server: &str, prompt: &str, json: bool) -> Result<()> {
                 "final_text": event.final_text,
                 "plan": event.plan.as_ref().map(|p| serde_json::json!({
                     "round": p.round,
-                    "calls": p.calls.iter().map(|c| serde_json::json!({
+                    "root_index": p.root_index,
+                    "calls": plan_calls(p).into_iter().map(|c| serde_json::json!({
                         "call_id": c.call_id,
                         "provider_id": c.provider_id,
                         "contract_id": c.contract_id,
@@ -130,9 +131,8 @@ pub async fn execute(server: &str, prompt: &str, json: bool) -> Result<()> {
                         writeln!(out)?;
                         last_was_chunk = false;
                     }
-                    let leaves: Vec<String> = plan
-                        .calls
-                        .iter()
+                    let leaves: Vec<String> = plan_calls(&plan)
+                        .into_iter()
                         .map(|c| {
                             c.contract_id
                                 .rsplit_once('/')
@@ -208,6 +208,13 @@ fn compact_one_line(s: &str, n: usize) -> String {
     } else {
         flat
     }
+}
+
+fn plan_calls(plan: &Plan) -> Vec<&CapabilityCall> {
+    plan.nodes
+        .iter()
+        .filter_map(|node| node.call.as_ref())
+        .collect()
 }
 
 fn now_ms() -> u64 {

--- a/rust/crates/robonix-cli/src/cmd/chat.rs
+++ b/rust/crates/robonix-cli/src/cmd/chat.rs
@@ -1796,7 +1796,7 @@ fn apply_pilot_event(
             // so we leaf-strip contract_id back into a tool-name lookalike to
             // preserve the same `[r{round}] {name}({args})` line shape.
             if let Some(ref p) = event.plan {
-                for call in &p.calls {
+                for call in plan_calls(p) {
                     let leaf = call
                         .contract_id
                         .rsplit_once('/')
@@ -1812,6 +1812,13 @@ fn apply_pilot_event(
         _ => {}
     }
     Ok(())
+}
+
+fn plan_calls(plan: &crate::pb::pilot::Plan) -> Vec<&crate::pb::pilot::CapabilityCall> {
+    plan.nodes
+        .iter()
+        .filter_map(|node| node.call.as_ref())
+        .collect()
 }
 
 fn apply_voice_event(

--- a/rust/crates/robonix-executor/README.md
+++ b/rust/crates/robonix-executor/README.md
@@ -1,0 +1,45 @@
+# robonix-executor
+
+`robonix-executor` is the RTDL plan execution service for Robonix. It receives
+Pilot `Plan` messages, validates the RTDL node arena, and dispatches each `do`
+node to a primitive, service, or skill provider through Atlas.
+
+## Build
+
+From `rust/`:
+
+```sh
+cargo build -p robonix-executor
+```
+
+The crate is also built by the workspace `make build` and installed by
+`make install`.
+
+## Run
+
+Manual launch:
+
+```sh
+robonix-executor --atlas 127.0.0.1:50051 --listen 127.0.0.1:50072
+```
+
+Important configuration:
+
+- `--atlas` / `ROBONIX_ATLAS_ENDPOINT`: Atlas endpoint. Defaults to `127.0.0.1:50051`.
+- `--listen` / `ROBONIX_EXECUTOR_LISTEN`: Executor gRPC listen address. Defaults to `127.0.0.1:50072`.
+- `--id` / `ROBONIX_EXECUTOR_PROVIDER_ID`: provider id registered with Atlas. Defaults to `executor`.
+- `--log`: env_logger filter. Falls back to `RUST_LOG`, then `robonix_executor=info`.
+
+## RTDL Execution
+
+Executor interprets `Plan.nodes` from `Plan.root_index`:
+
+- `sequence`: executes child nodes in order. A failed child marks the batch as failed, but later children still run.
+- `parallel`: starts one async task per child and waits for all children. A failed branch does not cancel sibling branches.
+- `do`: dispatches one `CapabilityCall`.
+
+The Execute stream emits `CapabilityCallEvent.started` and
+`CapabilityCallEvent.result` for each `do` node. In `parallel` branches, result
+events are emitted in completion order, not RTDL order. The final
+`BatchComplete` event contains `any_failed=true` when at least one capability
+call failed.

--- a/rust/crates/robonix-executor/src/service.rs
+++ b/rust/crates/robonix-executor/src/service.rs
@@ -7,10 +7,18 @@ use crate::dispatch;
 use crate::exec_wire;
 use crate::pb::contracts::robonix_system_executor_server::RobonixSystemExecutor;
 use crate::pb::executor::CapabilityCallEvent;
-use crate::pb::pilot::Plan;
+use crate::pb::pilot::{CapabilityCall, Plan};
 use robonix_atlas::client::AtlasClient;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use tokio::sync::mpsc::Sender;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status};
+
+const RTDL_SEQUENCE: u32 = 0;
+const RTDL_PARALLEL: u32 = 1;
+const RTDL_DO: u32 = 2;
 
 /// `AtlasClient` is cheap to clone — each Execute RPC clones it so per-plan
 /// dispatch runs without serialising on a single mutex.
@@ -41,52 +49,313 @@ impl RobonixSystemExecutor for ExecutorServiceImpl {
         request: Request<Plan>,
     ) -> Result<Response<Self::ExecuteStream>, Status> {
         let plan = request.into_inner();
+        validate_plan(&plan).map_err(Status::invalid_argument)?;
         let (tx, rx) = tokio::sync::mpsc::channel(64);
         let atlas = self.atlas.clone();
         let provider_id = self.provider_id.clone();
 
         tokio::spawn(async move {
             let plan_id = plan.plan_id.clone();
-            let mut any_failed = false;
-
-            for call in &plan.calls {
-                let _ = tx
-                    .send(Ok(exec_wire::started(
-                        call.call_id.clone(),
-                        call.provider_id.clone(),
-                        call.contract_id.clone(),
-                    )))
-                    .await;
-
-                log::info!(
-                    "[executor] dispatching call_id={} provider='{}' contract='{}'",
-                    call.call_id,
-                    call.provider_id,
-                    call.contract_id,
-                );
-                let mut atlas_for_call = atlas.clone();
-                let result = dispatch::dispatch(call, &provider_id, &mut atlas_for_call).await;
-
-                if result.success {
-                    let preview: String = result.output.chars().take(120).collect();
-                    let ellipsis = if result.output.len() > 120 { "…" } else { "" };
-                    log::info!(
-                        "[executor] '{}' ok: {}{}",
-                        call.contract_id,
-                        preview,
-                        ellipsis
-                    );
-                } else {
-                    any_failed = true;
-                    log::warn!("[executor] '{}' failed: {}", call.contract_id, result.error);
-                }
-
-                let _ = tx.send(Ok(exec_wire::result(result))).await;
-            }
+            let plan = Arc::new(plan);
+            let any_failed = execute_node(
+                Arc::clone(&plan),
+                plan.root_index as usize,
+                tx.clone(),
+                atlas,
+                provider_id,
+            )
+            .await;
 
             let _ = tx.send(Ok(exec_wire::complete(plan_id, any_failed))).await;
         });
 
         Ok(Response::new(ReceiverStream::new(rx)))
+    }
+}
+
+type ExecuteNodeFuture = Pin<Box<dyn Future<Output = bool> + Send + 'static>>;
+
+fn execute_node(
+    plan: Arc<Plan>,
+    node_index: usize,
+    tx: Sender<Result<CapabilityCallEvent, Status>>,
+    atlas: AtlasClient,
+    provider_id: String,
+) -> ExecuteNodeFuture {
+    Box::pin(async move {
+        let node = &plan.nodes[node_index];
+        match node.node_kind {
+            RTDL_SEQUENCE => {
+                let mut any_failed = false;
+                for child in &node.children {
+                    any_failed |= execute_node(
+                        Arc::clone(&plan),
+                        *child as usize,
+                        tx.clone(),
+                        atlas.clone(),
+                        provider_id.clone(),
+                    )
+                    .await;
+                }
+                any_failed
+            }
+            RTDL_PARALLEL => {
+                let mut handles = Vec::with_capacity(node.children.len());
+                for child in &node.children {
+                    let child_plan = Arc::clone(&plan);
+                    let child_tx = tx.clone();
+                    let child_atlas = atlas.clone();
+                    let child_provider_id = provider_id.clone();
+                    let child_index = *child as usize;
+                    handles.push(tokio::spawn(async move {
+                        execute_node(
+                            child_plan,
+                            child_index,
+                            child_tx,
+                            child_atlas,
+                            child_provider_id,
+                        )
+                        .await
+                    }));
+                }
+                let mut any_failed = false;
+                for handle in handles {
+                    match handle.await {
+                        Ok(child_failed) => any_failed |= child_failed,
+                        Err(e) => {
+                            any_failed = true;
+                            log::warn!("[executor] parallel branch task failed: {e}");
+                        }
+                    }
+                }
+                any_failed
+            }
+            RTDL_DO => {
+                let call = node
+                    .call
+                    .as_ref()
+                    .expect("validated do node must contain call");
+                execute_call(call, tx, atlas, provider_id).await
+            }
+            _ => {
+                log::warn!(
+                    "[executor] invalid node_kind={} reached after validation",
+                    node.node_kind
+                );
+                true
+            }
+        }
+    })
+}
+
+/// Dispatch one RTDL `do` node and stream its started/result events.
+async fn execute_call(
+    call: &CapabilityCall,
+    tx: Sender<Result<CapabilityCallEvent, Status>>,
+    atlas: AtlasClient,
+    provider_id: String,
+) -> bool {
+    // `tokio::sync::mpsc::Sender` is concurrency-safe when cloned (parallel branches).
+    // Outbound events ride the Execute server-stream to the gRPC client (Pilot).
+    let _ = tx
+        .send(Ok(exec_wire::started(
+            call.call_id.clone(),
+            call.provider_id.clone(),
+            call.contract_id.clone(),
+        )))
+        .await;
+
+    log::info!(
+        "[executor] dispatching call_id={} provider='{}' contract='{}'",
+        call.call_id,
+        call.provider_id,
+        call.contract_id,
+    );
+    let mut atlas_for_call = atlas.clone();
+    let result = dispatch::dispatch(call, &provider_id, &mut atlas_for_call).await;
+    let failed = !result.success;
+
+    if result.success {
+        let preview: String = result.output.chars().take(120).collect();
+        let ellipsis = if result.output.len() > 120 { "..." } else { "" };
+        log::info!(
+            "[executor] '{}' ok: {}{}",
+            call.contract_id,
+            preview,
+            ellipsis
+        );
+    } else {
+        log::warn!("[executor] '{}' failed: {}", call.contract_id, result.error);
+    }
+
+    let _ = tx.send(Ok(exec_wire::result(result))).await;
+    failed
+}
+
+/// Validate Plan arena shape before spawning execution work.
+fn validate_plan(plan: &Plan) -> Result<(), String> {
+    if plan.nodes.is_empty() {
+        return Err("Plan.nodes must not be empty".to_string());
+    }
+    let root = plan.root_index as usize;
+    if root >= plan.nodes.len() {
+        return Err(format!(
+            "Plan.root_index {} is out of bounds for {} nodes",
+            plan.root_index,
+            plan.nodes.len()
+        ));
+    }
+
+    for (idx, node) in plan.nodes.iter().enumerate() {
+        match node.node_kind {
+            RTDL_SEQUENCE | RTDL_PARALLEL => {
+                for child in &node.children {
+                    if *child as usize >= plan.nodes.len() {
+                        return Err(format!("node {idx} child index {child} is out of bounds"));
+                    }
+                }
+            }
+            RTDL_DO => {
+                if !node.children.is_empty() {
+                    return Err(format!("do node {idx} must not have children"));
+                }
+                let Some(call) = node.call.as_ref() else {
+                    return Err(format!("do node {idx} must contain a call"));
+                };
+                validate_call(idx, call)?;
+            }
+            other => return Err(format!("node {idx} has invalid node_kind {other}")),
+        }
+    }
+
+    let mut colors = vec![VisitColor::White; plan.nodes.len()];
+    visit_for_cycles(root, plan, &mut colors)
+}
+
+fn validate_call(node_index: usize, call: &CapabilityCall) -> Result<(), String> {
+    if call.call_id.is_empty() {
+        return Err(format!("do node {node_index} call_id must not be empty"));
+    }
+    if call.provider_id.is_empty() {
+        return Err(format!(
+            "do node {node_index} provider_id must not be empty"
+        ));
+    }
+    if call.contract_id.is_empty() {
+        return Err(format!(
+            "do node {node_index} contract_id must not be empty"
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum VisitColor {
+    White,
+    Gray,
+    Black,
+}
+
+/// DFS cycle check on the plan arena following only sequence/parallel child edges.
+///
+/// Uses White/Gray/Black marks: entering a Gray node means a back-edge to an ancestor.
+/// `RTDL_DO` nodes have no children in this graph. Returns `Ok` when the subgraph from
+/// `index` is acyclic; otherwise an error naming the node where the cycle was found.
+fn visit_for_cycles(index: usize, plan: &Plan, colors: &mut [VisitColor]) -> Result<(), String> {
+    match colors[index] {
+        VisitColor::Gray => return Err(format!("cycle detected at node {index}")),
+        VisitColor::Black => return Ok(()),
+        VisitColor::White => {}
+    }
+    colors[index] = VisitColor::Gray;
+    let node = &plan.nodes[index];
+    if matches!(node.node_kind, RTDL_SEQUENCE | RTDL_PARALLEL) {
+        for child in &node.children {
+            visit_for_cycles(*child as usize, plan, colors)?;
+        }
+    }
+    colors[index] = VisitColor::Black;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RTDL_DO, RTDL_PARALLEL, RTDL_SEQUENCE, validate_plan};
+    use crate::pb::pilot::{CapabilityCall, Plan, RtdlNode};
+
+    fn call(id: &str) -> CapabilityCall {
+        CapabilityCall {
+            call_id: id.to_string(),
+            provider_id: "provider".to_string(),
+            contract_id: "robonix/test/cap".to_string(),
+            args_json: "{}".to_string(),
+        }
+    }
+
+    fn node(kind: u32, children: Vec<u32>, call: Option<CapabilityCall>) -> RtdlNode {
+        RtdlNode {
+            node_kind: kind,
+            children,
+            call,
+        }
+    }
+
+    fn plan(nodes: Vec<RtdlNode>, root_index: u32) -> Plan {
+        Plan {
+            plan_id: "p".to_string(),
+            session_id: "s".to_string(),
+            round: 0,
+            nodes,
+            root_index,
+        }
+    }
+
+    #[test]
+    fn validates_sequence_and_parallel_nodes() {
+        let p = plan(
+            vec![
+                node(RTDL_SEQUENCE, vec![1, 2], None),
+                node(RTDL_DO, vec![], Some(call("p:0"))),
+                node(RTDL_PARALLEL, vec![3, 4], None),
+                node(RTDL_DO, vec![], Some(call("p:1"))),
+                node(RTDL_DO, vec![], Some(call("p:2"))),
+            ],
+            0,
+        );
+        validate_plan(&p).unwrap();
+    }
+
+    #[test]
+    fn rejects_invalid_root() {
+        let p = plan(vec![node(RTDL_SEQUENCE, vec![], None)], 3);
+        assert!(validate_plan(&p).unwrap_err().contains("root_index"));
+    }
+
+    #[test]
+    fn rejects_out_of_bounds_child() {
+        let p = plan(vec![node(RTDL_SEQUENCE, vec![9], None)], 0);
+        assert!(validate_plan(&p).unwrap_err().contains("out of bounds"));
+    }
+
+    #[test]
+    fn rejects_cycle() {
+        let p = plan(
+            vec![
+                node(RTDL_SEQUENCE, vec![1], None),
+                node(RTDL_PARALLEL, vec![0], None),
+            ],
+            0,
+        );
+        assert!(validate_plan(&p).unwrap_err().contains("cycle"));
+    }
+
+    #[test]
+    fn rejects_do_without_call() {
+        let p = plan(vec![node(RTDL_DO, vec![], None)], 0);
+        assert!(
+            validate_plan(&p)
+                .unwrap_err()
+                .contains("must contain a call")
+        );
     }
 }

--- a/rust/crates/robonix-interfaces/lib/pilot/msg/Plan.msg
+++ b/rust/crates/robonix-interfaces/lib/pilot/msg/Plan.msg
@@ -1,8 +1,8 @@
 # Plan: structural payload pilot hands to executor for execution.
-# Semantically a behavior tree; v1 is a degenerate linear list of calls.
-# TODO: evolve to explicit BT nodes + RTDL bindings; keep CapabilityCall[]
-# as the linear encoding until then.
+# Encodes an RTDL execution tree as arena nodes. Empty plans are represented
+# as one sequence root node with no children.
 string plan_id
 string session_id
 uint32 round
-CapabilityCall[] calls
+RtdlNode[] nodes
+uint32 root_index

--- a/rust/crates/robonix-interfaces/lib/pilot/msg/RtdlNode.msg
+++ b/rust/crates/robonix-interfaces/lib/pilot/msg/RtdlNode.msg
@@ -1,0 +1,9 @@
+# RTDL execution tree node encoded as an arena entry in Plan.nodes.
+# node_kind: 0=sequence, 1=parallel, 2=do.
+uint32 node_kind
+
+# Child node indices for sequence and parallel nodes. Empty for do nodes.
+uint32[] children
+
+# Capability call payload for do nodes. Sequence and parallel leave this empty.
+CapabilityCall call

--- a/rust/crates/robonix-liaison/src/main.rs
+++ b/rust/crates/robonix-liaison/src/main.rs
@@ -36,7 +36,7 @@ use pb::contracts::{
     robonix_system_pilot_client::RobonixSystemPilotClient,
 };
 use pb::liaison::{StartVoiceSessionRequest, VoiceEvent};
-use pb::pilot::{PilotEvent, Task};
+use pb::pilot::{CapabilityCall, PilotEvent, Plan, Task};
 use robonix_atlas::client::{self as atlas_client, AtlasClient};
 use robonix_atlas::pb as atlas_pb;
 use std::pin::Pin;
@@ -329,9 +329,9 @@ async fn run_text_loop(pipeline: Arc<LiaisonPipeline>) -> Result<()> {
                                 println!(
                                     "[round {}] dispatching {} call(s)…",
                                     p.round,
-                                    p.calls.len()
+                                    plan_calls(p).len()
                                 );
-                                for c in &p.calls {
+                                for c in plan_calls(p) {
                                     println!("  · {}", c.contract_id);
                                 }
                             }
@@ -557,6 +557,13 @@ fn now_ms() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis() as u64
+}
+
+fn plan_calls(plan: &Plan) -> Vec<&CapabilityCall> {
+    plan.nodes
+        .iter()
+        .filter_map(|node| node.call.as_ref())
+        .collect()
 }
 
 #[cfg(test)]

--- a/rust/crates/robonix-pilot/README.md
+++ b/rust/crates/robonix-pilot/README.md
@@ -37,6 +37,10 @@ Common configuration:
 - `ROBONIX_PILOT_SOUL`: optional path to a SOUL markdown file. If unset, Pilot tries `~/.robonix/SOUL.md`.
 - `ROBONIX_PILOT_MAX_TOOL_ROUNDS`: maximum RTDL execution rounds per turn. Defaults to `64`.
 
+## Prompt assets
+
+The VLM-facing RTDL envelope rules (grammar, example, constraints) live in `rtdl_protocol.md` at the crate root and are embedded at compile time via `include_str!` into the per-turn capability list prompt. Edit that file to change RTDL instructions without touching `planner.rs`.
+
 ## RTDL Planning Flow
 
 Pilot no longer sends OpenAI `tools` / function schemas as the primary planning path. Instead, it writes the RTDL grammar and available capability list into the prompt. The model must return a single JSON object:
@@ -60,9 +64,25 @@ Pilot no longer sends OpenAI `tools` / function schemas as the primary planning 
 MVP RTDL supports only:
 
 - `sequence`: ordered children.
+- `parallel`: concurrent children. Executor waits for every child and does not cancel sibling branches when one fails.
 - `do`: one capability call, where `cap` is the unique `capability_name` shown in the prompt and `args` is a JSON object.
 
-Pilot buffers the full assistant JSON before showing user-visible text, validates the RTDL, expands it into the existing `Plan { calls }` shape, sends that `Plan` to Liaison, and dispatches it to Executor. Executor still receives `Execute(Plan)` and does not parse RTDL.
+Pilot buffers the full assistant JSON before showing user-visible text, validates the RTDL, expands it into an arena-style `Plan { nodes, root_index }`, sends that `Plan` to Liaison, and dispatches it to Executor. Executor interprets `sequence`, `parallel`, and `do` nodes directly.
+
+Parallel example:
+
+```json
+{
+  "content": "I will inspect both signals.",
+  "rtdl": {
+    "op": "parallel",
+    "children": [
+      { "op": "do", "cap": "camera_snapshot", "args": {} },
+      { "op": "do", "cap": "battery_status", "args": {} }
+    ]
+  }
+}
+```
 
 An empty sequence means the model is done for the turn:
 

--- a/rust/crates/robonix-pilot/rtdl_protocol.md
+++ b/rust/crates/robonix-pilot/rtdl_protocol.md
@@ -1,0 +1,67 @@
+## RTDL output protocol
+
+Return a valid JSON object with exactly these top-level keys:
+- `content`: a string visible to the user.
+- `rtdl`: a Robot Task Description Language JSON AST.
+
+The whole assistant message MUST begin with `{` and end with `}`.
+Do not output markdown fences, headings, explanations, or any text outside the JSON object.
+
+RTDL nodes are JSON objects with an `op` string. MVP supports only:
+- `sequence`: fields `op` and `children`; `children` is an array of RTDL nodes executed in order.
+- `parallel`: fields `op` and `children`; `children` is an array of RTDL nodes executed concurrently. Executor waits for all children.
+- `do`: fields `op`, `cap`, and `args`.
+  - `cap` MUST be copied exactly from the `capability_name` field of one Available capabilities entry.
+  - `args` MUST be a JSON object whose keys and value shapes come from that capability's `args_schema`.
+
+Rules:
+1. Use ONLY capabilities listed in the Available capabilities section.
+2. In RTDL `do.cap`, use ONLY the listed `capability_name` value. Do NOT use path fragments with `/`, hidden provider ids, contract ids, or natural-language aliases.
+3. Build RTDL `do.args` from the listed `args_schema`. Do NOT invent argument keys.
+4. Do NOT invent new capabilities, robots, objects, locations, or relations.
+5. The value of `rtdl` MUST be a JSON object, not a string.
+6. Do not output `out`, variables, expressions, or any operator other than `sequence`, `parallel`, and `do`.
+7. If no capability call is needed, output an empty sequence: {"op":"sequence","children":[]}.
+
+Example JSON format (minimal `sequence` with one child; replace illustrated `cap` values with exact `capability_name` strings from Available capabilities):
+
+{
+  "content": "I will inspect the current scene.",
+  "rtdl": {
+    "op": "sequence",
+    "children": [
+      {
+        "op": "do",
+        "cap": "camera_snapshot",
+        "args": {}
+      }
+    ]
+  }
+}
+
+Example — `sequence` with multiple ordered `children` (runs first `do`, then second, then third):
+
+{
+  "content": "I'll take a snapshot, check power, then take another snapshot.",
+  "rtdl": {
+    "op": "sequence",
+    "children": [
+      { "op": "do", "cap": "camera_snapshot", "args": {} },
+      { "op": "do", "cap": "battery_status", "args": {} },
+      { "op": "do", "cap": "camera_snapshot", "args": {} }
+    ]
+  }
+}
+
+Example — root `parallel` (Executor runs every child concurrently and waits for all to finish):
+
+{
+  "content": "I'll grab a camera frame and query battery status in parallel.",
+  "rtdl": {
+    "op": "parallel",
+    "children": [
+      { "op": "do", "cap": "camera_snapshot", "args": {} },
+      { "op": "do", "cap": "battery_status", "args": {} }
+    ]
+  }
+}

--- a/rust/crates/robonix-pilot/src/memory.rs
+++ b/rust/crates/robonix-pilot/src/memory.rs
@@ -8,7 +8,7 @@
 
 use crate::discovery;
 use crate::history::decode_string_output;
-use crate::pb::pilot::{CapabilityCall, Plan};
+use crate::pb::pilot::{CapabilityCall, Plan, RtdlNode};
 use crate::planner::ExecutorConn;
 use robonix_atlas::client::AtlasClient;
 use tonic::Request;
@@ -16,6 +16,29 @@ use uuid::Uuid;
 
 /// Executor `CapabilityCallEvent.event_kind` for "tool result".
 const EX_RESULT: u32 = 1;
+const RTDL_SEQUENCE: u32 = 0;
+const RTDL_DO: u32 = 2;
+
+fn single_call_plan(plan_id: String, session_id: String, round: u32, call: CapabilityCall) -> Plan {
+    Plan {
+        plan_id,
+        session_id,
+        round,
+        nodes: vec![
+            RtdlNode {
+                node_kind: RTDL_SEQUENCE,
+                children: vec![1],
+                call: None,
+            },
+            RtdlNode {
+                node_kind: RTDL_DO,
+                children: Vec::new(),
+                call: Some(call),
+            },
+        ],
+        root_index: 0,
+    }
+}
 
 /// Dispatch one `search_memory` call and return the result text. Returns
 /// `None` if the provider is not registered, the index is empty, or any error
@@ -26,17 +49,17 @@ pub async fn prefetch(
     target: Option<(String, String)>,
 ) -> Option<String> {
     let (provider_id, contract_id) = target?;
-    let plan = Plan {
-        plan_id: Uuid::new_v4().to_string(),
-        session_id: "memory-prefetch".to_string(),
-        round: 0,
-        calls: vec![CapabilityCall {
+    let plan = single_call_plan(
+        Uuid::new_v4().to_string(),
+        "memory-prefetch".to_string(),
+        0,
+        CapabilityCall {
             call_id: Uuid::new_v4().to_string(),
             provider_id,
             contract_id,
             args_json: serde_json::json!({ "data": query }).to_string(),
-        }],
-    };
+        },
+    );
 
     let mut stream = executor
         .graph
@@ -76,17 +99,17 @@ pub async fn try_compact(executor: &mut ExecutorConn, atlas: &mut AtlasClient, _
         return;
     };
 
-    let plan = Plan {
-        plan_id: Uuid::new_v4().to_string(),
-        session_id: "memory-compact".to_string(),
-        round: 0,
-        calls: vec![CapabilityCall {
+    let plan = single_call_plan(
+        Uuid::new_v4().to_string(),
+        "memory-compact".to_string(),
+        0,
+        CapabilityCall {
             call_id: Uuid::new_v4().to_string(),
             provider_id: provider_id.clone(),
             contract_id: cap.contract_id.clone(),
             args_json: "{}".to_string(),
-        }],
-    };
+        },
+    );
 
     let Ok(mut stream) = executor
         .graph

--- a/rust/crates/robonix-pilot/src/planner.rs
+++ b/rust/crates/robonix-pilot/src/planner.rs
@@ -6,7 +6,8 @@ use crate::history;
 use crate::memory;
 use crate::pb::contracts::robonix_system_executor_client::RobonixSystemExecutorClient;
 use crate::pb::pilot::{
-    BatchResult, CapabilityCall, CapabilityCallResult, PilotEvent, Plan, SessionStatusEvent, Task,
+    BatchResult, CapabilityCall, CapabilityCallResult, PilotEvent, Plan, RtdlNode,
+    SessionStatusEvent, Task,
 };
 use crate::service::{self, PilotStreamBody, SessionState};
 use crate::vlm::{Message, VlmClient, VlmStreamItem};
@@ -29,6 +30,10 @@ pub struct ExecutorConn {
 
 type CapabilityTarget = (String, String);
 type CapabilityTargetMap = HashMap<String, CapabilityTarget>;
+
+const RTDL_SEQUENCE: u32 = 0;
+const RTDL_PARALLEL: u32 = 1;
+const RTDL_DO: u32 = 2;
 
 struct DisplayCapability<'a> {
     display_name: String,
@@ -313,10 +318,10 @@ pub async fn run_turn(
             "[pilot/rtdl] expanded plan_id={} round={} calls={}",
             graph.plan_id,
             graph.round,
-            graph.calls.len()
+            plan_call_count(&graph)
         );
 
-        if graph.calls.is_empty() {
+        if plan_call_count(&graph) == 0 {
             log::info!(
                 "[pilot/rtdl] empty sequence plan_id={} round={} final_text=true",
                 graph.plan_id,
@@ -348,7 +353,7 @@ pub async fn run_turn(
         log::debug!(
             "[pilot/rtdl] sending plan_id={} calls={} to liaison/executor",
             graph.plan_id,
-            graph.calls.len()
+            plan_call_count(&graph)
         );
         let _ = tx
             .send(Ok(service::pack(
@@ -484,51 +489,9 @@ fn build_capability_target_map(display_caps: &[DisplayCapability<'_>]) -> Capabi
 }
 
 fn build_rtdl_prompt(display_caps: &[DisplayCapability<'_>]) -> Result<String> {
-    let mut p = String::from(
-        "\
-## RTDL output protocol
-
-Return a valid JSON object with exactly these top-level keys:
-- `content`: a string visible to the user.
-- `rtdl`: a Robot Task Description Language JSON AST.
-
-The whole assistant message MUST begin with `{` and end with `}`.
-Do not output markdown fences, headings, explanations, or any text outside the JSON object.
-
-RTDL nodes are JSON objects with an `op` string. MVP supports only:
-- `sequence`: fields `op` and `children`; `children` is an array of RTDL nodes executed in order.
-- `do`: fields `op`, `cap`, and `args`.
-  - `cap` MUST be copied exactly from the `capability_name` field of one Available capabilities entry.
-  - `args` MUST be a JSON object whose keys and value shapes come from that capability's `args_schema`.
-
-Rules:
-1. Use ONLY capabilities listed in the Available capabilities section.
-2. In RTDL `do.cap`, use ONLY the listed `capability_name` value. Do NOT use path fragments with `/`, hidden provider ids, contract ids, or natural-language aliases.
-3. Build RTDL `do.args` from the listed `args_schema`. Do NOT invent argument keys.
-4. Do NOT invent new capabilities, robots, objects, locations, or relations.
-5. The value of `rtdl` MUST be a JSON object, not a string.
-6. Do not output `out`, variables, expressions, or any operator other than `sequence` and `do`.
-7. If no capability call is needed, output an empty sequence: {\"op\":\"sequence\",\"children\":[]}.
-
-Example JSON format:
-{
-  \"content\": \"I will inspect the current scene.\",
-  \"rtdl\": {
-    \"op\": \"sequence\",
-    \"children\": [
-      {
-        \"op\": \"do\",
-        \"cap\": \"camera_snapshot\",
-        \"args\": {}
-      }
-    ]
-  }
-}
-
-## Available capabilities
-
-",
-    );
+    // Compile-time embedded; edit `rtdl_protocol.md` in this crate root.
+    let mut p = String::from(include_str!("../rtdl_protocol.md"));
+    p.push_str("\n## Available capabilities\n\n");
 
     for cap in display_caps {
         let c = cap.cap;
@@ -547,6 +510,7 @@ Example JSON format:
         ));
     }
 
+    // log::debug!("[pilot/rtdl] rtdl prompt:\n{}", p);
     Ok(p)
 }
 
@@ -601,14 +565,15 @@ fn expand_rtdl_to_plan(
     session_id: String,
     round: u32,
 ) -> Result<Plan> {
-    let mut calls = Vec::new();
+    let mut nodes = Vec::new();
     let mut next_call = 0usize;
-    expand_rtdl_node(rtdl, "$", target_map, &plan_id, &mut next_call, &mut calls)?;
+    let root_index = expand_rtdl_node(rtdl, "$", target_map, &plan_id, &mut next_call, &mut nodes)?;
     Ok(Plan {
         plan_id,
         session_id,
         round,
-        calls,
+        nodes,
+        root_index,
     })
 }
 
@@ -618,8 +583,8 @@ fn expand_rtdl_node(
     target_map: &CapabilityTargetMap,
     plan_id: &str,
     next_call: &mut usize,
-    calls: &mut Vec<CapabilityCall>,
-) -> Result<()> {
+    nodes: &mut Vec<RtdlNode>,
+) -> Result<u32> {
     let obj = node
         .as_object()
         .ok_or_else(|| anyhow::anyhow!("{path}: RTDL node must be an object"))?;
@@ -629,24 +594,39 @@ fn expand_rtdl_node(
         .ok_or_else(|| anyhow::anyhow!("{path}.op must be a string"))?;
 
     match op {
-        "sequence" => {
+        "sequence" | "parallel" => {
             if obj.len() != 2 || !obj.contains_key("children") {
-                anyhow::bail!("{path}: sequence node must contain only `op` and `children`");
+                anyhow::bail!("{path}: {op} node must contain only `op` and `children`");
             }
             let children = obj
                 .get("children")
                 .and_then(|x| x.as_array())
                 .ok_or_else(|| anyhow::anyhow!("{path}.children must be an array"))?;
+            let node_index = nodes.len() as u32;
+            let node_kind = if op == "sequence" {
+                RTDL_SEQUENCE
+            } else {
+                RTDL_PARALLEL
+            };
+            nodes.push(RtdlNode {
+                node_kind,
+                children: Vec::new(),
+                call: None,
+            });
+            let mut child_indices = Vec::with_capacity(children.len());
             for (idx, child) in children.iter().enumerate() {
-                expand_rtdl_node(
+                let child_index = expand_rtdl_node(
                     child,
                     &format!("{path}.children[{idx}]"),
                     target_map,
                     plan_id,
                     next_call,
-                    calls,
+                    nodes,
                 )?;
+                child_indices.push(child_index);
             }
+            nodes[node_index as usize].children = child_indices;
+            Ok(node_index)
         }
         "do" => {
             if obj.len() != 3 || !obj.contains_key("cap") || !obj.contains_key("args") {
@@ -666,17 +646,28 @@ fn expand_rtdl_node(
                 .ok_or_else(|| anyhow::anyhow!("{path}.cap unknown capability `{cap}`"))?;
             let call_index = *next_call;
             *next_call += 1;
-            calls.push(CapabilityCall {
-                call_id: format!("{plan_id}:{call_index}"),
-                provider_id,
-                contract_id,
-                args_json: serde_json::to_string(args)?,
+            let node_index = nodes.len() as u32;
+            nodes.push(RtdlNode {
+                node_kind: RTDL_DO,
+                children: Vec::new(),
+                call: Some(CapabilityCall {
+                    call_id: format!("{plan_id}:{call_index}"),
+                    provider_id,
+                    contract_id,
+                    args_json: serde_json::to_string(args)?,
+                }),
             });
+            Ok(node_index)
         }
         other => anyhow::bail!("{path}.op unknown operator `{other}`"),
     }
+}
 
-    Ok(())
+fn plan_call_count(plan: &Plan) -> usize {
+    plan.nodes
+        .iter()
+        .filter(|node| node.node_kind == RTDL_DO && node.call.is_some())
+        .count()
 }
 
 fn rtdl_result_to_messages(r: &CapabilityCallResult) -> history::ToolResultHistory {
@@ -793,8 +784,8 @@ complete. Concretely:
 #[cfg(test)]
 mod tests {
     use super::{
-        CapabilityTargetMap, expand_rtdl_to_plan, parse_rtdl_assistant_response,
-        skip_memory_prefetch, task_is_session_end,
+        CapabilityTargetMap, RTDL_DO, RTDL_PARALLEL, RTDL_SEQUENCE, expand_rtdl_to_plan,
+        parse_rtdl_assistant_response, skip_memory_prefetch, task_is_session_end,
     };
     use crate::pb::pilot::Task;
     use serde_json::json;
@@ -881,16 +872,98 @@ mod tests {
         assert_eq!(plan.plan_id, "p");
         assert_eq!(plan.session_id, "s");
         assert_eq!(plan.round, 7);
-        assert_eq!(plan.calls.len(), 2);
-        assert_eq!(plan.calls[0].call_id, "p:0");
-        assert_eq!(plan.calls[0].provider_id, "cap-camera");
-        assert_eq!(
-            plan.calls[0].contract_id,
-            "robonix/primitive/camera/snapshot"
+        assert_eq!(plan.nodes.len(), 3);
+        assert_eq!(plan.root_index, 0);
+        assert_eq!(plan.nodes[0].node_kind, RTDL_SEQUENCE);
+        assert_eq!(plan.nodes[0].children, vec![1, 2]);
+        let first = plan.nodes[1].call.as_ref().unwrap();
+        let second = plan.nodes[2].call.as_ref().unwrap();
+        assert_eq!(plan.nodes[1].node_kind, RTDL_DO);
+        assert_eq!(first.call_id, "p:0");
+        assert_eq!(first.provider_id, "cap-camera");
+        assert_eq!(first.contract_id, "robonix/primitive/camera/snapshot");
+        assert_eq!(first.args_json, "{}");
+        assert_eq!(second.call_id, "p:1");
+        assert_eq!(second.args_json, r#"{"linear":0.1}"#);
+    }
+
+    #[test]
+    fn rtdl_expands_parallel_root() {
+        let mut targets = CapabilityTargetMap::new();
+        targets.insert(
+            "camera_snapshot".to_string(),
+            (
+                "cap-camera".to_string(),
+                "robonix/primitive/camera/snapshot".to_string(),
+            ),
         );
-        assert_eq!(plan.calls[0].args_json, "{}");
-        assert_eq!(plan.calls[1].call_id, "p:1");
-        assert_eq!(plan.calls[1].args_json, r#"{"linear":0.1}"#);
+        targets.insert(
+            "read_temp".to_string(),
+            (
+                "cap-temp".to_string(),
+                "robonix/primitive/sensor/temp".to_string(),
+            ),
+        );
+
+        let rtdl = json!({
+            "op": "parallel",
+            "children": [
+                { "op": "do", "cap": "camera_snapshot", "args": {} },
+                { "op": "do", "cap": "read_temp", "args": { "unit": "c" } }
+            ]
+        });
+        let plan = expand_rtdl_to_plan(&rtdl, &targets, "p".into(), "s".into(), 1).unwrap();
+
+        assert_eq!(plan.root_index, 0);
+        assert_eq!(plan.nodes[0].node_kind, RTDL_PARALLEL);
+        assert_eq!(plan.nodes[0].children, vec![1, 2]);
+        assert_eq!(plan.nodes[1].call.as_ref().unwrap().call_id, "p:0");
+        assert_eq!(plan.nodes[2].call.as_ref().unwrap().call_id, "p:1");
+    }
+
+    #[test]
+    fn rtdl_nested_call_ids_follow_json_traversal_order() {
+        let mut targets = CapabilityTargetMap::new();
+        for name in ["a", "b", "c"] {
+            targets.insert(
+                name.to_string(),
+                (format!("provider-{name}"), format!("robonix/test/{name}")),
+            );
+        }
+
+        let rtdl = json!({
+            "op": "sequence",
+            "children": [
+                { "op": "do", "cap": "a", "args": {} },
+                {
+                    "op": "parallel",
+                    "children": [
+                        { "op": "do", "cap": "b", "args": {} },
+                        { "op": "do", "cap": "c", "args": {} }
+                    ]
+                }
+            ]
+        });
+        let plan = expand_rtdl_to_plan(&rtdl, &targets, "p".into(), "s".into(), 1).unwrap();
+        let calls: Vec<_> = plan
+            .nodes
+            .iter()
+            .filter_map(|node| node.call.as_ref())
+            .map(|call| call.call_id.as_str())
+            .collect();
+        assert_eq!(calls, vec!["p:0", "p:1", "p:2"]);
+    }
+
+    #[test]
+    fn rtdl_empty_sequence_generates_root_node() {
+        let targets = CapabilityTargetMap::new();
+        let rtdl = json!({ "op": "sequence", "children": [] });
+        let plan = expand_rtdl_to_plan(&rtdl, &targets, "p".into(), "s".into(), 0).unwrap();
+
+        assert_eq!(plan.root_index, 0);
+        assert_eq!(plan.nodes.len(), 1);
+        assert_eq!(plan.nodes[0].node_kind, RTDL_SEQUENCE);
+        assert!(plan.nodes[0].children.is_empty());
     }
 
     #[test]
@@ -911,5 +984,36 @@ mod tests {
         });
         let err = expand_rtdl_to_plan(&rtdl, &targets, "p".into(), "s".into(), 0).unwrap_err();
         assert!(err.to_string().contains("only `op`, `cap`, and `args`"));
+    }
+
+    #[test]
+    fn rtdl_rejects_parallel_non_array_children() {
+        let targets = CapabilityTargetMap::new();
+        let rtdl = json!({ "op": "parallel", "children": {} });
+        let err = expand_rtdl_to_plan(&rtdl, &targets, "p".into(), "s".into(), 0).unwrap_err();
+        assert!(err.to_string().contains("children must be an array"));
+    }
+
+    #[test]
+    fn rtdl_rejects_do_non_object_args() {
+        let mut targets = CapabilityTargetMap::new();
+        targets.insert(
+            "camera_snapshot".to_string(),
+            (
+                "cap-camera".to_string(),
+                "robonix/primitive/camera/snapshot".to_string(),
+            ),
+        );
+        let rtdl = json!({ "op": "do", "cap": "camera_snapshot", "args": [] });
+        let err = expand_rtdl_to_plan(&rtdl, &targets, "p".into(), "s".into(), 0).unwrap_err();
+        assert!(err.to_string().contains("args must be an object"));
+    }
+
+    #[test]
+    fn rtdl_rejects_unknown_op() {
+        let targets = CapabilityTargetMap::new();
+        let rtdl = json!({ "op": "race", "children": [] });
+        let err = expand_rtdl_to_plan(&rtdl, &targets, "p".into(), "s".into(), 0).unwrap_err();
+        assert!(err.to_string().contains("unknown operator"));
     }
 }


### PR DESCRIPTION
I made some changes in this pr:
1. To support parallel operator, I changed Plan.msg and added RtdlNode.msg to represent the rtdl plan for executor.
2. I moved the rtdl-related prompt to rtdl_protocol.md, so this md acts both as the prompt to LLM and the doc for RTDL protocol.