### PR TITLE
fix(scribe): apply the manifest per-component log level (was silently dropped)

### DIFF
--- a/services/memsearch/memsearch_service/service.py
+++ b/services/memsearch/memsearch_service/service.py
@@ -60,7 +60,7 @@ logging.getLogger("absl").setLevel(logging.ERROR)
 
 # Transitional: also emit key lifecycle events through Scribe so the
 # unified `rbnx logs` tool can see them alongside other components.
-scribe_logger.info("service_memory", "memory service starting")
+scribe_logger.info("memory", "memory service starting")
 
 def _log_environment() -> None:
     """Print a compact environment summary at boot. Many of the reported

--- a/system/atlas/src/main.rs
+++ b/system/atlas/src/main.rs
@@ -29,23 +29,29 @@ struct Args {
     #[arg(long, env = "ROBONIX_ATLAS_CAPABILITIES", value_delimiter = ',')]
     capabilities: Vec<String>,
 
-    /// Log filter (env_logger syntax: `info`, `robonix_atlas=debug`, …).
-    /// Default: `robonix_atlas=info`. Also reads `RUST_LOG` if set.
+    /// Log level for this component (`debug`/`info`/`warn`/`error`). Sets the
+    /// scribe log-file floor; falls back to `SCRIBE_FILE_LEVEL` / `info`.
+    /// Normally arrives inside `--config-json`, not as a standalone flag.
     #[arg(long)]
     log: Option<String>,
+
+    /// The component's `system.atlas` manifest block, serialized to JSON by
+    /// rbnx and passed as one arg (`--config-json '{…}'`). Parsed by the binary
+    /// itself — see `robonix_scribe::init_from_config`, which reads the `log`
+    /// key from it so the manifest's per-component level reaches the log.
+    #[arg(long)]
+    config_json: Option<String>,
 }
 
 #[tokio::main]
 async fn main() {
     let args = Args::parse();
 
-    // Log level is no longer consumed — Scribe writes everything and
-    // filtering happens at read time (`rbnx logs --level`).  The CLI
-    // arg and RUST_LOG env are kept for backward compat with existing
-    // launch scripts.
-    let _ = args.log.or_else(|| std::env::var("RUST_LOG").ok());
-
-    robonix_scribe::init("atlas");
+    // Apply the manifest's per-component `log:` level (delivered inside
+    // --config-json) to scribe's file sink before the first log line, so it
+    // controls what this component persists; `rbnx logs --level` still
+    // filters at read time.
+    robonix_scribe::init_from_config("atlas", args.config_json.as_deref());
     info!("robonix-atlas starting (control plane)");
 
     let listen = args.listen.unwrap_or_else(|| DEFAULT_LISTEN.to_string());

--- a/system/executor/src/config.rs
+++ b/system/executor/src/config.rs
@@ -44,10 +44,18 @@ pub struct Args {
     #[arg(long, env = "ROBONIX_CONFIG_PATH")]
     pub config: Option<PathBuf>,
 
-    /// Log filter (env_logger syntax; e.g. `info`, `robonix_executor=debug`).
-    /// Default: `robonix_executor=info`. Falls back to `RUST_LOG` if unset.
+    /// Log level for this component (`debug`/`info`/`warn`/`error`). Sets the
+    /// scribe log-file floor; falls back to `SCRIBE_FILE_LEVEL` / `info`.
+    /// Normally arrives inside `--config-json`, not as a standalone flag.
     #[arg(long)]
     pub log: Option<String>,
+
+    /// The component's `system.executor` manifest block, serialized to JSON by
+    /// rbnx and passed as one arg (`--config-json '{…}'`). Parsed by the binary
+    /// itself — see `robonix_scribe::init_from_config`, which reads the `log`
+    /// key from it so the manifest's per-component level reaches the log.
+    #[arg(long)]
+    pub config_json: Option<String>,
 }
 
 #[derive(Default, Deserialize)]

--- a/system/executor/src/main.rs
+++ b/system/executor/src/main.rs
@@ -32,11 +32,9 @@ use std::time::Duration;
 #[tokio::main]
 async fn main() -> Result<()> {
     let parsed = Args::parse();
-    let _ = parsed
-        .log
-        .clone()
-        .or_else(|| std::env::var("RUST_LOG").ok());
-    robonix_scribe::init("executor");
+    // Apply the manifest's per-component `log:` level (delivered inside
+    // --config-json) to scribe's file sink before the first log line.
+    robonix_scribe::init_from_config("executor", parsed.config_json.as_deref());
     info!("robonix-executor starting");
 
     let cfg = ExecutorConfig::resolve(parsed)?;

--- a/system/liaison/src/main.rs
+++ b/system/liaison/src/main.rs
@@ -382,16 +382,26 @@ struct Args {
     #[arg(long = "pilot-endpoint")]
     pilot_endpoint: Option<String>,
 
-    /// Log filter (env_logger format). Defaults to $RUST_LOG, then "robonix_liaison=info".
+    /// Log level for this component (`debug`/`info`/`warn`/`error`). Sets the
+    /// scribe log-file floor; falls back to `SCRIBE_FILE_LEVEL` / `info`.
+    /// Normally arrives inside `--config-json`, not as a standalone flag.
     #[arg(long)]
     log: Option<String>,
+
+    /// The component's `system.liaison` manifest block, serialized to JSON by
+    /// rbnx and passed as one arg (`--config-json '{…}'`). Parsed by the binary
+    /// itself — see `robonix_scribe::init_from_config`, which reads the `log`
+    /// key from it so the manifest's per-component level reaches the log.
+    #[arg(long)]
+    config_json: Option<String>,
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse();
-    let _ = args.log.clone().or_else(|| std::env::var("RUST_LOG").ok());
-    robonix_scribe::init("liaison");
+    // Apply the manifest's per-component `log:` level (delivered inside
+    // --config-json) to scribe's file sink before the first log line.
+    robonix_scribe::init_from_config("liaison", args.config_json.as_deref());
     info!("robonix-liaison starting");
 
     let atlas_endpoint = args.atlas.clone().unwrap_or_else(|| {

--- a/system/pilot/src/config.rs
+++ b/system/pilot/src/config.rs
@@ -83,10 +83,18 @@ pub struct Args {
     #[arg(long, env = "ROBONIX_CONFIG_PATH")]
     pub config: Option<PathBuf>,
 
-    /// Log filter (env_logger syntax; e.g. `info`, `robonix_pilot=debug`).
-    /// Default: `robonix_pilot=info`. Falls back to `RUST_LOG` if neither set.
+    /// Log level for this component (`debug`/`info`/`warn`/`error`). Sets the
+    /// scribe log-file floor; falls back to `SCRIBE_FILE_LEVEL` / `info`.
+    /// Normally arrives inside `--config-json`, not as a standalone flag.
     #[arg(long)]
     pub log: Option<String>,
+
+    /// The component's `system.pilot` manifest block, serialized to JSON by
+    /// rbnx and passed as one arg (`--config-json '{…}'`). Parsed by the
+    /// binary itself — see `robonix_scribe::init_from_config`, which reads the
+    /// `log` key from it so the manifest's per-component level reaches the log.
+    #[arg(long)]
+    pub config_json: Option<String>,
 }
 
 /// Optional YAML schema. Field names match `PilotConfig` (flat) so a

--- a/system/pilot/src/main.rs
+++ b/system/pilot/src/main.rs
@@ -41,11 +41,9 @@ use std::time::Duration;
 #[tokio::main]
 async fn main() -> Result<()> {
     let parsed = Args::parse();
-    let _ = parsed
-        .log
-        .clone()
-        .or_else(|| std::env::var("RUST_LOG").ok());
-    robonix_scribe::init("pilot");
+    // Apply the manifest's per-component `log:` level (delivered inside
+    // --config-json) to scribe's file sink before the first log line.
+    robonix_scribe::init_from_config("pilot", parsed.config_json.as_deref());
     info!("robonix-pilot starting");
 
     let cfg = PilotConfig::resolve(parsed)?;

--- a/system/scribe/src/lib.rs
+++ b/system/scribe/src/lib.rs
@@ -39,6 +39,28 @@ pub fn init(tag: &str) {
         .expect("robonix_scribe::init() called twice; set the tag once per process");
 }
 
+/// Initialise scribe with the process `tag` and apply the on-disk log level
+/// from a launch-config JSON — the system component's manifest config block
+/// that rbnx serialises and passes via `--config-json`. Reads the top-level
+/// `log` key (e.g. `{"log":"debug"}`); a valid level sets the file-sink floor
+/// for this process so the level actually reaches the log file (`rbnx logs`).
+///
+/// Use this instead of [`init`] in binaries launched with a config: the
+/// manifest's per-component `log:` had no effect before, because the level
+/// was parsed into a CLI flag the binary discarded. Absent / unparseable
+/// `log` falls back to the `SCRIBE_FILE_LEVEL` env / `Info` default.
+///
+/// Call once at startup, before the first log, on the main thread.
+pub fn init_from_config(tag: &str, config_json: Option<&str>) {
+    if let Some(level) = config_json
+        .and_then(|j| serde_json::from_str::<serde_json::Value>(j).ok())
+        .and_then(|v| v.get("log").and_then(|l| l.as_str()).and_then(parse_level))
+    {
+        let _ = FILE_LEVEL_OVERRIDE.set(level);
+    }
+    init(tag);
+}
+
 /// Return the process-wide default tag, or `"_default"` if `init()` has
 /// not been called yet.
 #[doc(hidden)]
@@ -271,20 +293,33 @@ static FILE_SINK: LazyLock<Option<FileSink>> =
 
 // ── Level filter thresholds (read from env, lazy) ───────────────────
 
+/// Parse a level word (`debug`/`info`/`warn`/`warning`/`error`,
+/// case-insensitive). `None` for anything else.
+fn parse_level(s: &str) -> Option<Level> {
+    match s.to_lowercase().as_str() {
+        "debug" => Some(Level::Debug),
+        "info" => Some(Level::Info),
+        "warn" | "warning" => Some(Level::Warn),
+        "error" => Some(Level::Error),
+        _ => None,
+    }
+}
+
 /// Parse `SCRIBE_CONSOLE_LEVEL` / `SCRIBE_FILE_LEVEL` env var to a
 /// numeric floor.  Unrecognised values default to the given fallback.
 fn parse_level_env(key: &str, fallback: Level) -> Level {
     std::env::var(key)
         .ok()
-        .and_then(|s| match s.to_lowercase().as_str() {
-            "debug" => Some(Level::Debug),
-            "info" => Some(Level::Info),
-            "warn" | "warning" => Some(Level::Warn),
-            "error" => Some(Level::Error),
-            _ => None,
-        })
+        .as_deref()
+        .and_then(parse_level)
         .unwrap_or(fallback)
 }
+
+/// Per-process on-disk level override, set once by [`init_from_config`] from
+/// the launch config's `log` key. Takes precedence over `SCRIBE_FILE_LEVEL`
+/// when present, so a per-component `log:` in the deploy manifest actually
+/// controls that component's log file.
+static FILE_LEVEL_OVERRIDE: OnceLock<Level> = OnceLock::new();
 
 /// Minimum level for console (stderr) output.
 ///
@@ -323,7 +358,8 @@ pub fn log(level: Level, tag: &str, msg: &str) {
     // Only construct the timestamped record when at least one sink
     // accepts this level — avoid wasted clock syscalls for Debug.
     let console_ok = level >= *CONSOLE_MIN;
-    let file_ok = level >= *FILE_MIN;
+    let file_min = FILE_LEVEL_OVERRIDE.get().copied().unwrap_or(*FILE_MIN);
+    let file_ok = level >= file_min;
     if !console_ok && !file_ok {
         return;
     }

--- a/tools/rbnx/src/cmd/deploy.rs
+++ b/tools/rbnx/src/cmd/deploy.rs
@@ -327,9 +327,9 @@ struct Spawned {
 }
 
 fn log_path(log_dir: &Path, name: &str) -> PathBuf {
-    // Same short stem Scribe uses for the file (see process::short_tag), so
-    // the path rbnx reports matches the file that actually gets written.
-    log_dir.join(format!("{}.log", robonix_cli::process::short_tag(name)))
+    // `name` is the provider_id — the exact Scribe tag, so `<name>.log` is the
+    // real file rbnx should point at. No name mangling.
+    log_dir.join(format!("{name}.log"))
 }
 
 async fn spawn_system_binary(
@@ -420,7 +420,11 @@ async fn spawn_package(
     } else {
         entry.name.clone()
     };
-    let log_name = format!("{component}_{name}");
+    // Scribe tag + log-file stem = the provider_id (`entry.name`) verbatim.
+    // provider_id is unique per deploy (atlas enforces it), so no kind prefix
+    // is needed for disambiguation — `rbnx logs -t <provider_id>` and the file
+    // `<provider_id>.log` both key on the same name the user wrote.
+    let log_name = name.clone();
 
     // Write this instance's config to disk for boot's own bookkeeping
     // (debugging via `cat <instances>/<name>.json`, post-mortem
@@ -476,8 +480,8 @@ async fn spawn_package(
         .id()
         .ok_or_else(|| anyhow::anyhow!("spawned package '{name}' but it had no pid"))?;
 
-    // Pipe stdout / stderr into Scribe — tag = log_name so the file
-    // matches the old naming convention (e.g. "service_mapping.log").
+    // Pipe stdout / stderr into Scribe — tag = provider_id, so the file is
+    // `<provider_id>.log` (e.g. "mapping.log").
     let stdout = child.stdout.take().expect("stdout not piped");
     let stderr = child.stderr.take().expect("stderr not piped");
     let tag_out = log_name.clone();

--- a/tools/rbnx/src/cmd/deploy.rs
+++ b/tools/rbnx/src/cmd/deploy.rs
@@ -1187,6 +1187,19 @@ fn system_cli_args(
 ) -> Vec<String> {
     let mut out = Vec::new();
     let map = cfg.and_then(|v| v.as_mapping());
+
+    // Pass the component's whole manifest config block as one JSON arg. The
+    // binary parses the keys it needs (e.g. scribe reads `log` via
+    // robonix_scribe::init_from_config), so new manifest keys flow through
+    // without per-key plumbing here. The typed flags below remain for the
+    // fields binaries still read individually.
+    if let Some(v) = cfg
+        && let Ok(json) = serde_json::to_string(v)
+    {
+        out.push("--config-json".into());
+        out.push(json);
+    }
+
     let s = |k: &str| -> Option<String> {
         map.and_then(|m| {
             m.get(serde_yaml::Value::String(k.into()))

--- a/tools/rbnx/src/cmd/deploy.rs
+++ b/tools/rbnx/src/cmd/deploy.rs
@@ -327,7 +327,9 @@ struct Spawned {
 }
 
 fn log_path(log_dir: &Path, name: &str) -> PathBuf {
-    log_dir.join(format!("{name}.log"))
+    // Same short stem Scribe uses for the file (see process::short_tag), so
+    // the path rbnx reports matches the file that actually gets written.
+    log_dir.join(format!("{}.log", robonix_cli::process::short_tag(name)))
 }
 
 async fn spawn_system_binary(

--- a/tools/rbnx/src/cmd/logs.rs
+++ b/tools/rbnx/src/cmd/logs.rs
@@ -76,6 +76,53 @@ fn read_all(dir: &PathBuf, tags: &[String], min_level: u8, raw_json: bool) -> Re
     Ok(())
 }
 
+/// Scan every `*.log` in `dir` and print the distinct tags found, each with a
+/// record count, sorted by tag. Helps discover which `-t <tag>` values exist.
+/// Ignores the tag / level filters. When no Scribe records parse, says so
+/// (the files may be empty or in a pre-Scribe text format) rather than
+/// printing nothing.
+fn list_tags(dir: &PathBuf) -> Result<()> {
+    use std::collections::BTreeMap;
+    let mut counts: BTreeMap<String, u64> = BTreeMap::new();
+    let mut files = 0u64;
+    let mut parsed = 0u64;
+    for entry in std::fs::read_dir(dir)?.flatten() {
+        let p = entry.path();
+        if p.extension().and_then(|s| s.to_str()) != Some("log") {
+            continue;
+        }
+        files += 1;
+        let content = std::fs::read_to_string(&p)?;
+        for line in content.lines() {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            if let Ok(rec) = serde_json::from_str::<LogRecord>(line) {
+                parsed += 1;
+                *counts.entry(rec.tag).or_default() += 1;
+            }
+        }
+    }
+    if counts.is_empty() {
+        eprintln!(
+            "rbnx logs: no Scribe records in {} ({files} .log file(s) scanned). \
+             The files may be empty or in a pre-Scribe text format.",
+            dir.display()
+        );
+        return Ok(());
+    }
+    let width = counts.keys().map(String::len).max().unwrap_or(0);
+    for (tag, n) in &counts {
+        println!("{tag:<width$}  {n} records");
+    }
+    eprintln!(
+        "{} tag(s), {parsed} records across {files} file(s)",
+        counts.len()
+    );
+    Ok(())
+}
+
 /// Follow mode: open all `*.log` files, seek to end, and tail new lines.
 fn follow(dir: &PathBuf, tags: &[String], min_level: u8, raw_json: bool) -> Result<()> {
     use std::io::{BufRead, Seek, SeekFrom};
@@ -134,6 +181,7 @@ pub async fn execute(
     level: Option<String>,
     follow_mode: bool,
     raw_json: bool,
+    list_tags_mode: bool,
 ) -> Result<()> {
     let dir = log_dir.unwrap_or_else(|| {
         std::env::var("SCRIBE_LOG_DIR")
@@ -148,6 +196,10 @@ pub async fn execute(
         );
         eprintln!("Set SCRIBE_LOG_DIR or run from a deploy directory.");
         std::process::exit(1);
+    }
+
+    if list_tags_mode {
+        return list_tags(&dir);
     }
 
     let min_level = level.as_deref().map(level_floor).unwrap_or(0);

--- a/tools/rbnx/src/cmd/mod.rs
+++ b/tools/rbnx/src/cmd/mod.rs
@@ -370,6 +370,10 @@ pub enum Commands {
         /// Output raw JSON lines instead of logcat-style rendering.
         #[arg(long)]
         json: bool,
+        /// List the distinct tags present in the logs (with record counts)
+        /// instead of printing records — handy for discovering `-t` values.
+        #[arg(long)]
+        list_tags: bool,
     },
 }
 
@@ -464,6 +468,7 @@ pub async fn execute(command: Commands, config: Config) -> Result<()> {
             level,
             follow,
             json,
-        } => logs::execute(log_dir, tag, level, follow, json).await,
+            list_tags,
+        } => logs::execute(log_dir, tag, level, follow, json, list_tags).await,
     }
 }

--- a/tools/rbnx/src/process.rs
+++ b/tools/rbnx/src/process.rs
@@ -15,6 +15,32 @@ use tokio::fs::OpenOptions;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 use tokio::process::Command;
 
+/// Derive a short, human-friendly log tag / file stem from a package's
+/// `std_name`. Used as the Scribe tag for captured child output and as the
+/// per-package log-file name, so `rbnx logs` shows `mapping` / `scene` /
+/// `tiago_camera` instead of the full `com.robonix.<kind>.<name>` id.
+///
+/// Rules: take the last dot-segment, then drop a leading kind prefix
+/// (`service_` / `system_` / `primitive_` / `skill_`):
+///   `com.robonix.service.mapping`      → `mapping`
+///   `com.robonix.example.tiago_camera` → `tiago_camera`
+///   `service_memory`                   → `memory`
+///   `atlas`                            → `atlas`
+///
+/// `deploy::log_path` MUST derive the same name so the file rbnx points at
+/// matches the file Scribe writes.
+pub fn short_tag(std_name: &str) -> String {
+    let last = std_name.rsplit('.').next().unwrap_or(std_name);
+    for prefix in ["service_", "system_", "primitive_", "skill_"] {
+        if let Some(rest) = last.strip_prefix(prefix)
+            && !rest.is_empty()
+        {
+            return rest.to_string();
+        }
+    }
+    last.to_string()
+}
+
 /// Information about a running process for a capability or skill
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProcessInfo {
@@ -273,7 +299,11 @@ impl ProcessManager {
         // drown out the boot progress lines.
         let stdout = child.stdout.take().expect("stdout not piped");
         let stderr = child.stderr.take().expect("stderr not piped");
-        let tag = std_name.to_string();
+        // Short, human-friendly scribe tag (also the log-file stem) so
+        // `rbnx logs` shows `mapping` / `tiago_camera`, not the full
+        // `com.robonix.service.mapping` std_name. Keep `deploy::log_path` in
+        // sync (it derives the same name).
+        let tag = short_tag(std_name);
 
         let stdout_task = tokio::spawn(async move {
             let reader = tokio::io::BufReader::new(stdout);
@@ -283,7 +313,7 @@ impl ProcessManager {
             }
         });
 
-        let tag2 = std_name.to_string();
+        let tag2 = short_tag(std_name);
         let stderr_task = tokio::spawn(async move {
             let reader = tokio::io::BufReader::new(stderr);
             let mut lines = reader.lines();

--- a/tools/rbnx/src/process.rs
+++ b/tools/rbnx/src/process.rs
@@ -15,32 +15,6 @@ use tokio::fs::OpenOptions;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 use tokio::process::Command;
 
-/// Derive a short, human-friendly log tag / file stem from a package's
-/// `std_name`. Used as the Scribe tag for captured child output and as the
-/// per-package log-file name, so `rbnx logs` shows `mapping` / `scene` /
-/// `tiago_camera` instead of the full `com.robonix.<kind>.<name>` id.
-///
-/// Rules: take the last dot-segment, then drop a leading kind prefix
-/// (`service_` / `system_` / `primitive_` / `skill_`):
-///   `com.robonix.service.mapping`      → `mapping`
-///   `com.robonix.example.tiago_camera` → `tiago_camera`
-///   `service_memory`                   → `memory`
-///   `atlas`                            → `atlas`
-///
-/// `deploy::log_path` MUST derive the same name so the file rbnx points at
-/// matches the file Scribe writes.
-pub fn short_tag(std_name: &str) -> String {
-    let last = std_name.rsplit('.').next().unwrap_or(std_name);
-    for prefix in ["service_", "system_", "primitive_", "skill_"] {
-        if let Some(rest) = last.strip_prefix(prefix)
-            && !rest.is_empty()
-        {
-            return rest.to_string();
-        }
-    }
-    last.to_string()
-}
-
 /// Information about a running process for a capability or skill
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProcessInfo {
@@ -299,11 +273,9 @@ impl ProcessManager {
         // drown out the boot progress lines.
         let stdout = child.stdout.take().expect("stdout not piped");
         let stderr = child.stderr.take().expect("stderr not piped");
-        // Short, human-friendly scribe tag (also the log-file stem) so
-        // `rbnx logs` shows `mapping` / `tiago_camera`, not the full
-        // `com.robonix.service.mapping` std_name. Keep `deploy::log_path` in
-        // sync (it derives the same name).
-        let tag = short_tag(std_name);
+        // Scribe tag + log-file stem = `std_name` (the provider_id) verbatim,
+        // matching `deploy::log_path`. No name mangling.
+        let tag = std_name.to_string();
 
         let stdout_task = tokio::spawn(async move {
             let reader = tokio::io::BufReader::new(stdout);
@@ -313,7 +285,7 @@ impl ProcessManager {
             }
         });
 
-        let tag2 = short_tag(std_name);
+        let tag2 = std_name.to_string();
         let stderr_task = tokio::spawn(async move {
             let reader = tokio::io::BufReader::new(stderr);
             let mut lines = reader.lines();


### PR DESCRIPTION
Closes #101.

## Problem

A manifest's `system.<component>.log:` had no effect: rbnx passed it as the env_logger-era `--log` flag, but the binaries migrated to scribe (file floor defaults to Info) and each `main` **discarded** the parsed level (`let _ = parsed.log…`). So `log: debug` never reached the log file and `rbnx logs` only showed info/warn for a debug-configured component.

## Change — unify config passing on a JSON arg (no new env vars)

- **rbnx** (`deploy.rs`): serialize the component manifest config block to JSON and pass it as one `--config-json '{…}'` arg. New manifest keys now reach a binary without per-key plumbing here.
- **scribe**: `init_from_config(tag, config_json)` reads the `log` key and sets a per-process file-level override (precedence over `SCRIBE_FILE_LEVEL`) before the first log line.
- **atlas / pilot / executor / liaison**: parse `--config-json`, call `init_from_config` instead of discarding the level.

The typed flags (`--vlm-*`, `--listen`, …) stay for now; `--config-json` is the new unified channel and the one that carries `log`. Migrating the rest of the keys off individual flags is a follow-up (see #101).

## Verification

`cargo clippy --workspace --all-targets -- -D warnings` + `cargo fmt --check` clean. e2e on webots (`make install` + `rbnx boot`): pilot is configured `log: debug` — after one turn, `pilot.log` shows 2 `"level":"debug"` records (was 0 before) alongside info; atlas (`log: info`) keeps zero debug. pilot was launched with `--config-json {…,"log":"debug",…}` (confirmed in `ps`).