### PR TITLE
feat(scene): hardware-aware perception tiers with contract-sourced camera intrinsics

### DIFF
--- a/capabilities/primitive/camera/intrinsics.v1.toml
+++ b/capabilities/primitive/camera/intrinsics.v1.toml
@@ -1,0 +1,32 @@
+# Static camera intrinsics (pinhole K + image size). The camera
+# primitive declares this so downstream consumers (scene's depth
+# back-projection, any 3D reconstruction) get the *real* per-deployment
+# intrinsics instead of guessing.
+#
+# Why this is a contract and not a hardcoded default:
+#   Depth back-projection scales every 3D point by fx/fy and offsets it
+#   by cx/cy. A consumer that assumes one camera's intrinsics (e.g. the
+#   Webots head camera) and is fed another camera's depth (a RealSense
+#   at a different resolution / FOV) places objects at systematically
+#   wrong map positions — silently, with no crash. Routing K through
+#   atlas means the consumer asks for `primitive/camera/intrinsics` and
+#   gets the geometry of whichever camera is actually wired in.
+#
+# Payload: sensor_msgs/CameraInfo — `k` is the 3x3 row-major intrinsic
+# matrix (`k[0]=fx`, `k[2]=cx`, `k[4]=fy`, `k[5]=cy`); `width`/`height`
+# are the image dimensions the matrix is calibrated for. These describe
+# the same optical frame as `primitive/camera/extrinsics` publishes
+# (i.e. the camera the RGB/depth streams come from).
+#
+# Cadence: TRANSIENT_LOCAL + RELIABLE (latched). Intrinsics are static
+# within a deployment; publishers should send once at startup and on any
+# re-calibration event. Late subscribers (scene started after the
+# camera) are guaranteed to receive the cached value.
+[contract]
+id      = "robonix/primitive/camera/intrinsics"
+version = "1"
+kind    = "primitive"
+idl     = "common_interfaces/sensor_msgs/msg/CameraInfo.msg"
+
+[mode]
+type = "topic_out"

--- a/examples/webots/primitives/tiago_camera/camera_driver/driver.py
+++ b/examples/webots/primitives/tiago_camera/camera_driver/driver.py
@@ -10,6 +10,7 @@ Owns `primitive/camera/*`. Subscribes to RGB + depth image topics, exposes:
                                               facing tool, see snapshot below)
   primitive/camera/depth          topic_out
   primitive/camera/extrinsics     topic_out  (latched TransformStamped)
+  primitive/camera/intrinsics     topic_out  (latched CameraInfo)
   primitive/camera/snapshot       rpc        (MCP, RGB JPEG)
   primitive/camera/depth_snapshot rpc        (MCP, depth as 8-bit JPEG)
   primitive/camera/driver         rpc        (gRPC lifecycle)
@@ -36,6 +37,8 @@ state_lock = threading.Lock()
 latest_rgb_jpeg: bytes | None = None
 latest_depth_jpeg: bytes | None = None
 extrinsics_pub = None  # rclpy publisher for the latched TF
+intrinsics_pub = None  # rclpy publisher for the latched CameraInfo
+intrinsics_published = False  # publish K once; intrinsics are static
 
 
 # ── image conversion ─────────────────────────────────────────────────────────
@@ -201,13 +204,17 @@ def publish_extrinsics_when_ready(base_frame: str, cam_frame: str, topic: str) -
 # ── lifecycle ────────────────────────────────────────────────────────────────
 @tiago_camera.on_init
 def init(cfg):
-    global extrinsics_pub
+    global extrinsics_pub, intrinsics_pub
     rgb_topic = cfg.get("rgb_topic") or os.environ.get(
         "TIAGO_RGB_TOPIC", "/head_front_camera/rgb/image_raw")
     depth_topic = cfg.get("depth_topic") or os.environ.get(
         "TIAGO_DEPTH_TOPIC", "/head_front_camera/depth_registered/image_raw")
     extrinsics_topic = cfg.get("extrinsics_topic") or os.environ.get(
         "TIAGO_CAMERA_EXTRINSICS_TOPIC", "/tiago/camera/extrinsics")
+    camera_info_topic = cfg.get("camera_info_topic") or os.environ.get(
+        "TIAGO_CAMERA_INFO_TOPIC", "/head_front_camera/rgb/camera_info")
+    intrinsics_topic = cfg.get("intrinsics_topic") or os.environ.get(
+        "TIAGO_CAMERA_INTRINSICS_TOPIC", "/tiago/camera/intrinsics")
     base_frame = cfg.get("base_frame") or os.environ.get("TIAGO_BASE_FRAME", "base_link")
     cam_frame = cfg.get("cam_frame") or os.environ.get(
         "TIAGO_RGB_FRAME_ID", "head_front_camera_rgb_optical_frame")
@@ -230,6 +237,61 @@ def init(cfg):
     threading.Thread(
         target=publish_extrinsics_when_ready,
         args=(base_frame, cam_frame, extrinsics_topic),
+        daemon=True,
+    ).start()
+
+    # latched intrinsics relay: subscribe to the camera's own CameraInfo
+    # and republish the first sample on the contract topic (latched, so
+    # scene gets the cached K even though webots only streams it live).
+    # K is static, so we publish once and ignore the rest — see
+    # `on_camera_info`. declare=False on the source sub: the publisher
+    # above already declares the `intrinsics` capability on atlas.
+    from sensor_msgs.msg import CameraInfo  # type: ignore
+    intrinsics_pub = tiago_camera.create_publisher(
+        "robonix/primitive/camera/intrinsics",
+        topic=intrinsics_topic, msg_type=CameraInfo, qos="latched",
+    )
+
+    def on_camera_info(msg, _topic=intrinsics_topic):
+        global intrinsics_published
+        if intrinsics_pub is None or intrinsics_published:
+            return
+        # Validate K BEFORE latching: a TRANSIENT_LOCAL publish caches the
+        # last value, so latching a zero/partial CameraInfo would pin
+        # garbage and block a later good sample from winning. Skip until a
+        # populated frame arrives.
+        k = list(msg.k) if hasattr(msg, "k") else list(getattr(msg, "K", []))
+        if len(k) < 6 or k[0] <= 0 or k[4] <= 0:
+            return
+        intrinsics_pub.publish(msg)
+        intrinsics_published = True
+        print(f"[tiago_camera] published intrinsics: fx={k[0]:.1f} "
+              f"fy={k[4]:.1f} cx={k[2]:.1f} cy={k[5]:.1f} "
+              f"{msg.width}x{msg.height} -> {_topic}")
+
+    tiago_camera.create_subscription(
+        "robonix/primitive/camera/intrinsics",
+        topic=camera_info_topic, msg_type="CameraInfo",
+        callback=on_camera_info, qos="best_effort", declare=False,
+    )
+
+    # Give-up watchdog: if no usable CameraInfo lands on `camera_info_topic`
+    # the intrinsics contract is advertised but never publishes, and scene
+    # would wait forever for K. Warn after a deadline — mirrors the
+    # extrinsics give-up WARN — so a wrong topic name is visible.
+    def warn_if_no_intrinsics(source_topic: str, deadline_s: float = 60.0) -> None:
+        end = time.monotonic() + deadline_s
+        while time.monotonic() < end:
+            if intrinsics_published:
+                return
+            time.sleep(0.5)
+        if not intrinsics_published:
+            print(f"[tiago_camera] WARN: intrinsics never published — no "
+                  f"usable CameraInfo seen on {source_topic}")
+
+    threading.Thread(
+        target=warn_if_no_intrinsics,
+        args=(camera_info_topic,),
         daemon=True,
     ).start()
 

--- a/examples/webots/primitives/tiago_camera/package_manifest.yaml
+++ b/examples/webots/primitives/tiago_camera/package_manifest.yaml
@@ -27,3 +27,7 @@ capabilities:
   # T(world ← camera_optical) = service/map/pose ⊕ camera/extrinsics
   # without touching tf2 at all.
   - name: robonix/primitive/camera/extrinsics
+  # Static pinhole intrinsics (sensor_msgs/CameraInfo, latched). Lets
+  # scene back-project depth with the real camera's K instead of a
+  # hardcoded default — see capabilities/primitive/camera/intrinsics.v1.toml.
+  - name: robonix/primitive/camera/intrinsics

--- a/system/scene/README.md
+++ b/system/scene/README.md
@@ -26,6 +26,7 @@ system/scene/
 │   ├── geom/                    pointcloud / plane extraction (Open3D)
 │   ├── ingest/
 │   │   ├── ros_subscribers.py   rclpy hub: /tf2 + topic slots (rgb/depth/lidar/...)
+│   │   ├── capabilities.py      hardware probe → perception tier (metric/visual/geometric)
 │   │   ├── perception_concept_graphs.py  perception pipeline (this file)
 │   │   └── perception_vlm.py    VLM fallback (no-depth deploys only)
 │   └── static/urdf/meshes/      Tiago STL meshes (kept around for future URDF viz)
@@ -33,11 +34,17 @@ system/scene/
 
 ## What it actually does
 
-ConceptGraphs-style per-frame perception with 4 stages:
+**Perception tier.** Which pipeline runs is decided at startup by `ingest/capabilities.py` from the wired hardware, and logged once (`perception plan: tier=… detector=… grounding=… inputs=[…]`):
+
+- **metric** — RGB-D (+ intrinsics + pose) → ConceptGraphs below. Object-level 3D semantics, spatial relations, open-vocab queries.
+- **visual** — RGB only → `perception_vlm.py`. Approximate, region-level semantics; positions are coarse (no metric depth back-project).
+- **geometric** — no camera (LiDAR / 2D SLAM only) → no detector. The occupancy grid + `goal_near` BFS stay available; object/relation queries return empty.
+
+The metric pipeline is ConceptGraphs-style per-frame perception with 4 stages:
 
 1. **Detect.** YOLO-World v2 (open-vocab via CLIP text encoder) on the live RGB frame. Class list is a 55-entry indoor-office vocabulary; override at runtime via `SCENE_OPEN_VOCAB_CLASSES=cup,chair,...`.
 2. **Segment.** MobileSAM, prompted with each YOLO bbox, produces a per-detection mask.
-3. **Lift to 3D.** Mask-aware depth backprojection through pinhole intrinsics gives a per-detection point cloud in camera-optical frame. The world transform comes from atlas-resolved contracts, not tf2: `T(world ← base_link)` from `service/map/pose` and `T(base_link ← camera_optical)` from `primitive/camera/extrinsics`, composed into a single 4×4. The world frame name is whatever `header.frame_id` the localizer publishes — never a hardcoded `"map"`. tf2 stays only as a last-resort fallback for legacy stacks where the camera primitive hasn't declared `extrinsics` yet (logged once via "no pose contract resolved"). Reading `/odom` directly is **NOT** acceptable — once SLAM corrects `map → odom`, the registry drifts away from rviz.
+3. **Lift to 3D.** Mask-aware depth backprojection through pinhole intrinsics gives a per-detection point cloud in camera-optical frame. The intrinsics `K` come **only** from the atlas-resolved `primitive/camera/intrinsics` contract — the real per-deployment camera, exactly as extrinsics come from the camera's tf2/URDF rather than a scene-side env var. There is no hardcoded-default fallback: guessing `K` scales every point by `fx/fy` and silently misplaces objects, so when no usable intrinsics are wired the detector *waits* (logs `waiting for camera intrinsics`) instead. The world transform comes from atlas-resolved contracts, not tf2: `T(world ← base_link)` from `service/map/pose` and `T(base_link ← camera_optical)` from `primitive/camera/extrinsics`, composed into a single 4×4. The world frame name is whatever `header.frame_id` the localizer publishes — never a hardcoded `"map"`. tf2 stays only as a last-resort fallback for legacy stacks where the camera primitive hasn't declared `extrinsics` yet (logged once via "no pose contract resolved"). Reading `/odom` directly is **NOT** acceptable — once SLAM corrects `map → odom`, the registry drifts away from rviz.
 4. **Match + merge.** Per-detection 512-d OpenCLIP ViT-B-32 image feature + 3D-AABB IoU drives the concept-graphs merge pipeline: `compute_spatial_similarities` + `compute_visual_similarities` + `aggregate_similarities` + `merge_detections_to_objects`. Three hard gates filter the agg_sim matrix:
    * **Distance gate** — centroid > 1.5 m apart → never merge (kills "9 × 5 m bbox spanning the room" failure).
    * **Same-class gate** — different YOLO class names → never merge (kills "potted_plant on cabinet collapses to one record").
@@ -119,7 +126,6 @@ SCENE_CAMERA_FRAME=my_camera_optical bash scripts/start.sh
 | `SCENE_OPEN_VOCAB_CLASSES` | (55-entry default) | comma-separated YOLO-World class list |
 | `SCENE_CG_FORCE_CPU` | `` | set to `1` to force CPU mode (~3× slower) |
 | `SCENE_PERCEPTION_WAIT_S` | `30` | how long to wait for camera providers before falling back |
-| `SCENE_CAMERA_INTRINSICS` | webots tiago default | `fx,fy,cx,cy,w,h` |
 | `SCENE_YOLO_WORLD_WEIGHTS` | `/opt/models/yolov8l-world.pt` | path inside container |
 | `SCENE_MOBILE_SAM_WEIGHTS` | `/opt/models/mobile_sam.pt` | |
 | `SCENE_CLIP_MODEL` / `SCENE_CLIP_PRETRAINED` | `ViT-B-32` / `laion2b_s34b_b79k` | |
@@ -164,7 +170,7 @@ The cam panel shows the same RGB + depth frames the perception pipeline consumes
 
 ## Troubleshooting
 
-**`/api/state` returns 500 with "Out of range float values are not JSON compliant"** — depth backprojection produced NaN/Inf. Should be caught by the snapshot finite-mask + final-guard; if it still hits, the camera_info may be wrong. Check `SCENE_CAMERA_INTRINSICS`.
+**`/api/state` returns 500 with "Out of range float values are not JSON compliant"** — depth backprojection produced NaN/Inf. Should be caught by the snapshot finite-mask + final-guard; if it still hits, the camera's `K` may be wrong. Check the `primitive/camera/intrinsics` publisher (the `[scene] camera intrinsics from contract: …` startup log shows the K scene actually received).
 
 **Scene container exits with status 139 (SIGSEGV)** — was the Open3D `get_oriented_bounding_box(robust=True)` qhull bug; replaced with numpy PCA. If you still see it, `faulthandler.enable(all_threads=True)` (already on in `service.py`) prints the C trace to docker logs.
 

--- a/system/scene/scene_service/ingest/capabilities.py
+++ b/system/scene/scene_service/ingest/capabilities.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+"""Hardware-capability probe → perception tier selection.
+
+Scene supports three hardware classes, each with a different semantic
+ceiling. This module makes that routing *explicit and testable* instead
+of an inline if/elif: it probes which observation kinds are wired (via
+the subscribers hub) and reports the tier scene will run. `service.py`
+dispatches the detector on the result and logs the plan once at startup.
+
+The three tiers — named by outward semantic capability, not by which
+detector happens to implement them:
+
+  metric     RGB-D (+ intrinsics + pose) → ConceptGraphs: object-level
+             3D semantics, spatial relations, open-vocabulary queries.
+  visual     RGB only → VLM: approximate, region-level visual semantics;
+             object positions are coarse (no metric depth back-project).
+  geometric  no camera (LiDAR / 2D SLAM only) → no detector. The
+             occupancy grid + `goal_near` BFS stay available, but the
+             object/relation/scene-graph queries return empty.
+
+Tier selection depends only on which *camera* streams are wired. The
+intrinsics / pose / extrinsics slots are recorded for the startup log
+and grounding-quality note, but they do NOT gate the tier. Their absence
+degrades grounding rather than the tier: ConceptGraphs falls back to tf2
+for a missing pose contract, but it *waits* for intrinsics rather than
+guessing — a missing intrinsics contract stalls object output instead of
+silently misplacing it (intrinsics come only from the contract, never a
+scene-side default).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal, Optional
+
+Tier = Literal["metric", "visual", "geometric"]
+Detector = Optional[Literal["concept_graphs", "vlm"]]
+
+
+@dataclass(frozen=True)
+class PerceptionPlan:
+    """Resolved perception routing for the current hardware snapshot.
+
+    `tier` names the semantic ceiling; `detector` is which detector
+    `service.py` should start (None = geometric, no object detection).
+    The booleans record which inputs the probe found so the one-line
+    startup log explains itself. `grounding` is a coarse quality label
+    for the metric tier — "metric" when intrinsics + a pose contract are
+    both wired, "degraded" when one is missing (ConceptGraphs then waits
+    for intrinsics and/or falls back to tf2 pose); it is "n/a" off the
+    metric tier. It reflects wiring at startup, not live data arrival —
+    the detector's own logs are authoritative on whether K actually
+    landed."""
+
+    tier: Tier
+    detector: Detector
+    has_rgb: bool
+    has_depth: bool
+    has_intrinsics: bool
+    has_pose: bool
+    has_extrinsics: bool
+
+    @property
+    def grounding(self) -> Literal["metric", "degraded", "n/a"]:
+        if self.detector != "concept_graphs":
+            return "n/a"
+        return "metric" if (self.has_intrinsics and self.has_pose) else "degraded"
+
+    def summary(self) -> str:
+        """One-line, self-describing startup log: tier, chosen detector,
+        grounding quality, and the raw input flags that drove it."""
+        inputs = ",".join(
+            name
+            for name, present in (
+                ("rgb", self.has_rgb),
+                ("depth", self.has_depth),
+                ("intrinsics", self.has_intrinsics),
+                ("pose", self.has_pose),
+                ("extrinsics", self.has_extrinsics),
+            )
+            if present
+        ) or "none"
+        return (
+            f"tier={self.tier} detector={self.detector or 'none'} "
+            f"grounding={self.grounding} inputs=[{inputs}]"
+        )
+
+
+def plan_perception(hub: Any) -> PerceptionPlan:
+    """Probe `hub` for wired observation kinds and pick the perception tier.
+
+    Pure with respect to the hub snapshot: reads `hub.has(kind)` only, no
+    side effects. Tier is decided by camera availability alone —
+    RGB+depth → metric (ConceptGraphs); RGB only → visual (VLM); neither
+    → geometric (no detector). `hub.has(kind)` reflects whether a provider
+    advertised the contract (the kind was subscribed), matching the gate
+    `service.py` used before this module existed.
+    """
+    has_rgb = hub.has("rgb")
+    has_depth = hub.has("depth")
+    has_intrinsics = hub.has("intrinsics")
+    has_pose = hub.has("pose")
+    has_extrinsics = hub.has("camera_extrinsics")
+
+    if has_rgb and has_depth:
+        tier: Tier = "metric"
+        detector: Detector = "concept_graphs"
+    elif has_rgb:
+        tier, detector = "visual", "vlm"
+    else:
+        tier, detector = "geometric", None
+
+    return PerceptionPlan(
+        tier=tier,
+        detector=detector,
+        has_rgb=has_rgb,
+        has_depth=has_depth,
+        has_intrinsics=has_intrinsics,
+        has_pose=has_pose,
+        has_extrinsics=has_extrinsics,
+    )

--- a/system/scene/scene_service/ingest/perception_vlm.py
+++ b/system/scene/scene_service/ingest/perception_vlm.py
@@ -60,8 +60,10 @@ Limit to at most 12 detections, prioritising larger / closer items.
 @dataclass
 class _CamIntrinsics:
     """Pinhole intrinsics. Defaults match Webots Tiago's head_front_camera
-    at 640×480 (60° HFOV). Real cameras supply these via /camera/info;
-    v1 doesn't subscribe to it — we just default and document."""
+    at 640×480 (60° HFOV). The metric ConceptGraphs path sources real K
+    from the `primitive/camera/intrinsics` contract (and waits when it is
+    absent rather than using these defaults). These defaults remain only
+    as the VLM (approximate) path's coarse fallback."""
     width: int = 640
     height: int = 480
     fx: float = 554.0

--- a/system/scene/scene_service/ingest/ros_subscribers.py
+++ b/system/scene/scene_service/ingest/ros_subscribers.py
@@ -35,7 +35,7 @@ def _import_ros():
     from rclpy.qos import QoSProfile, ReliabilityPolicy, DurabilityPolicy, HistoryPolicy  # type: ignore
     from rclpy.duration import Duration  # type: ignore
     from rclpy.time import Time  # type: ignore
-    from sensor_msgs.msg import Image, LaserScan, PointCloud2  # type: ignore
+    from sensor_msgs.msg import Image, LaserScan, PointCloud2, CameraInfo  # type: ignore
     from geometry_msgs.msg import PoseWithCovarianceStamped, TransformStamped  # type: ignore
     from nav_msgs.msg import Odometry, OccupancyGrid  # type: ignore
     # tf2 is the authoritative source for `map → base_link` and
@@ -55,6 +55,7 @@ def _import_ros():
         "Time": Time,
         "Image": Image,
         "LaserScan": LaserScan,
+        "CameraInfo": CameraInfo,
         # mapping declares /rtabmap/cloud_map under
         # robonix/service/map/pointcloud — scene auto-classifies it
         # as kind=lidar3d. Without this import scene crashes the
@@ -263,11 +264,12 @@ class SubscribersHub:
                 history=HistoryPolicy.KEEP_LAST,
                 depth=1,
             )
-        elif spec.kind == "camera_extrinsics":
-            # Static camera mount transform (primitive/camera/extrinsics).
-            # Publisher emits once at startup; consumers must use
-            # TRANSIENT_LOCAL to pick up the cached value when scene
-            # starts after the camera primitive.
+        elif spec.kind in ("camera_extrinsics", "intrinsics"):
+            # Static camera mount transform (primitive/camera/extrinsics)
+            # or pinhole K (primitive/camera/intrinsics). Publisher emits
+            # once at startup; consumers must use TRANSIENT_LOCAL to pick
+            # up the cached value when scene starts after the camera
+            # primitive.
             qos = QoSProfile(
                 reliability=ReliabilityPolicy.RELIABLE,
                 durability=DurabilityPolicy.TRANSIENT_LOCAL,

--- a/system/scene/scene_service/service.py
+++ b/system/scene/scene_service/service.py
@@ -36,6 +36,7 @@ scene = Service(id="scene", namespace="robonix/system/scene")
 
 from . import mcp_tools
 from . import web as web_ui
+from .ingest.capabilities import plan_perception
 from .ingest.perception_concept_graphs import ConceptGraphsDetector
 from .ingest.perception_vlm import VLMObjectDetector, _CamIntrinsics
 from .ingest.ros_subscribers import (
@@ -101,6 +102,7 @@ _SCENE_CONTRACTS: list[tuple[str, str, str]] = [
     ("lidar2d",           "robonix/primitive/lidar/lidar",       "LaserScan"),
     ("lidar3d",           "robonix/primitive/lidar/pointcloud",  "PointCloud2"),
     ("camera_extrinsics", "robonix/primitive/camera/extrinsics", "TransformStamped"),
+    ("intrinsics",        "robonix/primitive/camera/intrinsics", "CameraInfo"),
     ("pose",              "robonix/service/map/pose",            "PoseWithCovarianceStamped"),
     ("odom",              "robonix/service/map/odom",            "Odometry"),
     ("occupancy_grid",    "robonix/service/map/occupancy_grid",  "OccupancyGrid"),
@@ -454,12 +456,15 @@ async def _start_ros_ingest(
         await asyncio.sleep(2.0)
 
     # ── perception ─────────────────────────────────────────────────────────
-    # ConceptGraphs path is *strongly* preferred: it owns metric-accurate
-    # depth-backprojected poses. The VLM path stays as a no-depth fallback
-    # but we log loudly when we fall into it because pose accuracy will
-    # suffer.
+    # Which perception tier the current hardware supports is decided by the
+    # capability probe, not inline here: `plan.detector` routes to the
+    # ConceptGraphs (metric), VLM (visual), or no (geometric) path. The
+    # metric path is strongly preferred — it owns depth-backprojected
+    # poses; the others are named, logged degradations, not silent ones.
+    plan = plan_perception(hub)
+    log.info("[scene] perception plan: %s", plan.summary())
     detector: Optional[Any] = None
-    if hub.has("rgb") and hub.has("depth"):
+    if plan.detector == "concept_graphs":
 
         def _rgb_msg() -> Optional[Any]:
             msg, stamp, _ = hub.latest("rgb")
@@ -473,14 +478,42 @@ async def _start_ros_ingest(
                 return None
             return msg
 
-        # Camera intrinsics: prefer a dedicated camera_info topic if a
-        # primitive ever publishes one (TODO: subscribe to camera_info as
-        # a separate kind). For now we fall back to the static webots
-        # tiago intrinsics — same as the VLM path used. If a deployment
-        # has different intrinsics it can override via
-        # SCENE_CAMERA_INTRINSICS=fx,fy,cx,cy,w,h.
+        # Camera intrinsics come *only* from the live
+        # `primitive/camera/intrinsics` contract — the real per-deployment
+        # K, exactly as extrinsics come from the camera's tf2/URDF rather
+        # than a scene-side env var. Back-projection scales every point by
+        # fx/fy, so a wrong guess silently misplaces objects; we therefore
+        # return None when no usable K is available and let the detector
+        # *wait* (it logs "waiting for camera intrinsics") instead of
+        # grounding perception on a default.
+        intrinsics_logged = {"ok": False, "bad": False}
+
         def _cam_info() -> Optional[_CamIntrinsics]:
-            return _resolved_cam_intrinsics()
+            if not hub.has("intrinsics"):
+                return None
+            msg, stamp, _ = hub.latest("intrinsics")
+            if msg is None or stamp <= 0.0:
+                return None
+            k = _cam_info_to_intrinsics(msg)
+            if k is not None:
+                if not intrinsics_logged["ok"]:
+                    log.info(
+                        "[scene] camera intrinsics from contract: "
+                        "fx=%.1f fy=%.1f cx=%.1f cy=%.1f %dx%d",
+                        k.fx, k.fy, k.cx, k.cy, k.width, k.height,
+                    )
+                    intrinsics_logged["ok"] = True
+                return k
+            # Contract is published but the CameraInfo K is zero/garbage —
+            # distinct from "no contract"; warn once so a miscalibrated
+            # publisher is visible rather than silently stalling perception.
+            if not intrinsics_logged["bad"]:
+                log.warning(
+                    "[scene] intrinsics contract published but CameraInfo K "
+                    "is unusable — detector will wait for valid intrinsics"
+                )
+                intrinsics_logged["bad"] = True
+            return None
 
         detector = ConceptGraphsDetector(
             rgb_fetcher_msg=_rgb_msg,
@@ -498,7 +531,7 @@ async def _start_ros_ingest(
         )
         await detector.start()
         log.info("[scene] perception: ConceptGraphsDetector (rgb+depth)")
-    elif hub.has("rgb"):
+    elif plan.detector == "vlm":
         log.warning(
             "[scene] perception: no depth stream — falling back to "
             "VLMObjectDetector. Object positions will be approximate. "
@@ -511,35 +544,69 @@ async def _start_ros_ingest(
                 return None
             return _image_msg_to_jpeg(msg)
 
+        # Use the contract K when it has already landed, else the built-in
+        # default. Unlike the metric path the visual tier must NOT wait for
+        # intrinsics: its depth is a VLM guess, so K is a minor term, and
+        # the tier's whole job is to emit approximate cues from minimal
+        # hardware. A one-time snapshot is fine — intrinsics are latched and
+        # this branch only runs after the perception-wait window.
+        vlm_intrinsics: Optional[_CamIntrinsics] = None
+        if hub.has("intrinsics"):
+            msg, stamp, _ = hub.latest("intrinsics")
+            if msg is not None and stamp > 0.0:
+                vlm_intrinsics = _cam_info_to_intrinsics(msg)
+        log.info(
+            "[scene] VLM intrinsics: %s",
+            "from contract" if vlm_intrinsics is not None else "built-in default",
+        )
+
         detector = VLMObjectDetector(
             rgb_fetcher=_rgb_jpeg,
             chassis_pose_fn=self_tracker.latest_xy_yaw,
             on_detections=lambda dets: _ingest_detections(registry, dets),
             period_s=4.0,
+            intrinsics=vlm_intrinsics,
         )
         await detector.start()
     else:
-        log.warning("[scene] perception: no RGB stream — detector disabled")
+        # geometric tier: no camera. Object detection is off, but the
+        # occupancy grid + goal_near BFS stay available, so navigation-
+        # style queries still work — this is a degraded mode, not a fault.
+        log.warning(
+            "[scene] perception: geometric tier — no camera wired; object "
+            "detection disabled (occupancy_grid + goal_near remain available)"
+        )
 
     return hub, detector, bg_tasks
 
 
-def _resolved_cam_intrinsics() -> _CamIntrinsics:
-    """Camera intrinsics for the ConceptGraphs detector. Default is
-    webots tiago head_front_camera at 640x480 (60° HFOV). Override
-    via SCENE_CAMERA_INTRINSICS=fx,fy,cx,cy,w,h."""
-    raw = os.environ.get("SCENE_CAMERA_INTRINSICS", "").strip()
-    if raw:
-        try:
-            parts = [float(s) for s in raw.split(",")]
-            if len(parts) >= 4:
-                fx, fy, cx, cy = parts[:4]
-                w = int(parts[4]) if len(parts) > 4 else 640
-                h = int(parts[5]) if len(parts) > 5 else 480
-                return _CamIntrinsics(width=w, height=h, fx=fx, fy=fy, cx=cx, cy=cy)
-        except Exception:  # noqa: BLE001
-            pass
-    return _CamIntrinsics()
+def _cam_info_to_intrinsics(msg: Any) -> Optional[_CamIntrinsics]:
+    """Convert a sensor_msgs/CameraInfo into _CamIntrinsics.
+
+    Reads the 3x3 row-major K matrix (`k[0]=fx`, `k[2]=cx`, `k[4]=fy`,
+    `k[5]=cy`) plus width/height. ROS2 exposes the field as lowercase
+    `k`; we also accept `K` for safety. Returns None when any of
+    fx/fy/cx/cy/width/height is non-positive — an all-zero or partially
+    populated CameraInfo carries no usable geometry, and the caller
+    treats None as "wait for valid intrinsics", never as "use a default".
+    The except is narrow on purpose: a genuinely unexpected error should
+    surface, not be swallowed as if intrinsics were merely missing."""
+    try:
+        k = list(getattr(msg, "k", None) or getattr(msg, "K", []) or [])
+        w = int(getattr(msg, "width", 0))
+        h = int(getattr(msg, "height", 0))
+        if len(k) < 6 or min(k[0], k[4], k[2], k[5]) <= 0 or w <= 0 or h <= 0:
+            return None
+        return _CamIntrinsics(
+            width=w,
+            height=h,
+            fx=float(k[0]),
+            fy=float(k[4]),
+            cx=float(k[2]),
+            cy=float(k[5]),
+        )
+    except (AttributeError, TypeError, ValueError, IndexError):
+        return None
 
 
 async def _self_pose_loop(hub: SubscribersHub, self_tracker: "_SelfTracker") -> None:

--- a/system/scene/tests/test_capabilities.py
+++ b/system/scene/tests/test_capabilities.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+"""Unit tests for the perception-tier capability probe.
+
+Pure Python — no ROS2 / atlas / hub. A fake hub stands in for
+SubscribersHub: the probe only ever calls `hub.has(kind)`.
+"""
+import importlib.util
+import os
+import sys
+
+# Load capabilities.py directly by path, bypassing scene_service.ingest's
+# __init__ — that eagerly imports the numpy-heavy detectors, which the
+# probe itself doesn't need. Keeps this test pure Python (no deps).
+_CAP_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "scene_service", "ingest", "capabilities.py"
+)
+_spec = importlib.util.spec_from_file_location("scene_capabilities", _CAP_PATH)
+_mod = importlib.util.module_from_spec(_spec)
+# Register before exec so dataclass string-annotation resolution can find
+# the module via sys.modules (required on Python 3.9; harmless on 3.10+).
+sys.modules["scene_capabilities"] = _mod
+_spec.loader.exec_module(_mod)
+plan_perception = _mod.plan_perception
+
+
+class _FakeHub:
+    """Minimal hub stub: `has(kind)` is True iff kind is in the set."""
+
+    def __init__(self, kinds):
+        self._kinds = set(kinds)
+
+    def has(self, kind):
+        return kind in self._kinds
+
+
+def test_metric_tier_full():
+    # RGB-D + intrinsics + pose → metric tier, ConceptGraphs, metric grounding.
+    plan = plan_perception(_FakeHub(
+        ["rgb", "depth", "intrinsics", "pose", "camera_extrinsics"]
+    ))
+    assert plan.tier == "metric"
+    assert plan.detector == "concept_graphs"
+    assert plan.grounding == "metric"
+    print("  [PASS] test_metric_tier_full")
+
+
+def test_metric_tier_degraded():
+    # RGB-D but no intrinsics/pose contract → still metric tier (depth is
+    # present), but grounding is flagged degraded (default K / tf2 pose).
+    plan = plan_perception(_FakeHub(["rgb", "depth"]))
+    assert plan.tier == "metric"
+    assert plan.detector == "concept_graphs"
+    assert plan.grounding == "degraded"
+    print("  [PASS] test_metric_tier_degraded")
+
+
+def test_visual_tier():
+    # RGB only → visual tier, VLM detector, grounding n/a (not the metric path).
+    plan = plan_perception(_FakeHub(["rgb", "pose"]))
+    assert plan.tier == "visual"
+    assert plan.detector == "vlm"
+    assert plan.grounding == "n/a"
+    print("  [PASS] test_visual_tier")
+
+
+def test_geometric_tier():
+    # No camera (lidar / occupancy only) → geometric tier, no detector.
+    plan = plan_perception(_FakeHub(["lidar2d", "occupancy_grid", "pose"]))
+    assert plan.tier == "geometric"
+    assert plan.detector is None
+    assert plan.grounding == "n/a"
+    print("  [PASS] test_geometric_tier")
+
+
+def test_summary_is_self_describing():
+    # The startup log line names tier, detector, grounding, and inputs.
+    s = plan_perception(_FakeHub(["rgb", "depth", "intrinsics", "pose"])).summary()
+    assert "tier=metric" in s
+    assert "detector=concept_graphs" in s
+    assert "grounding=metric" in s
+    assert "rgb" in s and "depth" in s and "intrinsics" in s
+    # Empty-input case reads "none", not an empty bracket.
+    assert "inputs=[none]" in plan_perception(_FakeHub([])).summary()
+    print("  [PASS] test_summary_is_self_describing")
+
+
+if __name__ == "__main__":
+    print("Running capability-probe unit tests...\n")
+    test_metric_tier_full()
+    test_metric_tier_degraded()
+    test_visual_tier()
+    test_geometric_tier()
+    test_summary_is_self_describing()
+    print("\nAll tests passed!")


### PR DESCRIPTION
Depth back-projection scales every 3D point by fx/fy and offsets it by cx/cy. Feeding ConceptGraphs incorrect intrinsics silently places objects at the wrong map position.
Scene previously defaulted every camera to the Webots Tiago K intrinsics: That default is correct for simulation only. Any other camera produced misplaced objects without crashing or warning unless an operator manually set SCENE_CAMERA_INTRINSICS.

Detector selection was previously implemented as an inline if/elif on hub.has(...), which silently fell through to detector disabled when no camera was wired.This change extracts detector selection into a pure, testable probe that names the tier Scene runs and logs the plan once at startup.

Adds plan_perception(hub), returning a frozen PerceptionPlan that selects one of three tiers based on camera availability:
metric: RGB-D camera → ConceptGraphs
visual: RGB camera → VLM
geometric: no camera → detector disabled; occupancy_grid and goal_near remain available