### PR TITLE
fix(robonix-api): advertise routable host for cross-host gRPC/MCP endpoints

### DIFF
--- a/examples/webots/robonix_manifest.yaml
+++ b/examples/webots/robonix_manifest.yaml
@@ -7,7 +7,7 @@ env:
 system:
   # basic layer
   atlas:
-    listen: 127.0.0.1:50051
+    listen: 0.0.0.0:50051
     log: info
   # soma+scene layer
   scene:

--- a/pylib/robonix-api/robonix_api/capability.py
+++ b/pylib/robonix-api/robonix_api/capability.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import inspect
 import json
 import logging
+import os
 import signal
 import threading
 from pathlib import Path
@@ -403,6 +404,26 @@ class _ProviderBase:
                 return toks[i + 1]
         return None
 
+    def _advertise_host(self) -> str:
+        """The IP a provider publishes into atlas for its gRPC / MCP
+        endpoints. Must be reachable by a cross-host consumer (e.g. an
+        executor on another machine), so hardcoding 127.0.0.1 breaks any
+        deployment where consumer and provider are not co-located: atlas
+        would hand the consumer "127.0.0.1:<port>" and it would dial its
+        own loopback instead of this host.
+
+        Resolution order: ROBONIX_ADVERTISE_HOST (explicit override) ->
+        the local source IP that routes toward the atlas host (this is the
+        interface a remote consumer reaches us on, since the atlas is the
+        rendezvous both sides already share) -> 127.0.0.1 (same-host only,
+        when route resolution fails)."""
+        explicit = os.environ.get("ROBONIX_ADVERTISE_HOST")
+        if explicit:
+            return explicit
+        atlas = os.environ.get("ROBONIX_ATLAS", "127.0.0.1:50051")
+        atlas_host = atlas.rsplit(":", 1)[0] if ":" in atlas else atlas
+        return self.resolve_host_ip(atlas_host) or "127.0.0.1"
+
     # -- Layer 2: ROS publisher / subscriber -------------------------------
 
     def create_publisher(
@@ -510,14 +531,27 @@ class _ProviderBase:
         if self._mcp_app is not None:
             return
         from mcp.server.fastmcp import FastMCP
+        from mcp.server.transport_security import TransportSecuritySettings
 
-        # Bind host="0.0.0.0" explicitly. FastMCP defaults to host="127.0.0.1",
-        # which makes the SDK auto-enable DNS-rebinding protection with
-        # allowed_hosts restricted to localhost. A cross-host consumer (e.g. a
-        # remote executor) dialing this provider by IP is then rejected with
-        # HTTP 421 "Invalid Host header". "0.0.0.0" skips that localhost-only
-        # restriction so the MCP endpoint is reachable cross-host.
-        self._mcp_app = FastMCP(self.id, host="0.0.0.0")
+        # Cross-host reachability. The MCP SDK auto-enables DNS-rebinding
+        # protection whenever the bound host is a loopback name
+        # (127.0.0.1 / localhost / ::1), pinning allowed_hosts to localhost.
+        # A consumer on another machine dialing this provider by LAN IP is
+        # then rejected with HTTP 421 "Misdirected Request" (Invalid Host
+        # header). Binding host="0.0.0.0" happens to sidestep that on the
+        # current SDK, but that is incidental — a newer SDK could enable the
+        # check for 0.0.0.0 too, and any provider that legitimately binds a
+        # loopback host would still 421. So disable the Host-header check
+        # explicitly: providers are reached through atlas-issued endpoints,
+        # not untrusted browser origins, so DNS-rebinding protection buys
+        # nothing here and only breaks cross-host dialing.
+        self._mcp_app = FastMCP(
+            self.id,
+            host="0.0.0.0",
+            transport_security=TransportSecuritySettings(
+                enable_dns_rebinding_protection=False
+            ),
+        )
 
     def use_mcp_app(self, app) -> None:
         if self._mcp_app is not None and self._mcp_app is not app:
@@ -528,7 +562,7 @@ class _ProviderBase:
 
     @property
     def mcp_endpoint(self) -> str:
-        return f"http://127.0.0.1:{self._mcp_port}/mcp/"
+        return f"http://{self._advertise_host()}:{self._mcp_port}/mcp/"
 
     # -- Layer 2: provides_grpc decorator + attach_grpc_servicer -----------
 
@@ -688,7 +722,7 @@ class _ProviderBase:
         log.info("Lifecycle gRPC serving on 0.0.0.0:%d", self._driver_port)
 
         # 3. atlas-declare every gRPC capability
-        endpoint = f"127.0.0.1:{self._driver_port}"
+        endpoint = f"{self._advertise_host()}:{self._driver_port}"
         if driver_decl is not None:
             driver_base, driver_method = driver_decl
             try:
@@ -758,7 +792,7 @@ class _ProviderBase:
         log.info("MCP HTTP serving on 0.0.0.0:%d", self._mcp_port)
 
     def _declare_mcp_handlers(self) -> None:
-        endpoint = f"http://127.0.0.1:{self._mcp_port}/mcp/"
+        endpoint = f"http://{self._advertise_host()}:{self._mcp_port}/mcp/"
         for fn in self._mcp_handlers:
             cid = getattr(fn, "_robonix_contract_id", None)
             if cid is None:


### PR DESCRIPTION
## Summary

Fixes the long-standing bug where a provider (e.g. an arm primitive) running on a **different machine** than the robonix core (atlas/executor/pilot) can never be called — the cross-host call "redirects to localhost" and fails.

Root cause is **two independent problems**, only one of which had been touched before.

## 1. Why it wasn't fixed before

A prior change set the MCP server's bind host to `0.0.0.0` (`FastMCP(self.id, host="0.0.0.0")`) and assumed that fixed cross-host access. It did not, for two reasons:

- **The bind address and the *advertised* address are different things.** Binding `0.0.0.0` only controls which interfaces the socket listens on. But the endpoint string a provider *registers into atlas* was still hardcoded `127.0.0.1:<port>` (for the gRPC driver endpoint, the MCP endpoint, and every declared MCP handler). So atlas kept handing every consumer `http://127.0.0.1:<port>/mcp/`. A consumer on another host then dialed **its own loopback** — this is the "redirects to localhost" symptom. Binding `0.0.0.0` never changed what got advertised, so the bug survived.
- **The `0.0.0.0` bind only sidestepped the Host-header check by luck.** The MCP SDK auto-enables DNS-rebinding / Host-header protection when the bind host is a loopback name, and rejects a cross-host LAN-IP dialer with `HTTP 421`. `0.0.0.0` happens to skip that on the current SDK version, but it is incidental: a newer SDK can enable the check for `0.0.0.0` too, and any provider that legitimately binds a loopback host still 421s.

So the earlier commit fixed neither the advertised endpoint nor the Host-header check robustly.

## 2. What this PR does

`pylib/robonix-api/robonix_api/capability.py`:

- **Advertise a routable host instead of hardcoding loopback.** New `_advertise_host()`:
  `ROBONIX_ADVERTISE_HOST` (explicit override) → the local source IP that routes toward the atlas host (`ip route get <atlas>` → `src`; this is exactly the interface a remote consumer reaches us on, since atlas is the rendezvous both sides already share) → `127.0.0.1` fallback when resolution fails. Used for the gRPC driver endpoint, the MCP endpoint, and the declared MCP handlers.
- **Disable the MCP DNS-rebinding / Host-header check explicitly** (`TransportSecuritySettings(enable_dns_rebinding_protection=False)`) rather than relying on the `0.0.0.0` accident. Providers are reached through atlas-issued endpoints, not untrusted browser origins, so the check buys nothing and only breaks cross-host dialing.

`examples/webots/robonix_manifest.yaml`:

- Bind atlas to `0.0.0.0:50051` (was `127.0.0.1:50051`) so a provider on another machine can register at all. Local consumers still reach it over loopback.

## 3. Current effect + how to reproduce on two machines

Verified live with the core on machine **A** (Debian 13, `100.117.99.116`) and an arm primitive on machine **B** (Jetson Thor, `100.70.12.70`).

**A — robonix core:**
```
# manifest: system.atlas.listen: 0.0.0.0:50051
rbnx boot
```

**B — arm primitive** (`ROBONIX_ATLAS` points at A; `start.sh`):
```
export ROBONIX_ATLAS=100.117.99.116:50051   # A's address reachable from B
python3 -m arm_driver.driver
```

**A — verify.** `rbnx caps` shows the arm registered cross-host. Then raw HTTP on both paths — `<ARM_MCP_PORT>` is what the arm logged (`MCP HTTP serving on 0.0.0.0:<port>`), chosen per process start:
```
# /mcp (no trailing slash) -> 200
curl -sS --noproxy '*' -D - -o /dev/null \
  -X POST http://100.70.12.70:<ARM_MCP_PORT>/mcp \
  -H 'content-type: application/json' \
  -H 'accept: application/json, text/event-stream' \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"curl","version":"1"}}}'
# -> HTTP/1.1 200 OK ; content-type: text/event-stream ; mcp-session-id: ...

# /mcp/ (trailing slash) -> 307, Location is the same host (never localhost)
curl -sS --noproxy '*' -D - -o /dev/null \
  -X POST http://100.70.12.70:<ARM_MCP_PORT>/mcp/ \
  -H 'content-type: application/json' \
  -H 'accept: application/json, text/event-stream' \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"curl","version":"1"}}}'
# -> HTTP/1.1 307 Temporary Redirect ; location: http://100.70.12.70:<ARM_MCP_PORT>/mcp
# add -L to follow the 307 and land on 200.
```
Full robonix path (atlas resolve → MCP call) from A:
```
ConnectCapability endpoint: http://100.70.12.70:39607/mcp/   # NOT 127.0.0.1
TOOLS: ['joint_ctrl']
CALL joint_ctrl -> <tool executed on B, result returned to A>
```

### Caveats / notes

- **`atlas.listen` must be `0.0.0.0`** (or a routable IP) for cross-host registration. This PR sets it for the webots example; real deployments must do the same.
- **A and B must mutually route** to the IP `_advertise_host()` resolves. It derives the advertised IP from the route toward `ROBONIX_ATLAS`, so point `ROBONIX_ATLAS` at the address of A that B can actually reach. Override with `ROBONIX_ADVERTISE_HOST` if the routing heuristic picks the wrong interface (multi-homed hosts).
- **Proxy environment**: the MCP client is httpx-based and honors `http_proxy`/`https_proxy`. A stale proxy makes a cross-host LAN/tailnet endpoint return `502 Bad Gateway`. `rbnx boot` already strips proxy env for the core; if you run a provider/consumer by hand, unset proxy (or `NO_PROXY` the target) for non-routed addresses.
- The MCP endpoint is advertised with a trailing slash (`/mcp/`); the server 307-redirects `/mcp/`→`/mcp`. Compliant clients (and `curl -L`) follow it and the redirect host is always the request host, never localhost.

## Validation

- `python -m py_compile` clean; in-process check confirms `transport_security` is disabled regardless of host.
- End-to-end two-machine run above: `rbnx caps` registration, raw curl on both paths, and a full `ConnectCapability` + `tools/call` cross-host invocation all pass.
