### PR TITLE
build(robonix-api): prep PyPI 0.1.0rc1 distribution

### DIFF
--- a/pylib/robonix-api/.gitignore
+++ b/pylib/robonix-api/.gitignore
@@ -3,3 +3,7 @@
 build/
 dist/
 __pycache__/
+
+# Generated at sdist build time by scripts/build_dist.sh — atlas_pb2*.py
+# is the wire stub baked into the wheel for pip-installed users.
+robonix_api/_generated/

--- a/pylib/robonix-api/LICENSE
+++ b/pylib/robonix-api/LICENSE
@@ -1,0 +1,127 @@
+                     木兰宽松许可证, 第2版
+
+   木兰宽松许可证， 第2版 
+   2020年1月 http://license.coscl.org.cn/MulanPSL2
+
+
+   您对“软件”的复制、使用、修改及分发受木兰宽松许可证，第2版（“本许可证”）的如下条款的约束：
+
+   0. 定义
+
+      “软件”是指由“贡献”构成的许可在“本许可证”下的程序和相关文档的集合。
+
+      “贡献”是指由任一“贡献者”许可在“本许可证”下的受版权法保护的作品。
+
+      “贡献者”是指将受版权法保护的作品许可在“本许可证”下的自然人或“法人实体”。
+
+      “法人实体”是指提交贡献的机构及其“关联实体”。
+
+      “关联实体”是指，对“本许可证”下的行为方而言，控制、受控制或与其共同受控制的机构，此处的控制是指有受控方或共同受控方至少50%直接或间接的投票权、资金或其他有价证券。
+
+   1. 授予版权许可
+
+      每个“贡献者”根据“本许可证”授予您永久性的、全球性的、免费的、非独占的、不可撤销的版权许可，您可以复制、使用、修改、分发其“贡献”，不论修改与否。
+
+   2. 授予专利许可
+
+      每个“贡献者”根据“本许可证”授予您永久性的、全球性的、免费的、非独占的、不可撤销的（根据本条规定撤销除外）专利许可，供您制造、委托制造、使用、许诺销售、销售、进口其“贡献”或以其他方式转移其“贡献”。前述专利许可仅限于“贡献者”现在或将来拥有或控制的其“贡献”本身或其“贡献”与许可“贡献”时的“软件”结合而将必然会侵犯的专利权利要求，不包括对“贡献”的修改或包含“贡献”的其他结合。如果您或您的“关联实体”直接或间接地，就“软件”或其中的“贡献”对任何人发起专利侵权诉讼（包括反诉或交叉诉讼）或其他专利维权行动，指控其侵犯专利权，则“本许可证”授予您对“软件”的专利许可自您提起诉讼或发起维权行动之日终止。
+
+   3. 无商标许可
+
+      “本许可证”不提供对“贡献者”的商品名称、商标、服务标志或产品名称的商标许可，但您为满足第4条规定的声明义务而必须使用除外。
+
+   4. 分发限制
+
+      您可以在任何媒介中将“软件”以源程序形式或可执行形式重新分发，不论修改与否，但您必须向接收者提供“本许可证”的副本，并保留“软件”中的版权、商标、专利及免责声明。
+
+   5. 免责声明与责任限制
+
+      “软件”及其中的“贡献”在提供时不带任何明示或默示的担保。在任何情况下，“贡献者”或版权所有者不对任何人因使用“软件”或其中的“贡献”而引发的任何直接或间接损失承担责任，不论因何种原因导致或者基于何种法律理论，即使其曾被建议有此种损失的可能性。 
+
+   6. 语言
+      “本许可证”以中英文双语表述，中英文版本具有同等法律效力。如果中英文版本存在任何冲突不一致，以中文版为准。
+
+   条款结束 
+
+   如何将木兰宽松许可证，第2版，应用到您的软件
+   
+   如果您希望将木兰宽松许可证，第2版，应用到您的新软件，为了方便接收者查阅，建议您完成如下三步：
+
+      1， 请您补充如下声明中的空白，包括软件名、软件的首次发表年份以及您作为版权人的名字；
+
+      2， 请您在软件包的一级目录下创建以“LICENSE”为名的文件，将整个许可证文本放入该文件中；
+
+      3， 请将如下声明文本放入每个源文件的头部注释中。
+
+   Copyright (c) [Year] [name of copyright holder]
+   [Software Name] is licensed under Mulan PSL v2.
+   You can use this software according to the terms and conditions of the Mulan PSL v2. 
+   You may obtain a copy of Mulan PSL v2 at:
+            http://license.coscl.org.cn/MulanPSL2 
+   THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.  
+   See the Mulan PSL v2 for more details.  
+
+
+                     Mulan Permissive Software License，Version 2
+
+   Mulan Permissive Software License，Version 2 (Mulan PSL v2)
+   January 2020 http://license.coscl.org.cn/MulanPSL2
+
+   Your reproduction, use, modification and distribution of the Software shall be subject to Mulan PSL v2 (this License) with the following terms and conditions: 
+   
+   0. Definition
+   
+      Software means the program and related documents which are licensed under this License and comprise all Contribution(s). 
+   
+      Contribution means the copyrightable work licensed by a particular Contributor under this License.
+   
+      Contributor means the Individual or Legal Entity who licenses its copyrightable work under this License.
+   
+      Legal Entity means the entity making a Contribution and all its Affiliates.
+   
+      Affiliates means entities that control, are controlled by, or are under common control with the acting entity under this License, ‘control’ means direct or indirect ownership of at least fifty percent (50%) of the voting power, capital or other securities of controlled or commonly controlled entity.
+
+   1. Grant of Copyright License
+
+      Subject to the terms and conditions of this License, each Contributor hereby grants to you a perpetual, worldwide, royalty-free, non-exclusive, irrevocable copyright license to reproduce, use, modify, or distribute its Contribution, with modification or not.
+
+   2. Grant of Patent License 
+
+      Subject to the terms and conditions of this License, each Contributor hereby grants to you a perpetual, worldwide, royalty-free, non-exclusive, irrevocable (except for revocation under this Section) patent license to make, have made, use, offer for sale, sell, import or otherwise transfer its Contribution, where such patent license is only limited to the patent claims owned or controlled by such Contributor now or in future which will be necessarily infringed by its Contribution alone, or by combination of the Contribution with the Software to which the Contribution was contributed. The patent license shall not apply to any modification of the Contribution, and any other combination which includes the Contribution. If you or your Affiliates directly or indirectly institute patent litigation (including a cross claim or counterclaim in a litigation) or other patent enforcement activities against any individual or entity by alleging that the Software or any Contribution in it infringes patents, then any patent license granted to you under this License for the Software shall terminate as of the date such litigation or activity is filed or taken.
+
+   3. No Trademark License
+
+      No trademark license is granted to use the trade names, trademarks, service marks, or product names of Contributor, except as required to fulfill notice requirements in Section 4.
+
+   4. Distribution Restriction
+
+      You may distribute the Software in any medium with or without modification, whether in source or executable forms, provided that you provide recipients with a copy of this License and retain copyright, patent, trademark and disclaimer statements in the Software.
+
+   5. Disclaimer of Warranty and Limitation of Liability
+
+      THE SOFTWARE AND CONTRIBUTION IN IT ARE PROVIDED WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED. IN NO EVENT SHALL ANY CONTRIBUTOR OR COPYRIGHT HOLDER BE LIABLE TO YOU FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO ANY DIRECT, OR INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING FROM YOUR USE OR INABILITY TO USE THE SOFTWARE OR THE CONTRIBUTION IN IT, NO MATTER HOW IT’S CAUSED OR BASED ON WHICH LEGAL THEORY, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+   6. Language
+
+      THIS LICENSE IS WRITTEN IN BOTH CHINESE AND ENGLISH, AND THE CHINESE VERSION AND ENGLISH VERSION SHALL HAVE THE SAME LEGAL EFFECT. IN THE CASE OF DIVERGENCE BETWEEN THE CHINESE AND ENGLISH VERSIONS, THE CHINESE VERSION SHALL PREVAIL.
+
+   END OF THE TERMS AND CONDITIONS
+
+   How to Apply the Mulan Permissive Software License，Version 2 (Mulan PSL v2) to Your Software
+
+      To apply the Mulan PSL v2 to your work, for easy identification by recipients, you are suggested to complete following three steps:
+
+      i Fill in the blanks in following statement, including insert your software name, the year of the first publication of your software, and your name identified as the copyright owner; 
+
+      ii Create a file named “LICENSE” which contains the whole context of this License in the first directory of your software package;
+
+      iii Attach the statement to the appropriate annotated syntax at the beginning of each source file.
+
+
+   Copyright (c) [Year] [name of copyright holder]
+   [Software Name] is licensed under Mulan PSL v2.
+   You can use this software according to the terms and conditions of the Mulan PSL v2. 
+   You may obtain a copy of Mulan PSL v2 at:
+               http://license.coscl.org.cn/MulanPSL2 
+   THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.  
+   See the Mulan PSL v2 for more details.  

--- a/pylib/robonix-api/README.md
+++ b/pylib/robonix-api/README.md
@@ -1,0 +1,72 @@
+# robonix-api
+
+Python client library for writing [Robonix](https://github.com/syswonder/robonix) capability providers — primitives, services, and skills — and talking to the Atlas registry.
+
+> Robonix is an embodied-AI operating system. `robonix-api` is the **client-side helper**: it gives you `Primitive` / `Service` / `Skill` classes that handle Atlas registration, the Driver lifecycle gRPC server, and thin wrappers over `rclpy` / `FastMCP` / `grpcio`. The Atlas server itself is a separate Rust binary (`robonix-atlas`, see the main repo).
+
+## Install
+
+```bash
+pip install robonix-api
+```
+
+Optional extras:
+
+```bash
+pip install "robonix-api[codegen]"   # adds grpcio-tools, only needed if you run `rbnx codegen` from Python
+```
+
+ROS 2 (`rclpy`, `sensor_msgs`, `geometry_msgs`, etc.) is **not** a pip dependency — install ROS 2 Humble via `apt` on the host. `robonix-api`'s ROS helpers import `rclpy` lazily, so the rest of the library works even without a ROS install.
+
+## Hello, primitive
+
+```python
+from robonix_api import Primitive, Ok, Deferred
+
+primitive = Primitive(
+    id="my_lidar",
+    namespace="robonix/primitive/lidar",
+)
+
+@primitive.on_init
+def init(cfg: dict):
+    topic = cfg.get("lidar_topic", "/scan")
+    if not primitive.wait_for_topic(topic, "LaserScan", 30.0):
+        return Deferred(f"no LaserScan on {topic} yet")
+    primitive.create_publisher(
+        contract_id="robonix/primitive/lidar/lidar2d",
+        topic=topic,
+        msg_type="LaserScan",
+    )
+    return Ok()
+
+if __name__ == "__main__":
+    primitive.run()
+```
+
+That's a complete Robonix primitive — registers with Atlas, serves the Driver lifecycle, waits for the upstream topic, declares a ROS 2 capability for downstream consumers, and blocks on SIGTERM.
+
+## What's in the box
+
+- **`ATLAS`** — module-level singleton client (`ATLAS.register`, `ATLAS.find_primitive`, `ATLAS.connect`, ...)
+- **`Primitive` / `Service` / `Skill`** — provider base classes with `on_init` / `on_activate` / `on_deactivate` / `on_shutdown` decorators
+- **`@provider.provides_grpc(contract)` / `@provider.provides_mcp(contract)`** — Layer-2 sugar for typed handlers
+- **`Ok` / `Err` / `Deferred`** — lifecycle return values
+- **`mcp_contract`** — standalone FastMCP decorator (use when you manage your own FastMCP app, e.g. in `scene_service`)
+
+The Atlas wire protocol (atlas_pb2 / atlas_pb2_grpc) is pre-generated and bundled in the wheel. Per-contract stubs (`robonix_contracts_pb2`, MCP typed dataclasses) are generated **per deployment** by `rbnx codegen` against your contract TOMLs — `robonix-api` automatically picks them up from `<pkg>/rbnx-build/codegen/` at runtime.
+
+## Versioning
+
+`robonix-api` tracks the Robonix v0.1.x series. Wire format and public API are frozen within v0.1.x. Pre-release builds (`0.1.0rc*`) are published to Test PyPI first; stable releases to PyPI.
+
+The Atlas server (Rust crate `robonix-atlas`) must be on a compatible minor version. Mixing `robonix-api 0.1.x` with an Atlas server on a different minor version is unsupported.
+
+## Links
+
+- [Robonix monorepo](https://github.com/syswonder/robonix) — Atlas server, `rbnx` CLI, examples, full developer guide
+- [Issues](https://github.com/syswonder/robonix/issues)
+
+## License
+
+Mulan PSL v2.

--- a/pylib/robonix-api/pyproject.toml
+++ b/pylib/robonix-api/pyproject.toml
@@ -1,13 +1,46 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 [project]
 name = "robonix-api"
-version = "0.1.0"
-description = "Robonix Python helper library: FastMCP contract decorator aligned with robonix-codegen --lang mcp ROS dataclasses, plus shared Python utilities."
+version = "0.1.0rc1"
+description = "Robonix Python client library: write Primitive/Service/Skill packages, talk to atlas, serve Driver lifecycle gRPC, wrap rclpy/FastMCP/grpcio middleware."
+readme = "README.md"
+license = { text = "MulanPSL-2.0" }
+authors = [
+    { name = "wheatfox", email = "wheatfox17@icloud.com" },
+]
 requires-python = ">=3.10"
+keywords = ["robotics", "robonix", "embodied-ai", "ros2", "mcp", "grpc"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
 dependencies = [
+    "grpcio>=1.50",
+    "protobuf>=4",
     "mcp>=1.0",
     "fastmcp>=3",
+    "pyyaml>=6",
 ]
+
+[project.optional-dependencies]
+codegen = [
+    "grpcio-tools>=1.50",
+]
+
+[project.urls]
+Homepage = "https://github.com/syswonder/robonix"
+Documentation = "https://github.com/syswonder/robonix/tree/main/docs"
+Repository = "https://github.com/syswonder/robonix"
+Issues = "https://github.com/syswonder/robonix/issues"
 
 [build-system]
 requires = ["setuptools>=61"]
@@ -16,3 +49,6 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["robonix_api*"]
+
+[tool.setuptools.package-data]
+robonix_api = ["_generated/*.py", "_generated/*.pyi"]

--- a/pylib/robonix-api/pyproject.toml
+++ b/pylib/robonix-api/pyproject.toml
@@ -51,4 +51,4 @@ where = ["."]
 include = ["robonix_api*"]
 
 [tool.setuptools.package-data]
-robonix_api = ["_generated/*.py", "_generated/*.pyi"]
+robonix_api = ["_generated/*.py"]

--- a/pylib/robonix-api/robonix_api/__init__.py
+++ b/pylib/robonix-api/robonix_api/__init__.py
@@ -91,6 +91,26 @@ except Exception:  # noqa: BLE001
 del _bootstrap_codegen_paths_from_caller
 
 
+# -- Wheel-bundled atlas_pb2 fallback ---------------------------------------
+# For pip-installed users (no monorepo / no `rbnx codegen` run): the sdist
+# build step pre-generates atlas_pb2.py + atlas_pb2_grpc.py into
+# `_generated/` and ships them in the wheel. Append (not insert) so any
+# deployment-side `<pkg>/rbnx-build/codegen/proto_gen/atlas_pb2.py` injected
+# above still wins -- monorepo dev flow is unchanged.
+def _bootstrap_bundled_atlas_stub() -> None:
+    import sys
+    from pathlib import Path
+    generated = Path(__file__).resolve().parent / "_generated"
+    if (generated / "atlas_pb2.py").is_file():
+        s = str(generated)
+        if s not in sys.path:
+            sys.path.append(s)
+
+
+_bootstrap_bundled_atlas_stub()
+del _bootstrap_bundled_atlas_stub
+
+
 __all__ = [
     # CapabilityProvider classes (three kinds).
     "Primitive", "Service", "Skill",

--- a/pylib/robonix-api/robonix_api/__init__.py
+++ b/pylib/robonix-api/robonix_api/__init__.py
@@ -91,26 +91,6 @@ except Exception:  # noqa: BLE001
 del _bootstrap_codegen_paths_from_caller
 
 
-# -- Wheel-bundled atlas_pb2 fallback ---------------------------------------
-# For pip-installed users (no monorepo / no `rbnx codegen` run): the sdist
-# build step pre-generates atlas_pb2.py + atlas_pb2_grpc.py into
-# `_generated/` and ships them in the wheel. Append (not insert) so any
-# deployment-side `<pkg>/rbnx-build/codegen/proto_gen/atlas_pb2.py` injected
-# above still wins -- monorepo dev flow is unchanged.
-def _bootstrap_bundled_atlas_stub() -> None:
-    import sys
-    from pathlib import Path
-    generated = Path(__file__).resolve().parent / "_generated"
-    if (generated / "atlas_pb2.py").is_file():
-        s = str(generated)
-        if s not in sys.path:
-            sys.path.append(s)
-
-
-_bootstrap_bundled_atlas_stub()
-del _bootstrap_bundled_atlas_stub
-
-
 __all__ = [
     # CapabilityProvider classes (three kinds).
     "Primitive", "Service", "Skill",

--- a/pylib/robonix-api/robonix_api/atlas.py
+++ b/pylib/robonix-api/robonix_api/atlas.py
@@ -97,8 +97,16 @@ class _Atlas:
         if self._stub is not None:
             return
         import grpc
-        import atlas_pb2          # type: ignore
-        import atlas_pb2_grpc     # type: ignore
+        # Deployment-side stubs (from `<pkg>/rbnx-build/codegen/proto_gen/`,
+        # injected onto sys.path by codegen.ensure_proto_gen) take priority.
+        # Fall back to the wheel-bundled stubs under `robonix_api._generated/`
+        # for pip-installed users without a monorepo codegen run.
+        try:
+            import atlas_pb2          # type: ignore
+            import atlas_pb2_grpc     # type: ignore
+        except ImportError:
+            from ._generated import atlas_pb2          # type: ignore
+            from ._generated import atlas_pb2_grpc     # type: ignore
         ep = self._endpoint or os.environ.get("ROBONIX_ATLAS", "127.0.0.1:50051")
         self._endpoint = ep
         self._pb = atlas_pb2

--- a/pylib/robonix-api/scripts/build_dist.sh
+++ b/pylib/robonix-api/scripts/build_dist.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MulanPSL-2.0
+#
+# Build robonix-api sdist + wheel for PyPI / Test PyPI.
+#
+# Steps:
+#   1. Run protoc against rust/crates/robonix-atlas/proto/atlas.proto
+#      and write atlas_pb2.py / atlas_pb2_grpc.py into robonix_api/_generated/.
+#   2. `python -m build` to produce dist/*.tar.gz + dist/*.whl.
+#
+# Does NOT upload. Run scripts/publish_testpypi.sh / scripts/publish_pypi.sh
+# afterwards to publish.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PKG_ROOT="$(cd "$HERE/.." && pwd)"
+REPO_ROOT="$(cd "$PKG_ROOT/../.." && pwd)"
+PROTO_DIR="$REPO_ROOT/rust/crates/robonix-atlas/proto"
+PROTO_FILE="$PROTO_DIR/atlas.proto"
+OUT_DIR="$PKG_ROOT/robonix_api/_generated"
+
+if [[ ! -f "$PROTO_FILE" ]]; then
+    echo "ERR: atlas.proto not found at $PROTO_FILE" >&2
+    exit 1
+fi
+
+PYTHON="${PYTHON:-python3}"
+
+if ! "$PYTHON" -c "import grpc_tools.protoc" 2>/dev/null; then
+    echo "ERR: grpc_tools not installed in $PYTHON." >&2
+    echo "     Install with: $PYTHON -m pip install grpcio-tools" >&2
+    exit 1
+fi
+if ! "$PYTHON" -c "import build" 2>/dev/null; then
+    echo "ERR: build not installed in $PYTHON." >&2
+    echo "     Install with: $PYTHON -m pip install build" >&2
+    exit 1
+fi
+
+echo "[build_dist] cleaning $OUT_DIR and dist/"
+rm -rf "$OUT_DIR" "$PKG_ROOT/dist" "$PKG_ROOT/build" "$PKG_ROOT"/*.egg-info
+mkdir -p "$OUT_DIR"
+
+echo "[build_dist] generating atlas_pb2*.py from $PROTO_FILE"
+"$PYTHON" -m grpc_tools.protoc \
+    -I "$PROTO_DIR" \
+    --python_out="$OUT_DIR" \
+    --grpc_python_out="$OUT_DIR" \
+    "$PROTO_FILE"
+
+# grpc_tools emits atlas_pb2_grpc.py with `import atlas_pb2 as ...` at top
+# level. That works because robonix_api/__init__.py appends _generated/ to
+# sys.path on import. Mark _generated as a package so wheel data inclusion
+# is clean.
+touch "$OUT_DIR/__init__.py"
+echo "[build_dist] generated files:"
+ls -1 "$OUT_DIR"
+
+echo "[build_dist] python -m build"
+cd "$PKG_ROOT"
+"$PYTHON" -m build
+
+echo "[build_dist] done. Artifacts:"
+ls -la "$PKG_ROOT/dist"

--- a/pylib/robonix-api/scripts/build_dist.sh
+++ b/pylib/robonix-api/scripts/build_dist.sh
@@ -49,10 +49,14 @@ echo "[build_dist] generating atlas_pb2*.py from $PROTO_FILE"
     --grpc_python_out="$OUT_DIR" \
     "$PROTO_FILE"
 
-# grpc_tools emits atlas_pb2_grpc.py with `import atlas_pb2 as ...` at top
-# level. That works because robonix_api/__init__.py appends _generated/ to
-# sys.path on import. Mark _generated as a package so wheel data inclusion
-# is clean.
+# Patch grpc_tools' default `import atlas_pb2 as ...` (top-level) into a
+# relative import so _generated/ ships as a proper sub-package and we
+# don't have to mutate global sys.path at runtime.
+sed -i 's|^import atlas_pb2 as |from . import atlas_pb2 as |' \
+    "$OUT_DIR/atlas_pb2_grpc.py"
+
+# Mark _generated as a sub-package — both for wheel data inclusion and
+# for the relative import from atlas_pb2_grpc.py above.
 touch "$OUT_DIR/__init__.py"
 echo "[build_dist] generated files:"
 ls -1 "$OUT_DIR"


### PR DESCRIPTION
## Summary

Make `pip install robonix-api` work for users outside the monorepo — first step towards growing the Robonix developer ecosystem.

**No public API surface changes** — v0.1 lock holds. All in-repo packages and existing monorepo workflows continue working unchanged.

## What this PR does

- **`pyproject.toml`**: complete deps (`grpcio`, `protobuf`, `pyyaml` — were implicit before), add `[codegen]` optional extras for `grpcio-tools`, PyPI classifiers / urls / readme / Mulan license metadata, bump version `0.1.0` → `0.1.0rc1`
- **`README.md`** (new): PyPI long_description with install + hello-primitive example + links back to monorepo
- **`LICENSE`** (new): copy of repo-root Mulan PSL v2 so the wheel ships license
- **`scripts/build_dist.sh`** (new): runs `grpc_tools.protoc` against `rust/crates/robonix-atlas/proto/atlas.proto` into `robonix_api/_generated/`, then `python -m build`. Atlas wire stub is wheel-bundled so pip-installed users don't need `rbnx codegen` to use the registry RPC layer.
- **`__init__.py`**: append `_generated/` to `sys.path` **AFTER** the existing deployment-side `proto_gen/` injection — append-not-insert is load-bearing, monorepo dev flow keeps resolving `atlas_pb2` from the deployment's codegen output first
- **`.gitignore`**: `robonix_api/_generated/` is build-time output, not source

## What this PR does NOT do

- Upload to Test PyPI or PyPI — that lands in a separate PR with the publish script + token handling once we've eyeballed the wheel contents
- Touch any public symbol, signature, or behavior in `atlas.py` / `capability.py` / `lifecycle.py` / `atlas_types.py` / `tool.py` / etc.
- Touch any in-repo package, upstream package, Rust crate, or contract TOML

## Validation

```bash
cd pylib/robonix-api
python3 -m venv /tmp/build-venv
/tmp/build-venv/bin/pip install build grpcio-tools
PYTHON=/tmp/build-venv/bin/python bash scripts/build_dist.sh
# -> dist/robonix_api-0.1.0rc1-py3-none-any.whl
# -> dist/robonix_api-0.1.0rc1.tar.gz
```

**Clean-venv smoke test** (no monorepo on `sys.path`, fresh interpreter):

```
all public symbols import OK
ATLAS: _Atlas
Primitive: <class 'robonix_api.capability.Primitive'>
atlas_pb2 imports: .../site-packages/robonix_api/_generated/atlas_pb2.py
atlas_pb2_grpc imports: .../site-packages/robonix_api/_generated/atlas_pb2_grpc.py
Primitive instance created: smoke_test robonix/primitive/smoke
```

**Monorepo precedence test** (simulated `proto_gen/atlas_pb2.py` on `sys.path` ahead of wheel):

```
PASS: deployment-side atlas_pb2 wins: /tmp/tmp4l131jya/proto_gen/atlas_pb2.py
```

## Test plan

- [ ] Smoke-build `examples/webots/` against this branch — verify no regression in the deployment-side codegen flow
- [ ] (Out of scope for this PR) Test PyPI upload + reinstall verification
- [ ] (Out of scope for this PR) Real PyPI release

## Notes for reviewers

The append-vs-insert ordering in `__init__.py:_bootstrap_bundled_atlas_stub` is intentional and load-bearing. Inverting it would shadow per-deployment `proto_gen/` stubs with the wheel's stub on every monorepo boot — see the precedence test above.