### PR TITLE
fix: default VLM model to gpt-5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ bash examples/webots/sim/start.sh
 # (2) — Robonix: system services + Tiago primitives + Nav2 + scene
 export VLM_BASE_URL=https://api.openai.com/v1   # any OpenAI-compatible endpoint
 export VLM_API_KEY=sk-...
-export VLM_MODEL=gpt-5.4-mini
+export VLM_MODEL=gpt-5.5
 cd examples/webots
 rbnx build       # first run pulls model weights + docker images, may take a while
 rbnx boot

--- a/examples/webots/README.md
+++ b/examples/webots/README.md
@@ -64,7 +64,7 @@ Pre-export before `rbnx boot` (or set in shell rc):
 ```bash
 export VLM_BASE_URL=https://api.openai.com/v1   # or your OpenAI-compatible endpoint
 export VLM_API_KEY=sk-...
-export VLM_MODEL=gpt-5.4-mini
+export VLM_MODEL=gpt-5.5
 ```
 
 The deploy manifest references these via `${VLM_*}`.

--- a/system/scene/scene_service/ingest/perception_vlm.py
+++ b/system/scene/scene_service/ingest/perception_vlm.py
@@ -106,7 +106,7 @@ class VLMObjectDetector:
         # visible at startup rather than first tick.
         self.base_url = (os.environ.get("VLM_BASE_URL") or os.environ.get("OPENAI_BASE_URL") or "").rstrip("/")
         self.api_key = os.environ.get("VLM_API_KEY") or os.environ.get("OPENAI_API_KEY") or ""
-        self.model = os.environ.get("VLM_MODEL") or os.environ.get("OPENAI_MODEL") or "gpt-5.4-mini"
+        self.model = os.environ.get("VLM_MODEL") or os.environ.get("OPENAI_MODEL") or "gpt-5.5"
         if not self.api_key:
             log.warning("[scene-vlm] VLM_API_KEY not set; perception will be inert")
 


### PR DESCRIPTION
gpt-5.4-mini is too weak for scene perception/planning. Sets the scene `perception_vlm` default plus the README / webots quickstart examples to gpt-5.5.