### PR TITLE
refactor(robonix-api): make MCP DNS-rebinding opt-out explicit (follow-up to #86)

### DIFF
--- a/pylib/robonix-api/robonix_api/capability.py
+++ b/pylib/robonix-api/robonix_api/capability.py
@@ -510,14 +510,29 @@ class _ProviderBase:
         if self._mcp_app is not None:
             return
         from mcp.server.fastmcp import FastMCP
+        from mcp.server.transport_security import TransportSecuritySettings
 
-        # Bind host="0.0.0.0" explicitly. FastMCP defaults to host="127.0.0.1",
-        # which makes the SDK auto-enable DNS-rebinding protection with
-        # allowed_hosts restricted to localhost. A cross-host consumer (e.g. a
-        # remote executor) dialing this provider by IP is then rejected with
-        # HTTP 421 "Invalid Host header". "0.0.0.0" skips that localhost-only
-        # restriction so the MCP endpoint is reachable cross-host.
-        self._mcp_app = FastMCP(self.id, host="0.0.0.0")
+        # Disable the MCP SDK's DNS-rebinding protection (Host-header allowlist)
+        # explicitly. The SDK auto-enables it with allowed_hosts restricted to
+        # localhost whenever no transport_security is given and the FastMCP host
+        # is loopback (its default). The executor reaches a remote provider by
+        # its LAN/VPN IP, so that Host header fails the localhost allowlist and
+        # the request is rejected with HTTP 421 "Invalid Host header" *after*
+        # the TCP connection is established. This is independent of the `/mcp/`
+        # trailing-slash 307 redirect — even a direct POST /mcp 421s under the
+        # default. DNS-rebinding protection defends a browser attack vector
+        # (a malicious page driving a victim browser at a loopback service);
+        # the executor↔provider call is server-to-server over a trusted
+        # LAN/VPN, so that control does not apply. The listen socket is bound
+        # by `_start_mcp_server` (uvicorn host="0.0.0.0") and is unaffected by
+        # this setting. Endpoint authentication is a separate, wire-wide
+        # hardening item, not introduced here.
+        self._mcp_app = FastMCP(
+            self.id,
+            transport_security=TransportSecuritySettings(
+                enable_dns_rebinding_protection=False
+            ),
+        )
 
     def use_mcp_app(self, app) -> None:
         if self._mcp_app is not None and self._mcp_app is not app:


### PR DESCRIPTION
Optional follow-up to the fix merged in #86, which used `FastMCP(self.id, host="0.0.0.0")`. **No behavior change** — this only makes the intent explicit and responds to the automated security review on the commit.

## Background

- Passing `host="0.0.0.0"` to `FastMCP` **does not change the listen socket**. The socket is bound by `_start_mcp_server`'s `uvicorn host="0.0.0.0"` (`capability.py:750`), and the lifecycle gRPC has always bound `0.0.0.0` (`:688`). The `host` arg only matters when `transport_security` is unset and the host is loopback, where the SDK adds a localhost-only `allowed_hosts` (`mcp/server/fastmcp/server.py:178`). So `"0.0.0.0"` was just a side-effect way of skipping that auto-allowlist, and reads misleadingly as if it changed the bind address.
- The 421 is therefore also **unrelated to the `/mcp/` trailing slash**: the 307 redirect is incidental, and a direct `POST /mcp` 421s under the old code too. The cause is the default host=127.0.0.1 triggering the localhost-only Host-header allowlist.

## Change

`host="0.0.0.0"` → explicit `transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False)`, with a clarifying comment.

## Security note (responding to the automated review)

- The 0.0.0.0 listen socket **pre-dates this change** (both uvicorn and the Driver gRPC). This change only relaxes the application-layer Host-header allowlist.
- DNS-rebinding protection defends a **browser** attack surface (a malicious page driving a victim browser at a loopback service). Robonix's executor→provider call is server-to-server and does not go through a browser, so the control does not apply to this threat model — leaving it on only blocks legitimate cross-host calls.
- The genuine residual risk is unauthenticated access to hardware-control endpoints on a routable network, which is a property of the entire v0.1 wire (atlas / Driver gRPC / MCP are all unauthenticated) and the trusted-LAN/VPN deployment posture — not something this single MCP change should carry. End-to-end authentication (token / mTLS) is a separate, wire-wide hardening item worth tracking in its own issue.

Does not touch the v0.1 frozen surface; purely an internal `robonix-api` expression change.
