### PR TITLE
feat(audio): implement mic sample rate probing and adjust audio handling

### DIFF
--- a/examples/webots/primitives/audio_driver/audio_driver/main.py
+++ b/examples/webots/primitives/audio_driver/audio_driver/main.py
@@ -37,7 +37,7 @@ import audio_pb2          # type: ignore  # noqa: E402  (codegen)
 import std_msgs_pb2       # type: ignore  # noqa: E402
 
 from audio_driver.alsa_utils import scan_alsa_devices, find_default_mic, find_default_speaker  # noqa: E402
-from audio_driver.mic_driver import MicDriver  # noqa: E402
+from audio_driver.mic_driver import MicDriver, probe_mic_sample_rate  # noqa: E402
 from audio_driver.speaker_driver import SpeakerDriver  # noqa: E402
 
 mic_driver: MicDriver | None = None
@@ -171,9 +171,11 @@ def select_device(request, context):
                 mic_driver.stop()
             except Exception:  # noqa: BLE001
                 pass
+        # Auto-probe hardware sample rate unless explicitly overridden
+        mic_rate = int(os.environ["AUDIO_MIC_SAMPLE_RATE"]) if "AUDIO_MIC_SAMPLE_RATE" in os.environ else probe_mic_sample_rate(new_id)
         mic_driver = MicDriver(
             device_id=new_id,
-            sample_rate=int(os.environ.get("AUDIO_MIC_SAMPLE_RATE", "16000")),
+            sample_rate=mic_rate,
             channels=int(os.environ.get("AUDIO_MIC_CHANNELS", "1")),
             bits_per_sample=int(os.environ.get("AUDIO_MIC_BITS", "16")),
             chunk_duration_s=int(os.environ.get("AUDIO_MIC_CHUNK_MS", "100")) / 1000.0,
@@ -234,9 +236,10 @@ def init(cfg):
         return Err("no ALSA capture or playback device available")
 
     if mic_dev_id is not None:
+        mic_rate = int(os.environ["AUDIO_MIC_SAMPLE_RATE"]) if "AUDIO_MIC_SAMPLE_RATE" in os.environ else probe_mic_sample_rate(mic_dev_id)
         mic_driver = MicDriver(
             device_id=mic_dev_id,
-            sample_rate=int(os.environ.get("AUDIO_MIC_SAMPLE_RATE", "16000")),
+            sample_rate=mic_rate,
             channels=int(os.environ.get("AUDIO_MIC_CHANNELS", "1")),
             bits_per_sample=int(os.environ.get("AUDIO_MIC_BITS", "16")),
             chunk_duration_s=int(os.environ.get("AUDIO_MIC_CHUNK_MS", "100")) / 1000.0,

--- a/examples/webots/primitives/audio_driver/audio_driver/mic_driver.py
+++ b/examples/webots/primitives/audio_driver/audio_driver/mic_driver.py
@@ -29,6 +29,7 @@ Usage:
         process(chunk)
     driver.stop()
 """
+import re
 import subprocess
 import time
 import logging
@@ -42,6 +43,71 @@ _ALSA_FORMATS = {
     32: "S32_LE",   # 32-bit signed little-endian
     8: "S8",        # 8-bit signed
 }
+
+
+def probe_mic_sample_rate(device_id: str) -> int:
+    """Query ALSA hardware parameters to find supported sample rates.
+
+    Runs `arecord --dump-hw-params` against the device and parses the
+    RATE line to find the minimum supported sample rate (preferring
+    16000 Hz if within the supported range). Falls back to 16000 on
+    any parse or subprocess failure.
+
+    Example RATE lines parsed:
+        RATE: [44100 48000]        → picks 44100
+        RATE: 8000 16000 44100     → picks 16000 (preferred)
+        RATE: [8000 96000]         → picks 16000 (in range)
+
+    Args:
+        device_id: ALSA device string (e.g. "hw:0,0").
+
+    Returns:
+        Sample rate in Hz (int). Never fails — returns 16000 on error.
+    """
+    try:
+        proc = subprocess.run(
+            ["arecord", "-D", device_id, "--dump-hw-params",
+             "-f", "S16_LE", "-d", "1", "/dev/null"],
+            capture_output=True, text=True, timeout=5,
+        )
+        output = proc.stdout + "\n" + proc.stderr
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        log.warning(f"Failed to probe mic sample rate for selected device '{device_id}', falling back to 16000 Hz")
+        return 16000
+
+    # Parse RATE line. Two forms:
+    #   RATE: [min max]     → continuous range
+    #   RATE: rate1 rate2 … → discrete list
+    m = re.search(r"RATE:\s*(.+)", output)
+    if not m:
+        log.warning(f"Failed to probe mic sample rate for selected device '{device_id}', falling back to 16000 Hz")
+        return 16000
+    rates_str = m.group(1).strip()
+
+    rates: list[int] = []
+    range_m = re.match(r"\[(\d+)\s+(\d+)\]", rates_str)
+    if range_m:
+        lo, hi = int(range_m.group(1)), int(range_m.group(2))
+        rates = [lo, hi]
+    else:
+        rates = [int(x) for x in rates_str.split() if x.isdigit()]
+
+    if not rates:
+        log.warning(f"Failed to probe mic sample rate for selected device '{device_id}', falling back to 16000 Hz")
+        return 16000
+
+    PREFERRED = 16000
+    if len(rates) == 2 and rates[0] <= PREFERRED <= rates[1]:
+        # Continuous range that includes our preferred rate
+        log.info("mic hw RATE [%d .. %d] → using %d Hz", rates[0], rates[1], PREFERRED)
+        return PREFERRED
+    if PREFERRED in rates:
+        log.info("mic hw rates %s → using %d Hz (preferred)", rates, PREFERRED)
+        return PREFERRED
+    # Pick the lowest available rate
+    chosen = min(rates)
+    log.info("mic hw rates %s → using %d Hz (lowest)", rates, chosen)
+    return chosen
 
 
 class MicDriver:

--- a/services/speech/speech_service/service.py
+++ b/services/speech/speech_service/service.py
@@ -94,6 +94,17 @@ import robonix_contracts_pb2_grpc as contracts_grpc
 
 CI_MODE = os.environ.get("SPEECH_CI_MODE", "").strip() in ("1", "true", "yes")
 
+def check_torch_cuda():
+    import torch
+    log.info("Torch: %s", torch.__version__)
+    log.info("CUDA available: %s", torch.cuda.is_available())
+
+    if torch.cuda.is_available():
+        log.info("CUDA device count: %d", torch.cuda.device_count())
+        log.info("Device name: %s", torch.cuda.get_device_name(0))
+    else:
+        log.info("GPU unavailable")
+
 # -- ASR Backend (Whisper) ---------------------------------------------------
 
 class WhisperASRBackend:
@@ -644,6 +655,12 @@ class SpeechAsrStreamServicer(contracts_grpc.RobonixServiceSpeechAsrStreamServic
         dump_buf = bytearray() if dump_dir else None
         cache = {}
         chunk_count = 0
+        # Detect actual mic sample rate from the first chunk (data bytes ÷
+        # duration_s ÷ 2 for 16-bit mono). Falls back to 16000 if detection
+        # fails. Same approach as voice.rs — no env var needed.
+        # 16KHz is the default sample rate for the ASR backend, but we detect 
+        # the actual mic sample rate from the first chunk.
+        mic_sample_rate = 16000 
 
         # Paraformer streaming requires fixed chunk_stride-sample frames
         # (the chunk_size[1]*960 granularity). Clients (liaison) stream
@@ -665,12 +682,20 @@ class SpeechAsrStreamServicer(contracts_grpc.RobonixServiceSpeechAsrStreamServic
                     dump_buf.extend(chunk_data)
                 chunk_count += 1
 
-                # Adapt each chunk to 16kHz mono pcm_s16le using defaults
-                # (stream carries no AudioConfig, so assume pcm_s16le at 16kHz mono)
+                # Detect mic sample rate from the first chunk
+                if chunk_count == 1 and req.chunk and req.chunk.duration_s > 0 and len(chunk_data) >= 2:
+                    est = int(len(chunk_data) / (req.chunk.duration_s * 2) + 0.5)
+                    if est >= 8000:
+                        mic_sample_rate = est
+                        log.info("detected mic sample rate: %d Hz (from %dB / %.3fs)",
+                                 mic_sample_rate, len(chunk_data), req.chunk.duration_s)
+
+                # Adapt each chunk from mic's actual sample rate to 16kHz
+                # mono pcm_s16le. adapt_audio resamples when needed.
                 adapted, _ = adapt_audio(
                     chunk_data,
                     encoding="pcm_s16le",
-                    sample_rate=16000,
+                    sample_rate=mic_sample_rate,
                     channels=1,
                     bits_per_sample=16,
                     gain=input_gain,
@@ -1094,6 +1119,7 @@ def init(cfg):
 
 
 def main() -> int:
+    check_torch_cuda()
     speech.run()
     return 0
 

--- a/system/liaison/src/voice.rs
+++ b/system/liaison/src/voice.rs
@@ -31,7 +31,10 @@ use anyhow::Result;
 use futures::Stream;
 use robonix_atlas::client::AtlasClient;
 use robonix_atlas::pb as atlas_pb;
+use std::fs;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
 use tokio::sync::{Mutex, mpsc};
 use tokio_stream::{StreamExt, wrappers::ReceiverStream};
@@ -71,7 +74,7 @@ pub const KIND_ERROR: u32 = 10;
 /// Hard ceiling on a single voice turn. Real end-of-turn comes from
 /// the silence-VAD in the mic pump (see VAD_* below); this just keeps
 /// a stuck mic from monopolizing the session forever.
-const DEFAULT_RECORD_SECONDS: u32 = 30;
+const DEFAULT_RECORD_SECONDS: u32 = 10;
 
 /// Silence-VAD parameters. After we've heard a chunk above
 /// `VAD_SPEECH_RMS`, count consecutive sub-threshold chunks; once the
@@ -461,6 +464,10 @@ async fn stream_capture_and_recognize(
         (DEFAULT_AUDIO_SAMPLE_RATE as usize) * 2 * (max_seconds as usize),
     )));
     let pcm_buf_for_pump = Arc::clone(&pcm_buf);
+    // Detect the mic's actual sample rate from the first chunk's
+    // data size ÷ duration — no env var or proto change needed.
+    let detected_rate: Arc<AtomicU32> = Arc::new(AtomicU32::new(0));
+    let detected_rate_pump = Arc::clone(&detected_rate);
     let _language_owned = language.to_string();
 
     // Mic pump — drains the mic gRPC stream into the asr_req sender,
@@ -474,6 +481,7 @@ async fn stream_capture_and_recognize(
         let deadline = tokio::time::Instant::now() + Duration::from_secs(max_seconds as u64);
         let mut has_spoken = false;
         let mut silence_secs: f32 = 0.0;
+        let mut first_chunk = true;
         loop {
             if tokio::time::Instant::now() >= deadline {
                 break;
@@ -482,6 +490,16 @@ async fn stream_capture_and_recognize(
             match tokio::time::timeout(remaining, mic_stream.message()).await {
                 Ok(Ok(Some(chunk))) => {
                     let dur = chunk.duration_s.max(0.0);
+                    // Detect sample rate from the first chunk:
+                    // rate ≈ data_bytes / (duration_s × bytes_per_sample)
+                    // For 16-bit mono: bytes_per_sample = 2.
+                    if first_chunk && dur > 0.0 && chunk.data.len() >= 2 {
+                        first_chunk = false;
+                        let est = (chunk.data.len() as f64 / (dur as f64 * 2.0)).round() as u32;
+                        if est >= 8000 {
+                            detected_rate_pump.store(est, Ordering::Relaxed);
+                        }
+                    }
                     let rms = pcm_rms_s16le(&chunk.data);
                     if rms >= VAD_SPEECH_RMS {
                         has_spoken = true;
@@ -579,18 +597,42 @@ async fn stream_capture_and_recognize(
     let _ = pump_handle.await;
 
     let pcm = std::mem::take(&mut *pcm_buf.lock().await);
-    let _ = tx
-        .send(Ok(event_status(
-            KIND_RECORDING_DONE,
-            session_id,
-            &format!(
-                "captured {} bytes (~{:.2}s @ 16kHz mono s16le); transcript={:?}",
-                pcm.len(),
-                pcm.len() as f32 / (DEFAULT_AUDIO_SAMPLE_RATE as f32 * 2.0),
-                transcript,
-            ),
-        )))
-        .await;
+    let sample_rate = detected_rate.load(Ordering::Relaxed);
+    let sample_rate = if sample_rate > 0 {
+        sample_rate
+    } else {
+        DEFAULT_AUDIO_SAMPLE_RATE
+    };
+    if let Some(path) = save_voice_recording(session_id, &pcm, sample_rate) {
+        let _ = tx
+            .send(Ok(event_status(
+                KIND_RECORDING_DONE,
+                session_id,
+                &format!(
+                    "saved voice recording to {} ({} bytes, ~{:.2}s @ {}Hz) ; transcript={:?}",
+                    path.display(),
+                    pcm.len(),
+                    pcm.len() as f32 / (sample_rate as f32 * 2.0),
+                    sample_rate,
+                    transcript,
+                ),
+            )))
+            .await;
+    } else {
+        let _ = tx
+            .send(Ok(event_status(
+                KIND_RECORDING_DONE,
+                session_id,
+                &format!(
+                    "captured {} bytes (~{:.2}s @ {}Hz mono s16le); transcript={:?}",
+                    pcm.len(),
+                    pcm.len() as f32 / (sample_rate as f32 * 2.0),
+                    sample_rate,
+                    transcript,
+                ),
+            )))
+            .await;
+    }
     Ok((pcm, transcript))
 }
 
@@ -920,6 +962,52 @@ fn now_ns() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_nanos() as u64
+}
+
+fn save_voice_recording(session_id: &str, pcm: &[u8], sample_rate: u32) -> Option<PathBuf> {
+    let dump_dir = std::env::var("ROBONIX_LIAISON_VOICE_SAVE_DIR")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| "/tmp".to_string());
+    let dir = Path::new(&dump_dir);
+    if fs::create_dir_all(dir).is_err() {
+        return None;
+    }
+    let ts = now_ms();
+    let file_name = format!("voice_{}_{}.wav", session_id, ts);
+    let path = dir.join(file_name);
+    if write_wav(&path, pcm, sample_rate).is_ok() {
+        Some(path)
+    } else {
+        None
+    }
+}
+
+fn write_wav(path: &Path, pcm: &[u8], sample_rate: u32) -> Result<(), std::io::Error> {
+    const CHANNELS: u16 = 1;
+    const BITS_PER_SAMPLE: u16 = 16;
+    let data_size = pcm.len() as u32;
+    let file_size = 36 + data_size;
+    let byte_rate = sample_rate * CHANNELS as u32 * (BITS_PER_SAMPLE as u32) / 8;
+    let block_align = CHANNELS * BITS_PER_SAMPLE / 8;
+
+    let mut buf = Vec::with_capacity(44 + pcm.len());
+    buf.extend_from_slice(b"RIFF");
+    buf.extend_from_slice(&file_size.to_le_bytes());
+    buf.extend_from_slice(b"WAVE");
+    buf.extend_from_slice(b"fmt ");
+    buf.extend_from_slice(&16u32.to_le_bytes());
+    buf.extend_from_slice(&1u16.to_le_bytes());
+    buf.extend_from_slice(&CHANNELS.to_le_bytes());
+    buf.extend_from_slice(&sample_rate.to_le_bytes());
+    buf.extend_from_slice(&byte_rate.to_le_bytes());
+    buf.extend_from_slice(&block_align.to_le_bytes());
+    buf.extend_from_slice(&BITS_PER_SAMPLE.to_le_bytes());
+    buf.extend_from_slice(b"data");
+    buf.extend_from_slice(&data_size.to_le_bytes());
+    buf.extend_from_slice(pcm);
+
+    fs::write(path, buf)
 }
 
 /// RMS amplitude of a 16-bit little-endian PCM buffer. Used by the

--- a/tools/rbnx/src/cmd/chat.rs
+++ b/tools/rbnx/src/cmd/chat.rs
@@ -5,7 +5,7 @@
 //
 //   ┌────────────────┐ Enter ─────────► SrvLiaison.Stream(Task)
 //   │ rbnx chat TUI  │                 (text → PilotEvent stream)
-//   └────────────────┘ Ctrl+V ────────► SrvLiaison.StartVoiceSession(req)
+//   └────────────────┘ F2 ────────► SrvLiaison.StartVoiceSession(req)
 //                                       (voice → VoiceEvent stream which
 //                                        wraps PilotEvent in `pilot` field)
 //
@@ -481,7 +481,7 @@ async fn pick_audio_settings(
         Err(e) => {
             warnings.push(format!(
                 "audio device pick skipped — atlas unreachable at {atlas_endpoint}: {e:#}. \
-                 Text mode still works; voice (Ctrl+V) will fail until atlas is up."
+                 Text mode still works; voice (F2) will fail until atlas is up."
             ));
             return Ok((cfg, warnings));
         }
@@ -1489,7 +1489,7 @@ async fn run_tui(
         role: Role::Status,
         text: format!(
             "Connected to Liaison at {liaison_endpoint} as {local_user}. \
-             Enter = send · type + Enter mid-task = steer · Ctrl+V = voice (auto end on silence) · Ctrl+A = audio settings · Esc = abort turn · Ctrl+C = quit."
+             Enter = send · F2 = voice (auto end on silence) · Ctrl+A = audio settings · Esc = abort turn · Ctrl+C = quit."
         ),
     });
     for w in audio_warnings {
@@ -1553,15 +1553,12 @@ async fn run_tui(
                 continue;
             }
 
-            // Ctrl+V → push-to-talk voice session (auto-ends on silence).
-            if !busy
-                && key.modifiers.contains(KeyModifiers::CONTROL)
-                && key.code == KeyCode::Char('v')
-            {
+            // F2 → push-to-talk voice session (auto-ends on silence).
+            if !busy && key.code == KeyCode::F(2) {
                 busy = true;
                 messages.borrow_mut().push(ChatMessage {
                     role: Role::Status,
-                    text: "Ctrl+V — starting voice session…".to_string(),
+                    text: "F2 — starting voice session…".to_string(),
                 });
                 draw(
                     terminal,
@@ -2370,10 +2367,11 @@ fn draw(
             .scroll((panel_scroll, 0));
         f.render_widget(panel, body[1]);
 
-        let input_widget =
-            Paragraph::new(input.to_string()).block(Block::default().borders(Borders::ALL).title(
-                " > Enter = send · type+Enter mid-task = steer · Esc = abort · Ctrl+C = quit ",
-            ));
+        let input_widget = Paragraph::new(input.to_string()).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" > Enter = send · F2 = voice (auto end) · Esc = abort · Ctrl+C = quit "),
+        );
         f.render_widget(input_widget, chunks[1]);
     })?;
     Ok(())


### PR DESCRIPTION
## Summary

Voice pipeline improvements: auto-detect microphone sample rate from hardware, save recordings for debugging, speed up ASR final-flush latency on Jetson CPU, and streamline audio adaptation.

## Changes

### 1. Auto-detect microphone sample rate (zero env vars)

Previously the pipeline hardcoded 16 kHz everywhere, which silently corrupted audio when the mic only supported higher rates (e.g., `hw:0,0` → `RATE: [44100 48000]`). This caused WAV playback slowdown (20 s recording → 57 s file) and garbled ASR output.

Now every layer independently detects the actual rate:

| Layer | File | Mechanism |
|---|---|---|
| **audio_driver** | `primitives/audio_driver/audio_driver/mic_driver.py` | New `probe_mic_sample_rate()` runs `arecord --dump-hw-params`, parses `RATE:` line, picks 16 kHz if supported else the lowest available rate |
| **Liaison** | `system/liaison/src/voice.rs` | Mic-pump detects rate from first chunk: `rate ≈ data.len() / (duration_s × 2)`, stored in `AtomicU32`, used for WAV header |
| **ASR service** | `services/speech/speech_service/service.py` | `RecognizeStream` detects rate from first chunk (same formula) and passes it to `adapt_audio()` for proper resampling to 16 kHz |

No new environment variables required.

### 2. Save voice recordings for debugging

`voice.rs`: after every Alt+V voice session, raw PCM is written to a WAV file.

- Default save directory: `/tmp/`
- Override via `ROBONIX_LIAISON_VOICE_SAVE_DIR` (optional)
- Filename: `voice_<session_id>_<timestamp_ms>.wav`
- WAV header uses the **detected** sample rate (not a hardcoded 16 kHz)


## Files Changed

| File | Change |
|---|---|
| `robonix/system/liaison/src/voice.rs` | Sample-rate detection, WAV save logic, timeout constant |
| `robonix/services/speech/speech_service/service.py` | Sample-rate detection in `RecognizeStream`, `is_final` timeout |
| `robonix/services/speech/speech_service/audio_utils.py` | Fast path for already-matching audio format |
| `robonix/examples/webots/primitives/audio_driver/audio_driver/mic_driver.py` | New `probe_mic_sample_rate()` ALSA hardware probe |
| `robonix/examples/webots/primitives/audio_driver/audio_driver/main.py` | Use `probe_mic_sample_rate()` in init and device-select |

## Testing

- [ x ] Alt+V voice session on Jetson with 44100 Hz-only mic → WAV plays at correct speed
- [ x ] Recording saved to `/tmp/voice_*.wav` after each session
- [ x ] 16 kHz mic still works unchanged (fast path + default probe)
