### PR TITLE
feat(liaison): use Tencent Cloud ASR for voice sessions

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -586,6 +586,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "data-url"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -667,6 +673,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -899,6 +906,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1126,6 +1148,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "hostname"
@@ -1795,6 +1826,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe 0.2.1",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1875,6 +1923,32 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl"
+version = "0.10.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "openssl-probe"
@@ -2904,9 +2978,11 @@ name = "robonix-liaison"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64",
  "clap",
  "env_logger",
  "futures",
+ "hmac",
  "log",
  "prost",
  "protoc-bin-vendored",
@@ -2914,12 +2990,15 @@ dependencies = [
  "robonix-codegen",
  "serde",
  "serde_json",
+ "sha1",
  "tokio",
  "tokio-stream",
+ "tokio-tungstenite",
  "tonic",
  "tonic-build",
  "tonic-prost",
  "tonic-prost-build",
+ "urlencoding",
  "uuid",
  "whoami",
 ]
@@ -3250,6 +3329,17 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -3688,6 +3778,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3706,6 +3806,20 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tungstenite",
 ]
 
 [[package]]
@@ -3924,6 +4038,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "native-tls",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4037,6 +4169,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "usvg"
 version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4063,6 +4201,12 @@ dependencies = [
  "unicode-vo",
  "xmlwriter",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/rust/crates/robonix-liaison/Cargo.toml
+++ b/rust/crates/robonix-liaison/Cargo.toml
@@ -21,6 +21,10 @@ path = "examples/mock_pilot.rs"
 name = "mock_audio"
 path = "examples/mock_audio.rs"
 
+[[example]]
+name = "voice_client"
+path = "examples/voice_client.rs"
+
 [dependencies]
 tokio.workspace = true
 tokio-stream = "0.1"
@@ -35,6 +39,11 @@ log.workspace = true
 env_logger.workspace = true
 uuid.workspace = true
 futures = "0.3"
+hmac = "0.12"
+sha1 = "0.10"
+base64 = "0.22"
+urlencoding = "2.1"
+tokio-tungstenite = { version = "0.28", features = ["native-tls"] }
 whoami = "1.5"
 robonix-atlas = { path = "../robonix-atlas" }
 

--- a/rust/crates/robonix-liaison/README.md
+++ b/rust/crates/robonix-liaison/README.md
@@ -21,7 +21,7 @@
       SrvLiaison.StartVoiceSession(req)
         │
         ├─ PrmAudioMic.Stream (录音 N 秒)
-        ├─ SrvSpeechAsr.Call (语音识别)
+        ├─ Tencent Cloud ASR WebSocket API (语音识别)
         ├─ SrvSpeechVoiceprint.Call (声纹识别 → user_id)
         ├─ 组装 pilot::Task { user_id, text=transcript, … }
         ├─ SrvPilot.Stream
@@ -62,6 +62,13 @@ cd rust
 | `ROBONIX_LIAISON_VOICE_MOCK` | (unset) | 设为 `1` 跳过 mic+ASR，使用预置文本 |
 | `ROBONIX_LIAISON_VOICE_MOCK_TEXT` | `你好，请介绍一下你自己。` | mock 模式下使用的文本 |
 | `ROBONIX_LIAISON_SOURCE` | (unset) | 设为 `text` 启用 stdin 文本循环 (headless) |
+| `ROBONIX_LIAISON_TENCENT_ASR_APP_ID` / `TENCENT_ASR_APP_ID` / `TENCENTCLOUD_APP_ID` | (必填) | 腾讯云账号 AppID |
+| `ROBONIX_LIAISON_TENCENT_ASR_SECRET_ID` / `TENCENT_ASR_SECRET_ID` / `TENCENTCLOUD_SECRET_ID` | (必填) | 腾讯云 API SecretId |
+| `ROBONIX_LIAISON_TENCENT_ASR_SECRET_KEY` / `TENCENT_ASR_SECRET_KEY` / `TENCENTCLOUD_SECRET_KEY` | (必填) | 腾讯云 API SecretKey |
+| `ROBONIX_LIAISON_TENCENT_ASR_HOST` | `asr.cloud.tencent.com` | 腾讯云实时 ASR WebSocket host |
+| `ROBONIX_LIAISON_TENCENT_ASR_PATH` | `/asr/v2` | 腾讯云实时 ASR WebSocket path |
+| `ROBONIX_LIAISON_TENCENT_ASR_ENGINE_MODEL_TYPE` / `TENCENT_ASR_ENGINE_MODEL_TYPE` | `16k_zh` | 识别引擎，默认 16 kHz 中文 |
+| `ROBONIX_LIAISON_TENCENT_ASR_NEED_VAD` | `1` | 是否启用腾讯云服务端 VAD |
 
 ## TUI 快捷键
 

--- a/rust/crates/robonix-liaison/examples/voice_client.rs
+++ b/rust/crates/robonix-liaison/examples/voice_client.rs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MulanPSL-2.0
+// Minimal non-interactive client for RobonixSystemLiaisonVoice.
+//
+// Useful for smoke-testing a running Robonix stack:
+//   cargo run -p robonix-liaison --example voice_client
+
+use anyhow::Result;
+use robonix_liaison::pb::contracts::robonix_system_liaison_voice_client::RobonixSystemLiaisonVoiceClient;
+use robonix_liaison::pb::liaison::{StartVoiceSessionRequest, VoiceEvent};
+use tokio_stream::StreamExt;
+use uuid::Uuid;
+
+const KIND_ASR_FINAL: u32 = 4;
+const KIND_SESSION_DONE: u32 = 9;
+const KIND_ERROR: u32 = 10;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let endpoint = std::env::var("ROBONIX_LIAISON_ENDPOINT")
+        .unwrap_or_else(|_| "http://127.0.0.1:50081".to_string());
+    let record_seconds = std::env::var("ROBONIX_VOICE_TEST_RECORD_SECONDS")
+        .ok()
+        .and_then(|v| v.parse::<u32>().ok())
+        .unwrap_or(8);
+
+    let req = StartVoiceSessionRequest {
+        session_id: Uuid::new_v4().to_string(),
+        client_user_id: "voice-test".to_string(),
+        record_seconds,
+        language: String::new(),
+        tts_enabled: false,
+        mic_node_id: std::env::var("ROBONIX_CHAT_MIC_NODE").unwrap_or_default(),
+        asr_node_id: String::new(),
+        voiceprint_node_id: String::new(),
+        tts_node_id: String::new(),
+        speaker_node_id: std::env::var("ROBONIX_CHAT_SPEAKER_NODE").unwrap_or_default(),
+        context_json: r#"{"test":"liaison_asr"}"#.to_string(),
+    };
+
+    let mut client = RobonixSystemLiaisonVoiceClient::connect(endpoint.clone()).await?;
+    let mut stream = client
+        .start_voice_session(tonic::Request::new(req))
+        .await?
+        .into_inner();
+
+    let mut asr_final = String::new();
+    let mut saw_done = false;
+    while let Some(item) = stream.next().await {
+        let event = item?;
+        print_event(&event);
+        match event.event_kind {
+            KIND_ASR_FINAL => asr_final = event.text.clone(),
+            KIND_SESSION_DONE => saw_done = true,
+            KIND_ERROR => anyhow::bail!("voice session error: {}", event.error),
+            _ => {}
+        }
+    }
+
+    if asr_final.trim().is_empty() {
+        anyhow::bail!("no ASR_FINAL text received");
+    }
+    if !saw_done {
+        anyhow::bail!("voice session ended without SESSION_DONE");
+    }
+    println!("ASR_FINAL={asr_final}");
+    Ok(())
+}
+
+fn print_event(event: &VoiceEvent) {
+    let kind = match event.event_kind {
+        0 => "SESSION_STARTED",
+        1 => "RECORDING_STARTED",
+        2 => "RECORDING_DONE",
+        3 => "ASR_PARTIAL",
+        4 => "ASR_FINAL",
+        5 => "USER_IDENTIFIED",
+        6 => "PILOT",
+        7 => "TTS_STARTED",
+        8 => "TTS_DONE",
+        9 => "SESSION_DONE",
+        10 => "ERROR",
+        _ => "UNKNOWN",
+    };
+    if !event.text.is_empty() {
+        println!("{kind}: {}", event.text);
+    } else if !event.status_message.is_empty() {
+        println!("{kind}: {}", event.status_message);
+    } else if !event.error.is_empty() {
+        println!("{kind}: {}", event.error);
+    } else if let Some(pilot) = &event.pilot {
+        println!("{kind}: pilot_event kind={}", pilot.event_kind);
+    } else {
+        println!("{kind}");
+    }
+}

--- a/rust/crates/robonix-liaison/src/voice.rs
+++ b/rust/crates/robonix-liaison/src/voice.rs
@@ -6,7 +6,7 @@
 //   RobonixPrimitiveAudioMic.Stream  (record_seconds)
 //       │
 //       ▼
-//   SystemSpeechAsr.Recognize    → transcript
+//   Tencent Cloud ASR WebSocket API   → transcript
 //       │
 //       ▼
 //   RobonixSystemSpeechVoiceprint.Identify → user_id  (graceful: hint fallback on absence)
@@ -28,13 +28,17 @@
 // audio hardware. This is what the demo script uses by default.
 
 use anyhow::Result;
-use futures::Stream;
+use base64::Engine as _;
+use futures::{SinkExt, Stream};
+use hmac::{Hmac, Mac};
 use robonix_atlas::client::AtlasClient;
 use robonix_atlas::pb as atlas_pb;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{Mutex, mpsc};
 use tokio_stream::{StreamExt, wrappers::ReceiverStream};
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, tungstenite::Message};
 use tonic::{Request, Status};
 use uuid::Uuid;
 
@@ -43,7 +47,6 @@ use crate::pb::contracts::{
     robonix_primitive_audio_mic_client::RobonixPrimitiveAudioMicClient,
     robonix_primitive_audio_speaker_client::RobonixPrimitiveAudioSpeakerClient,
     robonix_system_pilot_client::RobonixSystemPilotClient,
-    robonix_system_speech_asr_stream_client::RobonixSystemSpeechAsrStreamClient,
     robonix_system_speech_tts_client::RobonixSystemSpeechTtsClient,
     robonix_system_speech_voiceprint_client::RobonixSystemSpeechVoiceprintClient,
 };
@@ -75,7 +78,7 @@ const DEFAULT_RECORD_SECONDS: u32 = 30;
 /// Silence-VAD parameters. After we've heard a chunk above
 /// `VAD_SPEECH_RMS`, count consecutive sub-threshold chunks; once the
 /// silence lasts `VAD_END_SILENCE_SECS`, treat the utterance as done
-/// and close the ASR request stream so the server flushes its final.
+/// and stop collecting mic chunks before calling the ASR API.
 /// Tuned for 16 kHz mono s16le speech: speech RMS is typically 1k–8k,
 /// background noise sits around 50–300, so 500 is a comfortable gap.
 const VAD_SPEECH_RMS: f32 = 500.0;
@@ -83,6 +86,12 @@ const VAD_END_SILENCE_SECS: f32 = 1.2;
 const DEFAULT_ASR_LANGUAGE: &str = "";
 const DEFAULT_AUDIO_ENCODING: &str = "pcm_s16le";
 const DEFAULT_AUDIO_SAMPLE_RATE: u32 = 16_000;
+const TENCENT_ASR_DEFAULT_HOST: &str = "asr.cloud.tencent.com";
+const TENCENT_ASR_DEFAULT_PATH: &str = "/asr/v2";
+const TENCENT_ASR_DEFAULT_ENGINE: &str = "16k_zh";
+const TENCENT_ASR_CHUNK_BYTES: usize = 6400;
+const TENCENT_ASR_CHUNK_INTERVAL_MS: u64 = 200;
+const TENCENT_ASR_END_TAG: &str = r#"{"type":"end"}"#;
 
 // ── Discovery helpers ────────────────────────────────────────────────────────
 //
@@ -250,10 +259,10 @@ async fn run_session(
 ) -> Result<()> {
     let mock = is_mock_mode();
     // `record_seconds` is now a hard-stop ceiling on streaming capture
-    // (FunASR's VAD ends the turn under most conditions; this just
+    // (local silence-VAD ends the turn under most conditions; this just
     // protects against a sensor that never goes silent). 0 / unset →
-    // 30 s default. Whisper's old "record-then-recognize" pattern is
-    // gone; voice goes through `asr_stream` end-to-end.
+    // 30 s default. ASR recognition now goes through the Tencent Cloud ASR API
+    // after mic capture finishes.
     let max_seconds: u32 = if record_seconds == 0 {
         30
     } else {
@@ -281,16 +290,12 @@ async fn run_session(
             .await;
         (Vec::new(), canned)
     } else {
-        // Mic → AsrAudioChunk pump + asr_stream.RecognizeStream both
-        // run inside `stream_capture_and_recognize`. It returns once
-        // FunASR emits is_final, the user hits max_seconds, or the
-        // mic stream drops. Voiceprint still gets the accumulated PCM
-        // for downstream identification (currently fallback-only).
-        stream_capture_and_recognize(
+        // Mic capture still comes from the audio primitive. ASR now calls
+        // Tencent Cloud ASR over WebSocket directly instead of discovering a
+        // Robonix speech/asr_stream gRPC provider.
+        capture_and_transcribe_with_cloud_asr(
             &atlas,
             &req.mic_node_id,
-            &req.asr_node_id,
-            &language,
             max_seconds,
             &session_id,
             &tx,
@@ -396,50 +401,62 @@ async fn run_session(
     Ok(())
 }
 
-// ── Mic capture + streaming ASR ─────────────────────────────────────────────
+// ── Mic capture + Tencent Cloud ASR API ─────────────────────────────────────
 //
-// Open the mic primitive AND `robonix/system/speech/asr_stream` (FunASR
-// paraformer-zh-streaming bidi) at the same time. Mic AudioChunks get
-// wrapped as AsrAudioChunk and pumped up the request side; the response
-// side yields RecognizeStreamEvents (PARTIAL → … → FINAL). On FINAL,
-// stop both streams and return `(accumulated_pcm, final_text)`.
-//
-// `max_seconds` is a hard ceiling — FunASR's VAD usually ends the turn
-// well before that, but we don't want to hang on a stuck mic.
+// Open the mic primitive, collect one utterance with the local silence-VAD,
+// then send the PCM to Tencent Cloud ASR over WebSocket. Tencent expects
+// 16 kHz mono s16le audio in 6400-byte chunks roughly every 200 ms.
 
-#[allow(clippy::too_many_arguments)]
-async fn stream_capture_and_recognize(
+async fn capture_and_transcribe_with_cloud_asr(
     atlas: &Arc<Mutex<AtlasClient>>,
     mic_pin: &str,
-    asr_pin: &str,
-    language: &str,
     max_seconds: u32,
     session_id: &str,
     tx: &mpsc::Sender<Result<VoiceEvent, Status>>,
 ) -> Result<(Vec<u8>, String)> {
+    let audio_pcm = capture_audio_pcm(atlas, mic_pin, max_seconds, session_id, tx).await?;
+    let _ = tx
+        .send(Ok(event_status(
+            KIND_RECORDING_DONE,
+            session_id,
+            &format!(
+                "captured {} bytes (~{:.2}s @ 16kHz mono s16le); sending to Tencent ASR API",
+                audio_pcm.len(),
+                audio_pcm.len() as f32 / (DEFAULT_AUDIO_SAMPLE_RATE as f32 * 2.0),
+            ),
+        )))
+        .await;
+
+    let transcript = cloud_asr_transcribe_pcm(&audio_pcm).await?;
+    if !transcript.is_empty() {
+        let _ = tx
+            .send(Ok(event_text(KIND_ASR_FINAL, session_id, &transcript, 1.0)))
+            .await;
+    }
+    Ok((audio_pcm, transcript))
+}
+
+async fn capture_audio_pcm(
+    atlas: &Arc<Mutex<AtlasClient>>,
+    mic_pin: &str,
+    max_seconds: u32,
+    session_id: &str,
+    tx: &mpsc::Sender<Result<VoiceEvent, Status>>,
+) -> Result<Vec<u8>> {
     let mic_endpoint = resolve_endpoint(atlas, "robonix/primitive/audio/mic", mic_pin)
         .await
         .ok_or_else(|| {
             anyhow::anyhow!("no RobonixPrimitiveAudioMic provider registered in Atlas")
         })?;
-    let asr_endpoint = resolve_endpoint(atlas, "robonix/system/speech/asr_stream", asr_pin)
-        .await
-        .ok_or_else(|| {
-            anyhow::anyhow!("no RobonixSystemSpeechAsrStream provider registered in Atlas")
-        })?;
-
     let mut mic_client = RobonixPrimitiveAudioMicClient::connect(mic_endpoint.clone())
         .await
         .map_err(|e| anyhow::anyhow!("connect mic at {mic_endpoint}: {e}"))?;
-    let mut asr_client = RobonixSystemSpeechAsrStreamClient::connect(asr_endpoint.clone())
-        .await
-        .map_err(|e| anyhow::anyhow!("connect asr_stream at {asr_endpoint}: {e}"))?;
 
     let _ = tx
         .send(Ok(event_status(
             KIND_RECORDING_STARTED,
             session_id,
-            &format!("streaming mic {mic_endpoint} → asr_stream {asr_endpoint}"),
+            &format!("recording mic {mic_endpoint} for Tencent ASR API"),
         )))
         .await;
 
@@ -449,148 +466,328 @@ async fn stream_capture_and_recognize(
         .map_err(|e| anyhow::anyhow!("mic rpc failed: {e}"))?
         .into_inner();
 
-    // Buffered hand-off: mic-pump task drops AsrAudioChunks onto the
-    // mpsc; tonic forwards them up the bidi as the request stream.
-    let (asr_req_tx, asr_req_rx) = mpsc::channel::<crate::pb::asr::AsrAudioChunk>(64);
-    let asr_req_stream = ReceiverStream::new(asr_req_rx);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(max_seconds as u64);
+    let mut pcm_buf =
+        Vec::<u8>::with_capacity((DEFAULT_AUDIO_SAMPLE_RATE as usize) * 2 * (max_seconds as usize));
+    let mut has_spoken = false;
+    let mut silence_secs: f32 = 0.0;
 
-    // Accumulator the mic-pump writes into; the outer task reads it
-    // back at the end so we can hand the raw PCM to identify_user.
-    let pcm_buf = Arc::new(Mutex::new(Vec::<u8>::with_capacity(
-        (DEFAULT_AUDIO_SAMPLE_RATE as usize) * 2 * (max_seconds as usize),
-    )));
-    let pcm_buf_for_pump = Arc::clone(&pcm_buf);
-    let _language_owned = language.to_string();
-
-    // Mic pump — drains the mic gRPC stream into the asr_req sender,
-    // accumulates raw PCM, runs silence-VAD on each chunk, stops on
-    // (whichever first):
-    //   1. max_seconds hard ceiling
-    //   2. mic stream EOF / error
-    //   3. silence-VAD end-of-utterance (after speech then quiet)
-    //   4. outer task drops asr_req_rx (server already returned FINAL)
-    let pump_handle: tokio::task::JoinHandle<()> = tokio::spawn(async move {
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(max_seconds as u64);
-        let mut has_spoken = false;
-        let mut silence_secs: f32 = 0.0;
-        loop {
-            if tokio::time::Instant::now() >= deadline {
-                break;
-            }
-            let remaining = deadline - tokio::time::Instant::now();
-            match tokio::time::timeout(remaining, mic_stream.message()).await {
-                Ok(Ok(Some(chunk))) => {
-                    let dur = chunk.duration_s.max(0.0);
-                    let rms = pcm_rms_s16le(&chunk.data);
-                    if rms >= VAD_SPEECH_RMS {
-                        has_spoken = true;
-                        silence_secs = 0.0;
-                    } else if has_spoken {
-                        silence_secs += dur;
-                    }
-                    pcm_buf_for_pump.lock().await.extend_from_slice(&chunk.data);
-                    let asr_chunk = crate::pb::asr::AsrAudioChunk { chunk: Some(chunk) };
-                    if asr_req_tx.send(asr_chunk).await.is_err() {
-                        break;
-                    }
-                    if has_spoken && silence_secs >= VAD_END_SILENCE_SECS {
-                        // Drops asr_req_tx → server sees stream EOF →
-                        // FunASR emits its is_final flush → outer loop
-                        // collects the final transcript and breaks.
-                        break;
-                    }
-                }
-                Ok(Ok(None)) => break,
-                Ok(Err(_)) => break,
-                Err(_) => break,
-            }
-        }
-    });
-
-    // FunASR docs: AsrAudioChunk + ASR backend reads its own audio_config
-    // defaults (16 kHz mono pcm_s16le); language hint is on the bidi
-    // request metadata, not the per-chunk message. Tonic-codegen
-    // doesn't surface a separate header field here, so we just rely on
-    // FunASR's auto-detection — paraformer-zh-streaming is zh-only so
-    // this is fine. If a multi-lingual backend is ever wired in, the
-    // contract needs an extra preamble message.
-    let asr_resp = asr_client
-        .recognize_stream(Request::new(asr_req_stream))
-        .await
-        .map_err(|e| anyhow::anyhow!("asr_stream rpc failed: {e}"))?;
-    let mut asr_events = asr_resp.into_inner();
-
-    // FunASR's paraformer-zh-streaming emits *incremental* partials —
-    // each event carries only the words decoded from the most recent
-    // chunk window, not a cumulative transcript. The is_final flush
-    // (`recognize_chunk(b"", is_final=True)`) emits the residual
-    // window's text the same way (sometimes empty).
-    //
-    // Strategy: append every non-empty event text into `accumulated`,
-    // and use the accumulator as the final transcript. The server's
-    // is_final flag only tells us when to stop the loop — it does
-    // NOT mean "this event's text is the whole utterance"; treating
-    // it that way drops every prior partial and leaves the user with
-    // just the last syllable.
-    let mut accumulated = String::new();
-    let mut last_confidence = 0.0_f32;
-    while let Some(ev_or_err) = asr_events.next().await {
-        let ev = ev_or_err.map_err(|e| anyhow::anyhow!("asr_stream recv: {e}"))?;
-        if !ev.error.is_empty() {
-            anyhow::bail!("asr error: {}", ev.error);
-        }
-        let is_final = ev.is_final || ev.event_type == 1;
-        let text = ev.text.clone();
-        if !text.is_empty() {
-            accumulated.push_str(&text);
-            last_confidence = ev.confidence;
-            if !is_final {
-                let _ = tx
-                    .send(Ok(event_text(
-                        KIND_ASR_PARTIAL,
-                        session_id,
-                        &text,
-                        ev.confidence,
-                    )))
-                    .await;
-            }
-        }
-        if is_final {
+    loop {
+        if tokio::time::Instant::now() >= deadline {
             break;
         }
-    }
-    let transcript = accumulated;
-    if !transcript.is_empty() {
-        let _ = tx
-            .send(Ok(event_text(
-                KIND_ASR_FINAL,
-                session_id,
-                &transcript,
-                last_confidence,
-            )))
-            .await;
+        let remaining = deadline - tokio::time::Instant::now();
+        match tokio::time::timeout(remaining, mic_stream.message()).await {
+            Ok(Ok(Some(chunk))) => {
+                let dur = chunk.duration_s.max(0.0);
+                let rms = pcm_rms_s16le(&chunk.data);
+                if rms >= VAD_SPEECH_RMS {
+                    has_spoken = true;
+                    silence_secs = 0.0;
+                } else if has_spoken {
+                    silence_secs += dur;
+                }
+                pcm_buf.extend_from_slice(&chunk.data);
+                if has_spoken && silence_secs >= VAD_END_SILENCE_SECS {
+                    break;
+                }
+            }
+            Ok(Ok(None)) => break,
+            Ok(Err(e)) => anyhow::bail!("mic stream error: {e}"),
+            Err(_) => break,
+        }
     }
 
-    // Stop the mic pump (the outer task already dropped asr_req_rx by
-    // returning from the `while let` loop above, which closes the
-    // request stream).
-    pump_handle.abort();
-    let _ = pump_handle.await;
+    if pcm_buf.is_empty() {
+        anyhow::bail!("mic returned empty audio");
+    }
+    Ok(pcm_buf)
+}
 
-    let pcm = std::mem::take(&mut *pcm_buf.lock().await);
-    let _ = tx
-        .send(Ok(event_status(
-            KIND_RECORDING_DONE,
-            session_id,
-            &format!(
-                "captured {} bytes (~{:.2}s @ 16kHz mono s16le); transcript={:?}",
-                pcm.len(),
-                pcm.len() as f32 / (DEFAULT_AUDIO_SAMPLE_RATE as f32 * 2.0),
-                transcript,
-            ),
-        )))
-        .await;
-    Ok((pcm, transcript))
+async fn cloud_asr_transcribe_pcm(audio_pcm: &[u8]) -> Result<String> {
+    if audio_pcm.is_empty() {
+        anyhow::bail!("empty audio for Tencent ASR");
+    }
+
+    let config = TencentAsrConfig::from_env()?;
+    let url = config.signed_url()?;
+    let (mut ws, _resp) = tokio_tungstenite::connect_async(&url)
+        .await
+        .map_err(|e| anyhow::anyhow!("connect Tencent ASR websocket: {e}"))?;
+
+    let mut results = TencentAsrResults::default();
+    let mut send_finished = false;
+    wait_for_tencent_asr_handshake(&mut ws, &mut results).await?;
+
+    for chunk in audio_pcm.chunks(TENCENT_ASR_CHUNK_BYTES) {
+        ws.send(Message::Binary(chunk.to_vec().into()))
+            .await
+            .map_err(|e| anyhow::anyhow!("send Tencent ASR audio chunk: {e}"))?;
+        drain_tencent_asr_messages(&mut ws, &mut results).await?;
+        tokio::time::sleep(Duration::from_millis(TENCENT_ASR_CHUNK_INTERVAL_MS)).await;
+    }
+    ws.send(Message::Text(TENCENT_ASR_END_TAG.into()))
+        .await
+        .map_err(|e| anyhow::anyhow!("send Tencent ASR end tag: {e}"))?;
+
+    let final_deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    while tokio::time::Instant::now() < final_deadline {
+        match tokio::time::timeout(Duration::from_millis(500), ws.next()).await {
+            Ok(Some(Ok(msg))) => {
+                handle_tencent_asr_message(msg, &mut results, &mut send_finished)?;
+                if send_finished {
+                    break;
+                }
+            }
+            Ok(Some(Err(e))) => anyhow::bail!("receive Tencent ASR message: {e}"),
+            Ok(None) => break,
+            Err(_) if !results.is_empty() => break,
+            Err(_) => {}
+        }
+    }
+    let _ = ws.close(None).await;
+
+    Ok(results.transcript())
+}
+
+async fn wait_for_tencent_asr_handshake(
+    ws: &mut WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>,
+    results: &mut TencentAsrResults,
+) -> Result<()> {
+    match tokio::time::timeout(Duration::from_secs(5), ws.next()).await {
+        Ok(Some(Ok(msg))) => {
+            let mut finished = false;
+            handle_tencent_asr_message(msg, results, &mut finished)?;
+            Ok(())
+        }
+        Ok(Some(Err(e))) => anyhow::bail!("receive Tencent ASR handshake: {e}"),
+        Ok(None) => anyhow::bail!("Tencent ASR websocket closed before handshake"),
+        Err(_) => anyhow::bail!("Tencent ASR handshake timed out"),
+    }
+}
+
+async fn drain_tencent_asr_messages(
+    ws: &mut WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>,
+    results: &mut TencentAsrResults,
+) -> Result<()> {
+    loop {
+        match tokio::time::timeout(Duration::from_millis(10), ws.next()).await {
+            Ok(Some(Ok(msg))) => {
+                let mut finished = false;
+                handle_tencent_asr_message(msg, results, &mut finished)?;
+                if finished {
+                    break;
+                }
+            }
+            Ok(Some(Err(e))) => anyhow::bail!("receive Tencent ASR message: {e}"),
+            Ok(None) => break,
+            Err(_) => break,
+        }
+    }
+    Ok(())
+}
+
+fn handle_tencent_asr_message(
+    msg: Message,
+    results: &mut TencentAsrResults,
+    finished: &mut bool,
+) -> Result<TencentAsrAction> {
+    let text = match msg {
+        Message::Text(s) => s.to_string(),
+        Message::Binary(bytes) => String::from_utf8(bytes.to_vec())
+            .map_err(|e| anyhow::anyhow!("Tencent ASR binary message is not utf-8: {e}"))?,
+        Message::Close(_) => {
+            *finished = true;
+            return Ok(TencentAsrAction::Closed);
+        }
+        Message::Ping(_) | Message::Pong(_) | Message::Frame(_) => {
+            return Ok(TencentAsrAction::Other);
+        }
+    };
+    if text.is_empty() {
+        *finished = true;
+        return Ok(TencentAsrAction::Closed);
+    }
+
+    let value: serde_json::Value = serde_json::from_str(&text)
+        .map_err(|e| anyhow::anyhow!("parse Tencent ASR response JSON: {e}; raw={text}"))?;
+    let code = value.get("code").and_then(|v| v.as_i64()).unwrap_or(0);
+    if code != 0 {
+        let message = value
+            .get("message")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown error");
+        anyhow::bail!("Tencent ASR error code {code}: {message}; raw={text}");
+    }
+    if let Some(result) = value.get("result") {
+        results.push_result(result);
+    }
+    if value.get("final").and_then(|v| v.as_i64()) == Some(1) {
+        *finished = true;
+        Ok(TencentAsrAction::Final)
+    } else if value.get("result").is_some() {
+        Ok(TencentAsrAction::Result)
+    } else {
+        Ok(TencentAsrAction::Started)
+    }
+}
+
+#[derive(PartialEq, Eq)]
+enum TencentAsrAction {
+    Started,
+    Result,
+    Final,
+    Closed,
+    Other,
+}
+
+#[derive(Default)]
+struct TencentAsrResults {
+    latest: BTreeMap<i64, String>,
+    stable: BTreeMap<i64, String>,
+}
+
+impl TencentAsrResults {
+    fn push_result(&mut self, result: &serde_json::Value) {
+        let index = result.get("index").and_then(|v| v.as_i64()).unwrap_or(0);
+        let slice_type = result
+            .get("slice_type")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
+        let text = result
+            .get("voice_text_str")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        if text.is_empty() {
+            return;
+        }
+        self.latest.insert(index, text.clone());
+        if slice_type == 2 {
+            self.stable.insert(index, text);
+        }
+    }
+
+    fn transcript(&self) -> String {
+        let source = if self.stable.is_empty() {
+            &self.latest
+        } else {
+            &self.stable
+        };
+        source.values().cloned().collect::<String>()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.latest.is_empty() && self.stable.is_empty()
+    }
+}
+
+struct TencentAsrConfig {
+    app_id: String,
+    secret_id: String,
+    secret_key: String,
+    host: String,
+    path: String,
+    engine_model_type: String,
+    need_vad: String,
+}
+
+impl TencentAsrConfig {
+    /// Loads Tencent ASR credentials from environment so secrets do not land
+    /// in the repository or boot manifest by accident.
+    fn from_env() -> Result<Self> {
+        let app_id = std::env::var("ROBONIX_LIAISON_TENCENT_ASR_APP_ID")
+            .or_else(|_| std::env::var("TENCENT_ASR_APP_ID"))
+            .or_else(|_| std::env::var("TENCENTCLOUD_APP_ID"))
+            .map_err(|_| {
+                anyhow::anyhow!(
+                    "missing Tencent ASR app id; set ROBONIX_LIAISON_TENCENT_ASR_APP_ID or TENCENT_ASR_APP_ID"
+                )
+            })?;
+        let secret_id = std::env::var("ROBONIX_LIAISON_TENCENT_ASR_SECRET_ID")
+            .or_else(|_| std::env::var("TENCENT_ASR_SECRET_ID"))
+            .or_else(|_| std::env::var("TENCENTCLOUD_SECRET_ID"))
+            .map_err(|_| {
+                anyhow::anyhow!(
+                    "missing Tencent ASR SecretId; set ROBONIX_LIAISON_TENCENT_ASR_SECRET_ID or TENCENTCLOUD_SECRET_ID"
+                )
+            })?;
+        let secret_key = std::env::var("ROBONIX_LIAISON_TENCENT_ASR_SECRET_KEY")
+            .or_else(|_| std::env::var("TENCENT_ASR_SECRET_KEY"))
+            .or_else(|_| std::env::var("TENCENTCLOUD_SECRET_KEY"))
+            .map_err(|_| {
+                anyhow::anyhow!(
+                    "missing Tencent ASR SecretKey; set ROBONIX_LIAISON_TENCENT_ASR_SECRET_KEY or TENCENTCLOUD_SECRET_KEY"
+                )
+            })?;
+        let host = std::env::var("ROBONIX_LIAISON_TENCENT_ASR_HOST")
+            .unwrap_or_else(|_| TENCENT_ASR_DEFAULT_HOST.to_string());
+        let path = std::env::var("ROBONIX_LIAISON_TENCENT_ASR_PATH")
+            .unwrap_or_else(|_| TENCENT_ASR_DEFAULT_PATH.to_string());
+        let engine_model_type = std::env::var("ROBONIX_LIAISON_TENCENT_ASR_ENGINE_MODEL_TYPE")
+            .or_else(|_| std::env::var("TENCENT_ASR_ENGINE_MODEL_TYPE"))
+            .unwrap_or_else(|_| TENCENT_ASR_DEFAULT_ENGINE.to_string());
+        let need_vad = std::env::var("ROBONIX_LIAISON_TENCENT_ASR_NEED_VAD")
+            .unwrap_or_else(|_| "1".to_string());
+        Ok(Self {
+            app_id,
+            secret_id,
+            secret_key,
+            host,
+            path,
+            engine_model_type,
+            need_vad,
+        })
+    }
+
+    fn signed_url(&self) -> Result<String> {
+        type HmacSha1 = Hmac<sha1::Sha1>;
+        let timestamp = now_secs();
+        let expired = timestamp + 600;
+        let nonce = (timestamp % 10_000_000_000).to_string();
+        let mut params = BTreeMap::<String, String>::new();
+        params.insert("engine_model_type".into(), self.engine_model_type.clone());
+        params.insert("expired".into(), expired.to_string());
+        params.insert("filter_dirty".into(), "1".into());
+        params.insert("filter_modal".into(), "1".into());
+        params.insert("filter_punc".into(), "0".into());
+        params.insert("needvad".into(), self.need_vad.clone());
+        params.insert("nonce".into(), nonce);
+        params.insert("secretid".into(), self.secret_id.clone());
+        params.insert("timestamp".into(), timestamp.to_string());
+        params.insert("voice_format".into(), "1".into());
+        params.insert("voice_id".into(), Uuid::new_v4().to_string());
+
+        let query = params
+            .iter()
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect::<Vec<_>>()
+            .join("&");
+        let path = format!("{}/{}", self.path.trim_end_matches('/'), self.app_id);
+        let sign_payload = format!("{}{path}?{query}", self.host);
+        let mut mac = HmacSha1::new_from_slice(self.secret_key.as_bytes())
+            .map_err(|e| anyhow::anyhow!("create Tencent ASR hmac signer: {e}"))?;
+        mac.update(sign_payload.as_bytes());
+        let signature =
+            base64::engine::general_purpose::STANDARD.encode(mac.finalize().into_bytes());
+        let encoded_query = params
+            .iter()
+            .map(|(k, v)| format!("{}={}", urlencoding::encode(k), urlencoding::encode(v)))
+            .collect::<Vec<_>>()
+            .join("&");
+        Ok(format!(
+            "wss://{}{path}?{encoded_query}&signature={}",
+            self.host,
+            urlencoding::encode(&signature)
+        ))
+    }
+}
+
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
 }
 
 // ── Voiceprint ───────────────────────────────────────────────────────────────
@@ -985,5 +1182,60 @@ mod tests {
             &mut buf,
         );
         assert_eq!(buf, "hello world");
+    }
+
+    #[test]
+    fn tencent_asr_results_prefers_stable_slices() {
+        let mut results = TencentAsrResults::default();
+        results.push_result(&serde_json::json!({
+            "slice_type": 0,
+            "index": 0,
+            "voice_text_str": "你"
+        }));
+        results.push_result(&serde_json::json!({
+            "slice_type": 2,
+            "index": 0,
+            "voice_text_str": "你好"
+        }));
+        results.push_result(&serde_json::json!({
+            "slice_type": 2,
+            "index": 1,
+            "voice_text_str": "世界"
+        }));
+
+        assert_eq!(results.transcript(), "你好世界");
+    }
+
+    #[test]
+    fn tencent_asr_signed_url_has_required_query_params() {
+        let config = TencentAsrConfig {
+            app_id: "1250000000".into(),
+            secret_id: "AKIDexample".into(),
+            secret_key: "secret".into(),
+            host: TENCENT_ASR_DEFAULT_HOST.into(),
+            path: TENCENT_ASR_DEFAULT_PATH.into(),
+            engine_model_type: TENCENT_ASR_DEFAULT_ENGINE.into(),
+            need_vad: "1".into(),
+        };
+
+        let url = config.signed_url().unwrap();
+        assert!(url.starts_with("wss://asr.cloud.tencent.com/asr/v2/1250000000?"));
+        assert!(url.contains("engine_model_type=16k_zh"));
+        assert!(url.contains("secretid=AKIDexample"));
+        assert!(url.contains("voice_format=1"));
+        assert!(url.contains("signature="));
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn tencent_asr_live_connects_with_env_credentials() {
+        let mut pcm = Vec::with_capacity(DEFAULT_AUDIO_SAMPLE_RATE as usize * 2);
+        for i in 0..DEFAULT_AUDIO_SAMPLE_RATE {
+            let phase = i as f32 * 440.0 * std::f32::consts::TAU / DEFAULT_AUDIO_SAMPLE_RATE as f32;
+            let sample = (phase.sin() * 1200.0) as i16;
+            pcm.extend_from_slice(&sample.to_le_bytes());
+        }
+
+        let _ = cloud_asr_transcribe_pcm(&pcm).await.unwrap();
     }
 }


### PR DESCRIPTION
This PR replaces Liaison’s voice-session ASR path from the previous gRPC ASR stream provider to Tencent Cloud realtime ASR over WebSocket, while keeping the rest of the voice flow unchanged: mic capture is still discovered through Atlas, and voiceprint, Pilot, optional TTS, and speaker playback continue to use the existing pipeline. It adds Tencent Cloud ASR signing and configuration through environment variables, sends captured PCM audio to Tencent Cloud, parses the returned recognition results into `ASR_FINAL`, and updates the Liaison documentation accordingly. The change was verified with `cargo test -p robonix-liaison`, a live Tencent Cloud ASR API test using environment-provided credentials, and an end-to-end Liaison voice-session test that successfully produced an `ASR_FINAL` result followed by `SESSION_DONE`.