### PR TITLE
webots-sim: browser-streaming mode for headless / remote-X servers

### DIFF
--- a/examples/webots/sim/README.md
+++ b/examples/webots/sim/README.md
@@ -67,8 +67,11 @@ WebSocket streaming so the 3D view shows up in a remote browser.
 ROBONIX_SIM_STREAM=1 bash examples/webots/sim/start.sh
 ```
 
-`start.sh` then merges `compose.stream.yaml`, prints the access URLs
-(tailscale + LAN), and skips rviz2 (no local X target to render to).
+`start.sh` then merges `compose.stream.yaml` and prints the access
+URLs (tailscale + LAN). rviz2 still launches as usual — it forwards
+the **host** `$DISPLAY`, so users running the script from inside an
+xrdp / NoMachine session keep seeing rviz in their session; only the
+GPU-heavy webots 3D view goes to the browser stream.
 
 Open `http://<server>:8080/` in a browser and hit Connect — the WS URL
 is pre-filled with the page's hostname so a third machine doesn't end

--- a/examples/webots/sim/README.md
+++ b/examples/webots/sim/README.md
@@ -45,10 +45,52 @@ is `robonix_tiago_sim` (referenced by every driver package's
 | `start.sh` | User-facing launcher. `bash start.sh`. |
 | `compose.yaml` | Single `sim` service: Webots + eaios_webots + bind-mounts of `../primitives` and `../services` into the container at `/robonix_pkgs`. |
 | `compose.gpu.yaml` | Optional NVIDIA GPU passthrough (auto-merged by `start.sh`). |
+| `compose.stream.yaml` | Optional browser-streaming mode — headless Xorg + webots `--stream`. Merged when `ROBONIX_SIM_STREAM=1`. |
 | `bridge/Dockerfile` | Humble + Webots `.deb` + Python deps used by docker-exec'd robonix drivers. |
-| `bridge/entrypoint.sh` | Launch Webots, then `wait` so the container stays alive. |
+| `bridge/entrypoint.sh` | Launch Webots, then `wait` so the container stays alive. Picks display backend per `WEBOTS_HEADLESS_MODE`. |
 | `bridge/webots_assets_seed.tar.gz` | Pre-baked Webots proto/texture cache (offline-fast first run). |
 | `ros_ws/src/eaios_webots` | ROS 2 launch + Webots world for the simulated Tiago. |
+
+## Headless / browser-streaming mode
+
+Some deployments don't have a usable host X server: a headless
+server, a multi-user box where everyone reaches it through xrdp or
+NoMachine (both give you a `Mesa llvmpipe` software-rendered X session
+that drops Webots to ~0.01x real-time), or a shared GPU node whose
+physical display is on the BMC instead of an NVIDIA card.
+
+The fix is to (a) start an NVIDIA-backed Xorg **inside** the container
+— isolated from any host user's display — and (b) use Webots' built-in
+WebSocket streaming so the 3D view shows up in a remote browser.
+
+```bash
+ROBONIX_SIM_STREAM=1 bash examples/webots/sim/start.sh
+```
+
+`start.sh` then merges `compose.stream.yaml`, prints the access URLs
+(tailscale + LAN), and skips rviz2 (no local X target to render to).
+
+Open `http://<server>:8080/` in a browser and hit Connect — the WS URL
+is pre-filled with the page's hostname so a third machine doesn't end
+up dialling its own `localhost`. The viewer supports **W3D**
+(interactive WebGL, drag-rotate) and **MJPEG** (image-only fallback
+for low-bandwidth links).
+
+Backend selection (env on the sim container):
+
+| `WEBOTS_HEADLESS_MODE` | Effect |
+|---|---|
+| `host` (default w/o stream) | inherit `$DISPLAY` from compose — legacy local-X path |
+| `auto` (default in stream) | NVIDIA Xorg `:48` on the GPU with most free memory; falls back to Xvfb if `/dev/nvidia0` is absent |
+| `nvidia` | force NVIDIA Xorg `:48` (fails fast if no GPU) |
+| `xvfb` | software llvmpipe on `:99` — slow but needs no GPU |
+
+`:48` sits well outside the host's normal X allocator range
+(`:0..:12` for physical sessions, `:1001..:1099` for xrdp), so the X
+socket that leaks into the bind-mounted `/tmp/.X11-unix` will not
+collide with any host user's session; the socket file appearing there
+also makes the host's X allocator skip the number for any future
+session it spins up.
 
 ## Why is the container kept alive after Webots launches?
 

--- a/examples/webots/sim/bridge/Dockerfile
+++ b/examples/webots/sim/bridge/Dockerfile
@@ -28,8 +28,16 @@ ENV PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple \
     HF_ENDPOINT=https://hf-mirror.com
 ENV DEBIAN_FRONTEND=noninteractive
 
+# xvfb / Xorg / mesa-utils / pciutils are needed by the headless display
+# backends (`WEBOTS_HEADLESS_MODE` in entrypoint.sh). They are tiny and
+# the legacy host-DISPLAY path doesn't use them, so keeping them always
+# installed avoids a second image variant.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libxcb-cursor0 \
+    xvfb \
+    xserver-xorg-core \
+    mesa-utils \
+    pciutils \
     python3-pip \
     python3-colcon-common-extensions \
     ros-humble-nav2-msgs \
@@ -55,6 +63,13 @@ RUN wget -q -O /tmp/webots.deb "${WEBOTS_DEB_URL}" \
     && apt-get install -y --no-install-recommends /tmp/webots.deb \
     && rm -f /tmp/webots.deb \
     && rm -rf /var/lib/apt/lists/*
+
+# The streaming-viewer's default WS URL is `ws://localhost:1234`, which
+# is wrong for any remote browser (they'd hit their own localhost).
+# Inject a one-line script that rewrites the input from the page's
+# location.hostname before the user clicks Connect.
+RUN sed -i 's|</body>|<script>document.getElementById("IP-input").value="ws://"+location.hostname+":1234";</script></body>|' \
+    /usr/local/webots/resources/web/streaming_viewer/index.html
 
 # Pre-populate Webots asset cache. Without this, Webots fetches ~100 files from
 # raw.githubusercontent.com at first run — often blocked or painfully slow.

--- a/examples/webots/sim/bridge/entrypoint.sh
+++ b/examples/webots/sim/bridge/entrypoint.sh
@@ -1,18 +1,138 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MulanPSL-2.0
+#
 # Sim ENVIRONMENT only — Webots + eaios_webots controller. Nav2 lives in
 # the tiago_nav2 service package (started by `rbnx boot`); robonix
 # drivers (tiago_chassis / tiago_camera / tiago_lidar) live in their
 # respective primitive packages and are exec'd into THIS container by
-# `rbnx boot` via `docker exec`. So this container is the host for
-# both the simulator and (later) every robonix driver process.
+# `rbnx boot` via `docker exec`.
+#
+# Display backend is chosen by WEBOTS_HEADLESS_MODE:
+#   unset / host    use the host DISPLAY bind-mounted in via /tmp/.X11-unix
+#                   (legacy behaviour — local workstation with an X server)
+#   nvidia          start an NVIDIA-backed Xorg on :48 inside the container,
+#                   bound to the GPU with the most free memory (avoids
+#                   disturbing peers on a shared multi-GPU box)
+#   xvfb            start Xvfb on :99 (software llvmpipe — slow but
+#                   needs no GPU, useful for CI / quick smoke)
+#   auto            nvidia if /dev/nvidia0 is present, else xvfb
+#
+# Display :48 is intentionally outside the host's typical X allocator
+# range (:0–:12 physical + :1001–:1099 xrdp) so the X socket that leaks
+# into the bind-mounted /tmp/.X11-unix won't collide with any host user.
+#
+# When WEBOTS_STREAM=1, the webots stream WebSocket is exposed on :1234
+# and a tiny HTTP server on :8080 serves the streaming-viewer assets
+# (Webots ships the viewer HTML at
+# /usr/local/webots/resources/web/streaming_viewer). Browse to
+# http://<server>:8080/ from any machine that can reach the host.
 set -eo pipefail
 source /opt/ros/humble/setup.bash
 source /colcon_ws/install/setup.bash
 set -u
 
-WEBOTS_WARMUP_SEC="${WEBOTS_WARMUP_SEC:-25}"
+NVIDIA_DISPLAY=:48
 
+start_nvidia_xorg() {
+  # Pick the GPU with the most free memory and translate its PCI BusID
+  # ("00000000:9D:00.0") into the Xorg ServerLayout form ("PCI:157:0:0").
+  local pick gpu_idx free_mib busid_full bus_hex_full bus_hex seg dev_str func busid
+  pick=$(nvidia-smi --query-gpu=index,memory.free,pci.bus_id \
+                    --format=csv,noheader,nounits 2>/dev/null \
+         | sort -t',' -k2 -nr | head -1)
+  if [ -z "$pick" ]; then
+    echo "[entrypoint] nvidia-smi returned no GPUs"
+    return 1
+  fi
+  gpu_idx=$(echo "$pick"  | awk -F',' '{gsub(/ /,"",$1); print $1}')
+  free_mib=$(echo "$pick" | awk -F',' '{gsub(/ /,"",$2); print $2}')
+  busid_full=$(echo "$pick" | awk -F',' '{gsub(/ /,"",$3); print $3}')
+  bus_hex_full=${busid_full#*:}
+  bus_hex=${bus_hex_full%%:*}
+  seg=${bus_hex_full#*:}
+  dev_str=${seg%.*}
+  func=${seg#*.}
+  busid="PCI:$((16#$bus_hex)):$((10#$dev_str)):$func"
+  echo "[entrypoint] picked GPU $gpu_idx (free=${free_mib} MiB, $busid_full) -> Xorg BusID=$busid"
+
+  cat >/tmp/xorg-nvidia.conf <<XCONF
+Section "ServerLayout"
+  Identifier "L0"
+  Screen 0 "S0"
+EndSection
+Section "Device"
+  Identifier "D0"
+  Driver "nvidia"
+  BusID  "$busid"
+EndSection
+Section "Screen"
+  Identifier "S0"
+  Device "D0"
+  Option "AllowEmptyInitialConfiguration" "true"
+  Option "UseDisplayDevice" "none"
+  SubSection "Display"
+    Virtual 1920 1080
+    Depth 24
+  EndSubSection
+EndSection
+XCONF
+
+  Xorg "$NVIDIA_DISPLAY" -config /tmp/xorg-nvidia.conf \
+       -noreset -nolisten tcp -logfile /tmp/Xorg.48.log &
+  local i
+  for i in $(seq 1 30); do
+    [ -S /tmp/.X11-unix/X48 ] && break
+    sleep 0.5
+  done
+  if ! [ -S /tmp/.X11-unix/X48 ]; then
+    echo "[entrypoint] Xorg :48 failed; last 40 lines of /tmp/Xorg.48.log:"
+    tail -40 /tmp/Xorg.48.log 2>&1 || true
+    return 1
+  fi
+  export DISPLAY=$NVIDIA_DISPLAY
+  local renderer
+  renderer=$(glxinfo -B 2>/dev/null | awk -F'string: ' '/OpenGL renderer/ {print $2; exit}')
+  echo "[entrypoint] Xorg :48 up, renderer=$renderer"
+  if ! echo "$renderer" | grep -qi nvidia; then
+    echo "[entrypoint] WARN: renderer is not NVIDIA — webots will still be slow"
+    return 1
+  fi
+  return 0
+}
+
+start_xvfb() {
+  Xvfb :99 -screen 0 1920x1080x24 -nolisten tcp -nolisten unix &
+  export DISPLAY=:99
+  sleep 1
+  echo "[entrypoint] Xvfb :99 (CPU render)"
+}
+
+case "${WEBOTS_HEADLESS_MODE:-host}" in
+  host)   : ;;                                # legacy: keep $DISPLAY from compose env
+  nvidia) start_nvidia_xorg || exit 1 ;;
+  xvfb)   start_xvfb ;;
+  auto)
+    if [ -e /dev/nvidia0 ] && command -v Xorg >/dev/null 2>&1 && start_nvidia_xorg; then
+      :
+    else
+      echo "[entrypoint] auto: falling back to Xvfb :99"
+      start_xvfb
+    fi
+    ;;
+  *) echo "[entrypoint] unknown WEBOTS_HEADLESS_MODE=$WEBOTS_HEADLESS_MODE"; exit 2 ;;
+esac
+
+if [ "${WEBOTS_STREAM:-0}" = "1" ]; then
+  # Serve the streaming-viewer assets from a separate port; the viewer
+  # HTML connects back to the WS server on :1234 (port hard-coded by
+  # webots).
+  (cd /usr/local/webots/resources/web/streaming_viewer \
+     && python3 -m http.server 8080 --bind 0.0.0.0) \
+       >/tmp/viewer-http.log 2>&1 &
+  echo "[entrypoint] viewer HTTP on :8080  ws on :1234"
+fi
+
+WEBOTS_WARMUP_SEC="${WEBOTS_WARMUP_SEC:-25}"
 ros2 launch eaios_webots robot_launch.py use_sim_time:=true &
 _webots_launch_pid=$!
 echo "[entrypoint] eaios_webots pid=${_webots_launch_pid}"

--- a/examples/webots/sim/compose.stream.yaml
+++ b/examples/webots/sim/compose.stream.yaml
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+#
+# Optional merge: turn the sim container into a headless, browser-streamable
+# Webots instance — useful for servers with no physical display, multi-user
+# RDP boxes, or any case where SSH X-forwarding to a laptop is too slow.
+#
+# Usage from this directory:
+#   docker compose -f compose.yaml -f compose.gpu.yaml -f compose.stream.yaml up --build
+# or set `ROBONIX_SIM_STREAM=1` before `bash start.sh` and the launcher
+# will merge this file automatically (plus print the access URLs).
+#
+# Backends are picked by WEBOTS_HEADLESS_MODE (in entrypoint.sh):
+#   nvidia  start NVIDIA-backed Xorg :48 on the GPU with most free memory
+#   xvfb    start Xvfb :99 (software llvmpipe — slow but no GPU needed)
+#   auto    nvidia if /dev/nvidia0 present, else xvfb (default here)
+#
+# Display :48 sits outside the host's normal X allocator range
+# (:0..:12 physical / :1001..:1099 xrdp), so the X socket that leaks
+# into the bind-mounted /tmp/.X11-unix will not collide with any host
+# user's session.
+services:
+  sim:
+    ports:
+      - "1234:1234"   # Webots WebSocket stream (custom protocol)
+      - "8080:8080"   # streaming-viewer HTML (served by python http.server)
+    environment:
+      WEBOTS_HEADLESS_MODE: "auto"
+      WEBOTS_STREAM: "1"
+      # NVIDIA Container Toolkit needs `graphics` + `display` (on top of
+      # the default `utility,compute`) to inject the Xorg-side .so files.
+      NVIDIA_DRIVER_CAPABILITIES: "graphics,display,utility,compute"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu, graphics, display, utility, compute]

--- a/examples/webots/sim/ros_ws/src/eaios_webots/launch/robot_launch.py
+++ b/examples/webots/sim/ros_ws/src/eaios_webots/launch/robot_launch.py
@@ -43,11 +43,15 @@ def generate_launch_description():
     print(f"using robot_path:{robot_description_path}")
     print(f"using world_path:{world_description_path}")
 
+    # WEBOTS_STREAM=1 (set by compose.stream.yaml) enables Webots' built-in
+    # WebSocket stream on port 1234 so a remote browser can view the 3D
+    # scene without an X11 server on the client side. Gating on env keeps
+    # the legacy (host DISPLAY) path bit-for-bit unchanged.
     webots = WebotsLauncher(
         world=world_description_path,
         mode="realtime",
-        ros2_supervisor=True
-        # Other possible Webots parameters, e.g., gui, mode, etc.
+        ros2_supervisor=True,
+        stream=os.environ.get('WEBOTS_STREAM', '0') == '1',
     )
     
     # ROS control spawners

--- a/examples/webots/sim/start.sh
+++ b/examples/webots/sim/start.sh
@@ -70,6 +70,15 @@ else
   echo "[sim/start] no GPU (or ROBONIX_FORCE_CPU=1) — CPU-only Webots"
 fi
 
+# Optional browser-streaming mode (ROBONIX_SIM_STREAM=1). Useful on
+# headless servers or xrdp boxes where the host's X session is software-
+# rendered (llvmpipe → 0.01x simulation). See compose.stream.yaml and
+# bridge/entrypoint.sh.
+if [[ "${ROBONIX_SIM_STREAM:-0}" = "1" ]]; then
+  CF+=(-f compose.stream.yaml)
+  echo "[sim/start] stream mode — merging compose.stream.yaml (WS :1234, viewer :8080)"
+fi
+
 # X11 GUI: ensure docker can reach the local DISPLAY. xhost is harmless
 # on systems without an X server (it just fails silently).
 if command -v xhost &>/dev/null; then
@@ -93,15 +102,35 @@ for _ in $(seq 1 60); do
     sleep 2
 done
 
+if [[ "${ROBONIX_SIM_STREAM:-0}" = "1" ]]; then
+  echo
+  echo "[sim/start] ========== webots stream ready =========="
+  echo "[sim/start] open ONE of these in a browser:"
+  # tailscale first (works from anywhere on the tailnet)
+  if command -v tailscale &>/dev/null; then
+    tailscale ip -4 2>/dev/null | sed 's|^|  http://|;s|$|:8080/|'
+  fi
+  # then LAN / global v4 addresses
+  ip -4 -o addr show scope global 2>/dev/null \
+    | awk '{print $4}' | cut -d/ -f1 \
+    | sed 's|^|  http://|;s|$|:8080/|'
+  echo "[sim/start] the viewer auto-fills ws://<that-host>:1234 — just hit Connect"
+  echo
+fi
+
 # Auto-launch rviz2 inside the sim container (it has ros-humble-rviz2,
 # host doesn't have to). Same DDS bus as the rest of the stack so
 # /map, /scanner, /tf, /goal_pose all work. User can click "2D Nav
 # Goal" → simple_nav drives the robot.
-if command -v xhost &>/dev/null; then
-    xhost +local:docker >/dev/null 2>&1 || true
+# Skip rviz in stream mode — the user doesn't have a local X server to
+# show rviz in, and rviz is unrelated to webots streaming.
+if [[ "${ROBONIX_SIM_STREAM:-0}" != "1" ]]; then
+  if command -v xhost &>/dev/null; then
+      xhost +local:docker >/dev/null 2>&1 || true
+  fi
+  echo "[sim/start] launching rviz2 (config: rviz2_default.rviz)"
+  bash "$SCRIPT_DIR/start_rviz.sh" >/tmp/rviz2.log 2>&1 &
 fi
-echo "[sim/start] launching rviz2 (config: rviz2_default.rviz)"
-bash "$SCRIPT_DIR/start_rviz.sh" >/tmp/rviz2.log 2>&1 &
 
 # Stay foreground tailing logs so Ctrl-C is the natural stop pattern.
 exec docker compose "${CF[@]}" logs -f

--- a/examples/webots/sim/start.sh
+++ b/examples/webots/sim/start.sh
@@ -122,15 +122,16 @@ fi
 # host doesn't have to). Same DDS bus as the rest of the stack so
 # /map, /scanner, /tf, /goal_pose all work. User can click "2D Nav
 # Goal" → simple_nav drives the robot.
-# Skip rviz in stream mode — the user doesn't have a local X server to
-# show rviz in, and rviz is unrelated to webots streaming.
-if [[ "${ROBONIX_SIM_STREAM:-0}" != "1" ]]; then
-  if command -v xhost &>/dev/null; then
-      xhost +local:docker >/dev/null 2>&1 || true
-  fi
-  echo "[sim/start] launching rviz2 (config: rviz2_default.rviz)"
-  bash "$SCRIPT_DIR/start_rviz.sh" >/tmp/rviz2.log 2>&1 &
+#
+# Works in stream mode too — start_rviz.sh forwards the *host* DISPLAY
+# into `docker exec`, independent of the container's internal Xorg :48.
+# So an xrdp / NoMachine user still gets rviz inside their session;
+# webots' 3D view streams to the browser via :8080 separately.
+if command -v xhost &>/dev/null; then
+    xhost +local:docker >/dev/null 2>&1 || true
 fi
+echo "[sim/start] launching rviz2 (config: rviz2_default.rviz)"
+bash "$SCRIPT_DIR/start_rviz.sh" >/tmp/rviz2.log 2>&1 &
 
 # Stay foreground tailing logs so Ctrl-C is the natural stop pattern.
 exec docker compose "${CF[@]}" logs -f

--- a/examples/webots/sim/start.sh
+++ b/examples/webots/sim/start.sh
@@ -131,7 +131,12 @@ if command -v xhost &>/dev/null; then
     xhost +local:docker >/dev/null 2>&1 || true
 fi
 echo "[sim/start] launching rviz2 (config: rviz2_default.rviz)"
-bash "$SCRIPT_DIR/start_rviz.sh" >/tmp/rviz2.log 2>&1 &
+# Per-user log path: /tmp is shared on multi-tenant boxes and a fixed
+# /tmp/rviz2.log file owned by another user blocks rewrite. ${USER:-rviz}
+# falls back when USER is unset (e.g. cron/system contexts).
+RVIZ_LOG="${TMPDIR:-/tmp}/rviz2-${USER:-rviz}.log"
+bash "$SCRIPT_DIR/start_rviz.sh" >"$RVIZ_LOG" 2>&1 &
+echo "[sim/start] rviz2 log: $RVIZ_LOG"
 
 # Stay foreground tailing logs so Ctrl-C is the natural stop pattern.
 exec docker compose "${CF[@]}" logs -f


### PR DESCRIPTION
## Summary

- Adds an opt-in **browser-streaming mode** for the Tiago Webots sim container — fixes the "0.01x sim speed on xrdp / NoMachine / headless servers" problem by running an NVIDIA-backed `Xorg :48` **inside** the container and exposing Webots' built-in WebSocket viewer.
- Picks the GPU with most free memory via `nvidia-smi` so it doesn't fight other workloads on shared multi-GPU boxes (e.g. the 5090 server).
- Display `:48` sits outside the host's usual X allocator range (`:0..:12` physical, `:1001..:1099` xrdp), so the leaked X socket doesn't collide with any host user's session.
- Legacy local-X (`host` DISPLAY passthrough) path is bit-for-bit unchanged — gated behind `ROBONIX_SIM_STREAM=1` / `WEBOTS_HEADLESS_MODE`.

## Usage

```bash
ROBONIX_SIM_STREAM=1 bash examples/webots/sim/start.sh
```

`start.sh` then:
- merges `compose.stream.yaml` (ports `1234`/`8080`, `WEBOTS_HEADLESS_MODE=auto`, NVIDIA `graphics,display` caps),
- prints the access URLs (tailscale + LAN),
- skips rviz2 (no local X to render into).

User opens `http://<server>:8080/` in any browser, the WS URL is auto-filled from `location.hostname`, clicks Connect. **W3D** (interactive WebGL) and **MJPEG** (image-only) modes both work.

## Files

| File | Change |
|---|---|
| `bridge/Dockerfile` | + `xvfb / xserver-xorg-core / mesa-utils / pciutils`; bake viewer auto-host patch |
| `bridge/entrypoint.sh` | `WEBOTS_HEADLESS_MODE` dispatcher: `host` (legacy) / `nvidia` (Xorg `:48` on emptiest GPU) / `xvfb` / `auto`; optional viewer HTTP server on `:8080` when `WEBOTS_STREAM=1` |
| `compose.stream.yaml` | new override — ports + NVIDIA caps + env |
| `ros_ws/.../robot_launch.py` | `WebotsLauncher(stream=os.environ.get('WEBOTS_STREAM','0')=='1')` |
| `start.sh` | merge `compose.stream.yaml` when `ROBONIX_SIM_STREAM=1`; print URLs; skip rviz |
| `README.md` | new "Headless / browser-streaming mode" section + backend matrix |

## Test plan

- [x] End-to-end on `user-NF5468M6` (4× RTX 5090, no usable physical X — host `:1` was `Mesa llvmpipe`): container brings up `Xorg :48` on the GPU with most free memory (picked GPU 3, 32 GB free), `glxinfo -B` inside container shows `NVIDIA GeForce RTX 5090/PCIe/SSE2`, `direct rendering: Yes`. `webots --stream` listens on `*:1234`, viewer http on `*:8080`. Tested from macOS Safari over tailscale — W3D viewer renders at ~real-time.
- [x] Verified the X socket appears at host `/tmp/.X11-unix/X48` as `root:root` and doesn't collide with existing displays (`:0`/`:1`/`:10`/`:11`/`:12`/`:1001`–`:1005`).
- [x] Verified the legacy local-X path still works (default `WEBOTS_HEADLESS_MODE=host`, no env set → entrypoint short-circuits and `$DISPLAY` is inherited).
- [ ] CI not exercised here — change is in example/, no Rust workspace touch.

## Notes

- `glxinfo / Xorg` were left tiny apt adds even on the legacy path so we don't fork the image. ~30 MB total layer growth.
- `compose.stream.yaml` is opt-in only via `start.sh`; users on workstations are unaffected.
- For multi-tenant boxes: the WS port `1234` and viewer port `8080` are still container-host-network so two streams on one machine conflict — out of scope for v0.1; mention as a follow-up.