### PR TITLE
docs: generate contract descriptions from TOML

### DIFF
--- a/capabilities/primitive/audio/driver.v1.toml
+++ b/capabilities/primitive/audio/driver.v1.toml
@@ -7,6 +7,7 @@ id      = "robonix/primitive/audio/driver"
 version = "1"
 kind    = "primitive"
 idl     = "lifecycle/srv/Driver.srv"
+description = "Lifecycle control interface for audio primitive providers."
 
 [mode]
 type = "rpc"

--- a/capabilities/primitive/audio/list_devices.v1.toml
+++ b/capabilities/primitive/audio/list_devices.v1.toml
@@ -20,6 +20,7 @@ id      = "robonix/primitive/audio/list_devices"
 version = "1"
 kind    = "primitive"
 idl     = "audio/srv/ListAudioDevices.srv"
+description = "List audio input and output devices visible to the audio primitive."
 
 [mode]
 type = "rpc"

--- a/capabilities/primitive/audio/mic.v1.toml
+++ b/capabilities/primitive/audio/mic.v1.toml
@@ -4,6 +4,7 @@ id      = "robonix/primitive/audio/mic"
 version = "1"
 kind    = "primitive"
 idl     = "audio/msg/AudioChunk.msg"
+description = "Continuous microphone audio stream produced by an audio input primitive."
 
 [mode]
 type = "topic_out"

--- a/capabilities/primitive/audio/select_device.v1.toml
+++ b/capabilities/primitive/audio/select_device.v1.toml
@@ -9,6 +9,7 @@ id      = "robonix/primitive/audio/select_device"
 version = "1"
 kind    = "primitive"
 idl     = "audio/srv/SelectAudioDevice.srv"
+description = "Select the active audio input or output device used by an audio primitive."
 
 [mode]
 type = "rpc"

--- a/capabilities/primitive/audio/speaker.v1.toml
+++ b/capabilities/primitive/audio/speaker.v1.toml
@@ -4,6 +4,7 @@ id      = "robonix/primitive/audio/speaker"
 version = "1"
 kind    = "primitive"
 idl     = "audio/msg/AudioChunk.msg"
+description = "Audio playback stream consumed by an audio output primitive."
 
 [mode]
 type = "topic_in"

--- a/capabilities/primitive/camera/depth.v1.toml
+++ b/capabilities/primitive/camera/depth.v1.toml
@@ -4,6 +4,7 @@ id      = "robonix/primitive/camera/depth"
 version = "1"
 kind    = "primitive"
 idl     = "common_interfaces/sensor_msgs/msg/Image.msg"
+description = "Continuous depth image stream from a camera primitive."
 
 [mode]
 type = "topic_out"

--- a/capabilities/primitive/camera/depth_snapshot.v1.toml
+++ b/capabilities/primitive/camera/depth_snapshot.v1.toml
@@ -5,6 +5,7 @@ id      = "robonix/primitive/camera/depth_snapshot"
 version = "1"
 kind    = "primitive"
 idl     = "camera/srv/GetCameraImage.srv"
+description = "Capture one depth image frame on demand."
 
 [mode]
 type = "rpc"

--- a/capabilities/primitive/camera/driver.v1.toml
+++ b/capabilities/primitive/camera/driver.v1.toml
@@ -6,6 +6,7 @@ id      = "robonix/primitive/camera/driver"
 version = "1"
 kind    = "primitive"
 idl     = "lifecycle/srv/Driver.srv"
+description = "Lifecycle control interface for camera primitive providers."
 
 [mode]
 type = "rpc"

--- a/capabilities/primitive/camera/extrinsics.v1.toml
+++ b/capabilities/primitive/camera/extrinsics.v1.toml
@@ -31,6 +31,7 @@ id      = "robonix/primitive/camera/extrinsics"
 version = "1"
 kind    = "primitive"
 idl     = "common_interfaces/geometry_msgs/msg/TransformStamped.msg"
+description = "Static transform from the robot body frame to the camera optical frame."
 
 [mode]
 type = "topic_out"

--- a/capabilities/primitive/camera/intrinsics.v1.toml
+++ b/capabilities/primitive/camera/intrinsics.v1.toml
@@ -27,6 +27,7 @@ id      = "robonix/primitive/camera/intrinsics"
 version = "1"
 kind    = "primitive"
 idl     = "common_interfaces/sensor_msgs/msg/CameraInfo.msg"
+description = "Camera calibration and image geometry used for projection and 3D reconstruction."
 
 [mode]
 type = "topic_out"

--- a/capabilities/primitive/camera/rgb.v1.toml
+++ b/capabilities/primitive/camera/rgb.v1.toml
@@ -4,6 +4,7 @@ id      = "robonix/primitive/camera/rgb"
 version = "1"
 kind    = "primitive"
 idl     = "common_interfaces/sensor_msgs/msg/Image.msg"
+description = "Continuous RGB image stream from a camera primitive."
 
 [mode]
 type = "topic_out"

--- a/capabilities/primitive/camera/snapshot.v1.toml
+++ b/capabilities/primitive/camera/snapshot.v1.toml
@@ -5,6 +5,7 @@ id      = "robonix/primitive/camera/snapshot"
 version = "1"
 kind    = "primitive"
 idl     = "camera/srv/GetCameraImage.srv"
+description = "Capture one RGB image frame on demand."
 
 [mode]
 type = "rpc"

--- a/capabilities/primitive/chassis/driver.v1.toml
+++ b/capabilities/primitive/chassis/driver.v1.toml
@@ -6,6 +6,7 @@ id      = "robonix/primitive/chassis/driver"
 version = "1"
 kind    = "primitive"
 idl     = "lifecycle/srv/Driver.srv"
+description = "Lifecycle control interface for chassis primitive providers."
 
 [mode]
 type = "rpc"

--- a/capabilities/primitive/chassis/move.v1.toml
+++ b/capabilities/primitive/chassis/move.v1.toml
@@ -8,6 +8,7 @@ id      = "robonix/primitive/chassis/move"
 version = "1"
 kind    = "primitive"
 idl     = "chassis/srv/ExecuteMoveCommand.srv"
+description = "Low-level bounded chassis motion command without global path planning."
 
 [mode]
 type = "rpc"

--- a/capabilities/primitive/chassis/odom.v1.toml
+++ b/capabilities/primitive/chassis/odom.v1.toml
@@ -4,6 +4,7 @@ id      = "robonix/primitive/chassis/odom"
 version = "1"
 kind    = "primitive"
 idl     = "common_interfaces/nav_msgs/msg/Odometry.msg"
+description = "Raw chassis odometry in the local odom frame."
 
 [mode]
 type = "topic_out"

--- a/capabilities/primitive/chassis/twist_in.v1.toml
+++ b/capabilities/primitive/chassis/twist_in.v1.toml
@@ -3,6 +3,7 @@ id      = "robonix/primitive/chassis/twist_in"
 version = "1"
 kind    = "primitive"
 idl     = "common_interfaces/geometry_msgs/msg/Twist.msg"
+description = "Velocity command input consumed by a chassis controller."
 
 [mode]
 type = "topic_in"

--- a/capabilities/primitive/imu/driver.v1.toml
+++ b/capabilities/primitive/imu/driver.v1.toml
@@ -3,6 +3,7 @@ id      = "robonix/primitive/imu/driver"
 version = "1"
 kind    = "primitive"
 idl     = "lifecycle/srv/Driver.srv"
+description = "Lifecycle control interface for IMU primitive providers."
 
 [mode]
 type = "rpc"

--- a/capabilities/primitive/imu/imu.v1.toml
+++ b/capabilities/primitive/imu/imu.v1.toml
@@ -4,6 +4,7 @@ id      = "robonix/primitive/imu/imu"
 version = "1"
 kind    = "primitive"
 idl     = "common_interfaces/sensor_msgs/msg/Imu.msg"
+description = "Continuous inertial measurement stream from an IMU primitive."
 
 [mode]
 type = "topic_out"

--- a/capabilities/primitive/lidar/driver.v1.toml
+++ b/capabilities/primitive/lidar/driver.v1.toml
@@ -3,6 +3,7 @@ id      = "robonix/primitive/lidar/driver"
 version = "1"
 kind    = "primitive"
 idl     = "lifecycle/srv/Driver.srv"
+description = "Lifecycle control interface for lidar primitive providers."
 
 [mode]
 type = "rpc"

--- a/capabilities/primitive/lidar/lidar.v1.toml
+++ b/capabilities/primitive/lidar/lidar.v1.toml
@@ -3,6 +3,7 @@ id      = "robonix/primitive/lidar/lidar"
 version = "1"
 kind    = "primitive"
 idl     = "common_interfaces/sensor_msgs/msg/LaserScan.msg"
+description = "Continuous 2D laser scan stream from a lidar primitive."
 
 [mode]
 type = "topic_out"

--- a/capabilities/primitive/lidar/lidar3d.v1.toml
+++ b/capabilities/primitive/lidar/lidar3d.v1.toml
@@ -3,6 +3,7 @@ id      = "robonix/primitive/lidar/lidar3d"
 version = "1"
 kind    = "primitive"
 idl     = "common_interfaces/sensor_msgs/msg/PointCloud2.msg"
+description = "Continuous 3D point cloud stream from a lidar primitive."
 
 [mode]
 type = "topic_out"

--- a/capabilities/primitive/lidar/lidar_snapshot.v1.toml
+++ b/capabilities/primitive/lidar/lidar_snapshot.v1.toml
@@ -3,6 +3,7 @@ id      = "robonix/primitive/lidar/snapshot"
 version = "1"
 kind    = "primitive"
 idl     = "lidar/srv/GetLaserScan.srv"
+description = "Capture one 2D laser scan on demand."
 
 [mode]
 type = "rpc"

--- a/capabilities/service/map/delete_map.v1.toml
+++ b/capabilities/service/map/delete_map.v1.toml
@@ -5,6 +5,7 @@ id      = "robonix/service/map/delete_map"
 version = "1"
 kind    = "service"
 idl     = "map/srv/DeleteMap.srv"
+description = "Delete a saved map and its persisted artifacts by map id."
 
 [mode]
 type = "rpc"

--- a/capabilities/service/map/driver.v1.toml
+++ b/capabilities/service/map/driver.v1.toml
@@ -7,6 +7,7 @@ id      = "robonix/service/map/driver"
 version = "1"
 kind    = "service"
 idl     = "lifecycle/srv/Driver.srv"
+description = "Lifecycle control interface for map service providers."
 
 [mode]
 type = "rpc"

--- a/capabilities/service/map/get_mode.v1.toml
+++ b/capabilities/service/map/get_mode.v1.toml
@@ -5,6 +5,7 @@ id      = "robonix/service/map/get_mode"
 version = "1"
 kind    = "service"
 idl     = "map/srv/GetMode.srv"
+description = "Read whether the map service is currently mapping or localizing."
 
 [mode]
 type = "rpc"

--- a/capabilities/service/map/get_pose.v1.toml
+++ b/capabilities/service/map/get_pose.v1.toml
@@ -6,6 +6,7 @@ id      = "robonix/service/map/get_pose"
 version = "1"
 kind    = "service"
 idl     = "map/srv/GetPose.srv"
+description = "Read the robot pose in the map frame as scalar x, y, and yaw."
 
 [mode]
 type = "rpc"

--- a/capabilities/service/map/load_map.v1.toml
+++ b/capabilities/service/map/load_map.v1.toml
@@ -6,6 +6,7 @@ id      = "robonix/service/map/load_map"
 version = "1"
 kind    = "service"
 idl     = "map/srv/LoadMap.srv"
+description = "Load a saved map for localization or continued mapping."
 
 [mode]
 type = "rpc"

--- a/capabilities/service/map/occupancy_grid.v1.toml
+++ b/capabilities/service/map/occupancy_grid.v1.toml
@@ -5,6 +5,7 @@ id      = "robonix/service/map/occupancy_grid"
 version = "1"
 kind    = "service"
 idl     = "common_interfaces/nav_msgs/msg/OccupancyGrid.msg"
+description = "2D occupancy grid output produced by the mapping service."
 
 [mode]
 type = "topic_out"

--- a/capabilities/service/map/odom.v1.toml
+++ b/capabilities/service/map/odom.v1.toml
@@ -15,6 +15,7 @@ id      = "robonix/service/map/odom"
 version = "1"
 kind    = "service"
 idl     = "common_interfaces/nav_msgs/msg/Odometry.msg"
+description = "Continuous SLAM or localization odometry suitable for controllers."
 
 [mode]
 type = "topic_out"

--- a/capabilities/service/map/pointcloud.v1.toml
+++ b/capabilities/service/map/pointcloud.v1.toml
@@ -5,6 +5,7 @@ id      = "robonix/service/map/pointcloud"
 version = "1"
 kind    = "service"
 idl     = "common_interfaces/sensor_msgs/msg/PointCloud2.msg"
+description = "Registered world-frame point cloud output from the mapping service."
 
 [mode]
 type = "topic_out"

--- a/capabilities/service/map/pose.v1.toml
+++ b/capabilities/service/map/pose.v1.toml
@@ -10,6 +10,7 @@ id      = "robonix/service/map/pose"
 version = "1"
 kind    = "service"
 idl     = "common_interfaces/geometry_msgs/msg/PoseWithCovarianceStamped.msg"
+description = "Canonical map-frame robot pose produced by localization or SLAM."
 
 [mode]
 type = "topic_out"

--- a/capabilities/service/map/pose_estimate.v1.toml
+++ b/capabilities/service/map/pose_estimate.v1.toml
@@ -7,6 +7,7 @@ id      = "robonix/service/map/pose_estimate"
 version = "1"
 kind    = "service"
 idl     = "map/srv/PoseEstimate.srv"
+description = "Seed or reset localization with a map-frame pose estimate."
 
 [mode]
 type = "rpc"

--- a/capabilities/service/map/reset_map.v1.toml
+++ b/capabilities/service/map/reset_map.v1.toml
@@ -5,6 +5,7 @@ id      = "robonix/service/map/reset_map"
 version = "1"
 kind    = "service"
 idl     = "map/srv/ResetMap.srv"
+description = "Clear the live map state without deleting persisted maps."
 
 [mode]
 type = "rpc"

--- a/capabilities/service/map/save_map.v1.toml
+++ b/capabilities/service/map/save_map.v1.toml
@@ -6,6 +6,7 @@ id      = "robonix/service/map/save_map"
 version = "1"
 kind    = "service"
 idl     = "map/srv/SaveMap.srv"
+description = "Persist the current map under a stable map id."
 
 [mode]
 type = "rpc"

--- a/capabilities/service/map/switch_mode.v1.toml
+++ b/capabilities/service/map/switch_mode.v1.toml
@@ -7,6 +7,7 @@ id      = "robonix/service/map/switch_mode"
 version = "1"
 kind    = "service"
 idl     = "map/srv/SwitchMode.srv"
+description = "Switch the running map service between mapping and localization modes."
 
 [mode]
 type = "rpc"

--- a/capabilities/service/memory/compact.v1.toml
+++ b/capabilities/service/memory/compact.v1.toml
@@ -3,6 +3,7 @@ id      = "robonix/service/memory/compact"
 version = "1"
 kind    = "service"
 idl     = "memory/srv/Compact.srv"
+description = "Compact long-term memory into a shorter summary."
 
 [mode]
 type = "rpc"

--- a/capabilities/service/memory/save.v1.toml
+++ b/capabilities/service/memory/save.v1.toml
@@ -3,6 +3,7 @@ id      = "robonix/service/memory/save"
 version = "1"
 kind    = "service"
 idl     = "memory/srv/Save.srv"
+description = "Persist a fact, preference, or note into long-term memory."
 
 [mode]
 type = "rpc"

--- a/capabilities/service/memory/search.v1.toml
+++ b/capabilities/service/memory/search.v1.toml
@@ -3,6 +3,7 @@ id      = "robonix/service/memory/search"
 version = "1"
 kind    = "service"
 idl     = "memory/srv/Search.srv"
+description = "Search long-term memory for entries relevant to a query."
 
 [mode]
 type = "rpc"

--- a/capabilities/service/navigation/driver.v1.toml
+++ b/capabilities/service/navigation/driver.v1.toml
@@ -7,6 +7,7 @@ id      = "robonix/service/navigation/driver"
 version = "1"
 kind    = "service"
 idl     = "lifecycle/srv/Driver.srv"
+description = "Lifecycle control interface for navigation service providers."
 
 [mode]
 type = "rpc"

--- a/capabilities/service/navigation/navigate.v1.toml
+++ b/capabilities/service/navigation/navigate.v1.toml
@@ -5,6 +5,7 @@ id      = "robonix/service/navigation/navigate"
 version = "1"
 kind    = "service"
 idl     = "navigation/srv/Navigate.srv"
+description = "Navigate the robot to a target pose using planning and obstacle avoidance."
 
 [mode]
 type = "rpc"

--- a/capabilities/service/navigation/navigate/cancel.v1.toml
+++ b/capabilities/service/navigation/navigate/cancel.v1.toml
@@ -5,6 +5,7 @@ id      = "robonix/service/navigation/navigate/cancel"
 version = "1"
 kind    = "service"
 idl     = "navigation/srv/CancelNavigation.srv"
+description = "Cancel a previously accepted navigation run."
 
 [mode]
 type = "rpc"

--- a/capabilities/service/navigation/navigate/status.v1.toml
+++ b/capabilities/service/navigation/navigate/status.v1.toml
@@ -6,6 +6,7 @@ id      = "robonix/service/navigation/navigate/status"
 version = "1"
 kind    = "service"
 idl     = "navigation/srv/GetNavigationStatus.srv"
+description = "Read status for a previously accepted navigation run."
 
 [mode]
 type = "rpc"

--- a/capabilities/service/speech/asr.v1.toml
+++ b/capabilities/service/speech/asr.v1.toml
@@ -6,6 +6,7 @@ id      = "robonix/service/speech/asr"
 version = "1"
 kind    = "service"
 idl     = "asr/srv/Recognize.srv"
+description = "Recognize speech from one audio buffer."
 
 [mode]
 type = "rpc"

--- a/capabilities/service/speech/asr_stream.v1.toml
+++ b/capabilities/service/speech/asr_stream.v1.toml
@@ -5,6 +5,7 @@ id      = "robonix/service/speech/asr_stream"
 version = "1"
 kind    = "service"
 idl     = "asr/srv/RecognizeStream.srv"
+description = "Streaming speech recognition over an audio chunk stream."
 
 [mode]
 type = "rpc_bidirectional_stream"

--- a/capabilities/service/speech/dialog.v1.toml
+++ b/capabilities/service/speech/dialog.v1.toml
@@ -6,6 +6,7 @@ id      = "robonix/service/speech/dialog"
 version = "1"
 kind    = "service"
 idl     = "speech/srv/StartDialog.srv"
+description = "Run a voice dialog session that coordinates speech input and output."
 
 [mode]
 type = "rpc_server_stream"

--- a/capabilities/service/speech/driver.v1.toml
+++ b/capabilities/service/speech/driver.v1.toml
@@ -8,6 +8,7 @@ id      = "robonix/service/speech/driver"
 version = "1"
 kind    = "service"
 idl     = "lifecycle/srv/Driver.srv"
+description = "Lifecycle control interface for speech service providers."
 
 [mode]
 type = "rpc"

--- a/capabilities/service/speech/list_speakers.v1.toml
+++ b/capabilities/service/speech/list_speakers.v1.toml
@@ -5,6 +5,7 @@ id      = "robonix/service/speech/list_speakers"
 version = "1"
 kind    = "service"
 idl     = "speech/srv/ListSpeakers.srv"
+description = "List speaker playback targets available for speech output."
 
 [mode]
 type = "rpc"

--- a/capabilities/service/speech/speak.v1.toml
+++ b/capabilities/service/speech/speak.v1.toml
@@ -5,6 +5,7 @@ id      = "robonix/service/speech/speak"
 version = "1"
 kind    = "service"
 idl     = "speech/srv/Speak.srv"
+description = "Speak text aloud through a selected audio output target."
 
 [mode]
 type = "rpc"

--- a/capabilities/service/speech/tts.v1.toml
+++ b/capabilities/service/speech/tts.v1.toml
@@ -6,6 +6,7 @@ id      = "robonix/service/speech/tts"
 version = "1"
 kind    = "service"
 idl     = "tts/srv/Synthesize.srv"
+description = "Synthesize one text input into audio."
 
 [mode]
 type = "rpc"

--- a/capabilities/service/speech/tts_stream.v1.toml
+++ b/capabilities/service/speech/tts_stream.v1.toml
@@ -5,6 +5,7 @@ id      = "robonix/service/speech/tts_stream"
 version = "1"
 kind    = "service"
 idl     = "tts/srv/SynthesizeStream.srv"
+description = "Streaming text-to-speech synthesis that returns audio chunks."
 
 [mode]
 type = "rpc_server_stream"

--- a/capabilities/service/voiceprint/delete.v1.toml
+++ b/capabilities/service/voiceprint/delete.v1.toml
@@ -7,6 +7,7 @@ id      = "robonix/service/voiceprint/delete"
 version = "1"
 kind    = "service"
 idl     = "voiceprint/srv/DeleteEnrolled.srv"
+description = "Delete an enrolled speaker identity from the voiceprint database."
 
 [mode]
 type = "rpc"

--- a/capabilities/service/voiceprint/enroll.v1.toml
+++ b/capabilities/service/voiceprint/enroll.v1.toml
@@ -8,6 +8,7 @@ id      = "robonix/service/voiceprint/enroll"
 version = "1"
 kind    = "service"
 idl     = "voiceprint/srv/Enroll.srv"
+description = "Enroll a speaker identity from voice samples."
 
 [mode]
 type = "rpc"

--- a/capabilities/service/voiceprint/identify.v1.toml
+++ b/capabilities/service/voiceprint/identify.v1.toml
@@ -7,6 +7,7 @@ id      = "robonix/service/voiceprint/identify"
 version = "1"
 kind    = "service"
 idl     = "voiceprint/srv/Identify.srv"
+description = "Identify whether an audio sample matches an enrolled speaker."
 
 [mode]
 type = "rpc"

--- a/capabilities/service/voiceprint/list.v1.toml
+++ b/capabilities/service/voiceprint/list.v1.toml
@@ -7,6 +7,7 @@ id      = "robonix/service/voiceprint/list"
 version = "1"
 kind    = "service"
 idl     = "voiceprint/srv/ListEnrolled.srv"
+description = "List enrolled speaker identities known to the voiceprint service."
 
 [mode]
 type = "rpc"

--- a/capabilities/system/executor/cancel_all_plans.v1.toml
+++ b/capabilities/system/executor/cancel_all_plans.v1.toml
@@ -3,6 +3,7 @@ id      = "robonix/system/executor/cancel_all_plans"
 version = "1"
 kind    = "service"
 idl     = "executor/srv/CancelAll.srv"
+description = "Cancel all currently running executor plans."
 
 [mode]
 type = "rpc"

--- a/capabilities/system/executor/execute.v1.toml
+++ b/capabilities/system/executor/execute.v1.toml
@@ -3,6 +3,7 @@ id      = "robonix/system/executor/execute"
 version = "1"
 kind    = "service"
 idl     = "executor/srv/Execute.srv"
+description = "Execute an RTDL plan and stream execution events."
 
 [mode]
 type = "rpc_server_stream"

--- a/capabilities/system/liaison/submit.v1.toml
+++ b/capabilities/system/liaison/submit.v1.toml
@@ -4,6 +4,7 @@ id      = "robonix/system/liaison/submit"
 version = "1"
 kind    = "system"
 idl     = "liaison/srv/SubmitTask.srv"
+description = "Submit a user task through Liaison and stream Pilot events back."
 
 [mode]
 type = "rpc_server_stream"

--- a/capabilities/system/liaison/voice.v1.toml
+++ b/capabilities/system/liaison/voice.v1.toml
@@ -5,6 +5,7 @@ id      = "robonix/system/liaison/voice"
 version = "1"
 kind    = "system"
 idl     = "liaison/srv/StartVoiceSession.srv"
+description = "Run a voice interaction session through Liaison."
 
 [mode]
 type = "rpc_server_stream"

--- a/capabilities/system/pilot.v1.toml
+++ b/capabilities/system/pilot.v1.toml
@@ -4,6 +4,7 @@ id      = "robonix/system/pilot"
 version = "1"
 kind    = "service"
 idl     = "pilot/srv/SubmitTask.srv"
+description = "Submit a task to Pilot and stream planning events."
 
 [mode]
 type = "rpc_server_stream"

--- a/capabilities/system/scene/get_object_context.v1.toml
+++ b/capabilities/system/scene/get_object_context.v1.toml
@@ -6,6 +6,7 @@ id      = "robonix/system/scene/get_object_context"
 version = "1"
 kind    = "service"
 idl     = "semantic_map/srv/GetObjectContext.srv"
+description = "Return one scene object's node, relations, and nearby context."
 
 [mode]
 type = "rpc"

--- a/capabilities/system/scene/get_scene_graph.v1.toml
+++ b/capabilities/system/scene/get_scene_graph.v1.toml
@@ -5,6 +5,7 @@ id      = "robonix/system/scene/get_scene_graph"
 version = "1"
 kind    = "service"
 idl     = "semantic_map/srv/GetSceneGraph.srv"
+description = "Return the current scene graph snapshot."
 
 [mode]
 type = "rpc"

--- a/capabilities/system/scene/goal_near.v1.toml
+++ b/capabilities/system/scene/goal_near.v1.toml
@@ -5,6 +5,7 @@ id      = "robonix/system/scene/goal_near"
 version = "1"
 kind    = "service"
 idl     = "semantic_map/srv/GoalNear.srv"
+description = "Compute a navigation-safe approach pose near a known scene object."
 
 [mode]
 type = "rpc"

--- a/capabilities/system/scene/list_objects.v1.toml
+++ b/capabilities/system/scene/list_objects.v1.toml
@@ -6,6 +6,7 @@ id      = "robonix/system/scene/list_objects"
 version = "1"
 kind    = "service"
 idl     = "semantic_map/srv/ListObjects.srv"
+description = "List all objects currently known to the scene registry."
 
 [mode]
 type = "rpc"

--- a/capabilities/system/scene/list_relations.v1.toml
+++ b/capabilities/system/scene/list_relations.v1.toml
@@ -5,6 +5,7 @@ id      = "robonix/system/scene/list_relations"
 version = "1"
 kind    = "service"
 idl     = "semantic_map/srv/ListRelations.srv"
+description = "List scene graph relations, optionally filtered by relation type."
 
 [mode]
 type = "rpc"

--- a/capabilities/system/soma/description.v1.toml
+++ b/capabilities/system/soma/description.v1.toml
@@ -7,6 +7,7 @@ id      = "robonix/system/soma/description"
 version = "1"
 kind    = "service"
 idl     = "soma/srv/GetDescription.srv"
+description = "Return the robot body description, including URDF and high-level metadata."
 
 [mode]
 type = "rpc"

--- a/capabilities/system/soma/footprint.v1.toml
+++ b/capabilities/system/soma/footprint.v1.toml
@@ -9,6 +9,7 @@ id      = "robonix/system/soma/footprint"
 version = "1"
 kind    = "service"
 idl     = "soma/srv/GetFootprint.srv"
+description = "Return the robot 2D collision footprint in the base frame."
 
 [mode]
 type = "rpc"

--- a/capabilities/system/soma/sensor_extrinsics.v1.toml
+++ b/capabilities/system/soma/sensor_extrinsics.v1.toml
@@ -10,6 +10,7 @@ id      = "robonix/system/soma/sensor_extrinsics"
 version = "1"
 kind    = "service"
 idl     = "soma/srv/GetSensorExtrinsics.srv"
+description = "Return static sensor mount transforms from the robot body model."
 
 [mode]
 type = "rpc"

--- a/tools/codegen/src/codegen/contract_gen.rs
+++ b/tools/codegen/src/codegen/contract_gen.rs
@@ -31,6 +31,10 @@ struct ContractMeta {
     ///   `system/pilot/srv/SubmitTask.srv`        → lib/.../srv/SubmitTask.srv
     ///   `common_interfaces/sensor_msgs/msg/Image.msg` → lib/.../msg/Image.msg
     idl: String,
+    /// Documentation-only meaning of this abstract contract. This is not the
+    /// provider/runtime capability description declared to Atlas.
+    #[serde(default)]
+    description: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -84,6 +88,8 @@ pub struct ContractSummary {
     pub kind: String,
     pub mode: String,
     pub idl: String,
+    /// Documentation-only meaning of this abstract contract.
+    pub description: String,
     /// Absolute path to the source `.v1.toml`.
     pub toml_path: PathBuf,
 }
@@ -108,6 +114,7 @@ pub fn load_contract_summaries(dirs: &[PathBuf]) -> Result<Vec<ContractSummary>>
                     kind: c.contract.kind,
                     mode: c.mode.mode_type,
                     idl: c.contract.idl,
+                    description: c.contract.description.trim().to_string(),
                     toml_path: p,
                 },
             );

--- a/tools/codegen/src/codegen/docs_gen.rs
+++ b/tools/codegen/src/codegen/docs_gen.rs
@@ -128,9 +128,9 @@ fn render_contracts(
         let _ = writeln!(out);
         let _ = writeln!(
             out,
-            "| 能力约定 ID | kind | mode | 载荷（IDL） | 能力约定 TOML |"
+            "| 能力约定 ID | 接口含义 | kind | mode | 载荷（IDL） | 能力约定 TOML |"
         );
-        let _ = writeln!(out, "|---|---|---|---|---|");
+        let _ = writeln!(out, "|---|---|---|---|---|---|");
         for c in rows {
             let payload = if idl_rels.contains(c.idl.as_str()) {
                 format!("[`{}`](idl.md#{})", c.idl, idl_anchor(&c.idl))
@@ -138,16 +138,25 @@ fn render_contracts(
                 format!("`{}`", c.idl)
             };
             let toml_rel = rel_under(&c.toml_path, contracts_dirs);
+            let meaning = md_table_cell(&c.description);
             let _ = writeln!(
                 out,
-                "| `{}` | {} | `{}` | {} | `{}` |",
-                c.id, c.kind, c.mode, payload, toml_rel
+                "| `{}` | {} | {} | `{}` | {} | `{}` |",
+                c.id, meaning, c.kind, c.mode, payload, toml_rel
             );
         }
     }
     out
 }
 
+fn md_table_cell(value: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        "-".to_string()
+    } else {
+        trimmed.replace('|', "\\|").replace('\n', "<br>")
+    }
+}
 fn render_idl(idl: &[IdlFile], banner: &str) -> String {
     // Group by ROS package, then by file name (both sorted).
     let mut by_pkg: BTreeMap<&str, Vec<&IdlFile>> = BTreeMap::new();


### PR DESCRIPTION
## Summary
- Add [contract].description to all 67 capability TOMLs as the documentation-only meaning of each abstract contract.
- Teach robonix-codegen docs generation to read those descriptions and emit an interface-meaning column in docs/src/reference/contracts.md.
- Update the docs submodule pointer to syswonder/robonix-book#7.

Important: contract TOML descriptions are documentation/catalog data only. They do not participate in runtime provider description fallback and are not sent to the LLM tool catalog by this PR.

## Verification
- cargo fmt --check --package robonix-codegen
- cargo test -p robonix-codegen
- bash scripts/check-docs.sh
- robonix-book: ./scripts/build-highlight.sh

Related docs PR: https://github.com/syswonder/robonix-book/pull/7
