### PR TITLE
fix: cross-host MCP 421 + executor/pilot accept ROBONIX_ATLAS

### DIFF
--- a/pylib/robonix-api/robonix_api/capability.py
+++ b/pylib/robonix-api/robonix_api/capability.py
@@ -511,7 +511,13 @@ class _ProviderBase:
             return
         from mcp.server.fastmcp import FastMCP
 
-        self._mcp_app = FastMCP(self.id)
+        # Bind host="0.0.0.0" explicitly. FastMCP defaults to host="127.0.0.1",
+        # which makes the SDK auto-enable DNS-rebinding protection with
+        # allowed_hosts restricted to localhost. A cross-host consumer (e.g. a
+        # remote executor) dialing this provider by IP is then rejected with
+        # HTTP 421 "Invalid Host header". "0.0.0.0" skips that localhost-only
+        # restriction so the MCP endpoint is reachable cross-host.
+        self._mcp_app = FastMCP(self.id, host="0.0.0.0")
 
     def use_mcp_app(self, app) -> None:
         if self._mcp_app is not None and self._mcp_app is not app:

--- a/system/executor/src/config.rs
+++ b/system/executor/src/config.rs
@@ -27,7 +27,8 @@ pub struct ExecutorConfig {
     about = "Robonix Executor — tool-call dispatch runtime"
 )]
 pub struct Args {
-    /// Atlas control-plane endpoint.
+    /// Atlas control-plane endpoint. Also reads `ROBONIX_ATLAS` (the var rbnx /
+    /// the Python API / liaison use) as an alias; see `env_atlas`.
     #[arg(long, env = "ROBONIX_ATLAS_ENDPOINT")]
     pub atlas: Option<String>,
 
@@ -68,6 +69,7 @@ impl ExecutorConfig {
         Ok(Self {
             atlas_endpoint: args
                 .atlas
+                .or_else(env_atlas)
                 .or(file_cfg.atlas_endpoint)
                 .unwrap_or_else(|| DEFAULT_ATLAS_ENDPOINT.to_string()),
             listen: args
@@ -80,6 +82,23 @@ impl ExecutorConfig {
                 .unwrap_or_else(|| DEFAULT_EXECUTOR_PROVIDER_ID.to_string()),
         })
     }
+}
+
+/// Read the `ROBONIX_ATLAS` env var as an atlas-endpoint alias.
+///
+/// rbnx, the Python API, and liaison all configure the atlas endpoint via
+/// `ROBONIX_ATLAS`, while executor/pilot historically only honored
+/// `ROBONIX_ATLAS_ENDPOINT` (the clap `env`). Accepting `ROBONIX_ATLAS` here as
+/// well means a single env var configures every component. Without it, setting
+/// only `ROBONIX_ATLAS` left executor silently falling back to
+/// `DEFAULT_ATLAS_ENDPOINT` (127.0.0.1:50051) — it would then dial the wrong
+/// atlas and log 127.0.0.1 even after the operator "changed" the endpoint.
+/// Empty values are ignored so an exported-but-blank var doesn't shadow later
+/// sources.
+fn env_atlas() -> Option<String> {
+    std::env::var("ROBONIX_ATLAS")
+        .ok()
+        .filter(|v| !v.is_empty())
 }
 
 fn load_yaml(path: &Path) -> Result<FileConfig> {

--- a/system/pilot/src/config.rs
+++ b/system/pilot/src/config.rs
@@ -50,7 +50,8 @@ pub struct VlmConfig {
 #[derive(Parser, Debug)]
 #[command(name = "robonix-pilot", about = "Robonix Pilot — VLM planner")]
 pub struct Args {
-    /// Atlas control-plane endpoint.
+    /// Atlas control-plane endpoint. Also reads `ROBONIX_ATLAS` (the var rbnx /
+    /// the Python API / liaison use) as an alias; see `env_atlas`.
     #[arg(long, env = "ROBONIX_ATLAS_ENDPOINT")]
     pub atlas: Option<String>,
 
@@ -126,6 +127,7 @@ impl PilotConfig {
 
         let atlas_endpoint = args
             .atlas
+            .or_else(env_atlas)
             .or(file_cfg.atlas_endpoint)
             .unwrap_or_else(|| DEFAULT_ATLAS_ENDPOINT.to_string());
         let listen = args
@@ -174,6 +176,23 @@ impl PilotConfig {
             },
         })
     }
+}
+
+/// Read the `ROBONIX_ATLAS` env var as an atlas-endpoint alias.
+///
+/// rbnx, the Python API, and liaison all configure the atlas endpoint via
+/// `ROBONIX_ATLAS`, while executor/pilot historically only honored
+/// `ROBONIX_ATLAS_ENDPOINT` (the clap `env`). Accepting `ROBONIX_ATLAS` here as
+/// well means a single env var configures every component. Without it, setting
+/// only `ROBONIX_ATLAS` left pilot silently falling back to
+/// `DEFAULT_ATLAS_ENDPOINT` (127.0.0.1:50051) — it would then dial the wrong
+/// atlas and log 127.0.0.1 even after the operator "changed" the endpoint.
+/// Empty values are ignored so an exported-but-blank var doesn't shadow later
+/// sources.
+fn env_atlas() -> Option<String> {
+    std::env::var("ROBONIX_ATLAS")
+        .ok()
+        .filter(|v| !v.is_empty())
 }
 
 fn load_yaml(path: &Path) -> Result<FileConfig> {


### PR DESCRIPTION
Fixes the two cross-host connectivity bugs in #85.

## Changes

### 1. `robonix-api`: disable MCP DNS-rebinding protection for cross-host reachability

In `pylib/robonix-api/robonix_api/capability.py`, `_ensure_mcp_app` constructs the MCP app with DNS-rebinding protection explicitly disabled.

The MCP SDK auto-enables DNS-rebinding protection when `transport_security` is unset and the FastMCP host is loopback (its default), restricting `allowed_hosts` to localhost. A cross-host consumer (e.g. a remote executor dialing a provider by its LAN/VPN IP) then fails that Host-header allowlist and is rejected with `HTTP 421 "Invalid Host header"` — the connection is established but the handshake fails. This is independent of the `/mcp/` trailing-slash 307 redirect; the cause is the localhost-only allowlist. The listen socket is already bound on `0.0.0.0` by uvicorn (`_start_mcp_server`) regardless, and the advertised endpoint is still rewritten to the registrant source IP by atlas. DNS-rebinding protection defends a browser attack vector and does not apply to the server-to-server executor→provider call.

### 2. `executor` / `pilot`: accept `ROBONIX_ATLAS` as an env alias

`resolve()` in `system/executor/src/config.rs` and `system/pilot/src/config.rs` now also reads `ROBONIX_ATLAS`.

Previously executor/pilot only read `ROBONIX_ATLAS_ENDPOINT`, while rbnx, the Python API, and liaison all use `ROBONIX_ATLAS`. Setting only `ROBONIX_ATLAS` left executor/pilot silently falling back to `127.0.0.1:50051`, so changing the atlas ip still logged 127.0.0.1. Precedence is now `--atlas / ROBONIX_ATLAS_ENDPOINT > ROBONIX_ATLAS > config file > default`; empty values are ignored. `rbnx boot` uses the `--atlas` flag and is unchanged.

## Validation

- `cargo build -p robonix-executor -p robonix-pilot`
- `cargo fmt --check` + `cargo clippy -p robonix-executor -p robonix-pilot --all-targets -- -D warnings` clean
- Two-machine end-to-end: one host runs atlas+executor+pilot, the other runs an arm primitive (exposing one MCP tool) registered to the first.
  - Before (default `FastMCP`): cross-host dial → `HTTP 421 Misdirected Request: Invalid Host header`
  - After: `307 → 200 OK`, tool call returns successfully

## Compatibility

- `ROBONIX_ATLAS_ENDPOINT` still works (highest-precedence env); the alias is purely additive, no breaking change.
- Does not touch the v0.1 frozen surface (atlas.proto / Driver.srv / contract TOML schema / robonix-api public signatures).

Closes #85
