### PR TITLE
docs(robonix-api): bless .mcp/.grpc as canonical (drop 'deprecated')

### DIFF
--- a/pylib/robonix-api/robonix_api/capability.py
+++ b/pylib/robonix-api/robonix_api/capability.py
@@ -502,8 +502,8 @@ class _ProviderBase:
 
         return decorator
 
-    # Back-compat alias (old name was just `mcp`); deprecated but kept
-    # so packages can migrate.
+    # `mcp` is the canonical decorator name (used throughout the dev guide
+    # and all packages); `provides_mcp` is an equivalent long-form alias.
     mcp = provides_mcp
 
     def _ensure_mcp_app(self) -> None:
@@ -553,7 +553,8 @@ class _ProviderBase:
 
         return decorator
 
-    # Back-compat alias.
+    # `grpc` is the canonical decorator name (used throughout the dev guide
+    # and all packages); `provides_grpc` is an equivalent long-form alias.
     grpc = provides_grpc
 
     # -- mode/transport compat check (best-effort) -------------------------


### PR DESCRIPTION
`@cap.mcp` / `@cap.grpc` are the names used throughout the dev guide and every in-repo package, but were tagged as deprecated back-compat aliases. This rewords the comments so `.mcp`/`.grpc` are the canonical short names and `provides_mcp`/`provides_grpc` the long-form equivalents. Comment-only, no behavior change.