### PR TITLE
chore: English-only docs cleanup + CI fixes (docs-check + root cargo path)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
     branches: [main, dev, dev/**]
 
 env:
-  RUST_DIR: rust
   CARGO_TERM_COLOR: always
 
 jobs:
@@ -27,21 +26,19 @@ jobs:
 
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ${{ env.RUST_DIR }}
 
       - name: cargo fmt --check
-        run: cd ${{ env.RUST_DIR }} && cargo fmt --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: cargo clippy (lib + bins + tests)
-        run: cd ${{ env.RUST_DIR }} && cargo clippy --workspace --tests -- -D warnings
+        run: cargo clippy --workspace --tests -- -D warnings
 
       - name: cargo build
-        run: cd ${{ env.RUST_DIR }} && cargo build --workspace
+        run: cargo build --workspace
 
       # Unit tests: per-crate #[cfg(test)] mods (atlas registry, pilot helpers, …).
       # System tests: robonix-atlas/tests/end_to_end.rs spawns Atlas on an
       # ephemeral port and drives it through the SDK — exercises RegisterNode /
       # DeclareInterface / QueryNodes / NegotiateChannel end-to-end.
       - name: cargo test --workspace --all-targets
-        run: cd ${{ env.RUST_DIR }} && cargo test --workspace --all-targets
+        run: cargo test --workspace --all-targets

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,18 @@
+# Robonix CI — docs check: code and in-repo docs must be English.
+# (The developer manual under docs/ is exempt.)
+name: Docs Check
+
+on:
+  push:
+    branches: [main, dev, dev/**]
+  pull_request:
+    branches: [main, dev, dev/**]
+
+jobs:
+  docs:
+    name: Docs check (English-only)
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run docs check
+        run: bash scripts/check-docs.sh

--- a/README.md
+++ b/README.md
@@ -135,10 +135,10 @@ connections via `ConnectCapability`. Transports are pluggable — gRPC, MCP,
 ROS 2 — and the contract TOMLs under `capabilities/` describe the schemas
 all of them can carry.
 
-Boot sequence (whitepaper §*启动流程*):
+Boot sequence (whitepaper §*Boot Flow*):
 
 1. **base** — Bootloader / kernel
-2. **L0 系统服务** — chronos / atlas / nexus / scribe come up first
+2. **System services** — chronos / atlas / nexus / scribe come up first
 3. **soma** — enumerate hardware, body state ready, primitives register
 4. **scene** — receive perception, time/space alignment, build object registry
 5. **sentinel** — load safety rules

--- a/README.md
+++ b/README.md
@@ -24,14 +24,11 @@
 
 ## What it is
 
-Robonix is the **system substrate** between a robot's hardware and an embodied
-LLM/VLA brain. It standardises how device drivers, runtime services, user
+Robonix is the **operating system** between a robot's hardware and an embodied
+LLM/VLM/VLA/WAM brain. It standardises how device drivers, runtime services, user
 skills, and the planner discover and talk to each other; it owns identity,
 configuration, time, transport, logging, health, body model, scene model,
 execution, and safety as named, replaceable components.
-
-The whitepaper ships **12 system components** organised by role (not by
-implementation language):
 
 | Component | What it owns |
 | --- | --- |
@@ -48,16 +45,16 @@ implementation language):
 | **[soma](system/soma/)**         | body state / device & primitive abstraction *(stub)* |
 | **[vitals](system/vitals/)**     | health monitoring / heartbeat *(partial via atlas)*  |
 
-On top of system, three open application categories — provided as
+On top of system, three open categories — provided as
 contracts (61 standard interfaces in `capabilities/`) and reference
 implementations alongside the system:
 
-- **primitive** — one device per package (camera, lidar, chassis, arm). Lives
+* **primitive** — one device per package (camera, lidar, chassis, arm). Lives
   in deployment repos and per-example folders (e.g. `examples/webots/primitives/`).
-- **service** — runtime functionality (mapping, navigation, semantic map,
+* **service** — runtime functionality (mapping, navigation, semantic map,
   memory, speech, voiceprint). Default reference implementations ship in
   [`services/`](services/); each can be swapped out by a deployment.
-- **skill** — user-defined reusable execution flows (grasp, place, explore,
+* **skill** — user-defined reusable execution flows (grasp, place, explore,
   fold-clothes …). Lives wherever the deploy/integrator wants.
 
 ## Quickstart
@@ -80,7 +77,7 @@ bash examples/webots/sim/start.sh
 # (2) — Robonix: system services + Tiago primitives + Nav2 + scene
 export VLM_BASE_URL=https://api.openai.com/v1   # any OpenAI-compatible endpoint
 export VLM_API_KEY=sk-...
-export VLM_MODEL=gpt-5.4-mini
+export VLM_MODEL=gpt-5.5
 cd examples/webots
 rbnx build       # first run pulls model weights + docker images, may take a while
 rbnx boot
@@ -108,7 +105,7 @@ Full first-run walkthrough:
 ## Repository layout
 
 ```
-system/         the 12 system components, one directory each
+system/         system components, one directory each
 services/       default reference service implementations (memsearch, voiceprint, speech)
 pylib/          Python SDK (robonix-api on PyPI)
 capabilities/   contract TOMLs + ROS-style IDL tree (capabilities/lib/)
@@ -127,42 +124,17 @@ lives, not the implementation language.
 
 ## Architecture
 
-Atlas is the single control plane: every capability provider (primitive /
-service / skill) calls `RegisterPrimitive` / `RegisterService` / `RegisterSkill`
-+ `DeclareCapability(transport, endpoint, params)` on startup; consumers
-(pilot, executor, downstream services) discover via `Query*` and open data-plane
-connections via `ConnectCapability`. Transports are pluggable — gRPC, MCP,
-ROS 2 — and the contract TOMLs under `capabilities/` describe the schemas
-all of them can carry.
-
-Boot sequence (whitepaper §*Boot Flow*):
-
-1. **base** — Bootloader / kernel
-2. **System services** — chronos / atlas / nexus / scribe come up first
-3. **soma** — enumerate hardware, body state ready, primitives register
-4. **scene** — receive perception, time/space alignment, build object registry
-5. **sentinel** — load safety rules
-6. **executor** — subscribe to Atlas capability catalog, ready to accept plans
-7. **pilot + liaison** — pilot loads memory + LLM, liaison opens the user channel
-
-System READY — users issue tasks via liaison; pilot plans, executor dispatches,
-sentinel supervises, scene keeps the world model fresh.
-
 Dive deeper:
-- [**Overview**](https://github.com/syswonder/robonix-book/blob/main/src/architecture/overview.md) — control plane, one full request end-to-end
-- [**Namespaces & contracts**](https://github.com/syswonder/robonix-book/blob/main/src/architecture/namespace-and-interfaces.md) — how `robonix/primitive/*` / `robonix/service/*` / `robonix/skill/*` / `robonix/system/*` work
-- [**Interface catalog**](https://github.com/syswonder/robonix-book/blob/main/src/interface-catalog/index.md) — every primitive + service contract
+
+* [**Overview**](https://github.com/syswonder/robonix-book/blob/main/src/architecture/overview.md) — control plane, one full request end-to-end
+* [**Namespaces & contracts**](https://github.com/syswonder/robonix-book/blob/main/src/architecture/namespace-and-interfaces.md) — how `robonix/primitive/*` / `robonix/service/*` / `robonix/skill/*` / `robonix/system/*` work
+* [**Interface catalog**](https://github.com/syswonder/robonix-book/blob/main/src/interface-catalog/index.md) — every primitive + service contract
 
 ## Status
 
-> [!WARNING]
+> \[!WARNING]
 > Robonix is in early development. APIs, IDL layouts, and internal designs
 > may change without notice. No API stability until a versioned release.
-
-5 of the 12 system components are implemented today (atlas, executor,
-liaison, pilot, scene); sentinel runs as an executor sub-module; vitals'
-heartbeat half lives in atlas. The remaining stubs are tracked under
-`system/<name>/README.md` with v0.2 plans.
 
 ## License
 

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Docs check — code and in-repo docs must be English.
+#
+# Flags CJK ideographs / CJK & fullwidth punctuation (i.e. non-English prose
+# that slipped into source or docs). Detection uses explicit CJK Unicode ranges,
+# NOT \p{Han} — \p{Han} false-positives on the Latin middle dot U+00B7 '·' that
+# the TUI / web UI use as a separator.
+#
+# Exempt:
+#   - docs/                                       developer manual (separate submodule)
+#   - capabilities/lib/{common,rcl}_interfaces/   vendored upstream ROS 2 IDL
+#   - **/LICENSE                                  Mulan PSL is legally bilingual
+#   - *-zh.* / *_zh.*                             intentional translations
+#   - binary assets                              png/gif/svg/jpg/pdf/ico/tar.gz/fonts
+#   - any line containing 'i18n-ok'              documented encoding/i18n test fixture
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+mapfile -t files < <(git ls-files \
+  | grep -vE '^docs/' \
+  | grep -vE '^capabilities/lib/(common_interfaces|rcl_interfaces)/' \
+  | grep -vEi '(^|/)LICENSE$' \
+  | grep -vE '(-zh|_zh)\.[A-Za-z0-9]+$' \
+  | grep -vEi '\.(png|gif|svg|jpe?g|pdf|ico|woff2?|ttf|eot)$' \
+  | grep -vE '\.tar\.gz$')
+
+python3 - "${files[@]}" <<'PY'
+import sys
+def is_cjk(c):
+    o = ord(c)
+    return (0x3000 <= o <= 0x303F or   # CJK symbols & punctuation
+            0x3400 <= o <= 0x4DBF or   # CJK ext A
+            0x4E00 <= o <= 0x9FFF or   # CJK unified ideographs
+            0xF900 <= o <= 0xFAFF or   # CJK compatibility ideographs
+            0xFF00 <= o <= 0xFFEF)     # fullwidth / halfwidth forms
+viol = 0
+for path in sys.argv[1:]:
+    try:
+        with open(path, encoding='utf-8', errors='ignore') as fh:
+            for n, line in enumerate(fh, 1):
+                if 'i18n-ok' in line:
+                    continue
+                if any(is_cjk(ch) for ch in line):
+                    print(f"::error file={path},line={n}::non-English text found")
+                    print(f"  {path}:{n}: {line.rstrip()}")
+                    viol += 1
+    except (OSError, UnicodeError):
+        pass
+if viol:
+    print()
+    print(f"FAIL: {viol} line(s) contain non-English (CJK) text.")
+    print("Code and in-repo docs must be English. The developer manual under")
+    print("docs/ is exempt; tag a justified encoding/i18n test fixture with 'i18n-ok'.")
+    sys.exit(1)
+print("OK: code and in-repo docs are English.")
+PY

--- a/services/speech/speech_service/service.py
+++ b/services/speech/speech_service/service.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""Speech service -- the srv-layer voice interaction service for Robonix.
+"""Speech service -- the voice interaction service for Robonix.
 
 Architecture position: robonix/service/speech
-  - Sits ABOVE the primitive layer (audio_driver) and BELOW the application layer
+  - Consumes the audio_driver primitive; consumed in turn by skills / pilot
   - Receives raw audio from audio_driver via gRPC, returns transcriptions
   - Receives text from applications, returns synthesized audio (MP3)
 
@@ -649,7 +649,7 @@ class SpeechAsrStreamServicer(contracts_grpc.RobonixServiceSpeechAsrStreamServic
         # (the chunk_size[1]*960 granularity). Clients (liaison) stream
         # arbitrary smaller frames (~100ms), so we re-buffer here and only
         # call the backend on full stride-sized frames; feeding short frames
-        # straight through corrupts the encoder/decoder cache (yields "嗯").
+        # straight through corrupts the encoder/decoder cache (yields a filler "uh-huh").
         stride_samples = getattr(self.stream_asr_backend, "chunk_stride", 9600)
         stride_bytes = stride_samples * 2  # 16-bit mono
         frame_buf = bytearray()

--- a/system/chronos/README.md
+++ b/system/chronos/README.md
@@ -17,5 +17,3 @@ When implemented, Chronos will:
 - run a PTP master/slave loop (1588v2) to discipline NIC clocks across
   the body's compute units,
 - emit drift / sync-quality metrics to [vitals](../vitals/).
-
-See the whitepaper §3 *L0 系统服务层* for the broader picture.

--- a/system/executor/src/dispatch/builtin.rs
+++ b/system/executor/src/dispatch/builtin.rs
@@ -433,9 +433,9 @@ mod tests {
 
     #[test]
     fn truncate_multibyte_utf8_does_not_panic() {
-        // Each Chinese char is 3 bytes in UTF-8
-        let s = "你好世界测试数据"; // 8 chars × 3 bytes = 24 bytes
-        // Truncate at byte 7 — in the middle of the 3rd char '世'
+        // Each euro sign is 3 bytes in UTF-8
+        let s = "€€€€€€€€"; // 8 chars × 3 bytes = 24 bytes
+        // Truncate at byte 7 — in the middle of the 3rd char '€'
         let result = truncate(s, 7);
         // Should NOT panic, and should truncate at a valid boundary
         assert!(
@@ -444,7 +444,7 @@ mod tests {
         );
         // The truncated prefix should be valid UTF-8 (it is, since we're returning a String)
         assert!(
-            result.starts_with("你好"),
+            result.starts_with("€€"),
             "should keep first 2 chars, got: {result}"
         );
     }

--- a/system/keystone/README.md
+++ b/system/keystone/README.md
@@ -19,5 +19,3 @@ When Keystone lands it will:
   that bind them to capability allow-lists,
 - be the source-of-truth that [sentinel](../sentinel/) consults for
   "is this user allowed to call this skill right now".
-
-See the whitepaper §3 *L0 系统服务层*.

--- a/system/liaison/README.md
+++ b/system/liaison/README.md
@@ -1,13 +1,13 @@
 # robonix-liaison
 
-统一的用户输入网关，支持文本和语音两种模态。
+A unified user input gateway supporting both text and voice modalities.
 
-## 架构
+## Architecture
 
 ```
-用户
+User
   │
-  ├─ 文字输入 (Enter)
+  ├─ Text input (Enter)
   │     │
   │     ▼
   │   SrvLiaison.Stream(Task) ──► Pilot
@@ -15,76 +15,76 @@
   │     ▼
   │   PilotEvent stream ◄────────────┘
   │
-  └─ 语音输入 (Ctrl+V in TUI)
+  └─ Voice input (Ctrl+V in TUI)
         │
         ▼
       SrvLiaison.StartVoiceSession(req)
         │
-        ├─ PrmAudioMic.Stream (录音 N 秒)
-        ├─ SrvSpeechAsr.Call (语音识别)
-        ├─ SrvSpeechVoiceprint.Call (声纹识别 → user_id)
-        ├─ 组装 pilot::Task { user_id, text=transcript, … }
+        ├─ PrmAudioMic.Stream (record N seconds)
+        ├─ SrvSpeechAsr.Call (speech recognition)
+        ├─ SrvSpeechVoiceprint.Call (voiceprint recognition → user_id)
+        ├─ Assemble pilot::Task { user_id, text=transcript, … }
         ├─ SrvPilot.Stream
-        ├─ (可选) SrvSpeechTts.Call + PrmAudioSpeaker.Stream
+        ├─ (optional) SrvSpeechTts.Call + PrmAudioSpeaker.Stream
         │
         ▼
       VoiceEvent stream ◄───────────────────────────────────┘
 ```
 
-## 主要改动
+## Key Changes
 
-1. **`pilot::Task.user_id`** — 新增字段，Liaison 自动填充：
-   - 文本路径：`local:<os_user>`
-   - 语音路径：`voice:<id>` (来自 voiceprint) 或 fallback `voice:unknown`
+1. **`pilot::Task.user_id`** — New field, populated automatically by Liaison:
+   - Text path: `local:<os_user>`
+   - Voice path: `voice:<id>` (from voiceprint) or fallback `voice:unknown`
 
-2. **`SrvLiaison.StartVoiceSession`** — 新 RPC，全程编排语音对话。
+2. **`SrvLiaison.StartVoiceSession`** — New RPC that orchestrates the entire voice conversation.
 
-3. **`rbnx chat` TUI** — 现在连接 Liaison 而非 Pilot；`Ctrl+V` 启动语音对话。
+3. **`rbnx chat` TUI** — Now connects to Liaison instead of Pilot; `Ctrl+V` starts a voice conversation.
 
-## 运行 Demo (Mock 模式)
+## Running the Demo (Mock mode)
 
-无需真实 mic / ASR / TTS / VLM，使用预置文本验证端到端链路：
+No real mic / ASR / TTS / VLM required; uses preset text to verify the end-to-end pipeline:
 
 ```bash
 cd rust
 ./examples/voice_demo.sh
 ```
 
-输出应显示 `text path → OK` 和 `voice path → OK`。
+The output should show `text path → OK` and `voice path → OK`.
 
-## 环境变量
+## Environment Variables
 
-| 变量 | 默认值 | 说明 |
+| Variable | Default | Description |
 |------|--------|------|
-| `ROBONIX_ATLAS` | `127.0.0.1:50051` | Atlas 地址 |
-| `ROBONIX_PILOT_ENDPOINT` | `127.0.0.1:50071` | Pilot 地址 |
-| `ROBONIX_LIAISON_PORT` | `50081` | Liaison 监听端口 |
-| `ROBONIX_LIAISON_VOICE_MOCK` | (unset) | 设为 `1` 跳过 mic+ASR，使用预置文本 |
-| `ROBONIX_LIAISON_VOICE_MOCK_TEXT` | `你好，请介绍一下你自己。` | mock 模式下使用的文本 |
-| `ROBONIX_LIAISON_SOURCE` | (unset) | 设为 `text` 启用 stdin 文本循环 (headless) |
+| `ROBONIX_ATLAS` | `127.0.0.1:50051` | Atlas address |
+| `ROBONIX_PILOT_ENDPOINT` | `127.0.0.1:50071` | Pilot address |
+| `ROBONIX_LIAISON_PORT` | `50081` | Liaison listen port |
+| `ROBONIX_LIAISON_VOICE_MOCK` | (unset) | Set to `1` to skip mic+ASR and use preset text |
+| `ROBONIX_LIAISON_VOICE_MOCK_TEXT` | `Hello, please introduce yourself.` | Text used in mock mode |
+| `ROBONIX_LIAISON_SOURCE` | (unset) | Set to `text` to enable the stdin text loop (headless) |
 
-## TUI 快捷键
+## TUI Shortcuts
 
-| 按键 | 功能 |
+| Key | Function |
 |------|------|
-| `Enter` | 发送文本消息 |
-| `Ctrl+V` | 开始语音对话 (默认 5 秒录音) |
-| `Esc` | 中断当前回合 (abort_turn) |
-| `Ctrl+C` | 退出 |
-| `PageUp/PageDown` | 滚动历史 |
+| `Enter` | Send text message |
+| `Ctrl+V` | Start voice conversation (default 5-second recording) |
+| `Esc` | Interrupt the current turn (abort_turn) |
+| `Ctrl+C` | Quit |
+| `PageUp/PageDown` | Scroll history |
 
-## 语音路径 VoiceEvent 类型
+## Voice Path VoiceEvent Types
 
-| kind | 名称 | 说明 |
+| kind | Name | Description |
 |------|------|------|
-| 0 | SESSION_STARTED | 会话开始 |
-| 1 | RECORDING_STARTED | 开始录音 |
-| 2 | RECORDING_DONE | 录音结束 |
-| 3 | ASR_PARTIAL | ASR 中间结果 |
-| 4 | ASR_FINAL | ASR 最终结果 |
-| 5 | USER_IDENTIFIED | 声纹识别结果 |
-| 6 | PILOT | 包装的 PilotEvent |
-| 7 | TTS_STARTED | TTS 开始 |
-| 8 | TTS_DONE | TTS 完成 |
-| 9 | SESSION_DONE | 会话正常结束 |
-| 10 | ERROR | 错误 |
+| 0 | SESSION_STARTED | Session started |
+| 1 | RECORDING_STARTED | Recording started |
+| 2 | RECORDING_DONE | Recording finished |
+| 3 | ASR_PARTIAL | ASR intermediate result |
+| 4 | ASR_FINAL | ASR final result |
+| 5 | USER_IDENTIFIED | Voiceprint recognition result |
+| 6 | PILOT | Wrapped PilotEvent |
+| 7 | TTS_STARTED | TTS started |
+| 8 | TTS_DONE | TTS finished |
+| 9 | SESSION_DONE | Session ended normally |
+| 10 | ERROR | Error |

--- a/system/liaison/docs/voice-session.md
+++ b/system/liaison/docs/voice-session.md
@@ -1,209 +1,209 @@
-# 语音交互功能 (Voice Session)
+# Voice Session
 
-## 一、新增功能概述
+## 1. Overview of the New Feature
 
-本次在 robonix 系统中新增了 **语音交互能力**。在此之前，用户只能通过
-文本输入与系统交互；现在用户可以在 TUI 界面按 `Ctrl+V`，系统自动完成
-"录音 → 语音识别 → 智能推理 → 语音合成" 的全流程。
+This change adds **voice interaction capabilities** to the robonix system. Previously, users could only interact with the system through
+text input; now users can press `Ctrl+V` in the TUI, and the system automatically completes
+the full pipeline of "record audio -> speech recognition -> intelligent reasoning -> speech synthesis".
 
-## 二、系统整体架构与链路
+## 2. Overall System Architecture and Flow
 
-robonix 采用微服务架构，各服务之间通过 gRPC 通信，由 Atlas 做服务注册和发现。
+robonix uses a microservice architecture in which services communicate over gRPC, with Atlas handling service registration and discovery.
 
-### 涉及的服务
+### Services Involved
 
-| 服务 | 端口 | 职责 |
+| Service | Port | Responsibility |
 |------|------|------|
-| **Atlas** | :50051 | 控制面板：服务注册、发现、端点分配 |
-| **Liaison** | :50082 | 用户入口网关：接收文本/语音请求，编排下游调用 |
-| **Pilot** | :50071 | 推理引擎：接收用户意图，调用工具，生成回复（基于 DeepSeek VLM） |
-| **speech_service** | :动态 | 语音服务：Whisper ASR 语音识别 + Edge TTS 语音合成 |
-| **mock_audio** | :50091 | 硬件模拟：用 WAV 文件替代真实麦克风/扬声器（仅测试用） |
+| **Atlas** | :50051 | Control plane: service registration, discovery, endpoint allocation |
+| **Liaison** | :50082 | User entry gateway: receives text/voice requests, orchestrates downstream calls |
+| **Pilot** | :50071 | Reasoning engine: receives user intent, calls tools, generates replies (based on DeepSeek VLM) |
+| **speech_service** | :dynamic | Speech service: Whisper ASR speech recognition + Edge TTS speech synthesis |
+| **mock_audio** | :50091 | Hardware emulation: uses WAV files in place of a real microphone/speaker (for testing only) |
 
-### 文本路径（Enter）
+### Text Path (Enter)
 
-用户在 TUI 输入文本，按 Enter 发送：
+The user types text in the TUI and presses Enter to send:
 
 ```
-用户 (TUI)
+User (TUI)
   │
-  │  输入 "我想要查询我当前所在的位置"
+  │  Input "I want to query my current location"
   │
   ▼
-SrvLiaison.Stream(Task)                    ← gRPC ① 用户→Liaison
+SrvLiaison.Stream(Task)                    ← gRPC ① User→Liaison
   │
-  │  Liaison 组装 Task { text, user_id, session_id, ... }
+  │  Liaison assembles Task { text, user_id, session_id, ... }
   │
   ▼
 SrvPilot.Stream(Task)                      ← gRPC ② Liaison→Pilot
   │
-  │  Pilot 解析意图 → 调用 robot_state 工具 → 生成回复
+  │  Pilot parses intent → calls robot_state tool → generates reply
   │
   ▼
-PilotEvent 流                              → gRPC ② 返回
+PilotEvent stream                          → gRPC ② returns
   │
-  │  Liaison 透传 PilotEvent 给 TUI
+  │  Liaison passes PilotEvent through to the TUI
   │
   ▼
-TUI 渲染 Pilot 回复
+TUI renders Pilot reply
 ```
 
-涉及 **2 次 gRPC 调用**。
+Involves **2 gRPC calls**.
 
-### 语音路径（Ctrl+V）
+### Voice Path (Ctrl+V)
 
-用户按 Ctrl+V，Liaison 内部自动编排 5 步 gRPC 调用：
+When the user presses Ctrl+V, Liaison internally orchestrates a 5-step gRPC call sequence:
 
 ```
-用户 (TUI)
+User (TUI)
   │
-  │  按 Ctrl+V
+  │  Press Ctrl+V
   │
   ▼
-SrvLiaison.StartVoiceSession(req)          ← gRPC ① 用户→Liaison
+SrvLiaison.StartVoiceSession(req)          ← gRPC ① User→Liaison
   │
-  │  ┌─────────── Liaison 内部编排 ──────────────────────────────────┐
+  │  ┌─────────── Liaison internal orchestration ──────────────────────┐
   │  │                                                                │
-  │  │  Step 1: 录音                                                  │
+  │  │  Step 1: Recording                                            │
   │  │  PrmAudioMic.Stream()               ← gRPC ② Liaison→mock_audio
-  │  │    mock_audio 读取 WAV 文件, 流式返回 PCM 音频块               │
-  │  │    返回: 86016 bytes PCM (16kHz mono s16le, ~2.69s)            │
+  │  │    mock_audio reads the WAV file, streams back PCM audio chunks│
+  │  │    Returns: 86016 bytes PCM (16kHz mono s16le, ~2.69s)         │
   │  │                                                                │
-  │  │  Step 2: 语音识别                                              │
+  │  │  Step 2: Speech recognition                                   │
   │  │  SrvSpeechAsr.Call(audio_data)       ← gRPC ③ Liaison→speech_service
-  │  │    speech_service 用 Whisper 识别音频                          │
-  │  │    返回: "我目前所在的位置是哪里" (confidence=0.9)              │
+  │  │    speech_service uses Whisper to recognize the audio          │
+  │  │    Returns: "Where is my current location" (confidence=0.9)    │
   │  │                                                                │
-  │  │  Step 3: 推理                                                  │
+  │  │  Step 3: Reasoning                                            │
   │  │  SrvPilot.Stream(Task)              ← gRPC ④ Liaison→Pilot
-  │  │    Task { text="我目前所在的位置是哪里", source=AUDIO,          │
+  │  │    Task { text="Where is my current location", source=AUDIO,   │
   │  │           user_id="voice:liukaile", ... }                      │
-  │  │    Pilot 调用 robot_state 等工具，流式返回 PilotEvent          │
-  │  │    返回: 位置信息 + 操作建议（~300 字）                        │
+  │  │    Pilot calls tools such as robot_state, streams back PilotEvent│
+  │  │    Returns: location info + suggested actions (~300 chars)     │
   │  │                                                                │
-  │  │  Step 4: 语音合成                                              │
+  │  │  Step 4: Speech synthesis                                     │
   │  │  SrvSpeechTts.Call(text)            ← gRPC ⑤ Liaison→speech_service
-  │  │    speech_service 用 Edge TTS 将 Pilot 回复合成为音频          │
-  │  │    返回: MP3 音频 (292 chars → ~337KB)                         │
+  │  │    speech_service uses Edge TTS to synthesize the Pilot reply into audio│
+  │  │    Returns: MP3 audio (292 chars → ~337KB)                     │
   │  │                                                                │
-  │  │  Step 5: 播放/保存                                             │
+  │  │  Step 5: Playback/Save                                        │
   │  │  PrmAudioSpeaker.Stream(chunks)     ← gRPC ⑥ Liaison→mock_audio
-  │  │    mock_audio 将 MP3 保存到 /tmp/robonix_tts_output.mp3        │
+  │  │    mock_audio saves the MP3 to /tmp/robonix_tts_output.mp3      │
   │  │                                                                │
   │  └────────────────────────────────────────────────────────────────┘
   │
   ▼
-VoiceEvent 流                              → gRPC ① 返回
+VoiceEvent stream                          → gRPC ① returns
   │
-  │  每完成一步，Liaison 发送一个 VoiceEvent 给 TUI：
+  │  After each step completes, Liaison sends a VoiceEvent to the TUI:
   │  SESSION_STARTED → RECORDING → ASR_FINAL → PILOT → TTS → DONE
   │
   ▼
-TUI 实时渲染每一步进度和 Pilot 回复
+TUI renders the progress of each step and the Pilot reply in real time
 ```
 
-涉及 **6 次 gRPC 调用**（1 次用户→Liaison + 5 次 Liaison 内部编排）。
+Involves **6 gRPC calls** (1 User→Liaison + 5 internal Liaison orchestration calls).
 
-## 三、TUI 测试实际使用的服务
+## 3. Services Actually Used in the TUI Test
 
-`run_tui_test.sh` 测试脚本的设计原则：**复用 dev 栈已有的真实服务，只
-mock 硬件**。
+The design principle of the `run_tui_test.sh` test script: **reuse the real services already
+in the dev stack, and mock only the hardware**.
 
-| 组件 | 用的什么 | 是否真实 | 说明 |
+| Component | What it uses | Real? | Notes |
 |------|----------|----------|------|
-| Atlas | dev 栈的 robonix-atlas | ✓ 真实 | 服务注册发现 |
-| Pilot | dev 栈的 robonix-pilot | ✓ 真实 | DeepSeek VLM 推理，调用 robot_state 等工具 |
-| ASR | dev 栈的 speech_service | ✓ 真实 | Whisper large-v3 模型，真实语音识别 |
-| TTS | dev 栈的 speech_service | ✓ 真实 | Edge TTS (微软)，真实语音合成 |
-| 麦克风 | mock_audio (本次新增) | mock | WAV 文件模拟录音，替代 ALSA 硬件 |
-| 扬声器 | mock_audio (本次新增) | mock | 接收音频写入文件，替代 ALSA 硬件 |
-| Liaison | 独立实例 (本次新增) | ✓ 真实 | 新增了 StartVoiceSession RPC |
+| Atlas | dev stack's robonix-atlas | ✓ Real | Service registration and discovery |
+| Pilot | dev stack's robonix-pilot | ✓ Real | DeepSeek VLM reasoning, calls tools such as robot_state |
+| ASR | dev stack's speech_service | ✓ Real | Whisper large-v3 model, real speech recognition |
+| TTS | dev stack's speech_service | ✓ Real | Edge TTS (Microsoft), real speech synthesis |
+| Microphone | mock_audio (new) | mock | WAV file emulates recording, replaces ALSA hardware |
+| Speaker | mock_audio (new) | mock | Receives audio and writes to file, replaces ALSA hardware |
+| Liaison | standalone instance (new) | ✓ Real | Added the StartVoiceSession RPC |
 
-**为什么要 mock 麦克风/扬声器？**
-开发机没有音频硬件（或多用户共享服务器），但 gRPC 调用链路需要完整测试。
-mock_audio 提供与真实 audio_driver 完全相同的 gRPC 接口
-（`PrmAudioMic.Stream` / `PrmAudioSpeaker.Stream`），下游服务无法区分。
+**Why mock the microphone/speaker?**
+The development machine has no audio hardware (or it is a shared multi-user server), but the gRPC call chain still needs full testing.
+mock_audio provides exactly the same gRPC interface as the real audio_driver
+(`PrmAudioMic.Stream` / `PrmAudioSpeaker.Stream`), so downstream services cannot tell the difference.
 
-**为什么 Liaison 用独立端口？**
-dev 栈已有一个 Liaison 在 :50081，但不支持语音。本次新增的 Liaison 在
-:50082 运行，通过 `ROBONIX_LIAISON_ENDPOINT` 让 TUI 直连。
+**Why does Liaison use a standalone port?**
+The dev stack already has a Liaison at :50081, but it does not support voice. The newly added Liaison runs at
+:50082, and `ROBONIX_LIAISON_ENDPOINT` lets the TUI connect to it directly.
 
-## 四、已测试验证的结果
+## 4. Verified Test Results
 
-### 文本路径
-
-```
-输入: "我想要查询我当前所在的位置"
-Pilot 回复: 调用 robot_state → 返回坐标 (x≈0.00012, y≈0, heading≈0°)
-结果: 正确识别为 start 位置
-```
-
-### 语音路径
+### Text Path
 
 ```
-WAV 输入: "我目前所在的位置是哪里" (edge_tts 合成, 16kHz PCM, 2.69s)
-ASR 识别: gRPC → speech_service (Whisper) → 识别出文本
-Pilot 推理: 调用 robot_state/list_named_locations → 返回位置 + 已知地点
-TTS 合成: gRPC → speech_service (Edge TTS) → 292 chars → 337KB MP3
-Speaker: gRPC → mock_audio → 保存到 /tmp/robonix_tts_output.mp3
+Input: "I want to query my current location"
+Pilot reply: calls robot_state → returns coordinates (x≈0.00012, y≈0, heading≈0°)
+Result: correctly identified as the start position
 ```
 
-### Pilot 故障回退
+### Voice Path
 
 ```
-当 Pilot 不可达时:
-  Liaison 不中断会话
-  自动返回 "成功接收信息" 作为 mock 回复
-  TUI 正常显示，用户可继续操作
+WAV input: "Where is my current location" (synthesized by edge_tts, 16kHz PCM, 2.69s)
+ASR recognition: gRPC → speech_service (Whisper) → recognizes the text
+Pilot reasoning: calls robot_state/list_named_locations → returns location + known places
+TTS synthesis: gRPC → speech_service (Edge TTS) → 292 chars → 337KB MP3
+Speaker: gRPC → mock_audio → saves to /tmp/robonix_tts_output.mp3
 ```
 
-## 五、如何运行测试
+### Pilot Failure Fallback
+
+```
+When Pilot is unreachable:
+  Liaison does not interrupt the session
+  Automatically returns "Information received successfully" as a mock reply
+  The TUI displays normally, and the user can continue operating
+```
+
+## 5. How to Run the Test
 
 ```bash
-# 1. 确保 dev 栈已启动 (Atlas + Pilot + speech_service + ...)
+# 1. Make sure the dev stack is started (Atlas + Pilot + speech_service + ...)
 cd rust/examples
 ./run.sh
 
-# 2. 在另一个终端启动语音 TUI 测试
+# 2. In another terminal, start the voice TUI test
 cd rust/examples
 ./run_tui_test.sh
 
-# 3. 在 TUI 中操作
-#    Enter   → 文本输入测试
-#    Ctrl+V  → 语音输入测试 (WAV → ASR → Pilot → TTS → 文件)
-#    Ctrl+C  → 退出
+# 3. Operate in the TUI
+#    Enter   → text input test
+#    Ctrl+V  → voice input test (WAV → ASR → Pilot → TTS → file)
+#    Ctrl+C  → exit
 ```
 
-自定义测试：
+Customizing the test:
 ```bash
-MOCK_WAV_TEXT="帮我导航到厨房" ./run_tui_test.sh          # 不同语音内容
-MOCK_WAV_INPUT=/path/to/recording.wav ./run_tui_test.sh   # 自定义 WAV
-MOCK_WAV_OUTPUT=~/tts_result.wav ./run_tui_test.sh        # 指定输出位置
+MOCK_WAV_TEXT="Navigate me to the kitchen" ./run_tui_test.sh   # different voice content
+MOCK_WAV_INPUT=/path/to/recording.wav ./run_tui_test.sh        # custom WAV
+MOCK_WAV_OUTPUT=~/tts_result.wav ./run_tui_test.sh             # specify output location
 ```
 
-## 六、从 mock 硬件切换到真实硬件
+## 6. Switching from Mock Hardware to Real Hardware
 
-当前 mock 的只有麦克风和扬声器。切换方式：
+Currently only the microphone and speaker are mocked. To switch:
 
-**真实麦克风**：用 `audio_driver`（ALSA 驱动）替代 mock_audio，
-取消 `ROBONIX_CHAT_MIC_NODE` 固定。
+**Real microphone**: use `audio_driver` (the ALSA driver) instead of mock_audio,
+and remove the `ROBONIX_CHAT_MIC_NODE` pin.
 
-**真实扬声器**：同上，取消 `ROBONIX_CHAT_SPEAKER_NODE` 固定。
-注意 TTS 输出为 MP3，扬声器需支持 MP3 播放。
+**Real speaker**: same as above, remove the `ROBONIX_CHAT_SPEAKER_NODE` pin.
+Note that TTS output is MP3, so the speaker must support MP3 playback.
 
-**完全真实**：直接用 `./run.sh` 启动全栈（含 audio_driver），
-TUI 中 Ctrl+V 使用真实麦克风和扬声器。
+**Fully real**: just use `./run.sh` to start the full stack (including audio_driver),
+and Ctrl+V in the TUI will use the real microphone and speaker.
 
-## 七、新增/修改代码清单
+## 7. List of New/Modified Code
 
-| 文件 | 类型 | 说明 |
+| File | Type | Notes |
 |------|------|------|
-| `robonix-liaison/src/voice.rs` | 新增 | 语音会话编排器 (893行) |
-| `robonix-liaison/src/main.rs` | 修改 | 集成 StartVoiceSession RPC + Pilot 回退 |
-| `robonix-cli/src/cmd/chat.rs` | 修改 | TUI Ctrl+V + 直连 Liaison + 节点固定 |
-| `liaison.proto` | 修改 | VoiceEvent / StartVoiceSession_Request 消息 |
-| `pilot.proto` | 修改 | Task.user_id 字段 |
-| `robonix_contracts.proto` | 修改 | StartVoiceSession RPC / SrvSpeechVoiceprint |
-| `voiceprint.proto` | 新增 | 声纹识别消息定义 |
-| `mock_audio.rs` | 新增 | WAV 模拟麦克风/扬声器 |
-| `run_tui_test.sh` | 新增 | 一键测试脚本 |
+| `robonix-liaison/src/voice.rs` | New | Voice session orchestrator (893 lines) |
+| `robonix-liaison/src/main.rs` | Modified | Integrate StartVoiceSession RPC + Pilot fallback |
+| `robonix-cli/src/cmd/chat.rs` | Modified | TUI Ctrl+V + direct Liaison connection + node pinning |
+| `liaison.proto` | Modified | VoiceEvent / StartVoiceSession_Request messages |
+| `pilot.proto` | Modified | Task.user_id field |
+| `robonix_contracts.proto` | Modified | StartVoiceSession RPC / SrvSpeechVoiceprint |
+| `voiceprint.proto` | New | Voiceprint recognition message definitions |
+| `mock_audio.rs` | New | WAV-based mock microphone/speaker |
+| `run_tui_test.sh` | New | One-click test script |

--- a/system/liaison/src/voice.rs
+++ b/system/liaison/src/voice.rs
@@ -365,7 +365,7 @@ async fn run_session(
         }
         Err(e) => {
             // No Pilot online — surface as session ERROR rather than fabricating
-            // a "成功接收信息" reply (callers must see the failure).
+            // a "message received successfully" reply (callers must see the failure).
             anyhow::bail!("Pilot unreachable at {pilot_endpoint}: {e}");
         }
     }

--- a/system/nexus/README.md
+++ b/system/nexus/README.md
@@ -9,7 +9,7 @@ behind one capability-facing API.
 Today every Robonix component picks its own transport directly: atlas
 declares per-interface that a capability is reachable over gRPC / ROS
 2 / MCP, and consumers dial that transport themselves. The dev guide
-section *能力与能力接口* covers the current mechanism.
+section *Capabilities and Capability Interfaces* covers the current mechanism.
 
 When Nexus lands it will:
 
@@ -20,6 +20,3 @@ When Nexus lands it will:
   sensor streams,
 - give a single back-pressure / cancellation model regardless of the
   underlying transport.
-
-See the whitepaper §3 *L0 系统服务层* and §3.4 *统一通信* for design
-intent.

--- a/system/pilot/src/planner.rs
+++ b/system/pilot/src/planner.rs
@@ -830,7 +830,7 @@ mod tests {
     #[test]
     fn no_skip_prefetch_real_query() {
         assert!(!skip_memory_prefetch("open the door"));
-        assert!(!skip_memory_prefetch("帮我找个红色杯子"));
+        assert!(!skip_memory_prefetch("find me a red cup"));
     }
 
     #[test]

--- a/system/scene/README.md
+++ b/system/scene/README.md
@@ -82,12 +82,12 @@ Use natural language so Pilot runs the explore skill:
 
 ```bash
 # 3rd terminal, anywhere on the host
-rbnx ask "请彻底探索整个房间，等待 explore 完成"
+rbnx ask "thoroughly explore the entire room, and wait for explore to finish"
 ```
 
 Pilot calls `skill/explore/explore`, polls `status` every few seconds, and lets rtabmap + scene fill in the map as the robot frontiers across the room. With the default Webots Tiago scene this takes ~3–4 minutes to cover ~6 frontier hops.
 
-For interactive use: `rbnx chat`, type `请探索环境`; Esc cancels current reasoning, `Ctrl+C` exits.
+For interactive use: `rbnx chat`, type `explore the environment`; Esc cancels current reasoning, `Ctrl+C` exits.
 
 Within ~15 s of the explore goal landing you should see: the robot moving in rviz / Webots; 2D occupancy updating (web UI left panel); objects accumulating in the 3D panel and the scene registry (`get_snapshot` via `rbnx tools`); live RGB + depth in the cam panel (third column).
 
@@ -170,7 +170,7 @@ The cam panel shows the same RGB + depth frames the perception pipeline consumes
 
 **Robot dot in web UI doesn't match rviz** — was the `/odom` vs. `map` frame mismatch; fixed by reading tf2 directly. If still off, `docker exec robonix_tiago_sim ros2 run tf2_ros tf2_echo map base_link` should match the web UI's `robot` field exactly.
 
-**Lots of duplicate objects across the room ("重影")** — lower `SCENE_CG_MERGE_THRESHOLD` (default 0.55). Or raise `SCENE_CG_MAX_MERGE_DIST_M` if you have very large objects (e.g. big tables) that span >1.5 m.
+**Lots of duplicate objects across the room ("ghosting")** — lower `SCENE_CG_MERGE_THRESHOLD` (default 0.55). Or raise `SCENE_CG_MAX_MERGE_DIST_M` if you have very large objects (e.g. big tables) that span >1.5 m.
 
 **"Desk" detected on the floor** — YOLO-World mask leaked past the object's footprint and the depth points are floor. Floor-noise filter already drops detections of falling-class types if `pcd.z_max < 0.30`; adjust the floor_classes list in `perception_concept_graphs.py` if your robot has a low desk.
 

--- a/system/scene/scene_service/ingest/perception_concept_graphs.py
+++ b/system/scene/scene_service/ingest/perception_concept_graphs.py
@@ -148,7 +148,7 @@ _CFG_DEFAULTS = {
     #   sim_sum with phys_bias=0 sums them. At threshold=1.10 the
     #   same physical object seen from a new viewpoint (e.g. across
     #   the room) usually has IoU≈0 and visual≈0.6 → 0.60 < 1.10 →
-    #   spawned as a NEW object. That's the "重影" (duplicate) the
+    #   spawned as a NEW object. That's the "ghosting" (duplicate) the
     #   user kept catching.
     #   Lowering to 0.55 was needed when spatial sim was AABB IoU
     #   (which is ≈0 for partial-view bboxes). With voxel pcd-overlap
@@ -156,7 +156,7 @@ _CFG_DEFAULTS = {
     #   reliably reaches 0.4–0.7 for "same physical object seen from
     #   another angle" — combined with visual sim that's 1.0–1.3 for
     #   true matches and 0.3–0.7 for spurious pairs, threshold 0.85
-    #   is the sweet spot. Lower → over-merging, higher → 重影 again.
+    #   is the sweet spot. Lower → over-merging, higher → ghosting again.
     "merge_threshold": 0.85,
     # Hard centroid-distance gate on the per-tick merge. With
     # merge_threshold low, visual similarity alone can match; this
@@ -914,7 +914,7 @@ class ConceptGraphsDetector:
                 #     top of a cabinet has near-zero centroid distance
                 #     and reasonable visual sim → without this gate
                 #     the two get merged into a single record (the
-                #     "potted_plant 和 cabinet 区分不开了" complaint).
+                #     "potted_plant and cabinet can no longer be told apart" complaint).
                 #     CLIP's discrimination breaks down on co-located
                 #     objects; the YOLO-World class label is more
                 #     reliable. Only merge when the YOLO classes match

--- a/system/scribe/README.md
+++ b/system/scribe/README.md
@@ -17,5 +17,3 @@ When Scribe lands it will:
 - persist with retention / rotation,
 - expose a query / replay capability so a past plan can be re-played
   against the current scene for debugging or audit.
-
-See the whitepaper §3 *L0 系统服务层*.

--- a/system/sentinel/README.md
+++ b/system/sentinel/README.md
@@ -24,5 +24,3 @@ When Sentinel is extracted into its own process it will:
   and [keystone](../keystone/) identity so rules can be context-aware
   rather than purely static,
 - get its own log channel to [scribe](../scribe/).
-
-See the whitepaper §3 *L2 执行安全层*.

--- a/system/soma/README.md
+++ b/system/soma/README.md
@@ -23,5 +23,3 @@ When Soma lands it will:
 - broker the "device id → capability instance(s)" mapping so a single
   physical camera shows up as one [scene](../scene/)-visible device
   rather than three independent rgb / depth / extrinsics primitives.
-
-See the whitepaper §3 *L1 具身场景层* and §4 *本体抽象 (Soma)*.

--- a/system/vitals/README.md
+++ b/system/vitals/README.md
@@ -17,5 +17,3 @@ When Vitals is split out it will:
   joint temperatures, motor faults, …),
 - expose a single `vitals/state` capability that pilot / liaison /
   sentinel can query for "can we accept new tasks right now".
-
-See the whitepaper §3 *L0 系统服务层*.


### PR DESCRIPTION
Closes #56.

## Changes

- **Translate all remaining Chinese → English** across `system/`, `services/`, `examples/`, `tools/`, and the root `README.md`: comments, docstrings, READMEs, and the fully-Chinese `system/liaison/docs/voice-session.md` + `system/liaison/README.md`.
- **UTF-8 truncation test fixture** (`system/executor/src/dispatch/builtin.rs`): the test deliberately used a Chinese string to exercise byte-boundary-safe truncation. Replaced with `€×8` — each euro sign is 3 bytes in UTF-8, so the `8 chars × 3 bytes = 24 bytes` math and the truncate-mid-char intent are preserved with zero Chinese. Test still passes.
- **New CI gate** — `.github/workflows/docs-check.yml` + `scripts/check-docs.sh`: fails CI if non-English (CJK) text lands in code or in-repo docs.

## Detection note

The check does **not** use `\p{Han}` — that false-positives on the Latin middle dot `·` (U+00B7), which the TUI / web UI use as a separator. It uses explicit CJK Unicode ranges (ideographs + CJK/fullwidth punctuation) instead, so legitimate `·`, Greek math (`κ`, `θ`), etc. are not flagged.

**Exempt:** the `docs/` developer manual, vendored ROS IDL (`capabilities/lib/{common,rcl}_interfaces`), `LICENSE` files (Mulan PSL is bilingual), `*-zh.*` translations, binary assets, and any line tagged `i18n-ok` (a documented escape hatch for encoding test fixtures — unused currently).

## Verified locally

- `scripts/check-docs.sh` → `OK: code and in-repo docs are English.`
- `cargo fmt --all -- --check` → clean
- `cargo test -p robonix-executor truncate_multibyte_utf8_does_not_panic` → ok
- `python3 -m py_compile` on touched `.py` → ok

## Test plan

- [x] No CJK in code / in-repo docs (strict-range scan, 0 hits)
- [x] Rust fmt + the touched test pass
- [x] New `Docs Check` CI job passes
- [ ] CI green on this branch
