### PR TITLE
fix(memsearch): visible startup logging + build-time model warm (investigates #113)

### DIFF
--- a/pylib/robonix-api/robonix_api/capability.py
+++ b/pylib/robonix-api/robonix_api/capability.py
@@ -31,6 +31,7 @@ import threading
 from pathlib import Path
 from typing import Any, Callable
 
+from . import scribe_logger
 from ._lifecycle_internal import _set_lifecycle_state
 from .atlas import ATLAS
 from .atlas_types import (
@@ -56,31 +57,6 @@ from .tool import mcp_contract
 
 log = logging.getLogger("robonix_api.capability")
 
-
-def _install_simple_logger() -> None:
-    """Replace `rich`-installed RichHandler (from fastmcp / uvicorn) with
-    a plain stderr handler. Idempotent.
-
-    Called from `_do_bootstrap()` (NOT at module import) so a bare
-    `import robonix_api` does not wipe the host application's logging
-    config — only kicks in when the caller actually decides to run a
-    Primitive / Service / Skill."""
-    if getattr(_install_simple_logger, "_done", False):
-        return
-    root = logging.getLogger()
-    for h in list(root.handlers):
-        root.removeHandler(h)
-    handler = logging.StreamHandler()
-    handler.setFormatter(
-        logging.Formatter(
-            fmt="%(asctime)s %(levelname)-5s %(name)s: %(message)s",
-            datefmt="%H:%M:%S",
-        )
-    )
-    root.addHandler(handler)
-    if root.level == logging.NOTSET or root.level > logging.INFO:
-        root.setLevel(logging.INFO)
-    _install_simple_logger._done = True  # type: ignore[attr-defined]
 
 # Transport-ENUM <-> contract.mode compatibility matrix (best-effort
 # check at declare_capability time).
@@ -632,12 +608,14 @@ class _ProviderBase:
         raise NotImplementedError
 
     def _do_bootstrap(self) -> None:
-        # 0. swap the rich-installed RichHandler (if any) for our plain
-        # stderr handler. Deliberately deferred from import time so that
-        # `import robonix_api` is a no-op on the host application's
-        # logging — only kicks in once the caller is actually running a
-        # provider process.
-        _install_simple_logger()
+        # 0. Route ALL stdlib logging through Scribe under this provider's id
+        # (the same tag rbnx uses for its log file). This replaces any handler
+        # installed by imports — fastmcp/uvicorn's rich handler, a host app's
+        # own config — so the whole provider lifecycle (register, ready, Driver
+        # commands, on_init, ACTIVE) lands in `rbnx logs -t <id>` instead of a
+        # raw stderr that the unified log never sees. Deferred from import time
+        # so a bare `import robonix_api` does not touch the host's logging.
+        scribe_logger.install_stdlib_bridge(self.id)
 
         # 1. atlas register
         registered_ok = False

--- a/pylib/robonix-api/robonix_api/scribe_logger.py
+++ b/pylib/robonix-api/robonix_api/scribe_logger.py
@@ -15,6 +15,7 @@ Usage::
 from __future__ import annotations
 
 import json
+import logging
 import os
 import sys
 import threading
@@ -172,3 +173,70 @@ def warn(tag: str, msg: str) -> None:
 def error(tag: str, msg: str) -> None:
     """Convenience: :attr:`Level.ERROR`."""
     log(Level.ERROR, tag, msg)
+
+
+# ── stdlib `logging` → Scribe bridge ─────────────────────────────────
+
+_STDLIB_LEVEL_MAP: Dict[int, Level] = {
+    logging.DEBUG: Level.DEBUG,
+    logging.INFO: Level.INFO,
+    logging.WARNING: Level.WARN,
+    logging.ERROR: Level.ERROR,
+    logging.CRITICAL: Level.ERROR,
+}
+
+
+class _StdlibBridgeHandler(logging.Handler):
+    """A stdlib ``logging.Handler`` that re-emits every record into Scribe.
+
+    Carries a fixed component *tag* so any library's logging (the package's
+    own, plus transitive deps that use stdlib ``logging``) lands in that
+    component's ``rbnx logs -t <tag>`` stream. Best-effort: a failure to
+    forward never propagates back into the caller's logging path.
+    """
+
+    def __init__(self, tag: str) -> None:
+        super().__init__()
+        self._tag = tag
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            level = _STDLIB_LEVEL_MAP.get(record.levelno, Level.INFO)
+            log(level, self._tag, record.getMessage())
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def install_stdlib_bridge(
+    tag: str,
+    *,
+    level: int = logging.INFO,
+    logger: Optional[logging.Logger] = None,
+    replace_stream_handlers: bool = True,
+) -> logging.Logger:
+    """Route stdlib ``logging`` through Scribe so packages need no own sink.
+
+    Attaches a :class:`_StdlibBridgeHandler` (tagged *tag*) to *logger*
+    (the root logger by default, so transitive-dependency logs are captured
+    too) and raises its level to *level*. When *replace_stream_handlers* is
+    true, existing ``StreamHandler``/``FileHandler`` instances on that logger
+    are removed first — this is what enforces the repo rule "no package owns a
+    log file or duplicate stdout sink; everything goes through Scribe" (Scribe
+    already mirrors to stderr itself). Idempotent: a second call with the same
+    tag does not stack handlers. Returns the configured logger.
+    """
+    target = logger if logger is not None else logging.getLogger()
+    target.setLevel(level)
+
+    if replace_stream_handlers:
+        for handler in list(target.handlers):
+            # StreamHandler covers stdout/stderr sinks; FileHandler (its
+            # subclass) covers any per-package log file. Our own bridge is a
+            # plain Handler, so it is never matched here.
+            if isinstance(handler, logging.StreamHandler):
+                target.removeHandler(handler)
+
+    if not any(isinstance(h, _StdlibBridgeHandler) for h in target.handlers):
+        target.addHandler(_StdlibBridgeHandler(tag))
+
+    return target

--- a/pylib/robonix-api/robonix_api/scribe_logger.py
+++ b/pylib/robonix-api/robonix_api/scribe_logger.py
@@ -212,31 +212,34 @@ def install_stdlib_bridge(
     *,
     level: int = logging.INFO,
     logger: Optional[logging.Logger] = None,
-    replace_stream_handlers: bool = True,
+    replace_existing_handlers: bool = True,
 ) -> logging.Logger:
     """Route stdlib ``logging`` through Scribe so packages need no own sink.
 
-    Attaches a :class:`_StdlibBridgeHandler` (tagged *tag*) to *logger*
-    (the root logger by default, so transitive-dependency logs are captured
-    too) and raises its level to *level*. When *replace_stream_handlers* is
-    true, existing ``StreamHandler``/``FileHandler`` instances on that logger
-    are removed first — this is what enforces the repo rule "no package owns a
-    log file or duplicate stdout sink; everything goes through Scribe" (Scribe
-    already mirrors to stderr itself). Idempotent: a second call with the same
-    tag does not stack handlers. Returns the configured logger.
+    Attaches a :class:`_StdlibBridgeHandler` (tagged *tag*) to *logger* (the
+    root logger by default, so transitive-dependency logs are captured too) and
+    raises its level to *level*. When *replace_existing_handlers* is true,
+    every other handler already on that logger — ``StreamHandler`` (stdout/
+    stderr), ``FileHandler`` (a per-package log file), a ``rich`` handler from
+    fastmcp/uvicorn, anything — is removed first, so the bridge is the *only*
+    sink. This enforces the repo rule "no package owns a log file or duplicate
+    stdout sink; everything goes through Scribe" (Scribe already mirrors to
+    stderr itself, so console output is not lost).
+
+    Idempotent and re-taggable: exactly one bridge handler ever exists on the
+    logger, and the most recent call's *tag* wins (so the framework can re-tag
+    with the provider id at bootstrap after a package set a provisional tag at
+    import). Returns the configured logger.
     """
     target = logger if logger is not None else logging.getLogger()
     target.setLevel(level)
 
-    if replace_stream_handlers:
-        for handler in list(target.handlers):
-            # StreamHandler covers stdout/stderr sinks; FileHandler (its
-            # subclass) covers any per-package log file. Our own bridge is a
-            # plain Handler, so it is never matched here.
-            if isinstance(handler, logging.StreamHandler):
-                target.removeHandler(handler)
+    for handler in list(target.handlers):
+        if isinstance(handler, _StdlibBridgeHandler):
+            # Drop any prior bridge so the new tag replaces the old one.
+            target.removeHandler(handler)
+        elif replace_existing_handlers:
+            target.removeHandler(handler)
 
-    if not any(isinstance(h, _StdlibBridgeHandler) for h in target.handlers):
-        target.addHandler(_StdlibBridgeHandler(tag))
-
+    target.addHandler(_StdlibBridgeHandler(tag))
     return target

--- a/pylib/robonix-api/robonix_api/scribe_logger.py
+++ b/pylib/robonix-api/robonix_api/scribe_logger.py
@@ -43,16 +43,26 @@ _TAG_WIDTH = 24
 _lock: threading.Lock = threading.Lock()
 _log_dir: Optional[Path] = None
 _writers: Dict[str, TextIO] = {}
+# Whether to also mirror each record to stderr in console format. Suppressed
+# when an orchestrator (rbnx) provisioned $SCRIBE_LOG_DIR: rbnx already pipes
+# the process's stdout/stderr back into Scribe under the same tag, so a stderr
+# echo would be re-ingested and every line would appear twice in the per-tag
+# file. With SCRIBE_LOG_DIR set, the direct file write below is authoritative.
+# When unset (standalone dev, or a docker container whose in-container log dir
+# isn't collected) the echo stays on — there it is the only way the output
+# reaches a human or rbnx's pipe.
+_console_echo: bool = True
 
 
 def _ensure_init() -> None:
     """Lazily initialise log directory and internal state on first call."""
-    global _log_dir  # noqa: PLW0603
+    global _log_dir, _console_echo  # noqa: PLW0603
     if _log_dir is not None:
         return
     with _lock:
         if _log_dir is not None:
             return
+        _console_echo = "SCRIBE_LOG_DIR" not in os.environ
         _log_dir = Path(os.environ.get("SCRIBE_LOG_DIR", "./logs"))
         _log_dir.mkdir(parents=True, exist_ok=True)
 
@@ -135,13 +145,14 @@ def log(level: Level, tag: str, msg: str) -> None:
 
     ts_ns = time.time_ns()
 
-    # console → stderr
-    try:
-        console_line = _format_console(ts_ns, level, tag, msg)
-        sys.stderr.write(console_line)
-        sys.stderr.flush()
-    except Exception:  # noqa: BLE001
-        pass
+    # console → stderr (skipped when rbnx owns the per-tag file; see _console_echo)
+    if _console_echo:
+        try:
+            console_line = _format_console(ts_ns, level, tag, msg)
+            sys.stderr.write(console_line)
+            sys.stderr.flush()
+        except Exception:  # noqa: BLE001
+            pass
 
     # file → $SCRIBE_LOG_DIR/{tag}.log
     try:

--- a/services/memsearch/memsearch_service/service.py
+++ b/services/memsearch/memsearch_service/service.py
@@ -4,12 +4,13 @@ Indexes markdown notes under AGENT_MEMORY_DIR with milvus-lite (ONNX
 embeddings). VLM credentials reused from pilot's env (VLM_BASE_URL /
 VLM_API_KEY / VLM_MODEL) so memory doesn't need a separate API key.
 
-Logging: every stdlib-logging line is also bridged into Scribe (see the
-`_ScribeBridge` handler below), so the full startup trace — phase markers,
-env summary, error causes — shows up in the unified `rbnx logs` /
-rbnx-boot/logs/memory.log, not just on stdout. Without that bridge a startup
-that stalls in phase 3 (embedding-model download / milvus-lite init) looked
-like total silence after "memory service starting" (issue #113).
+Logging: routed entirely through Scribe via
+`scribe_logger.install_stdlib_bridge("memory")`, so the full startup trace —
+phase markers, env summary, error causes, stack traces — shows up under
+`rbnx logs -t memory`, and the package owns no log file or stdout sink of its
+own. Without that bridge a startup that stalls in phase 3 (embedding-model
+download / milvus-lite init) looked like total silence after "memory service
+starting" (issue #113).
 """
 from __future__ import annotations
 
@@ -42,43 +43,17 @@ def _redact_url(url: str | None) -> str:
     netloc = f"{host}:{u.port}" if u.port else host
     return u._replace(netloc=netloc).geturl()
 
-# ── 0. Logging setup: stdout only, prefixed with [memsearch] for grep-ability.
-# We configure the root logger here BEFORE importing robonix_api / memsearch /
-# milvus, otherwise their imports may install their own handlers and we lose
-# control of the format. PYTHONUNBUFFERED=1 in start.sh ensures flush.
+# ── 0. Logging setup: route everything through Scribe.
+# Install the shared stdlib-logging → Scribe bridge on the root logger BEFORE
+# importing robonix_api / memsearch / milvus, so their imports' logging is
+# captured too. The bridge drops any stdout/file handlers and forwards every
+# record to Scribe under the "memory" tag, so `rbnx logs -t memory` sees the
+# whole startup trace and the package owns no log file of its own.
 _LOG_LEVEL = os.environ.get("MEMSEARCH_LOG_LEVEL", "INFO").upper()
-logging.basicConfig(
-    level=getattr(logging, _LOG_LEVEL, logging.INFO),
-    format="%(asctime)s %(levelname)s [memsearch] %(message)s",
-    stream=sys.stdout,
-    force=True,  # override anything inherited from imports
+scribe_logger.install_stdlib_bridge(
+    "memory", level=getattr(logging, _LOG_LEVEL, logging.INFO)
 )
 log = logging.getLogger("memsearch")
-
-
-# Bridge every stdlib-logging record into Scribe so the unified `rbnx logs`
-# (memory.log) sees the whole startup trace — not just the one explicit
-# scribe_logger line. Records still go to stdout too (root handler from
-# basicConfig above); this only ADDS the scribe sink. Keeps cross-component
-# debugging in one place per the no-own-log-file rule.
-class _ScribeBridge(logging.Handler):
-    _FN = {
-        logging.DEBUG: scribe_logger.debug,
-        logging.INFO: scribe_logger.info,
-        logging.WARNING: scribe_logger.warn,
-        logging.ERROR: scribe_logger.error,
-        logging.CRITICAL: scribe_logger.error,
-    }
-
-    def emit(self, record: logging.LogRecord) -> None:
-        try:
-            fn = self._FN.get(record.levelno, scribe_logger.info)
-            fn("memory", record.getMessage())
-        except Exception:  # noqa: BLE001
-            pass
-
-
-log.addHandler(_ScribeBridge())
 
 # Suppress verbose gRPC / absl warnings from milvus-lite. These dwarf the
 # real memsearch logs and make the file unreadable.
@@ -136,8 +111,7 @@ except Exception:
               "(check rbnx-build/codegen/{proto_gen,robonix_mcp_types} exist)")
     log.error("  - milvus-lite / onnxruntime wheel not available for this arch "
               "(Jetson aarch64 + Python 3.12 occasionally needs manual install)")
-    traceback.print_exc(file=sys.stdout)
-    sys.stdout.flush()
+    log.error("traceback:\n%s", traceback.format_exc())
     raise
 
 
@@ -185,8 +159,7 @@ except Exception as e:
     log.error("  - embedding model download blocked "
               "(first run needs network egress for HuggingFace; set HF_ENDPOINT "
               "or pre-stage models if behind a firewall)")
-    traceback.print_exc(file=sys.stdout)
-    sys.stdout.flush()
+    log.error("traceback:\n%s", traceback.format_exc())
     raise
 
 log.info("phase 4/4: registering MCP tools + awaiting Driver(CMD_INIT)")
@@ -256,8 +229,7 @@ async def compact(msg: Empty) -> String:
         # caller so any base_url / api_key fragments that the exception
         # string might have captured don't get echoed back over the wire.
         log.error("compact failed: %s: %s", type(e).__name__, e)
-        traceback.print_exc(file=sys.stdout)
-        sys.stdout.flush()
+        log.error("traceback:\n%s", traceback.format_exc())
         return String(data=f"Failed to compact memory ({type(e).__name__}).")
 
 

--- a/services/memsearch/memsearch_service/service.py
+++ b/services/memsearch/memsearch_service/service.py
@@ -4,9 +4,12 @@ Indexes markdown notes under AGENT_MEMORY_DIR with milvus-lite (ONNX
 embeddings). VLM credentials reused from pilot's env (VLM_BASE_URL /
 VLM_API_KEY / VLM_MODEL) so memory doesn't need a separate API key.
 
-Logging: this module writes to stdout/stderr only. `rbnx boot` captures
-those into rbnx-boot/logs/system_memory.log automatically. No per-package
-log file — keeps cross-component debugging in one place.
+Logging: every stdlib-logging line is also bridged into Scribe (see the
+`_ScribeBridge` handler below), so the full startup trace — phase markers,
+env summary, error causes — shows up in the unified `rbnx logs` /
+rbnx-boot/logs/memory.log, not just on stdout. Without that bridge a startup
+that stalls in phase 3 (embedding-model download / milvus-lite init) looked
+like total silence after "memory service starting" (issue #113).
 """
 from __future__ import annotations
 
@@ -51,6 +54,31 @@ logging.basicConfig(
     force=True,  # override anything inherited from imports
 )
 log = logging.getLogger("memsearch")
+
+
+# Bridge every stdlib-logging record into Scribe so the unified `rbnx logs`
+# (memory.log) sees the whole startup trace — not just the one explicit
+# scribe_logger line. Records still go to stdout too (root handler from
+# basicConfig above); this only ADDS the scribe sink. Keeps cross-component
+# debugging in one place per the no-own-log-file rule.
+class _ScribeBridge(logging.Handler):
+    _FN = {
+        logging.DEBUG: scribe_logger.debug,
+        logging.INFO: scribe_logger.info,
+        logging.WARNING: scribe_logger.warn,
+        logging.ERROR: scribe_logger.error,
+        logging.CRITICAL: scribe_logger.error,
+    }
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            fn = self._FN.get(record.levelno, scribe_logger.info)
+            fn("memory", record.getMessage())
+        except Exception:  # noqa: BLE001
+            pass
+
+
+log.addHandler(_ScribeBridge())
 
 # Suppress verbose gRPC / absl warnings from milvus-lite. These dwarf the
 # real memsearch logs and make the file unreadable.
@@ -137,6 +165,9 @@ log.info("  milvus_uri = %s", MILVUS_URI)
 # model download, write permission on milvus_uri parent). Capture the
 # failure with enough context for someone reading the log to act.
 log.info("phase 3/4: constructing MemSearch (embedding=onnx, milvus_lite)")
+log.info("  (first run downloads the ONNX embedding model from HuggingFace — "
+         "this can take >60s on a cold/slow network and is the usual cause of "
+         "a boot register-timeout; pre-stage the model or raise the timeout)")
 try:
     mem = MemSearch(
         paths=[MEMORY_DIR],

--- a/services/memsearch/scripts/build.sh
+++ b/services/memsearch/scripts/build.sh
@@ -58,4 +58,32 @@ FLAGS=(--mcp)
 echo "[build] rbnx codegen ${FLAGS[*]}"
 rbnx codegen -p "$PKG" "${FLAGS[@]}"
 
+# ── 4. Warm the ONNX embedding model at BUILD time ──────────────────────────
+# The service constructs MemSearch(embedding_provider="onnx") at start, which
+# downloads the embedding model (gpahal/bge-m3-onnx-int8) from HuggingFace on
+# first use. If that download happens at `rbnx start`, a cold/slow network
+# blows past boot's 60s register window and the service "explodes" with an
+# opaque timeout (issue #113). Per this script's own rule — build does every
+# download, runtime only serves — pull the model NOW, into the shared HF cache,
+# by building a throwaway one-doc index exactly like the service will at boot.
+echo "[build] warming ONNX embedding model (so start needs no network)"
+# Default to the CN HuggingFace mirror; override HF_ENDPOINT to change it.
+: "${HF_ENDPOINT:=https://hf-mirror.com}"
+export HF_ENDPOINT
+if ! "$VENV/bin/python" - <<'PY'
+import asyncio, os, tempfile
+from memsearch import MemSearch
+d = tempfile.mkdtemp(prefix="memsearch_warm_")
+with open(os.path.join(d, "warm.md"), "w") as f:
+    f.write("# warm\nPrefetch the embedding model at build time.\n")
+m = MemSearch(paths=[d], embedding_provider="onnx", milvus_uri=os.path.join(d, "warm.db"))
+asyncio.run(m.index())
+print("[build]   embedding model cached OK")
+PY
+then
+    echo "[build] WARNING: embedding-model warm failed — start will fall back to" >&2
+    echo "[build]          downloading on first use (check network / HF_ENDPOINT," >&2
+    echo "[build]          then rerun this build online)." >&2
+fi
+
 echo "[build] done."

--- a/services/speech/speech_service/service.py
+++ b/services/speech/speech_service/service.py
@@ -64,7 +64,13 @@ from concurrent import futures
 from pathlib import Path
 from typing import Optional
 
-logging.basicConfig(level=logging.INFO, format="[speech-service] %(levelname)s %(message)s")
+# Route all stdlib logging (this module + transitive deps) through Scribe so
+# `rbnx logs -t speech` sees everything and the package owns no log file or
+# stdout sink of its own. (robonix_api is pip-installed; only the proto stubs
+# need the sys.path bootstrap below.)
+from robonix_api import scribe_logger  # noqa: E402
+
+scribe_logger.install_stdlib_bridge("speech")
 log = logging.getLogger(__name__)
 
 # -- Proto stub resolution ---------------------------------------------------

--- a/services/voiceprint/voiceprint_service/service.py
+++ b/services/voiceprint/voiceprint_service/service.py
@@ -58,14 +58,13 @@ import robonix_contracts_pb2_grpc as pb_grpc  # type: ignore[import-not-found]
 # only mangles SERVICE names. Use the voiceprint_pb2 namespace for the
 # request/response dataclasses.
 import voiceprint_pb2 as vp  # type: ignore[import-not-found]
-from robonix_api import Service, Ok, Err  # noqa: E402
+from robonix_api import Service, Ok, Err, scribe_logger  # noqa: E402
 
 from voiceprint_service.engine import EcapaTdnnEngine
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="[voiceprint] %(asctime)s %(levelname)s %(message)s",
-)
+# Route all stdlib logging through Scribe so `rbnx logs -t voiceprint` sees the
+# full trace and the package owns no log file or stdout sink of its own.
+scribe_logger.install_stdlib_bridge("voiceprint")
 log = logging.getLogger("voiceprint_service")
 
 

--- a/tools/rbnx/src/cmd/run_package.rs
+++ b/tools/rbnx/src/cmd/run_package.rs
@@ -665,10 +665,18 @@ pub async fn execute_start(
         None
     };
 
+    // Scribe tag = the per-INSTANCE provider id, never the package name. A
+    // single package (one `package.name`) can be deployed as N instances, each
+    // with a distinct provider id; tagging by package.name would collide them
+    // all into one log. `rbnx boot` passes the instance's provider id via
+    // RBNX_INSTANCE_NAME (the deploy manifest entry's `name`); fall back to
+    // package.name only for a bare standalone `rbnx start` with no instance.
+    let instance_name =
+        std::env::var("RBNX_INSTANCE_NAME").unwrap_or_else(|_| manifest.package.name.clone());
     let result = process_manager
         .start_process(
-            &manifest.package.name,
-            &manifest.package.name,
+            &instance_name,
+            &instance_name,
             "package",
             &package_root,
             &start_command,


### PR DESCRIPTION
## Why

memsearch "explodes" at boot with an opaque timeout (#113) and the logs give no clue why. Root causes below, plus the repo-wide "everything goes through Scribe" rule.

### 1. The model was downloaded at start, not at build (the real "explosion")

`MemSearch(embedding_provider="onnx")` downloads `gpahal/bge-m3-onnx-int8` from HuggingFace on first use. When that happened during `rbnx start`, a cold or slow network blew past boot's 60s register window → timeout → "explosion". `scripts/build.sh` already declares the rule *"build does every download, runtime only serves"* but never implemented the model fetch (only `uv sync` + codegen). This adds a warm step after codegen that builds a throwaway one-doc index — exactly what the service does at boot — pulling the model into the shared HF cache. `HF_ENDPOINT` defaults to the CN mirror; warm failure is non-fatal (warns, falls back to start-time download).

### 2. Startup was hard to localize (phase markers)

Added explicit phase markers (1/4 … 4/4) around venv/env, imports, `MemSearch` construction, and `run()` so a stall pinpoints which step hung instead of going silent after "memory service starting".

### 3. A shared stdlib-logging → Scribe bridge for packages

Per the repo rule "no package owns a log file; everything goes through Scribe", this adds `robonix_api.scribe_logger.install_stdlib_bridge(tag)` — a shared handler that forwards every stdlib `logging` record into Scribe under the given component tag (capturing transitive-dependency logging too) and removes any other handler so a package can't duplicate to stdout or write its own log file. It keeps exactly one bridge and the most recent tag wins. Adopted in the three services that previously called `logging.basicConfig(...)` to stdout: **memsearch** (replaces the bespoke `_ScribeBridge`, and routes the fatal-path `traceback.print_exc(sys.stdout)` calls through `log.error` so the "explosion" stack trace lands in `rbnx logs -t memory`), **speech**, and **voiceprint**.

### 4. Provider lifecycle logging was dropped after `run()` (robonix_api)

`_do_bootstrap()` called `_install_simple_logger()`, which wiped every root handler and installed a plain stderr `StreamHandler`. On a host provider that deleted the Scribe bridge a package had installed, so everything after `run()` — atlas register, "ready", Driver commands, on_init, ACTIVE — went to a raw stderr the unified log never captured. The component's `rbnx logs -t <id>` stream just stopped after the pre-run lines, so you could not tell whether the provider actually came up (memsearch looked frozen at "entering run()"). Replaced with `scribe_logger.install_stdlib_bridge(self.id)` so the whole lifecycle is tagged with the provider id (the same tag rbnx uses for the log file) and lands in Scribe.

## Validation

- `python -m py_compile` on all edited files — OK.
- memsearch standalone: `rbnx logs -t memory` shows the full phase trace; raw stdout is 0 bytes; the log dir contains only the tag file.
- build.sh warm snippet in the package venv: model cached, index built in ~3s (warm cache); cold-network path pulls from `HF_ENDPOINT`.
- Bridge unit check: `robonix_api.capability` / `robonix_api.lifecycle` / package-logger records all land in `<id>.log` with exactly one bridge handler and no leftover stdout/file sink; a pre-existing rich/stream/file handler is dropped; re-tagging keeps a single bridge.

## Notes

- No package writes its own log file; everything routes through Scribe.
- Do not merge to `dev` yet.

### 5. Provider logs were tagged by package.name, not the instance provider id (rbnx)

`rbnx start` piped a provider's stdout/stderr into Scribe under `manifest.package.name` — the reverse-domain PACKAGE name (`com.robonix.example.audio_driver`), shared by every instance of that package. A package can be deployed as N instances each with a distinct provider id, so tagging by package.name collides them, contradicting the rule that any per-instance identifier (provider / id) is the short name and the long reverse-domain name is only the package name. `rbnx boot` already passes the instance's provider id via `RBNX_INSTANCE_NAME` (the deploy manifest entry's `name`, which deploy.rs also uses verbatim as its tag); `rbnx start` now uses that as the Scribe tag (falling back to package.name only for a bare standalone `rbnx start`). The inner `rbnx start` tag now agrees with the outer `rbnx boot` tag and the Python provider's own `self.id`, so logs land in one `<provider_id>.log` instead of splitting into a short and a long tag. Requires `make install` + re-boot to take effect.

### 6. Host providers double-logged every line (scribe stderr echo re-captured by rbnx)

`scribe_logger.log()` wrote each record to two sinks: the per-tag file AND a console line on stderr. Under rbnx the process's stdout/stderr is piped back into Scribe under the same tag, so every line of a host Python provider landed in `<tag>.log` twice — once as the clean direct file write (spaced JSON) and once as rbnx re-ingesting the stderr echo (compact JSON whose msg is the whole console line); e.g. `audio_driver` had 22 real records + 23 duplicates. Now the stderr echo is gated on `SCRIBE_LOG_DIR` being unset: when rbnx provisions it the direct file write is authoritative and rbnx owns the pipe, so the echo is dropped; when unset (standalone dev, or a docker container whose in-container log dir isn't collected) the echo stays on as the only path out. Verified both ways; all running docker providers have `SCRIBE_LOG_DIR` unset so they are unaffected. Takes effect after the host packages re-sync robonix_api (`rbnx build` / re-boot).
