### PR TITLE
chore(github): modernize issue templates to current component taxonomy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,43 +1,64 @@
 ---
 name: Bug Report
-about: Report a bug in the Robonix
+about: Report a bug in Robonix
 title: '[BUG] '
-labels: 'bug'
+labels: 'type:bug'
 assignees: ''
 
 ---
 
-## Bug Description
-Brief description of the issue.
+## Bug description
+A clear, one-paragraph description of what's wrong.
 
-## Component
+## Affected component
+Tick the closest match — maintainers confirm the final `comp:*` label.
 
-- [ ] **Managers** (Task, Maps, AI Model services)
-- [ ] **UI System**
-- [ ] **RIDL Executor**
-- [ ] **Skill Library**
-- [ ] **Primitive HAL** (Camera, Base, Arm, …)
-- [ ] **Libraries / ROS2** (stack, bindings)
+**System** (core OS services)
+- [ ] atlas (capability registry)
+- [ ] executor
+- [ ] pilot (planner / VLM)
+- [ ] liaison (voice / user I/O)
+- [ ] scene (semantic + spatial map)
+- [ ] sentinel (safety) / soma (body model) / scribe (logging) / chronos / keystone / vitals / nexus
+
+**Service** (scene-level capabilities)
+- [ ] mapping (`service/map`)
+- [ ] navigation
+- [ ] speech (ASR / TTS)
+- [ ] voiceprint
+- [ ] memory
+
+**Skill / Primitive**
+- [ ] skill: `__________` (e.g. explore)
+- [ ] primitive: `__________` (camera / chassis / lidar / audio / arm)
+
+**Tooling / cross-cutting**
+- [ ] rbnx (CLI) / codegen / robonix-api (pylib) / capabilities & contracts / docs / ci
 - [ ] Other / not sure
 
-## Steps to Reproduce
+## Steps to reproduce
 1. 
 2. 
 3. 
 
-## Expected Behavior
+## Expected behavior
 What should happen instead.
 
+## Actual behavior
+What actually happens. Include `rbnx caps` output if a provider is in ERROR.
+
 ## Environment
-- OS: [e.g. Ubuntu 22.04]
-- ROS2 Version: [e.g. Humble]
-- Rust Version: [e.g. 1.75]
-- Hardware: [e.g. robot base, camera, simulator]
+- OS / kernel: [e.g. Ubuntu 22.04, Linux 6.8 Jetson Thor]
+- rbnx version: [`rbnx --version`]
+- ROS 2 distro: [e.g. Humble] — only if a ROS-backed component is involved
+- Deployment: [ ] webots sim  [ ] real robot — manifest: [e.g. `examples/webots/robonix_manifest.yaml`]
+- Terminal (for `rbnx chat` / TUI issues): [e.g. VSCode integrated / gnome-terminal / TTY]
+- Hardware: [robot base, camera, mic, …]
 
-## Error Logs
+## Logs
 ```
-Paste relevant error messages here
+# relevant lines from rbnx-boot/logs/<component>.log, or `docker logs <container>`
 ```
 
-## Additional Context
-Any other relevant information.
+## Additional context
+Anything else — screenshots, related issues / PRs, suspected cause.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question / discussion
+    url: https://github.com/syswonder/robonix/discussions
+    about: Usage questions and open-ended discussion — please don't open these as bug reports.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,36 +1,52 @@
 ---
 name: Feature Request
-about: Suggest a new feature for the Robonix
+about: Suggest a new feature for Robonix
 title: '[FEATURE] '
-labels: 'enhancement'
+labels: 'type:feature'
 assignees: ''
 
 ---
 
-## Feature Description
-Brief description of the proposed feature.
+## Feature description
+A clear, one-paragraph description of the proposed feature.
 
-## Component
+## Affected component
+Tick the closest match — maintainers confirm the final `comp:*` label.
 
-- [ ] **Managers** (Task, Maps, AI Model services)
-- [ ] **UI System**
-- [ ] **RIDL Executor**
-- [ ] **Skill Library**
-- [ ] **Primitive HAL** (Camera, Base, Arm, …)
-- [ ] **Libraries / ROS2** (stack, bindings)
+**System** (core OS services)
+- [ ] atlas (capability registry)
+- [ ] executor
+- [ ] pilot (planner / VLM)
+- [ ] liaison (voice / user I/O)
+- [ ] scene (semantic + spatial map)
+- [ ] sentinel (safety) / soma (body model) / scribe (logging) / chronos / keystone / vitals / nexus
+
+**Service** (scene-level capabilities)
+- [ ] mapping (`service/map`)
+- [ ] navigation
+- [ ] speech (ASR / TTS)
+- [ ] voiceprint
+- [ ] memory
+
+**Skill / Primitive**
+- [ ] skill: `__________` (e.g. explore)
+- [ ] primitive: `__________` (camera / chassis / lidar / audio / arm)
+
+**Tooling / cross-cutting**
+- [ ] rbnx (CLI) / codegen / robonix-api (pylib) / capabilities & contracts / docs / ci
 - [ ] Other / not sure
 
-## Problem Statement
+## Problem statement
 What problem does this feature solve?
 
-## Proposed Solution
+## Proposed solution
 Describe your proposed solution.
 
-## Alternatives Considered
+## Alternatives considered
 Any alternative approaches you've considered.
 
-## Use Case
-Describe a specific scenario where this feature would be useful.
+## Use case
+A specific scenario where this feature would be useful.
 
-## Additional Context
+## Additional context
 Any other relevant information or mockups.


### PR DESCRIPTION
## What

Refresh the bug / feature issue templates, which still listed the
pre-whitepaper components (Managers / UI System / RIDL Executor / Skill
Library / Primitive HAL) — these no longer map to anything. Issues are
already labelled with the real `comp:*` taxonomy (see #99: comp:atlas,
comp:executor, comp:pilot, …).

## Changes

- **Affected component** re-grouped by **system / service / skill / primitive
  / tooling** layers, aligned with `.github/labels.yml` `comp:*` labels.
- Frontmatter labels → `type:bug` / `type:feature` (new `type:*` taxonomy).
- Bug template Environment now asks for `rbnx --version`, sim-vs-real +
  manifest, and **terminal** (TUI bugs such as #99 are terminal-dependent);
  split *Expected* vs *Actual behavior*.
- Add `config.yml`: disable blank issues, route questions to Discussions.

No code impact — `.github/ISSUE_TEMPLATE/` only.