### PR TITLE
feat(codegen): contract + ROS IDL reference generator (`rbnx docs`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ implementation language):
 | **[executor](system/executor/)** | capability orchestration & dispatch              |
 | **[keystone](system/keystone/)** | identity / configuration / policy         *(stub)*  |
 | **[liaison](system/liaison/)**   | human–machine interaction (chat / audio / TUI)   |
-| **[nexus](system/nexus/)**       | high-performance transport abstraction    *(stub)*  |
+| **[nexus](system/nexus/)**       | gRPC / MCP / ROS 2 communication libraries *(library, not a process)* |
 | **[pilot](system/pilot/)**       | planning / decision / memory / world model       |
 | **[scene](system/scene/)**       | scene state / semantic map / object registry     |
 | **[scribe](system/scribe/)**     | structured logs / replay / audit          *(stub)*  |
@@ -138,7 +138,7 @@ all of them can carry.
 Boot sequence (whitepaper §*启动流程*):
 
 1. **base** — Bootloader / kernel
-2. **L0 系统服务** — chronos / atlas / nexus / scribe come up first
+2. **L0 系统服务** — chronos / atlas / scribe come up first
 3. **soma** — enumerate hardware, body state ready, primitives register
 4. **scene** — receive perception, time/space alignment, build object registry
 5. **sentinel** — load safety rules
@@ -149,8 +149,8 @@ System READY — users issue tasks via liaison; pilot plans, executor dispatches
 sentinel supervises, scene keeps the world model fresh.
 
 Dive deeper:
-- [**Overview**](https://github.com/syswonder/robonix-book/blob/main/src/architecture/overview.md) — control plane, one full request end-to-end
-- [**Namespaces & contracts**](https://github.com/syswonder/robonix-book/blob/main/src/architecture/namespace-and-interfaces.md) — how `robonix/primitive/*` / `robonix/service/*` / `robonix/skill/*` / `robonix/system/*` work
+- [**System components**](https://github.com/syswonder/robonix-book/blob/main/src/architecture/components.md) — the 12 components and what's implemented vs stub
+- [**Namespaces & contracts**](https://github.com/syswonder/robonix-book/blob/main/src/architecture/namespace-and-contracts.md) — how `robonix/primitive/*` / `robonix/service/*` / `robonix/skill/*` / `robonix/system/*` work
 - [**Interface catalog**](https://github.com/syswonder/robonix-book/blob/main/src/interface-catalog/index.md) — every primitive + service contract
 
 ## Status
@@ -161,8 +161,10 @@ Dive deeper:
 
 5 of the 12 system components are implemented today (atlas, executor,
 liaison, pilot, scene); sentinel runs as an executor sub-module; vitals'
-heartbeat half lives in atlas. The remaining stubs are tracked under
-`system/<name>/README.md` with v0.2 plans.
+heartbeat half lives in atlas; nexus is the gRPC / MCP / ROS 2 library set
+every component links (not a process). The remaining stubs (chronos,
+keystone, scribe, soma) are tracked under `system/<name>/README.md` with
+v0.2 plans.
 
 ## License
 

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -11,6 +11,9 @@
 #   - capabilities/lib/{common,rcl}_interfaces/   vendored upstream ROS 2 IDL
 #   - **/LICENSE                                  Mulan PSL is legally bilingual
 #   - *-zh.* / *_zh.*                             intentional translations
+#   - tools/codegen/src/codegen/docs_gen.rs       the Chinese-doc generator
+#                                                 (`rbnx docs` emits a Chinese
+#                                                 manual; its templates live here)
 #   - binary assets                              png/gif/svg/jpg/pdf/ico/tar.gz/fonts
 #   - any line containing 'i18n-ok'              documented encoding/i18n test fixture
 set -uo pipefail
@@ -19,6 +22,7 @@ cd "$(git rev-parse --show-toplevel)"
 mapfile -t files < <(git ls-files \
   | grep -vE '^docs/' \
   | grep -vE '^capabilities/lib/(common_interfaces|rcl_interfaces)/' \
+  | grep -vE '^tools/codegen/src/codegen/docs_gen\.rs$' \
   | grep -vEi '(^|/)LICENSE$' \
   | grep -vE '(-zh|_zh)\.[A-Za-z0-9]+$' \
   | grep -vEi '\.(png|gif|svg|jpe?g|pdf|ico|woff2?|ttf|eot)$' \

--- a/system/nexus/README.md
+++ b/system/nexus/README.md
@@ -1,25 +1,15 @@
-# Nexus — high-performance communication
+# Nexus — communication libraries
 
-One of the 12 Robonix system components. The transport-abstraction
-layer that subsumes ROS 2, gRPC, MCP, and shared-memory transports
-behind one capability-facing API.
+One of the 12 Robonix system components, but not a process or a daemon.
+Nexus is the set of transport libraries Robonix communicates over — the
+gRPC, MCP, and ROS 2 client/server stacks that every component links
+directly. There is nothing to start.
 
-**Status — v0.1 stub.** Not yet implemented.
+Robonix contracts are transport-agnostic; `rbnx codegen` projects each
+onto gRPC / MCP / ROS 2, and those three stacks are nexus. atlas declares
+per interface which transport a capability is reachable over, and
+consumers dial it with the matching nexus library. The dev guide section
+*能力与能力接口* covers that mechanism.
 
-Today every Robonix component picks its own transport directly: atlas
-declares per-interface that a capability is reachable over gRPC / ROS
-2 / MCP, and consumers dial that transport themselves. The dev guide
-section *能力与能力接口* covers the current mechanism.
-
-When Nexus lands it will:
-
-- own the transport-independent `(contract_id, transport) → endpoint`
-  resolution that today is split between atlas and the Python /
-  Rust client helpers,
-- add zero-copy in-process / shared-memory transports for high-rate
-  sensor streams,
-- give a single back-pressure / cancellation model regardless of the
-  underlying transport.
-
-See the whitepaper §3 *L0 系统服务层* and §3.4 *统一通信* for design
-intent.
+Roadmap: a self-built ROS 2 zero-copy / shared-memory transport for
+high-rate sensor streams, added alongside the existing three.

--- a/tools/codegen/src/codegen/contract_gen.rs
+++ b/tools/codegen/src/codegen/contract_gen.rs
@@ -23,9 +23,7 @@ struct ContractToml {
 #[derive(Debug, Deserialize)]
 struct ContractMeta {
     id: String,
-    #[allow(dead_code)]
     version: String,
-    #[allow(dead_code)]
     kind: String,
     /// IDL reference: full path under one of the merged lib roots
     /// (`<robonix>/capabilities/lib/` or `<pkg>/capabilities/lib/`),
@@ -75,6 +73,47 @@ pub fn collect_referenced_srvs(contracts_dir: &Path) -> Result<BTreeSet<(String,
         }
     }
     Ok(set)
+}
+
+/// Lightweight per-contract view for documentation generation. Built from
+/// the same TOML parse + directory walk as proto generation, so the docs
+/// reference can't drift from what codegen / atlas actually read.
+pub struct ContractSummary {
+    pub id: String,
+    pub version: String,
+    pub kind: String,
+    pub mode: String,
+    pub idl: String,
+    /// Absolute path to the source `.v1.toml`.
+    pub toml_path: PathBuf,
+}
+
+/// Load every contract under `dirs` (recursively, skipping `lib/`), de-duped
+/// by id (later dir wins, matching atlas merge semantics), sorted by id.
+/// Backs `robonix-codegen --lang docs`.
+pub fn load_contract_summaries(dirs: &[PathBuf]) -> Result<Vec<ContractSummary>> {
+    let mut by_id: std::collections::BTreeMap<String, ContractSummary> =
+        std::collections::BTreeMap::new();
+    for d in dirs {
+        for p in collect_tomls(d)? {
+            let raw =
+                fs::read_to_string(&p).with_context(|| format!("read contract {}", p.display()))?;
+            let c: ContractToml =
+                toml::from_str(&raw).with_context(|| format!("parse TOML {}", p.display()))?;
+            by_id.insert(
+                c.contract.id.clone(),
+                ContractSummary {
+                    id: c.contract.id,
+                    version: c.contract.version,
+                    kind: c.contract.kind,
+                    mode: c.mode.mode_type,
+                    idl: c.contract.idl,
+                    toml_path: p,
+                },
+            );
+        }
+    }
+    Ok(by_id.into_values().collect())
 }
 
 pub fn generate(

--- a/tools/codegen/src/codegen/docs_gen.rs
+++ b/tools/codegen/src/codegen/docs_gen.rs
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: MulanPSL-2.0
+// Generate the browsable contract + ROS IDL reference for the mdBook
+// (`docs/src/reference/{contracts,idl}.md`). Reuses the same contract
+// loader as proto generation (`contract_gen::load_contract_summaries`),
+// so the reference can't drift from what codegen / atlas actually parse.
+//
+// Two pages, cross-linked:
+//   contracts.md — every contract; its payload cell links into idl.md.
+//   idl.md       — every .msg/.srv under the lib root(s), raw, anchored.
+
+use anyhow::{Context, Result};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write as _;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use super::contract_gen::load_contract_summaries;
+
+/// One ROS IDL file discovered under a lib root.
+struct IdlFile {
+    /// lib-relative path with extension, e.g. `chassis/srv/ExecuteMoveCommand.srv`.
+    rel: String,
+    /// ROS package (the dir above `msg/`/`srv/`), e.g. `chassis`, `sensor_msgs`.
+    pkg: String,
+    /// Type name without extension, e.g. `ExecuteMoveCommand`.
+    name: String,
+    /// "msg" | "srv".
+    kind: &'static str,
+    /// Raw file content.
+    body: String,
+}
+
+/// Emit `contracts.md` + `idl.md` into `out`. `stamp` is the version line
+/// (e.g. `v0.1 @ abc1234 (2026-06-06)`) written verbatim into each header.
+pub fn generate(
+    contracts_dirs: &[PathBuf],
+    lib_roots: &[PathBuf],
+    out: &Path,
+    stamp: Option<&str>,
+    verbose: bool,
+) -> Result<()> {
+    let contracts = load_contract_summaries(contracts_dirs)?;
+    let idl = collect_idl(lib_roots)?;
+    let idl_rels: BTreeSet<&str> = idl.iter().map(|f| f.rel.as_str()).collect();
+    let banner = stamp.unwrap_or("(version unknown)");
+
+    let contracts_md = render_contracts(&contracts, contracts_dirs, &idl_rels, banner);
+    let idl_md = render_idl(&idl, banner);
+
+    fs::create_dir_all(out)?;
+    let cpath = out.join("contracts.md");
+    let ipath = out.join("idl.md");
+    fs::write(&cpath, contracts_md).with_context(|| format!("write {}", cpath.display()))?;
+    fs::write(&ipath, idl_md).with_context(|| format!("write {}", ipath.display()))?;
+
+    eprintln!(
+        "[robonix-codegen] docs: {} contracts, {} IDL files -> {}",
+        contracts.len(),
+        idl.len(),
+        out.display()
+    );
+    let _ = verbose;
+    Ok(())
+}
+
+/// Stable in-page anchor for a lib-relative IDL path. Both pages compute it
+/// from the same string (contract `idl` field == idl file `rel`), so links
+/// always resolve. `chassis/srv/ExecuteMoveCommand.srv` → `chassis-srv-executemovecommand-srv`.
+fn idl_anchor(rel: &str) -> String {
+    rel.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+/// First namespace segment after `robonix/` — primitive / service / system / skill.
+fn category_of(id: &str) -> &str {
+    id.split('/').nth(1).unwrap_or("other")
+}
+
+fn render_contracts(
+    contracts: &[super::contract_gen::ContractSummary],
+    contracts_dirs: &[PathBuf],
+    idl_rels: &BTreeSet<&str>,
+    banner: &str,
+) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "# 契约参考（自动生成）");
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "> 由 robonix {banner} 自动生成，请勿手改。重新生成：`rbnx docs`。"
+    );
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "本页罗列 `capabilities/` 下的所有标准契约（共 {} 条）。",
+        contracts.len()
+    );
+    let _ = writeln!(
+        out,
+        "载荷列链到对应的 [ROS IDL](idl.md)。概念与字段含义见 [接口目录](../interface-catalog/index.md)。"
+    );
+    let _ = writeln!(out);
+    let _ = writeln!(out, "[toc]");
+
+    // Stable category order; anything unexpected lands in "other".
+    for cat in ["primitive", "service", "system", "skill", "other"] {
+        let rows: Vec<&super::contract_gen::ContractSummary> = contracts
+            .iter()
+            .filter(|c| {
+                let cc = category_of(&c.id);
+                cc == cat
+                    || (cat == "other"
+                        && !matches!(cc, "primitive" | "service" | "system" | "skill"))
+            })
+            .collect();
+        if rows.is_empty() {
+            continue;
+        }
+        let _ = writeln!(out);
+        let _ = writeln!(out, "## {cat}");
+        let _ = writeln!(out);
+        let _ = writeln!(out, "| 契约 ID | kind | mode | 载荷（IDL） | 契约 TOML |");
+        let _ = writeln!(out, "|---|---|---|---|---|");
+        for c in rows {
+            let payload = if idl_rels.contains(c.idl.as_str()) {
+                format!("[`{}`](idl.md#{})", c.idl, idl_anchor(&c.idl))
+            } else {
+                format!("`{}`", c.idl)
+            };
+            let toml_rel = rel_under(&c.toml_path, contracts_dirs);
+            let _ = writeln!(
+                out,
+                "| `{}` | {} | `{}` | {} | `{}` |",
+                c.id, c.kind, c.mode, payload, toml_rel
+            );
+        }
+    }
+    out
+}
+
+fn render_idl(idl: &[IdlFile], banner: &str) -> String {
+    // Group by ROS package, then by file name (both sorted).
+    let mut by_pkg: BTreeMap<&str, Vec<&IdlFile>> = BTreeMap::new();
+    for f in idl {
+        by_pkg.entry(f.pkg.as_str()).or_default().push(f);
+    }
+    for v in by_pkg.values_mut() {
+        v.sort_by(|a, b| a.name.cmp(&b.name));
+    }
+
+    let mut out = String::new();
+    let _ = writeln!(out, "# ROS IDL 参考（自动生成）");
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "> 由 robonix {banner} 自动生成，请勿手改。重新生成：`rbnx docs`。"
+    );
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "本页是 `capabilities/lib/` 下全部 ROS IDL（`.msg` / `.srv`）的原文，按 ROS 包分组（共 {} 个文件）。[契约参考](contracts.md) 的载荷列链到这里对应的锚点。",
+        idl.len()
+    );
+    let _ = writeln!(out);
+    let _ = writeln!(out, "[toc]");
+
+    for (pkg, files) in &by_pkg {
+        let _ = writeln!(out);
+        let _ = writeln!(out, "## {pkg}");
+        for f in files {
+            let _ = writeln!(out);
+            // Explicit HTML anchor so the contract page's computed link
+            // resolves regardless of mdBook's heading-slug rules.
+            let _ = writeln!(out, "<a id=\"{}\"></a>", idl_anchor(&f.rel));
+            let _ = writeln!(out, "### {} `{}`", f.name, f.kind);
+            let _ = writeln!(out);
+            let _ = writeln!(out, "`{}`", f.rel);
+            let _ = writeln!(out);
+            let _ = writeln!(out, "```rosidl");
+            let _ = write!(out, "{}", f.body);
+            if !f.body.ends_with('\n') {
+                let _ = writeln!(out);
+            }
+            let _ = writeln!(out, "```");
+        }
+    }
+    out
+}
+
+/// Path relative to whichever `dirs` prefix it lives under, `/`-normalised.
+fn rel_under(p: &Path, dirs: &[PathBuf]) -> String {
+    for d in dirs {
+        if let Ok(r) = p.strip_prefix(d) {
+            return r.to_string_lossy().replace('\\', "/");
+        }
+    }
+    p.to_string_lossy().replace('\\', "/")
+}
+
+/// ROS package for a lib-relative path: the segment just above `msg/`/`srv/`,
+/// else the first segment. `common_interfaces/sensor_msgs/msg/Image.msg`
+/// → `sensor_msgs`; `chassis/srv/X.srv` → `chassis`.
+fn ros_pkg_of(rel: &str) -> String {
+    let parts: Vec<&str> = rel.split('/').collect();
+    for (i, seg) in parts.iter().enumerate() {
+        if (*seg == "msg" || *seg == "srv") && i > 0 {
+            return parts[i - 1].to_string();
+        }
+    }
+    parts.first().map(|s| s.to_string()).unwrap_or_default()
+}
+
+fn collect_idl(lib_roots: &[PathBuf]) -> Result<Vec<IdlFile>> {
+    let mut by_rel: BTreeMap<String, IdlFile> = BTreeMap::new();
+    for root in lib_roots {
+        let mut files = Vec::new();
+        walk_idl(root, &mut files)?;
+        for p in files {
+            let kind: &'static str = match p.extension().and_then(|e| e.to_str()) {
+                Some("srv") => "srv",
+                Some("msg") => "msg",
+                _ => continue,
+            };
+            let rel = p
+                .strip_prefix(root)
+                .unwrap_or(&p)
+                .to_string_lossy()
+                .replace('\\', "/");
+            let name = p
+                .file_stem()
+                .map(|s| s.to_string_lossy().to_string())
+                .unwrap_or_default();
+            let pkg = ros_pkg_of(&rel);
+            let body = fs::read_to_string(&p).with_context(|| format!("read {}", p.display()))?;
+            by_rel.entry(rel.clone()).or_insert(IdlFile {
+                rel,
+                pkg,
+                name,
+                kind,
+                body,
+            });
+        }
+    }
+    Ok(by_rel.into_values().collect())
+}
+
+fn walk_idl(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+    if !dir.is_dir() {
+        return Ok(());
+    }
+    for entry in fs::read_dir(dir).with_context(|| format!("read_dir {}", dir.display()))? {
+        let p = entry?.path();
+        if p.is_dir() {
+            walk_idl(&p, out)?;
+        } else if matches!(
+            p.extension().and_then(|e| e.to_str()),
+            Some("msg") | Some("srv")
+        ) {
+            out.push(p);
+        }
+    }
+    Ok(())
+}

--- a/tools/codegen/src/codegen/docs_gen.rs
+++ b/tools/codegen/src/codegen/docs_gen.rs
@@ -165,7 +165,7 @@ fn render_idl(idl: &[IdlFile], banner: &str) -> String {
     let _ = writeln!(out);
     let _ = writeln!(
         out,
-        "本页是 `capabilities/lib/` 下全部 ROS IDL（`.msg` / `.srv`）的原文，按 ROS 包分组（共 {} 个文件）。[契约参考](contracts.md) 的载荷列链到这里对应的锚点。",
+        "本页收录从 IDL 包含根（`rbnx docs --include`，默认 `capabilities/lib/`）收集的全部 ROS IDL（`.msg` / `.srv`）原文，按 ROS 包分组（共 {} 个文件）。[契约参考](contracts.md) 的载荷列链到这里对应的锚点。",
         idl.len()
     );
     let _ = writeln!(out);

--- a/tools/codegen/src/codegen/mod.rs
+++ b/tools/codegen/src/codegen/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod contract_gen;
 pub mod contract_proto_modules_gen;
+pub mod docs_gen;
 pub mod err;
 pub mod mcp_python_gen;
 pub mod msg_parser;

--- a/tools/codegen/src/main.rs
+++ b/tools/codegen/src/main.rs
@@ -7,7 +7,9 @@ use std::collections::BTreeSet;
 use std::io::{self, IsTerminal};
 use std::path::PathBuf;
 
-use robonix_codegen::codegen::{contract_gen, mcp_python_gen, msg_parser, proto_gen, ros2_gen};
+use robonix_codegen::codegen::{
+    contract_gen, docs_gen, mcp_python_gen, msg_parser, proto_gen, ros2_gen,
+};
 
 #[derive(Parser)]
 #[command(name = "robonix-codegen")]
@@ -31,10 +33,16 @@ struct Args {
     out: PathBuf,
 
     /// Target language: "proto" (gRPC stubs + contracts), "mcp"
-    /// (Python typed-input helpers for MCP servers), or "ros2"
-    /// (a colcon overlay of the canonical ROS interface packages).
+    /// (Python typed-input helpers for MCP servers), "ros2"
+    /// (a colcon overlay of the canonical ROS interface packages), or
+    /// "docs" (the mdBook contract + ROS IDL reference pages).
     #[arg(long = "lang", default_value = "proto")]
     lang: String,
+
+    /// For `--lang docs` only: version line written verbatim into the
+    /// generated reference headers (e.g. "v0.1 @ abc1234 (2026-06-06)").
+    #[arg(long = "doc-stamp")]
+    doc_stamp: Option<String>,
 
     /// Print per-package lines and every IDL resolution warning (default: one summary line; set ROBONIX_CODEGEN_VERBOSE=1 for same without flag)
     #[arg(long, short = 'v')]
@@ -69,10 +77,10 @@ fn main() -> Result<()> {
     }
 
     match args.lang.as_str() {
-        "proto" | "mcp" | "ros2" => {}
+        "proto" | "mcp" | "ros2" | "docs" => {}
         other => {
             bail!(
-                "[robonix-codegen] unsupported --lang '{other}'. Supported: 'proto', 'mcp', 'ros2'."
+                "[robonix-codegen] unsupported --lang '{other}'. Supported: 'proto', 'mcp', 'ros2', 'docs'."
             )
         }
     }
@@ -91,6 +99,20 @@ fn main() -> Result<()> {
     }
 
     std::fs::create_dir_all(&args.out)?;
+
+    // Docs reference: a pure file walk over contracts + lib IDL — no
+    // resolver / proto build needed. Handle before building the resolver
+    // so an unrelated task doesn't emit IDL-resolution warnings.
+    if args.lang == "docs" {
+        docs_gen::generate(
+            &args.contracts,
+            &args.include,
+            &args.out,
+            args.doc_stamp.as_deref(),
+            verbose,
+        )?;
+        return Ok(());
+    }
 
     let mut resolver = msg_parser::MsgResolver::new(&args.include)?;
     let mut idl_skips = 0usize;

--- a/tools/rbnx/src/cmd/codegen.rs
+++ b/tools/rbnx/src/cmd/codegen.rs
@@ -25,7 +25,7 @@ use robonix_cli::{Config, SourcePathKey};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-fn run_cmd(label: &str, cmd: &mut Command) -> Result<()> {
+pub(crate) fn run_cmd(label: &str, cmd: &mut Command) -> Result<()> {
     log::debug!("[codegen] {}: {:?}", label, cmd);
     let status = cmd
         .status()
@@ -297,7 +297,7 @@ pub async fn execute(
 /// Returns `None` only when none of those exist; callers fall back to
 /// `cargo run -p robonix-codegen` which keeps a fresh-checkout workflow
 /// alive even before the user has installed any binaries.
-fn locate_codegen_bin(rust_root: &Path) -> Option<PathBuf> {
+pub(crate) fn locate_codegen_bin(rust_root: &Path) -> Option<PathBuf> {
     if let Ok(s) = std::env::var("ROBONIX_CODEGEN_BIN")
         && !s.is_empty()
     {
@@ -375,7 +375,11 @@ fn probe_python_grpc_tools() -> Result<()> {
 /// (preferred — picks up `$ROBONIX_CODEGEN_BIN` / installed bin / target/
 /// in that order) or via `cargo run -p robonix-codegen` as a last
 /// resort. Caller appends the actual `--lang … -I … -o …` args.
-fn build_codegen_cmd(direct: Option<&PathBuf>, cargo: Option<&str>, rust_root: &Path) -> Command {
+pub(crate) fn build_codegen_cmd(
+    direct: Option<&PathBuf>,
+    cargo: Option<&str>,
+    rust_root: &Path,
+) -> Command {
     if let Some(bin) = direct {
         Command::new(bin)
     } else {

--- a/tools/rbnx/src/cmd/docs.rs
+++ b/tools/rbnx/src/cmd/docs.rs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MulanPSL-2.0
+// `rbnx docs` — regenerate the mdBook contract + ROS IDL reference
+// (`docs/src/reference/{contracts,idl}.md`) from `capabilities/`.
+//
+// This is a developer-side step run inside the robonix source tree: it
+// reads the live `capabilities/` (contracts + lib IDL) through the same
+// loader codegen uses, and writes plain-markdown pages into the docs
+// (robonix-book) submodule. Those pages are committed there, so the
+// mdBook / GitHub Pages build compiles them with NO robonix environment —
+// no rbnx, no Rust, no `capabilities/`. Re-run after changing a contract
+// or IDL so the browsable reference stays in sync.
+
+use anyhow::{Context, Result};
+use colored::*;
+use robonix_cli::{Config, SourcePathKey};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use super::codegen::{build_codegen_cmd, locate_codegen_bin, run_cmd};
+
+pub async fn execute(config: Config, out_dir: Option<PathBuf>) -> Result<()> {
+    let root = config.resolve_source_path(SourcePathKey::Root)?;
+    let rust_root = config.resolve_source_path(SourcePathKey::RustRoot)?;
+    let capabilities_dir = config.resolve_source_path(SourcePathKey::Capabilities)?;
+    let interfaces_lib = config.resolve_source_path(SourcePathKey::InterfacesLib)?;
+
+    // Default into the docs submodule's reference dir. The generated files
+    // are committed there; mdBook / Pages need only the markdown.
+    let out = match out_dir {
+        Some(d) if d.is_absolute() => d,
+        Some(d) => root.join(d),
+        None => root.join("docs").join("src").join("reference"),
+    };
+    std::fs::create_dir_all(&out)
+        .with_context(|| format!("create reference dir {}", out.display()))?;
+
+    let stamp = version_stamp(&root);
+
+    let direct = locate_codegen_bin(&rust_root);
+    let cargo = if direct.is_none() {
+        Some(std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string()))
+    } else {
+        None
+    };
+
+    println!(
+        "{} robonix-codegen --lang docs → {}",
+        "[docs]".bold(),
+        out.display()
+    );
+    println!("{} version stamp: {}", "[docs]".bold(), stamp);
+    let mut cmd = build_codegen_cmd(direct.as_ref(), cargo.as_deref(), &rust_root);
+    cmd.args(["--lang", "docs", "-I"])
+        .arg(&interfaces_lib)
+        .arg("--contracts")
+        .arg(&capabilities_dir)
+        .arg("-o")
+        .arg(&out)
+        .arg("--doc-stamp")
+        .arg(&stamp);
+    run_cmd("robonix-codegen docs", &mut cmd)?;
+
+    println!(
+        "{} wrote contracts.md + idl.md. Commit them into the docs repo — \
+         the mdBook / Pages build needs no robonix environment.",
+        "[docs]".green().bold()
+    );
+    Ok(())
+}
+
+/// `v<rbnx-version> · robonix commit <short-sha>[-dirty] · <commit-date>`,
+/// read from git in `root`. The commit is what the reference was generated
+/// from — always stated explicitly. Degrades gracefully when git or repo
+/// metadata is unavailable so the reference still carries *some* version.
+fn version_stamp(root: &Path) -> String {
+    let git = |args: &[&str]| -> Option<String> {
+        let out = Command::new("git")
+            .arg("-C")
+            .arg(root)
+            .args(args)
+            .output()
+            .ok()?;
+        if !out.status.success() {
+            return None;
+        }
+        let s = String::from_utf8(out.stdout).ok()?.trim().to_string();
+        (!s.is_empty()).then_some(s)
+    };
+    let sha = git(&["rev-parse", "--short", "HEAD"]).unwrap_or_else(|| "unknown".to_string());
+    let dirty = git(&["status", "--porcelain"]).is_some_and(|s| !s.is_empty());
+    let date = git(&["log", "-1", "--format=%cd", "--date=short"]).unwrap_or_default();
+    let ver = env!("CARGO_PKG_VERSION");
+    let dirty_tag = if dirty { "-dirty" } else { "" };
+    let date_part = if date.is_empty() {
+        String::new()
+    } else {
+        format!(" · {date}")
+    };
+    format!("v{ver} · commit {sha}{dirty_tag}{date_part}")
+}

--- a/tools/rbnx/src/cmd/mod.rs
+++ b/tools/rbnx/src/cmd/mod.rs
@@ -16,6 +16,7 @@ mod clean;
 mod codegen;
 mod config;
 mod deploy;
+mod docs;
 mod info;
 mod init;
 mod inspect;
@@ -172,6 +173,15 @@ pub enum Commands {
         /// Directory (relative to package root, or absolute) where proto_gen/ and robonix_mcp_types/
         /// should be placed. Defaults to package root; use e.g. `--out-dir tiago_bridge` to put
         /// stubs inside a package subdirectory.
+        #[arg(long)]
+        out_dir: Option<PathBuf>,
+    },
+    /// Regenerate the mdBook contract + ROS IDL reference
+    /// (`docs/src/reference/{contracts,idl}.md`) from `capabilities/`. The
+    /// pages are auto-generated and version-stamped — run after changing any
+    /// contract or IDL so the browsable reference stays in sync.
+    Docs {
+        /// Output directory (default: `<root>/docs/src/reference`).
         #[arg(long)]
         out_dir: Option<PathBuf>,
     },
@@ -349,6 +359,7 @@ pub async fn execute(command: Commands, config: Config) -> Result<()> {
             clean,
             out_dir,
         } => codegen::execute(config, package, mcp, ros2, clean, out_dir).await,
+        Commands::Docs { out_dir } => docs::execute(config, out_dir).await,
         Commands::Setup { path } => setup::execute(config, path).await,
         Commands::Path { key } => path::execute(config, key).await,
         Commands::Caps {


### PR DESCRIPTION
Stacked on #58 (`feat/codegen-ros2-idl`) — base retargets to `dev` once #58 merges.

## What
- `robonix-codegen --lang docs`: emits two cross-linked, version-stamped mdBook pages from `capabilities/` — **contracts.md** (every contract; payload links into the IDL) and **idl.md** (every `.msg`/`.srv` under `capabilities/lib/`, raw). Reuses codegen's contract loader, so it can't drift from what atlas parses.
- `rbnx docs`: new command that stamps the robonix commit and writes the pages into the docs submodule's `reference/`. The generated pages are plain markdown — mdBook / Pages build them with no robonix environment.
- nexus README fixes: it's the gRPC/MCP/ROS 2 library set, not a process/abstraction stub.

## Validation
- `cargo fmt --all` + `cargo clippy -p robonix-codegen -p robonix-cli --tests` clean
- ran `rbnx docs` → 57 contracts, 250 IDL files; mdBook builds the result (rosidl-highlighted, cross-links resolve)

The robonix-book side (interface-catalog rewrite, the generated reference, theme, CI) is a separate push to the docs repo.