### PR TITLE
docs: add MAINTAINERS.md + fix README component descriptions

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,63 @@
+# Robonix MAINTAINERS
+
+Per-component ownership for [syswonder/robonix](https://github.com/syswonder/robonix).
+Each maintainer is written `Name (@github, email)` so the contact stays bound to
+the person; components with two owners separate them with `;`. A public email is
+shown only where the person publishes one on their GitHub profile.
+
+- Project: <https://robonix.syswonder.org>
+- Mailing list: robotos@syswonder.org
+- Contributor roster: <https://www.syswonder.org>
+
+Lead maintainer: Yulong Han ([@enkerewpo](https://github.com/enkerewpo), wheatfox17@icloud.com)
+
+## System components
+
+| Component | What it does | Path | Maintainer(s) | Issue |
+|-----------|--------------|------|---------------|-------|
+| atlas | Capability registry and discovery | `system/atlas` | Yulong Han ([@enkerewpo](https://github.com/enkerewpo), wheatfox17@icloud.com) | - |
+| executor | RTDL plan execution and capability dispatch | `system/executor` | Guowei Li ([@kouweilee](https://github.com/kouweilee), 2401213322@stu.pku.edu.cn); Longchun Zhao ([@1mujue](https://github.com/1mujue)) | [#52](https://github.com/syswonder/robonix/issues/52) |
+| pilot | VLM planning and decision loop | `system/pilot` | Yulong Han ([@enkerewpo](https://github.com/enkerewpo), wheatfox17@icloud.com) | [#53](https://github.com/syswonder/robonix/issues/53) |
+| liaison | Human interaction (chat / voice / TUI) | `system/liaison` | Kaile Liu ([@kaileliu](https://github.com/kaileliu)) | [#70](https://github.com/syswonder/robonix/issues/70) |
+| scene | Scene state, semantic map, object registry | `system/scene` | Feiyang Li ([@HeartLinked](https://github.com/HeartLinked), lifeiyang@zju.edu.cn) | [#42](https://github.com/syswonder/robonix/issues/42) |
+| soma | Robot self-description (body model) | `system/soma` | Yanting Chen ([@Chenyantt](https://github.com/Chenyantt)) | - |
+| sentinel | Rule-based safety gate before dispatch | `system/sentinel` | Zhaobo Zhang ([@HustWolfzzb](https://github.com/HustWolfzzb), hustwolfzzb@gmail.com) | [#69](https://github.com/syswonder/robonix/issues/69) |
+| scribe | Structured logging / replay / audit | `system/scribe` | Yunlong Hou ([@ohhhHwH](https://github.com/ohhhHwH)) | [#63](https://github.com/syswonder/robonix/issues/63) |
+| vitals | Power and component-health monitoring | `system/vitals` | Jinyang Xu ([@AuYang261](https://github.com/AuYang261)) | [#68](https://github.com/syswonder/robonix/issues/68) |
+| keystone | Identity, config, access policy | `system/keystone` | Kaile Liu ([@kaileliu](https://github.com/kaileliu)) | [#67](https://github.com/syswonder/robonix/issues/67) |
+| nexus | gRPC / MCP / ROS 2 comms libraries | `system/nexus` | Jun Zeng ([@ZZJJWarth](https://github.com/ZZJJWarth)) | - |
+| chronos | Unified clock / timestamp alignment | `system/chronos` | _unassigned_ | [#62](https://github.com/syswonder/robonix/issues/62) |
+
+## Services
+
+| Service | What it does | Path | Maintainer(s) |
+|---------|--------------|------|---------------|
+| memory | Long-term memory: search / save / compact | `services/memsearch` | Yunlong Hou ([@ohhhHwH](https://github.com/ohhhHwH)) |
+| speech | ASR / TTS / dialogue (one-shot and streaming) | `services/speech` | Kaile Liu ([@kaileliu](https://github.com/kaileliu)) |
+| voiceprint | Speaker enrollment and recognition | `services/voiceprint` | Kaile Liu ([@kaileliu](https://github.com/kaileliu)) |
+
+## Tools and libraries
+
+| Module | What it does | Path | Maintainer(s) |
+|--------|--------------|------|---------------|
+| rbnx | Robonix CLI: build / boot / codegen / chat / clean | `tools/rbnx` | Yulong Han ([@enkerewpo](https://github.com/enkerewpo), wheatfox17@icloud.com) |
+| codegen | Contract IDL to proto / Rust / MCP-type codegen | `tools/codegen` | Yulong Han ([@enkerewpo](https://github.com/enkerewpo), wheatfox17@icloud.com) |
+| robonix-api | Python framework: Primitive/Service/Skill bases, atlas client, Driver lifecycle | `pylib/robonix-api` | Yulong Han ([@enkerewpo](https://github.com/enkerewpo), wheatfox17@icloud.com) |
+
+## Upstream packages
+
+Separate repositories, cloned into a deployment's boot cache (`rbnx-boot/cache/`) at boot.
+
+| Package | What it does | Repo | Maintainer(s) |
+|---------|--------------|------|---------------|
+| explore_rbnx | Autonomous frontier-based exploration skill | [enkerewpo/explore_rbnx](https://github.com/enkerewpo/explore_rbnx) | Yulong Han ([@enkerewpo](https://github.com/enkerewpo), wheatfox17@icloud.com) |
+| mapping_rbnx | SLAM / mapping service (`service/map/*`) | [enkerewpo/mapping_rbnx](https://github.com/enkerewpo/mapping_rbnx) | Yulong Han ([@enkerewpo](https://github.com/enkerewpo), wheatfox17@icloud.com) |
+| nav2_wrapper_rbnx | Nav2-backed navigation for Ranger Mini (`service/navigation/*`) | [enkerewpo/nav2_wrapper_rbnx](https://github.com/enkerewpo/nav2_wrapper_rbnx) | Yulong Han ([@enkerewpo](https://github.com/enkerewpo), wheatfox17@icloud.com) |
+| simple_nav_rbnx | A* + Pure-Pursuit navigation (no Nav2) | [enkerewpo/simple_nav_rbnx](https://github.com/enkerewpo/simple_nav_rbnx) | Yulong Han ([@enkerewpo](https://github.com/enkerewpo), wheatfox17@icloud.com) |
+
+## Reporting an issue
+
+File the problem under the component's tracking issue above (or open a new one),
+and `@`-mention the maintainer so they are notified. For an out-of-band reach,
+use the public email where listed, otherwise the project mailing list
+(robotos@syswonder.org).

--- a/README.md
+++ b/README.md
@@ -36,20 +36,20 @@ skills, and the planner discover and talk to each other; it owns identity,
 configuration, time, transport, logging, health, body model, scene model,
 execution, and safety as named, replaceable components.
 
-| Component                        | Responsibility                                                                          | Status (v0.1)        |
-| -------------------------------- | --------------------------------------------------------------------------------------- | -------------------- |
-| **[atlas](system/atlas/)**       | Capability discovery: the catalog of every registered capability and its contract       | Implemented          |
-| **[chronos](system/chronos/)**   | Unified time source with PTP / IEEE-1588 alignment across sensors and hosts             | Stub                 |
-| **[executor](system/executor/)** | Plan execution: validates Pilot plans and dispatches each step to capability providers  | Implemented          |
-| **[keystone](system/keystone/)** | Body identity, persistent configuration, and policy                                     | Stub                 |
-| **[liaison](system/liaison/)**   | Human–machine interaction gateway: chat, voice, and TUI                                 | Implemented          |
-| **[nexus](system/nexus/)**       | Transport libraries for gRPC / MCP / ROS 2 (a library, not a process)                   | Implemented          |
-| **[pilot](system/pilot/)**       | VLM-driven planning and decision making, memory, and world model                        | Implemented          |
-| **[scene](system/scene/)**       | Live environment estimate: object registry, semantic relations, and occupancy grid     | Implemented          |
-| **[scribe](system/scribe/)**     | Structured, persistent, replayable system journal for audit                             | Stub                 |
-| **[sentinel](system/sentinel/)** | Safety supervision over capability calls                                                | Merged into executor |
-| **[soma](system/soma/)**         | Body model: device topology and primitive abstraction                                   | Stub                 |
-| **[vitals](system/vitals/)**     | Liveness and health aggregation across all running components                           | Partial (via atlas)  |
+| Component                        | Responsibility                                                                          |
+| -------------------------------- | --------------------------------------------------------------------------------------- |
+| **[atlas](system/atlas/)**       | Capability registry and discovery: the catalog of every registered capability and its contract |
+| **[chronos](system/chronos/)**   | Unified clock and cross-sensor timestamp alignment (PTP / IEEE-1588)                     |
+| **[executor](system/executor/)** | RTDL plan execution and capability dispatch (`sequence` / `parallel` / `do`)             |
+| **[keystone](system/keystone/)** | User identity, persistent configuration, and access policy                              |
+| **[liaison](system/liaison/)**   | Human–machine interaction gateway: chat, voice, and TUI                                 |
+| **[nexus](system/nexus/)**       | Communication libraries for gRPC / MCP / ROS 2 (not a standalone process)               |
+| **[pilot](system/pilot/)**       | VLM-driven planning and decision loop; emits RTDL plans for the executor                 |
+| **[scene](system/scene/)**       | Live environment estimate: object registry, semantic relations, and occupancy grid     |
+| **[scribe](system/scribe/)**     | Structured, persistent, replayable system journal for audit                             |
+| **[sentinel](system/sentinel/)** | Rule-based safety gate checked before each capability dispatch                          |
+| **[soma](system/soma/)**         | Robot self-description (body model): device topology and primitive abstraction          |
+| **[vitals](system/vitals/)**     | Robot power and component-health monitoring                                             |
 
 On top of system, three open categories — provided as
 contracts (61 standard interfaces in `capabilities/`) and reference


### PR DESCRIPTION
Adds a top-level `MAINTAINERS.md` mapping each Robonix component to its maintainer (English name + GitHub id + public email where exposed) and tracking issue.

Sources: the Robonix developer doc (component ownership), the syswonder community contributor roster (name ↔ GitHub id), and `gh` for GitHub-public emails.

- All 12 components covered; **chronos** is the only one still unassigned.
- `atlas` is attributed to the lead (core) since the dev doc names no owner — adjust if a dedicated owner is preferred.
- Public emails are included only where the person publishes one on their GitHub profile (@enkerewpo, @kouweilee, @HeartLinked, @HustWolfzzb).
- Adds a 'Reporting an issue / contacting an owner' section pointing at the per-component tracking issues + mailing list.