### PR TITLE
chore:render Webots on NVIDIA dGPU via PRIME offload

### DIFF
--- a/examples/webots/sim/compose.gpu.yaml
+++ b/examples/webots/sim/compose.gpu.yaml
@@ -6,6 +6,12 @@
 
 services:
   sim:
+    environment:
+      # PRIME render-offload: prefer the passed-in dGPU for GL. On Optimus
+      # laptops Webots/rviz otherwise fall to the iGPU. Export =0 to opt out.
+      __NV_PRIME_RENDER_OFFLOAD: "${__NV_PRIME_RENDER_OFFLOAD:-1}"
+      __GLX_VENDOR_LIBRARY_NAME: "${__GLX_VENDOR_LIBRARY_NAME:-nvidia}"
+      __VK_LAYER_NV_optimus: "${__VK_LAYER_NV_optimus:-NVIDIA_only}"  # Vulkan apps -> dGPU too
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
On Optimus laptops (Intel iGPU + NVIDIA dGPU in prime-select on-demand), the Wayland compositor and Xwayland run on the iGPU, so the Webots sim container defaulted to rendering on the weak Intel UHD — ~0.25x real-time, shared with rviz2. This adds three GLVND/Vulkan PRIME render-offload env vars to the sim service in compose.gpu.yaml so GL/Vulkan bind the (already-injected) NVIDIA vendor libraries and render on the dGPU instead. The vars are overridable and the file is only merged when nvidia-smi is present, so they're no-ops on single-GPU NVIDIA hosts and never reach pure Intel/AMD setups.