### PR TITLE
fix(robonix-api): pre-PyPI hardening — 4 HIGH fixes (#44)

### DIFF
--- a/pylib/robonix-api/robonix_api/_lifecycle_internal.py
+++ b/pylib/robonix-api/robonix_api/_lifecycle_internal.py
@@ -57,4 +57,8 @@ def _set_lifecycle_state(
             detail=detail,
         ))
     except Exception as e:  # noqa: BLE001
-        log.debug("SetLifecycleState(%s, %s): %s", id, cs.name, e)
+        # State pushes are a correctness signal — when atlas drops them
+        # the local provider thinks ACTIVE but `rbnx caps` still shows
+        # the old state. Warn loudly so the silent-divergence is visible
+        # in default-level logs (was log.debug; silenced real outages).
+        log.warning("SetLifecycleState(%s, %s) failed: %s", id, cs.name, e)

--- a/pylib/robonix-api/robonix_api/atlas.py
+++ b/pylib/robonix-api/robonix_api/atlas.py
@@ -90,28 +90,37 @@ class _Atlas:
         self._channel: Any = None
         self._stub: Any = None
         self._pb: Any = None
+        # Guards the singleton cold start: heartbeat thread + main thread
+        # race the first declare_capability otherwise (double channel +
+        # leaked grpc.aio polling threads). Double-checked under the lock.
+        self._stub_lock = threading.Lock()
 
     # -- lazy stub bootstrap -------------------------------------------------
 
     def _ensure_stub(self) -> None:
         if self._stub is not None:
             return
-        import grpc
-        # Deployment-side stubs (from `<pkg>/rbnx-build/codegen/proto_gen/`,
-        # injected onto sys.path by codegen.ensure_proto_gen) take priority.
-        # Fall back to the wheel-bundled stubs under `robonix_api._generated/`
-        # for pip-installed users without a monorepo codegen run.
-        try:
-            import atlas_pb2          # type: ignore
-            import atlas_pb2_grpc     # type: ignore
-        except ImportError:
-            from ._generated import atlas_pb2          # type: ignore
-            from ._generated import atlas_pb2_grpc     # type: ignore
-        ep = self._endpoint or os.environ.get("ROBONIX_ATLAS", "127.0.0.1:50051")
-        self._endpoint = ep
-        self._pb = atlas_pb2
-        self._channel = grpc.insecure_channel(ep)
-        self._stub = atlas_pb2_grpc.AtlasStub(self._channel)
+        with self._stub_lock:
+            if self._stub is not None:
+                return
+            import grpc
+            # Deployment-side stubs (from `<pkg>/rbnx-build/codegen/proto_gen/`,
+            # injected onto sys.path by codegen.ensure_proto_gen) take priority.
+            # Fall back to the wheel-bundled stubs under `robonix_api._generated/`
+            # for pip-installed users without a monorepo codegen run.
+            try:
+                import atlas_pb2          # type: ignore
+                import atlas_pb2_grpc     # type: ignore
+            except ImportError:
+                from ._generated import atlas_pb2          # type: ignore
+                from ._generated import atlas_pb2_grpc     # type: ignore
+            ep = self._endpoint or os.environ.get("ROBONIX_ATLAS", "127.0.0.1:50051")
+            self._endpoint = ep
+            self._pb = atlas_pb2
+            channel = grpc.insecure_channel(ep)
+            stub = atlas_pb2_grpc.AtlasStub(channel)
+            self._channel = channel
+            self._stub = stub
 
     @property
     def _wire_pb(self):
@@ -180,13 +189,28 @@ class _Atlas:
         except Exception as e:  # noqa: BLE001
             log.debug("heartbeat(%s): %s", id, e)
 
-    def start_heartbeat(self, id: str, period_s: float = 30.0) -> threading.Thread:
+    def start_heartbeat(
+        self,
+        id: str,
+        period_s: float = 30.0,
+        stop: threading.Event | None = None,
+    ) -> threading.Thread:
         """Background daemon thread that pings Heartbeat every `period_s`
-        seconds. Returns the thread for caller bookkeeping (or to ignore)."""
+        seconds. Returns the thread for caller bookkeeping (or to ignore).
+
+        If `stop` is given, the loop polls it via `stop.wait(period_s)` and
+        exits cleanly when set — providers should pass their teardown
+        Event so the heartbeat thread stops trying to ping atlas after
+        `_set_state(TERMINATED)`. Default `None` keeps the legacy
+        unbounded loop (interpreter-exit relies on daemon=True)."""
         def _loop():
-            while True:
-                time.sleep(period_s)
-                self.heartbeat(id)
+            if stop is None:
+                while True:
+                    time.sleep(period_s)
+                    self.heartbeat(id)
+            else:
+                while not stop.wait(period_s):
+                    self.heartbeat(id)
         t = threading.Thread(target=_loop, name=f"robonix-hb-{id}", daemon=True)
         t.start()
         return t

--- a/pylib/robonix-api/robonix_api/capability.py
+++ b/pylib/robonix-api/robonix_api/capability.py
@@ -58,7 +58,12 @@ log = logging.getLogger("robonix_api.capability")
 
 def _install_simple_logger() -> None:
     """Replace `rich`-installed RichHandler (from fastmcp / uvicorn) with
-    a plain stderr handler. Idempotent."""
+    a plain stderr handler. Idempotent.
+
+    Called from `_do_bootstrap()` (NOT at module import) so a bare
+    `import robonix_api` does not wipe the host application's logging
+    config — only kicks in when the caller actually decides to run a
+    Primitive / Service / Skill."""
     if getattr(_install_simple_logger, "_done", False):
         return
     root = logging.getLogger()
@@ -75,9 +80,6 @@ def _install_simple_logger() -> None:
     if root.level == logging.NOTSET or root.level > logging.INFO:
         root.setLevel(logging.INFO)
     _install_simple_logger._done = True  # type: ignore[attr-defined]
-
-
-_install_simple_logger()
 
 # Transport-ENUM <-> contract.mode compatibility matrix (best-effort
 # check at declare_capability time).
@@ -589,6 +591,13 @@ class _ProviderBase:
         raise NotImplementedError
 
     def _do_bootstrap(self) -> None:
+        # 0. swap the rich-installed RichHandler (if any) for our plain
+        # stderr handler. Deliberately deferred from import time so that
+        # `import robonix_api` is a no-op on the host application's
+        # logging — only kicks in once the caller is actually running a
+        # provider process.
+        _install_simple_logger()
+
         # 1. atlas register
         registered_ok = False
         try:
@@ -710,8 +719,9 @@ class _ProviderBase:
             if self._mcp_handlers:
                 self._declare_mcp_handlers()
 
-        # 5. heartbeat
-        self._heartbeat_thread = ATLAS.start_heartbeat(self.id)
+        # 5. heartbeat — pass the provider's stop Event so the thread
+        # exits on _teardown instead of pinging atlas after TERMINATED.
+        self._heartbeat_thread = ATLAS.start_heartbeat(self.id, stop=self._stopping)
 
         # 6. state promotion: caps WITHOUT a Driver contract (system
         # services with only MCP tools) are fully ready as soon as gRPC


### PR DESCRIPTION
Addresses the 4 **HIGH**-severity items in #44 — pre-publish review of `robonix-api` before we push `0.1.0rc1` to PyPI. **No public API surface changes.** v0.1 lock holds.

## Fixes (commit `827b507`)

### 1. `_Atlas._ensure_stub` TOCTOU race — `atlas.py:96-114`
Heartbeat thread (`_do_bootstrap` starts it immediately) raced the main thread's first `declare_capability`; both could pass `self._stub is None`, both build a `grpc.insecure_channel`, the losing channel leaked along with its `grpc.aio` polling threads.

**Fix:** double-checked lock on `self._stub_lock`.

### 2. `start_heartbeat` thread never stops — `atlas.py:183-192` + `capability.py:714`
`while True: time.sleep; heartbeat(id)` had no exit condition. Heartbeat kept pinging atlas after `_teardown` had already transitioned the provider to TERMINATED; REPL/test scenarios saw dangling threads pinging stale ids.

**Fix:** new optional `stop: threading.Event` kwarg on `start_heartbeat`. Default `None` preserves the legacy unbounded loop. `_do_bootstrap` now passes `self._stopping`, which `_teardown` already `.set()`s.

### 3. State push to atlas silently swallowed — `_lifecycle_internal.py:53-60`
`SetLifecycleState` RPC failures logged at DEBUG. At default INFO level an atlas-unavailable error was invisible — local provider thought ACTIVE, `rbnx caps` still showed the old state, no warning explained the divergence.

**Fix:** escalate to WARNING. Keep the swallow (transient atlas blip shouldn't crash provider), but make the failure visible.

### 4. `_install_simple_logger()` import-time host-logging wipe — `capability.py:80`
`import robonix_api` removed every root handler from the host application. Anyone with their own `dictConfig` / Sentry / FileHandler etc. silently lost it. The justification (RichHandler from fastmcp/uvicorn) was wrong — those imports are lazy inside robonix-api, so the handlers haven't been installed yet at module-import time.

**Fix:** move the call from `capability.py` module top-level into `_ProviderBase._do_bootstrap()`. The wipe only kicks in when the caller actually runs a Primitive / Service / Skill.

## What does NOT change

`from robonix_api import ATLAS, Primitive, Service, Skill, Ok, Err, Deferred, Result, Capability, CapabilityProvider, Channel, ContractDescriptor, GrpcParams, Ros2Params, McpParams, Kind, LifecycleState, Transport, mcp_contract` — 18 public symbols, signatures, return types: all unchanged.

`start_heartbeat`'s new `stop` kwarg is additive with `None` default.

## Verification

**Unit checks** in a clean venv against the rebuilt wheel:

```
PASS#1:  has _stub_lock
PASS#2:  start_heartbeat has stop=, default= None
PASS#3:  warning emitted on RPC fail: SetLifecycleState(smoke, ACTIVE) failed: <_InactiveRpcError ... UNAVAILABLE>
PASS#11: host FileHandler intact after import robonix_api
```

**e2e** via `rbnx boot` of an out-of-tree Primitive:

```
[ OK ]  atlas               :50051
[ OK ]  e2e_hard            ACTIVE

$ rbnx caps -v
● e2e_hard [ACTIVE] robonix/primitive/audio
    └─ robonix/primitive/audio/driver (grpc)

# After rbnx shutdown (atlas dies first, provider tries final state push):
WARNING robonix_api._lifecycle_internal: SetLifecycleState(e2e_hard, TERMINATED) failed: UNAVAILABLE
```

The warning on shutdown is **exactly** the silent failure #3 was hiding — before, this was sunk to DEBUG and invisible.

## Out of scope

8 MEDIUM items remain tracked in #44 for follow-up PRs:
- Channel close race
- `connect_capability` contract_id mismatch validation
- `_atlas_register` return-type fiction
- Hardcoded `127.0.0.1` advertise address (`ROBONIX_ADVERTISE_ADDR`)
- `resolve_servicer` `vars()` heuristic
- `RosBackend.shutdown()` unreachable
- `create_subscription(declare=True)` default
- `tool.make_shim` `exec()` with unvalidated identifiers

None are silent-correctness bugs and several need API design discussion (e.g. #7 multi-host advertise, #10 default flip).