### PR TITLE
feat(scene): Jetson deployment targets (native + docker)

### DIFF
--- a/system/scene/README.md
+++ b/system/scene/README.md
@@ -53,6 +53,64 @@ The metric pipeline is ConceptGraphs-style per-frame perception with 4 stages:
 
 Periodic cleanup (every 30 ticks) runs concept-graphs's `denoise_objects` + `filter_objects` + `merge_overlap_objects` so duplicates from edge-case detections eventually collapse.
 
+## Deployment targets (x86 / Jetson)
+
+Unlike the Rust system binaries (atlas / executor / pilot / liaison — one
+static binary, architecture-agnostic), scene ships a heavy Python + CUDA
+perception stack, so it is **platform-specific at both build and run time**.
+One repo covers three targets, picked by the per-target package manifest
+(`rbnx deploy` selects it via the deploy entry's `manifest:` field):
+
+| Target | manifest | torch source | how it runs |
+|---|---|---|---|
+| **x86-docker** (default) | `package_manifest.yaml` | cu128 x86 wheels baked into `docker/Dockerfile` | `docker run --gpus all` |
+| **jetson-docker** | `package_manifest.jetson-docker.yaml` | NVIDIA jetson-ai-lab wheels in `docker/Dockerfile.jetson` | `docker run --runtime nvidia` |
+| **jetson-native** | `package_manifest.jetson-native.yaml` | **host JetPack torch** (no image) | host `python3 -m scene_service.service` |
+
+`scripts/build.sh` branches on `RBNX_BUILD_TARGET`; `scripts/start.sh` branches
+on `ROBONIX_SCENE_FORCE` (`native`/`docker`, or auto from
+`ROBONIX_SCENE_PLATFORM=jetson_orin`). On most Jetsons **jetson-native is the
+recommended path** — it reuses the JetPack CUDA stack instead of building a
+multi-GB L4T image.
+
+### Jetson native prerequisites (install the JetPack CUDA stack)
+
+`jetson-native` does **not** install torch — it expects a CUDA-capable host
+python already has it, and only pip-installs scene's light pure-python deps
+(`pip install --user`) on top. On a fresh Jetson (JetPack 6 / L4T r36 /
+CUDA 12.6) install the GPU stack first:
+
+```bash
+# 1. ROS 2 Humble on the host (apt, from the ROS 2 repo) — scene needs it
+#    for tf2 + the message types. (Skip if already installed.)
+
+# 2. JetPack CUDA-enabled torch / torchvision from NVIDIA's Jetson index.
+#    The index tag matches your JetPack: jp6/cu126 here; use jp6/cu128 etc.
+#    if your JetPack ships a different CUDA. (apt install nvidia-jetpack
+#    provides the CUDA toolkit these wheels link against.)
+pip install --user --index-url https://pypi.jetson-ai-lab.dev/jp6/cu126 \
+    torch torchvision
+
+# 3. perception extras that have native aarch64 wheels
+pip install --user ultralytics open3d
+
+# verify CUDA is live before building scene
+python3 -c "import torch; print(torch.__version__, torch.cuda.is_available())"
+#   → e.g.  2.10.0 True
+```
+
+Then build + run scene native (what `rbnx build`/`rbnx boot` do via the
+jetson-native manifest):
+
+```bash
+RBNX_BUILD_TARGET=jetson-native bash scripts/build.sh   # venv-free; pip --user the light deps
+ROBONIX_SCENE_FORCE=native     bash scripts/start.sh    # host python, host RMW (CycloneDDS)
+```
+
+> Native scene shares the **host RMW** (the ranger runs CycloneDDS) rather than
+> the container's FastRTPS, so it sees the live camera / pointcloud topics the
+> other native nodes publish. Set `ROBONIX_FORCE_CPU=1` to skip CUDA.
+
 ## Build + run
 
 ### Canonical Webots demo (sim + full stack)

--- a/system/scene/docker/Dockerfile.jetson
+++ b/system/scene/docker/Dockerfile.jetson
@@ -1,0 +1,150 @@
+# syntax=docker/dockerfile:1.7
+# SPDX-License-Identifier: MulanPSL-2.0
+# system/scene container — Jetson (arm64 / L4T) variant.
+#
+# Same shape as docker/Dockerfile, with ONE deliberate difference: the
+# torch / torchvision wheels come from NVIDIA's Jetson index (jetson-ai-lab,
+# JetPack 6 / CUDA 12.6) instead of the cu128 x86_64 wheels. The base stays
+# the multi-arch `ros:${ROS_DISTRO}-ros-base` (its arm64 manifest is what
+# `docker build` picks on a Jetson), so ROS 2 + the scene Python stack are
+# identical to the x86 image — only the CUDA wheels differ.
+#
+# IMPORTANT — run with the NVIDIA container runtime so the container can use
+# the GPU: scripts/start.sh adds `--runtime nvidia` on the jetson-docker path.
+# The Jetson's CUDA/cuDNN userspace libraries are bind-mounted from the host by
+# that runtime; the image itself only carries the torch python wheels.
+#
+# For most Jetsons the lighter `package_manifest.jetson-native.yaml` (host
+# ROS + host JetPack torch, no image build) is the recommended path; this
+# image exists for hosts that want a self-contained scene container.
+
+ARG ROS_DISTRO=humble
+FROM ros:${ROS_DISTRO}-ros-base
+
+# ── Build-time proxy helpers (identical to the x86 Dockerfile) ────────
+RUN cat > /usr/local/bin/with-build-proxy <<'EOF' \
+ && chmod +x /usr/local/bin/with-build-proxy \
+ && cat > /usr/local/bin/without-proxy <<'EOF2' \
+ && chmod +x /usr/local/bin/without-proxy
+#!/usr/bin/env sh
+set -eu
+export HTTP_PROXY="${HTTP_PROXY_HOST:-}"
+export HTTPS_PROXY="${HTTPS_PROXY_HOST:-}"
+export http_proxy="${HTTP_PROXY_HOST:-}"
+export https_proxy="${HTTPS_PROXY_HOST:-}"
+export NO_PROXY="${NO_PROXY_HOST:-}"
+export no_proxy="${NO_PROXY_HOST:-}"
+exec "$@"
+EOF
+#!/usr/bin/env sh
+set -eu
+unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy
+unset ALL_PROXY all_proxy NO_PROXY no_proxy
+exec "$@"
+EOF2
+
+# ── TUNA mirrors for domestic (CN) networks ─────────────────────────────
+RUN set -eux; \
+    find /etc/apt/sources.list.d/ -maxdepth 1 \( -name '*.list' -o -name '*.sources' \) -print0 \
+      | xargs -0 -r sed -i --follow-symlinks \
+          -e 's|http://packages\.ros\.org/ros2/ubuntu|https://mirrors.tuna.tsinghua.edu.cn/ros2/ubuntu|g' \
+          -e 's|^Types: deb deb-src$|Types: deb|'; \
+    if [ -f /etc/apt/sources.list ]; then \
+        sed -i --follow-symlinks \
+            -e 's|http://ports\.ubuntu\.com/ubuntu-ports/\?|https://mirrors.tuna.tsinghua.edu.cn/ubuntu-ports/|g' \
+            /etc/apt/sources.list; \
+    fi
+
+ENV PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple \
+    UV_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple \
+    HF_ENDPOINT=https://hf-mirror.com
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# System packages we need at runtime (same set as the x86 image).
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    without-proxy sh -c ' \
+        apt-get update && \
+        apt-get install -y --no-install-recommends \
+            python3-pip \
+            python3-cv-bridge \
+            python3-numpy \
+            ros-$ROS_DISTRO-tf2-ros \
+            ros-$ROS_DISTRO-tf-transformations \
+            ros-$ROS_DISTRO-rmw-zenoh-cpp \
+            ros-$ROS_DISTRO-zenoh-bridge-dds && \
+        rm -rf /var/lib/apt/lists/* \
+    '
+
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    without-proxy python3 -m pip install --progress-bar on --timeout 60 --retries 3 --upgrade pip
+
+# torch + torchvision — JETSON wheels (JetPack 6 / L4T r36 / CUDA 12.6).
+# NVIDIA's jetson-ai-lab index serves CUDA-enabled aarch64 wheels; pin the
+# index via JETSON_PIP_INDEX to match a different JetPack (e.g. jp6/cu128).
+ARG JETSON_PIP_INDEX=https://pypi.jetson-ai-lab.dev/jp6/cu126
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    without-proxy python3 -m pip install --progress-bar on --timeout 120 --retries 3 \
+        --index-url "${JETSON_PIP_INDEX}" \
+        torch torchvision
+
+# Generic scene deps + concept-graphs perception stack (same requirements as
+# the x86 image — torch is already satisfied above, so pip skips it).
+COPY requirements/scene-base.txt /tmp/requirements/scene-base.txt
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    without-proxy pip install -r /tmp/requirements/scene-base.txt --progress-bar on --timeout 60 --retries 3 \
+    && rm /tmp/requirements/scene-base.txt
+
+COPY requirements/scene-perception-core.txt /tmp/requirements/scene-perception-core.txt
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    without-proxy pip install -r /tmp/requirements/scene-perception-core.txt --progress-bar on --timeout 60 --retries 3 \
+    && rm /tmp/requirements/scene-perception-core.txt
+
+COPY requirements/scene-perception-heavy.txt /tmp/requirements/scene-perception-heavy.txt
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    without-proxy pip install -r /tmp/requirements/scene-perception-heavy.txt --progress-bar on --timeout 60 --retries 3 \
+    && rm /tmp/requirements/scene-perception-heavy.txt
+
+# ── Proxy-needed network layers ────────────────────────────────────
+ARG HTTP_PROXY_HOST
+ARG HTTPS_PROXY_HOST
+ARG NO_PROXY_HOST
+
+RUN set -eux; \
+    rm -rf /opt/concept-graphs; \
+    with-build-proxy git clone --depth 1 --branch ali-dev \
+        https://ghfast.top/https://github.com/concept-graphs/concept-graphs.git \
+        /opt/concept-graphs \
+    || ( rm -rf /opt/concept-graphs && \
+         with-build-proxy git clone --depth 1 --branch ali-dev \
+            https://github.com/concept-graphs/concept-graphs.git /opt/concept-graphs )
+
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    without-proxy pip install --no-deps -e /opt/concept-graphs
+
+# Bake CV model weights into the image.
+ENV HF_HOME=/opt/models/hf
+RUN mkdir -p /opt/models /opt/models/hf /root/.cache/clip
+COPY _weights/yolov8l-world.pt /opt/models/yolov8l-world.pt
+COPY _weights/mobile_sam.pt    /opt/models/mobile_sam.pt
+RUN with-build-proxy sh <<'EOF'
+set -eux
+export HF_ENDPOINT=https://hf-mirror.com
+export HF_HUB_DOWNLOAD_TIMEOUT=120
+python3 -c "import open_clip; open_clip.create_model_and_transforms('ViT-B-32', pretrained='laion2b_s34b_b79k')"
+python3 -c "import clip; clip.load('ViT-B/32', device='cpu', download_root='/root/.cache/clip')"
+EOF
+
+ENV SCENE_YOLO_WORLD_WEIGHTS=/opt/models/yolov8l-world.pt \
+    SCENE_MOBILE_SAM_WEIGHTS=/opt/models/mobile_sam.pt \
+    SCENE_CLIP_MODEL=ViT-B-32 \
+    SCENE_CLIP_PRETRAINED=laion2b_s34b_b79k
+
+WORKDIR /scene
+COPY entrypoint.sh /entrypoint.sh
+COPY no_shm_profile.xml /etc/fastrtps_no_shm.xml
+RUN chmod +x /entrypoint.sh
+ENV FASTRTPS_DEFAULT_PROFILES_FILE=/etc/fastrtps_no_shm.xml
+ENV RMW_IMPLEMENTATION=rmw_fastrtps_cpp
+ENTRYPOINT ["/entrypoint.sh"]

--- a/system/scene/package_manifest.jetson-docker.yaml
+++ b/system/scene/package_manifest.jetson-docker.yaml
@@ -1,0 +1,28 @@
+# Scene MCP server — Jetson + DOCKER deployment target.
+#
+#   build → RBNX_BUILD_TARGET=jetson-docker scripts/build.sh: docker build
+#           with docker/Dockerfile.jetson (NVIDIA L4T PyTorch base, so torch +
+#           CUDA come from the image instead of host-cu128 x86 wheels).
+#   start → ROBONIX_SCENE_FORCE=docker scripts/start.sh: docker run with the
+#           NVIDIA container runtime for GPU passthrough.
+#
+# Use this on a Jetson when you want a self-contained image (no host ROS /
+# torch needed). Heavier first build than jetson-native; see the scene README.
+manifestVersion: 1
+
+package:
+  name: com.robonix.system.scene
+  version: 0.1.0
+  vendor: robonix
+  description: Scene — semantic + geometric live map (Jetson + docker / L4T target).
+  license: MulanPSL-2.0
+
+build: RBNX_BUILD_TARGET=jetson-docker bash scripts/build.sh
+start: ROBONIX_SCENE_FORCE=docker bash scripts/start.sh
+
+capabilities:
+  - name: robonix/system/scene/list_objects
+  - name: robonix/system/scene/goal_near
+  - name: robonix/system/scene/get_scene_graph
+  - name: robonix/system/scene/get_object_context
+  - name: robonix/system/scene/list_relations

--- a/system/scene/package_manifest.jetson-native.yaml
+++ b/system/scene/package_manifest.jetson-native.yaml
@@ -1,0 +1,32 @@
+# Scene MCP server — Jetson + NATIVE host-ROS2 deployment target.
+#
+#   build → RBNX_BUILD_TARGET=jetson-native scripts/build.sh: no docker.
+#           Creates rbnx-build/venv (--system-site-packages) and pip-installs
+#           only the light pure-python deps; torch / torchvision / ultralytics /
+#           open3d come from the host JetPack stack (see the scene README
+#           "Jetson native prerequisites" for how to install them).
+#   start → ROBONIX_SCENE_FORCE=native scripts/start.sh → start_native.sh:
+#           runs scene_service on the host python, sharing the host RMW
+#           (CycloneDDS on the ranger) so it sees the live camera/pointcloud.
+#
+# Use this on a Jetson whose host already has ROS 2 Humble + a CUDA-enabled
+# python (the common JetPack setup). For a self-contained image instead, use
+# package_manifest.jetson-docker.yaml.
+manifestVersion: 1
+
+package:
+  name: com.robonix.system.scene
+  version: 0.1.0
+  vendor: robonix
+  description: Scene — semantic + geometric live map (Jetson + native host-ROS2 target).
+  license: MulanPSL-2.0
+
+build: RBNX_BUILD_TARGET=jetson-native bash scripts/build.sh
+start: ROBONIX_SCENE_FORCE=native bash scripts/start.sh
+
+capabilities:
+  - name: robonix/system/scene/list_objects
+  - name: robonix/system/scene/goal_near
+  - name: robonix/system/scene/get_scene_graph
+  - name: robonix/system/scene/get_object_context
+  - name: robonix/system/scene/list_relations

--- a/system/scene/scripts/build.sh
+++ b/system/scene/scripts/build.sh
@@ -39,6 +39,14 @@ cd "$PKG"
 BUILD="rbnx-build"
 CLEAN="${RBNX_BUILD_CLEAN:-}"
 IMG="${ROBONIX_SCENE_IMAGE:-robonix-scene}"
+# Deployment target (same scheme as mapping_rbnx). Chosen by the per-target
+# package manifest's `build:` line:
+#   x86-docker     x86_64 + docker, ROS2 + cu128 torch in image  [default]
+#   jetson-docker  arm64 Jetson + docker, L4T base (docker/Dockerfile.jetson)
+#   jetson-native  arm64 Jetson + host ROS2 + host JetPack torch — no docker;
+#                  builds rbnx-build/venv (--system-site-packages) for the
+#                  light pure-python deps only.
+TARGET="${RBNX_BUILD_TARGET:-x86-docker}"
 
 # ROS distro the scene image is built against. Robonix does not bind to a
 # single ROS release: pick it here and the Dockerfile threads it through
@@ -137,11 +145,60 @@ fetch_weight \
     "https://github.com/ChaoningZhang/MobileSAM/raw/master/weights/mobile_sam.pt" \
     "$WEIGHTS_DIR/mobile_sam.pt"
 
+# ── 2a. jetson-native: host venv, no docker ────────────────────────────────
+# The heavy CUDA wheels (torch / torchvision / ultralytics / open3d) come from
+# the host JetPack stack via --system-site-packages; we only pip-install the
+# light pure-python deps on top. Mirrors mapping_rbnx's native target.
+if [[ "$TARGET" == "jetson-native" ]]; then
+    # No venv on purpose. A --system-site-packages venv can't see the host
+    # JetPack torch (it's typically a `pip install --user` in ~/.local), and
+    # forcing the user-site onto PYTHONPATH drags shadowing shims (e.g. enum34)
+    # ahead of the stdlib and breaks the interpreter. The host python already
+    # has the correct sys.path order AND sees the JetPack torch — so install
+    # scene's light pure-python deps into the user site alongside it.
+    PY=python3
+    PIP_IDX="${PIP_INDEX_URL:-https://pypi.tuna.tsinghua.edu.cn/simple}"
+    echo "[build] jetson-native: host python ($("$PY" --version 2>&1)), pip install --user"
+    "$PY" -c "import torch" 2>/dev/null || {
+        echo "[build] error: host python has no torch — install the JetPack CUDA" >&2
+        echo "        stack first (see scene README 'Jetson native prerequisites'):" >&2
+        echo "        pip install --user --index-url https://pypi.jetson-ai-lab.dev/jp6/cu126 torch torchvision" >&2
+        exit 1
+    }
+    "$PY" -m pip install --user --upgrade pip --index-url "$PIP_IDX" || true
+    # torch & friends are already satisfied by the host stack, so pip skips
+    # them; only the missing pure-python deps get installed.
+    for req in scene-base scene-perception-core scene-perception-heavy; do
+        f="docker/requirements/${req}.txt"
+        [[ -f "$f" ]] || continue
+        echo "[build] pip install --user -r $f"
+        "$PY" -m pip install --user -r "$f" --index-url "$PIP_IDX" \
+            || echo "[build] warning: some deps in $f failed (perception may degrade)"
+    done
+    # concept-graphs (perception backbone) — editable, no deps.
+    CG="$PKG/rbnx-build/concept-graphs"
+    GH="${RBNX_GH_MIRROR-https://ghfast.top/}"
+    if [[ ! -d "$CG/.git" ]]; then
+        echo "[build] cloning concept-graphs"
+        git clone --depth 1 --branch ali-dev \
+            "${GH%/}/https://github.com/concept-graphs/concept-graphs.git" "$CG" \
+        || git clone --depth 1 --branch ali-dev \
+            https://github.com/concept-graphs/concept-graphs.git "$CG"
+    fi
+    "$PY" -m pip install --user --no-deps -e "$CG" || echo "[build] warning: concept-graphs install failed"
+    "$PY" -c "import torch,torchvision,ultralytics; print('[build] torch',torch.__version__,'cuda',torch.cuda.is_available())" || true
+    echo "[build] done (jetson-native)."
+    exit 0
+fi
+
 # ── 2. Docker image (scene's Python deps + ROS Humble base) ────────────────
 if ! command -v docker >/dev/null 2>&1; then
-    echo "[build] error: docker not found on PATH" >&2
+    echo "[build] error: target $TARGET needs docker on PATH" >&2
     exit 1
 fi
+# jetson-docker uses the L4T-based Dockerfile; x86-docker the default one.
+SCENE_DOCKERFILE="docker/Dockerfile"
+[[ "$TARGET" == "jetson-docker" ]] && SCENE_DOCKERFILE="docker/Dockerfile.jetson"
 
 DOCKER_BUILD_FLAGS=(--network=host --build-arg "ROS_DISTRO=${ROS_DISTRO_BUILD}")
 [[ "$CLEAN" == "1" ]] && DOCKER_BUILD_FLAGS+=(--no-cache)
@@ -205,7 +262,7 @@ case "$USE_PROXY" in
         ;;
 esac
 
-echo "[build] docker build -t $IMG docker/"
-docker build "${DOCKER_BUILD_FLAGS[@]}" -t "$IMG" docker/
+echo "[build] docker build -f $SCENE_DOCKERFILE -t $IMG docker/  (target=$TARGET)"
+docker build "${DOCKER_BUILD_FLAGS[@]}" -f "$SCENE_DOCKERFILE" -t "$IMG" docker/
 
 echo "[build] done."

--- a/system/scene/scripts/start.sh
+++ b/system/scene/scripts/start.sh
@@ -15,6 +15,23 @@
 
 set -euo pipefail
 
+# ── Platform dispatch (same scheme as mapping_rbnx) ─────────────────────────
+#   ROBONIX_SCENE_FORCE=native|docker     explicit hard pin
+#   else auto: ROBONIX_SCENE_PLATFORM=jetson_orin → native, otherwise docker
+# native → scripts/start_native.sh (host venv + host JetPack torch, no docker).
+PKG="${RBNX_PACKAGE_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+is_native_platform() { case "$1" in jetson_orin|jetson*|orin*) return 0 ;; *) return 1 ;; esac }
+case "${ROBONIX_SCENE_FORCE:-}" in
+    native) MODE=native ;;
+    docker) MODE=docker ;;
+    "") if is_native_platform "${ROBONIX_SCENE_PLATFORM:-}"; then MODE=native; else MODE=docker; fi ;;
+    *) echo "[scene/start] ROBONIX_SCENE_FORCE=${ROBONIX_SCENE_FORCE} not in {native,docker}" >&2; exit 2 ;;
+esac
+echo "[scene/start] mode=${MODE} (FORCE=${ROBONIX_SCENE_FORCE:-} PLATFORM=${ROBONIX_SCENE_PLATFORM:-})"
+if [[ "$MODE" == "native" ]]; then
+    exec bash "${PKG}/scripts/start_native.sh"
+fi
+
 CT="${ROBONIX_SCENE_CONTAINER:-robonix_scene}"
 IMG="${ROBONIX_SCENE_IMAGE:-robonix-scene}"
 
@@ -43,8 +60,14 @@ fi
 # ROBONIX_FORCE_CPU=1. Without this flag the container sees CPU only
 # and CLIP/YOLO run ~5x slower.
 declare -a GPU_ARGS=()
-if [[ "${ROBONIX_FORCE_CPU:-0}" != "1" ]] && command -v nvidia-smi &>/dev/null && nvidia-smi &>/dev/null; then
-    GPU_ARGS=(--gpus all)
+if [[ "${ROBONIX_FORCE_CPU:-0}" != "1" ]]; then
+    if is_native_platform "${ROBONIX_SCENE_PLATFORM:-}" || [[ -e /etc/nv_tegra_release ]]; then
+        # Jetson / L4T: the container gets the GPU via the NVIDIA container
+        # runtime (which bind-mounts the host CUDA libs); `--gpus all` is x86.
+        GPU_ARGS=(--runtime nvidia)
+    elif command -v nvidia-smi &>/dev/null && nvidia-smi &>/dev/null; then
+        GPU_ARGS=(--gpus all)
+    fi
 fi
 
 exec docker run --rm \

--- a/system/scene/scripts/start_native.sh
+++ b/system/scene/scripts/start_native.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MulanPSL-2.0
+# scene native start — run scene_service directly on the host (no docker).
+#
+# Used on Jetson (and any host with ROS 2 + a CUDA-capable python that already
+# has torch/torchvision/ultralytics/open3d). Selected by the jetson-native
+# manifest (`ROBONIX_SCENE_FORCE=native bash scripts/start.sh`, which execs
+# this). The build phase (build_native.sh) created rbnx-build/venv with
+# --system-site-packages so the heavy CUDA wheels come from the host JetPack
+# stack and only the light pure-python deps live in the venv.
+#
+# Unlike the docker path this does NOT force FastRTPS/no-shm: native scene must
+# share the host's RMW (the car runs CycloneDDS) to actually see the camera /
+# pointcloud topics published by the other native nodes.
+set -euo pipefail
+
+PKG="${RBNX_PACKAGE_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+cd "$PKG"
+
+# Native scene runs on the host python (the build installed scene's light deps
+# into the user site next to the host JetPack torch — no venv; see build.sh).
+PY="${SCENE_NATIVE_PYTHON:-python3}"
+"$PY" -c "import torch" 2>/dev/null || {
+    echo "[scene/native] error: '$PY' has no torch — run the jetson-native build" >&2
+    echo "               and install the JetPack CUDA stack first (see scene README)." >&2
+    exit 1
+}
+
+ROS_DISTRO="${ROS_DISTRO:-humble}"
+# shellcheck disable=SC1091
+set +u; source "/opt/ros/${ROS_DISTRO}/setup.bash"; set -u
+
+# Codegen stubs (proto_gen + robonix_mcp_types) + robonix-api + the package.
+export PYTHONPATH="$PKG/rbnx-build/codegen/proto_gen:$PKG/rbnx-build/codegen/robonix_mcp_types:$PKG:${PYTHONPATH:-}"
+if ROBONIX_API="$(rbnx path robonix-api 2>/dev/null)"; then
+    export PYTHONPATH="$ROBONIX_API:$PYTHONPATH"
+fi
+
+# Model weights: build.sh fetches yolo + mobile_sam to docker/_weights (shared
+# with the docker path); CLIP downloads to a host HF cache on first run.
+W="$PKG/docker/_weights"
+export SCENE_YOLO_WORLD_WEIGHTS="${SCENE_YOLO_WORLD_WEIGHTS:-$W/yolov8l-world.pt}"
+export SCENE_MOBILE_SAM_WEIGHTS="${SCENE_MOBILE_SAM_WEIGHTS:-$W/mobile_sam.pt}"
+export SCENE_CLIP_MODEL="${SCENE_CLIP_MODEL:-ViT-B-32}"
+export SCENE_CLIP_PRETRAINED="${SCENE_CLIP_PRETRAINED:-laion2b_s34b_b79k}"
+export HF_ENDPOINT="${HF_ENDPOINT:-https://hf-mirror.com}"
+export HF_HOME="${HF_HOME:-$PKG/rbnx-build/data/hf}"
+
+# Host-persisted scene state (object-memory DB + scene-graph caches).
+mkdir -p "$PKG/rbnx-build/data/robonix"
+export SCENE_GRAPH_CACHE_DIR="${SCENE_GRAPH_CACHE_DIR:-$PKG/rbnx-build/data/robonix/scene_graph/cache}"
+
+# Service knobs (same defaults the docker run wires via -e).
+export SCENE_WEB_PORT="${SCENE_WEB_PORT:-50107}"
+export SCENE_LOG_LEVEL="${SCENE_LOG_LEVEL:-INFO}"
+
+echo "[scene/native] python=$PY ros=$ROS_DISTRO rmw=${RMW_IMPLEMENTATION:-<default>} web=$SCENE_WEB_PORT"
+exec "$PY" -m scene_service.service


### PR DESCRIPTION
## Summary

`scene` previously shipped a **single x86-docker target** (cu128 torch baked into the image), so it could not run on the arm64 Jetson cars — it hung registering with atlas on L4T. This adds **two Jetson targets from the same package**, selected by per-target manifests, mirroring the `mapping_rbnx` / `nav2_wrapper_rbnx` layout so the whole stack deploys uniformly across x86 and Jetson.

Now others can run `scene` (and, already, `mapping`) on their own Jetson cars.

## Targets (one repo, picked by `manifest:`)

| manifest | platform | torch source | run |
|---|---|---|---|
| `package_manifest.yaml` (default) | x86_64 + docker | cu128 x86 wheels in `docker/Dockerfile` | `docker run --gpus all` |
| `package_manifest.jetson-docker.yaml` | arm64 Jetson + docker | NVIDIA jetson-ai-lab wheels in `docker/Dockerfile.jetson` | `docker run --runtime nvidia` |
| `package_manifest.jetson-native.yaml` | arm64 Jetson + native | **host JetPack torch** (no image) | host `python3 -m scene_service.service` |

- `scripts/build.sh` branches on `RBNX_BUILD_TARGET`; `scripts/start.sh` on `ROBONIX_SCENE_FORCE` (`native`/`docker`, auto from `ROBONIX_SCENE_PLATFORM=jetson_orin`).
- **jetson-native is the recommended path** — it reuses the host JetPack CUDA stack instead of building a multi-GB L4T image. `build.sh` deliberately uses **no venv**: a `--system-site-packages` venv can't see the host `~/.local` JetPack torch, and forcing user-site onto `PYTHONPATH` drags shadowing shims (e.g. `enum34`) ahead of the stdlib and breaks the interpreter — so it `pip install --user`s only scene's light pure-python deps next to the host torch. `start_native.sh` shares the host RMW (CycloneDDS) so scene sees the live camera / pointcloud topics the other native nodes publish.

## Validation

Tested on a JetPack 6 / L4T r36.4 / CUDA 12.6 Orin (ranger):

- `RBNX_BUILD_TARGET=jetson-native scripts/build.sh` → `torch 2.10.0 cuda True`, concept-graphs installed.
- Full `rbnx boot` → **`scene [ACTIVE] robonix/system/scene (5 caps)`**; scene web (`:50107`) serves objects + occupancy underlay; `list_objects` returns the live object store.
- `jetson-docker` Dockerfile is provided but not yet built end-to-end on a Jetson (native is the validated path).

## Docs

`README.md` gains a **Deployment targets** section + **Jetson native prerequisites** (how to install the JetPack CUDA `torch`/`torchvision`/`ultralytics` stack from `pypi.jetson-ai-lab.dev`), so a fresh Jetson can be brought up from scratch.