### PR TITLE
feat(scene): user map annotations with epoch-aware staleness

### DIFF
--- a/capabilities/lib/map/msg/MapLifecycle.msg
+++ b/capabilities/lib/map/msg/MapLifecycle.msg
@@ -1,0 +1,17 @@
+# Map identity + lifecycle broadcast from the mapping service.
+#
+# Published latched (transient_local) so late-joining consumers (e.g. the
+# scene service) learn the current map identity at startup, and re-published
+# on every lifecycle transition (init / load / reset / mode switch; save
+# does not change the live identity — its re-key semantics are a later,
+# separate design).
+#
+# The (map_id, generation) pair is the map-frame identity key: consumers
+# holding map-frame coordinates must treat a change in EITHER field as
+# "previous coordinates are no longer anchored" — reset_map keeps map_id
+# but moves the map origin, which only generation makes visible.
+string map_id      # named-map id currently bound; empty when ephemeral (no map_id configured)
+string mode        # "mapping" or "localization"
+uint64 generation  # monotonic; +1 when the map origin may have changed: mapping-mode
+                   # session start/load and reset_map. NEVER bumped by a localization
+                   # load (stable frame is the point) or by a mode switch.

--- a/capabilities/service/map/lifecycle.v1.toml
+++ b/capabilities/service/map/lifecycle.v1.toml
@@ -1,0 +1,17 @@
+# Map identity + lifecycle events. The mapping service is the sole
+# authority on which named map is active; this topic broadcasts that
+# identity ({map_id, mode, generation}) latched, so consumers that key
+# state by map (e.g. scene's semantic object store) can discover the
+# current map at startup and react to init/load/reset/mode-switch
+# transitions without polling. Additive to the v0.1 surface: the four
+# original topic_out streams (occupancy_grid / pose / odom / pointcloud)
+# are unchanged.
+[contract]
+id      = "robonix/service/map/lifecycle"
+version = "1"
+kind    = "service"
+idl     = "map/msg/MapLifecycle.msg"
+description = "Latched map identity and lifecycle events ({map_id, mode, generation}) from the mapping service."
+
+[mode]
+type = "topic_out"

--- a/examples/webots/robonix_manifest.yaml
+++ b/examples/webots/robonix_manifest.yaml
@@ -2,10 +2,15 @@ manifestVersion: 1
 name: robonix-webots-example-deploy
 
 env:
-  # Bind scene's semantic store to the same named SLAM map as `mapping`
-  # below (the join key between geometric + semantic maps). Propagated by
-  # `rbnx boot` into the process env, which scene's start.sh forwards as
-  # `-e SCENE_MAP_ID` into the container. Keep this id == mapping's `map_id`.
+  # FALLBACK binding of scene's semantic store to the named SLAM map of
+  # `mapping` below (the join key between geometric + semantic maps).
+  # Scene now learns the map identity from mapping's latched
+  # robonix/service/map/lifecycle broadcast (authoritative, wins over
+  # this env) — but in this boot order scene starts BEFORE mapping, so
+  # the first boot binds from this env; keep it == mapping's `map_id`.
+  # A scene restart while mapping runs binds from the broadcast alone.
+  # Propagated by `rbnx boot` into the process env, which scene's
+  # start.sh forwards as `-e SCENE_MAP_ID` into the container.
   SCENE_MAP_ID: webots_lab
 
 # boot in sequence: system -> soma+scene -> execution -> interaction

--- a/system/scene/README.md
+++ b/system/scene/README.md
@@ -257,6 +257,7 @@ plain `humble`.
 | `SCENE_OBJECT_MEMORY_DB` | `/data/robonix/scene_memory/objects.db` | milvus-lite DB path (inside container; host-mounted via `rbnx-build/data/robonix`) |
 | `SCENE_MAP_ID` | `default` | FALLBACK map binding: mapping's latched `robonix/service/map/lifecycle` broadcast wins when present at startup; this env (below manifest `map_id`) applies when mapping isn't up yet (normal full-boot order) or doesn't broadcast |
 | `SCENE_MAP_BINDING_WAIT_S` | `3.0` | how long the startup probe waits for the lifecycle contract to appear on atlas before falling back to static binding; `0` disables the probe |
+| `SCENE_ANNOTATIONS_DIR` | `/data/robonix/scene_annotations` | per-map JSON files holding user annotations (rooms / POIs); host-mounted like the object DB |
 | `VLM_REASONING_EFFORT` | `` (unset) | opt-in, forwarded to all scene VLM/LLM calls (relation inference + VLM perception): `minimal`\|`low`\|`medium`\|`high`. **Unset → the field is omitted**, so non-reasoning models and strict endpoints are unaffected. Set `minimal` (= no thinking) to keep a reasoning `VLM_MODEL` (e.g. `doubao-seed-2-1-pro`) answering in ~2 s instead of timing out |
 
 ## Object memory (warm restore)
@@ -292,6 +293,43 @@ mapping-mode session start) drifts from the startup binding, scene logs a
 warning and keeps its binding — reacting (flush + re-anchor) is the planned
 lifecycle linkage (P3).
 
+## User annotations (rooms / POIs)
+
+Scene also stores **user-authored** semantics: annotations the user draws on
+the map canvas — a `room` (named polygon) or a `poi` (named point, optional
+heading; model-ready, no UI yet). They live on the same foundation as
+perceived objects: coordinates are map-frame meters, storage partitions by
+the map binding's `map_id`, and validity follows mapping's `generation`
+epoch. Unlike perceived objects they are user assets: a map rebuild (reset /
+re-mapping) never deletes them — they are flagged `stale` (with a reason)
+for the user to confirm ("still valid" clears the flag) or redraw (new
+geometry is authored against the current frame, so redrawing also clears it).
+
+Storage is one JSON file per map under `SCENE_ANNOTATIONS_DIR`
+(`<map_id>.json`, atomic writes, no vectors — deliberately not in the milvus
+object DB). CRUD goes through the web server's REST API (same trust domain
+as the rest of this LAN debug/UI server — no auth):
+
+| Route | Body | Returns |
+|---|---|---|
+| `GET /api/annotations` | — | `{ok, annotations: [...]}` |
+| `POST /api/annotations` | `{kind, name, points, theta?}` | `{ok, annotation}` (with generated id) |
+| `PUT /api/annotations/{id}` | any of `{name, points, theta, stale: false}` | `{ok, annotation}` |
+| `DELETE /api/annotations/{id}` | — | `{ok}` |
+
+Errors: `400` invalid fields (unknown kind, room polygon < 3 points, poi ≠ 1
+point, non-finite numbers, `theta` on a room — headings are poi-only), `404`
+unknown id, `503` store unavailable — those carry `{ok: false, detail}`; a
+store write failure (e.g. disk full) surfaces as a plain `500` because the
+edit was not saved. On `PUT`, `theta: null` (or absent) means "keep the
+current heading" — a set heading can be changed but not cleared (deliberate
+until the poi UI lands). `points` are `[[x, y], ...]` map-frame
+meters. **This shape is the contract any frontend builds on; treat changes
+as breaking.** The full annotation list also rides along in `GET /api/state`
+(field `annotations`, next to `map_binding`) so map pages get everything in
+one poll. There is deliberately no atlas/MCP surface yet — exposing rooms to
+Pilot (scene-graph `in_room` edges) is a planned follow-up.
+
 ## Capabilities exposed
 
 | Contract                                       | Tool name        | What it does                                                        |
@@ -314,12 +352,14 @@ curl -s http://127.0.0.1:50106/mcp/ -H "Content-Type: application/json" \
 ## Web UI quick tour
 
 * `/` — combined 3-column layout (default): 2D map · 3D scene · cam stack
+* `/user` — **end-user map page**: SLAM map + room annotations (draw a polygon, name it, rename / delete / confirm-stale) with a lightweight object overlay; the debug pages above are untouched by it
 * `/2d` — only the 2D top-down map
 * `/3d` — only the 3D point clouds + bboxes
 * `/cam` — only the camera stack: live RGB on top, live depth below
-* `/api/state` — JSON: registry + relations + occupancy PNG + robot pose
+* `/api/state` — JSON: registry + relations + occupancy PNG + robot pose + user annotations + map binding
 * `/api/objects3d` — JSON: per-object pcd + 8 bbox corners + CLIP class
 * `/api/camera` — JSON: latest RGB + depth as base64 PNGs (5 Hz polling)
+* `/api/annotations` — user annotation CRUD (see "User annotations" above)
 
 The 3D viz draws the OccupancyGrid as a translucent floor plane at z = -0.01 (so you can read room geometry under the point clouds), each detected object as a coloured pcd + yaw-rotated wireframe bbox + class label sprite, and the robot as a composite Tiago-shaped proxy (mobile base + torso + shoulder + head + arm), all parented to a `THREE.Group` that updates from `/api/state`'s `robot` field at 4 Hz.
 
@@ -347,7 +387,7 @@ The cam panel shows the same RGB + depth frames the perception pipeline consumes
 
 ## Scope (what's NOT here)
 
-- **No write API.** No `IngestObservation`, no `UpdateTaskContext`. Per the spec, scene is a sink.
+- **No write contract.** No `IngestObservation`, no `UpdateTaskContext` on atlas/MCP — perception-wise, scene is a sink. (The web server's annotation REST is an internal UI API, not a capability contract.)
 - **No subscribe-stream.** `SubscribeUpdates` doesn't fit MCP semantics. Pilot polls.
 - **No episodic memory.** Long-term memory belongs to memory services, not scene.
 - **No direct motion control.** `goal_near` returns an approach pose; navigation is performed by `robonix/service/navigation/navigate`.

--- a/system/scene/README.md
+++ b/system/scene/README.md
@@ -255,7 +255,8 @@ plain `humble`.
 | `SCENE_PORT` / `SCENE_WEB_PORT` | `50106` / `50107` | gRPC + web UI ports |
 | `SCENE_OBJECT_MEMORY_ENABLED` | `true` | persist stable objects + warm-restore the registry on boot |
 | `SCENE_OBJECT_MEMORY_DB` | `/data/robonix/scene_memory/objects.db` | milvus-lite DB path (inside container; host-mounted via `rbnx-build/data/robonix`) |
-| `SCENE_MAP_ID` | `default` | SLAM map the persisted objects belong to; restore loads only this map's objects (manifest `map_id` overrides) |
+| `SCENE_MAP_ID` | `default` | FALLBACK map binding: mapping's latched `robonix/service/map/lifecycle` broadcast wins when present at startup; this env (below manifest `map_id`) applies when mapping isn't up yet (normal full-boot order) or doesn't broadcast |
+| `SCENE_MAP_BINDING_WAIT_S` | `3.0` | how long the startup probe waits for the lifecycle contract to appear on atlas before falling back to static binding; `0` disables the probe |
 | `VLM_REASONING_EFFORT` | `` (unset) | opt-in, forwarded to all scene VLM/LLM calls (relation inference + VLM perception): `minimal`\|`low`\|`medium`\|`high`. **Unset → the field is omitted**, so non-reasoning models and strict endpoints are unaffected. Set `minimal` (= no thinking) to keep a reasoning `VLM_MODEL` (e.g. `doubao-seed-2-1-pro`) answering in ~2 s instead of timing out |
 
 ## Object memory (warm restore)
@@ -273,13 +274,23 @@ DB — and lives under the host-mounted `/data/robonix`, which also makes the
 scene-graph JSON caches survive boots. Writes are driven by the scene-graph
 builder, so disabling `SCENE_GRAPH_ENABLED` stops new writes (restore still runs).
 
-Persistence is partitioned by `SCENE_MAP_ID` (or the manifest `map_id`): an
-object's pose is only meaningful in the `map` frame of the SLAM map it was
-observed on, so restore loads exactly the current map's objects and never mixes
-two maps. The same `object_id` may exist on different maps without colliding.
-`map_id` is a deploy-controlled string today (default `"default"`) and stays
-internal to scene — no atlas/MCP contract changes — until mapping emits a real
-map identity to wire in here.
+Persistence is partitioned by the map binding: an object's pose is only
+meaningful in the `map` frame of the SLAM map it was observed on, so restore
+loads exactly the current map's objects and never mixes two maps. The same
+`object_id` may exist on different maps without colliding.
+
+The binding itself (`scene_service/map_binding.py`) is learned at startup with
+this precedence: mapping's latched `robonix/service/map/lifecycle` broadcast
+(`{map_id, mode, generation}` — the authoritative map identity, probed for
+`SCENE_MAP_BINDING_WAIT_S`) → manifest `config.map_id` → `SCENE_MAP_ID` env →
+`"default"`. The broadcast needs the generated `map` interface package
+(`rbnx codegen --ros2` → colcon overlay, built by `scripts/build.sh`, sourced
+by the container entrypoint); without it scene falls back to static binding
+with a warning. At runtime scene only WATCHES the broadcast: if mapping's
+identity or `generation` (bumped when the map origin may have changed: reset /
+mapping-mode session start) drifts from the startup binding, scene logs a
+warning and keeps its binding — reacting (flush + re-anchor) is the planned
+lifecycle linkage (P3).
 
 ## Capabilities exposed
 

--- a/system/scene/docker/entrypoint.sh
+++ b/system/scene/docker/entrypoint.sh
@@ -16,6 +16,16 @@ set -eo pipefail
 # shellcheck disable=SC1091
 source "/opt/ros/${ROS_DISTRO:-humble}/setup.bash"
 
+# Robonix ros2_idl overlay (generated `map` interface package — mapping's
+# latched lifecycle broadcast that scene's map binding subscribes to).
+# Built by scripts/build.sh onto the bind-mounted rbnx-build/; when absent
+# scene logs a warning and falls back to static map binding.
+ROS2_IDL_SETUP=/scene/rbnx-build/codegen/ros2_idl/install/setup.bash
+if [ -f "$ROS2_IDL_SETUP" ]; then
+    # shellcheck disable=SC1090
+    source "$ROS2_IDL_SETUP"
+fi
+
 configure_zenoh_session() {
     if [ "${RMW_IMPLEMENTATION:-}" != "rmw_zenoh_cpp" ] || [ -z "${ROBONIX_ZENOH_ROUTER:-}" ]; then
         return 0

--- a/system/scene/scene_service/annotations.py
+++ b/system/scene/scene_service/annotations.py
@@ -1,0 +1,354 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+"""User annotations — user-authored semantics anchored to the SLAM map.
+
+An annotation is a named geometric mark the user draws on the map canvas:
+a `room` (polygon + name) or a `poi` (single point, optional heading).
+Annotations share the same foundation as perceived objects: coordinates
+are map-frame meters, storage is partitioned by `map_id`, and validity is
+judged by mapping's `generation` epoch (see map_binding.py). Unlike
+perceived objects they are USER ASSETS: a map rebuild never deletes them —
+they are kept and flagged `stale` for the user to confirm or redraw.
+
+Storage is one JSON file per map (`<base_dir>/<map_id>.json`, atomic
+tmp+rename writes). Annotations carry no vectors, so they stay out of the
+milvus object store on purpose; the per-map JSON mirrors SceneGraphStore's
+partitioning pattern.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+import threading
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+from .map_binding import sanitize_map_id
+
+log = logging.getLogger(__name__)
+
+# The kind whitelist lives here (single source); every consumer checks it
+# through validate_annotation_fields below. `poi` is model-reserved: the
+# store handles it, the first UI iteration only draws rooms.
+VALID_KINDS = ("room", "poi")
+MAX_NAME_LEN = 128
+
+
+def validate_annotation_fields(
+    kind: str,
+    name: Any,
+    points: Any,
+    theta: Any,
+) -> Optional[str]:
+    """Validate user-supplied annotation fields; return an error string on
+    the first violation, None when everything is acceptable.
+
+    Rules: `kind` must be whitelisted; `name` a string ≤ MAX_NAME_LEN;
+    `points` a list of finite [x, y] number pairs — exactly 1 for a poi,
+    ≥3 for a room (a polygon needs three vertices); `theta` (a heading)
+    only applies to a poi and must be None or a finite number — a region
+    has no heading, so a room carrying theta is rejected rather than
+    silently stored. NaN/inf anywhere is rejected so bad JSON can never
+    poison the stored file."""
+    if kind not in VALID_KINDS:
+        return f"kind must be one of {list(VALID_KINDS)}, got {kind!r}"
+    if not isinstance(name, str):
+        return "name must be a string"
+    if len(name) > MAX_NAME_LEN:
+        return f"name too long (max {MAX_NAME_LEN} chars)"
+    if not isinstance(points, list):
+        return "points must be a list of [x, y] pairs"
+    for p in points:
+        if (
+            not isinstance(p, (list, tuple))
+            or len(p) != 2
+            or not all(isinstance(v, (int, float)) and not isinstance(v, bool) for v in p)
+            or not all(math.isfinite(float(v)) for v in p)
+        ):
+            return "each point must be a finite [x, y] number pair"
+    if kind == "poi" and len(points) != 1:
+        return "a poi takes exactly one point"
+    if kind == "room" and len(points) < 3:
+        return "a room polygon needs at least 3 points"
+    if theta is not None:
+        if kind != "poi":
+            return "theta (heading) only applies to a poi"
+        if not isinstance(theta, (int, float)) or isinstance(theta, bool) or not math.isfinite(float(theta)):
+            return "theta must be a finite number or null"
+    return None
+
+
+@dataclass
+class Annotation:
+    """One user annotation. `points` are map-frame meters; `stale` means
+    the map's generation changed after this was drawn — geometry may no
+    longer line up, and the user must confirm or redraw (never auto-deleted)."""
+    annotation_id: str
+    kind: str                       # "room" | "poi" (see VALID_KINDS)
+    name: str
+    points: list[list[float]] = field(default_factory=list)   # [[x, y], ...]
+    # Optional poi heading, radians (rooms never carry one — validated).
+    # API semantics: theta=None on update means "keep"; a set heading
+    # cannot be cleared, only changed. Revisit if/when the poi UI lands.
+    theta: Optional[float] = None
+    created_at: float = 0.0
+    updated_at: float = 0.0
+    stale: bool = False
+    stale_reason: str = ""
+
+    def to_json(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_json(cls, d: dict) -> "Annotation":
+        """Rebuild from a stored dict, dropping unknown keys so a file
+        written by a newer scene still loads (forward-tolerant)."""
+        known = set(cls.__dataclass_fields__)
+        return cls(**{k: v for k, v in d.items() if k in known})
+
+
+class AnnotationStore:
+    """Per-map JSON persistence for user annotations.
+
+    One file per map: `<base_dir>/<map_id>.json` (map_id sanitized with the
+    same rule as the object store so the two partitions always agree). The
+    file records `{map_id, generation, annotations}`; on load, a stored
+    generation that differs from the current binding's means the map frame
+    was rebuilt since the annotations were drawn — every annotation is
+    marked stale (kept, never dropped: user assets, unlike perceived
+    objects, are never cleaned up automatically). When either side
+    has no generation (static binding, pre-P2 file) staleness cannot be
+    judged and the stored value is preserved for the next boot that can.
+
+    All methods are synchronous and guarded by an internal lock; writes are
+    atomic (tmp + os.replace) and happen on every mutation — annotation
+    traffic is human-speed, so write-through is cheap and never loses an
+    accepted edit."""
+
+    def __init__(self, base_dir: str, *, map_id: str, generation: Optional[int] = None) -> None:
+        """Open (creating dirs as needed) the store for `map_id` and load
+        its file, applying the generation staleness check described on the
+        class. A corrupt file is set aside (renamed `*.corrupt-<ts>`) and
+        the store starts empty — loudly, and without destroying the bytes."""
+        self._lock = threading.Lock()
+        self._map_id = sanitize_map_id(map_id)
+        self._base = Path(base_dir).expanduser()
+        self._base.mkdir(parents=True, exist_ok=True)
+        self._path = self._base / f"{self._map_id}.json"
+        self._generation = generation
+        self._annotations: dict[str, Annotation] = {}
+        self._load(current_generation=generation)
+
+    @property
+    def map_id(self) -> str:
+        return self._map_id
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    # ── load / save ──────────────────────────────────────────────────────
+    def _load(self, current_generation: Optional[int]) -> None:
+        """Read the per-map file into memory. Missing file → empty store.
+        A file that fails to parse, has an unexpected shape, or contains a
+        record that would not pass `validate_annotation_fields` (the file
+        is a user-visible JSON asset, so hand edits happen) is treated as
+        corrupt as a whole: renamed aside + empty store — the user's bytes
+        are never dropped or overwritten by a failed load. A stored
+        generation differing from `current_generation` marks everything
+        stale and persists the flag."""
+        if not self._path.exists():
+            return
+        try:
+            data = json.loads(self._path.read_text(encoding="utf-8"))
+            if not isinstance(data, dict):
+                raise ValueError(f"top-level JSON is {type(data).__name__}, not an object")
+            stored_gen = data.get("generation")
+            if stored_gen is not None:
+                stored_gen = int(stored_gen)
+            anns = []
+            for d in data.get("annotations", []):
+                if not isinstance(d, dict):
+                    raise ValueError(f"annotation entry is {type(d).__name__}, not an object")
+                a = Annotation.from_json(d)
+                err = validate_annotation_fields(a.kind, a.name, a.points, a.theta)
+                if err:
+                    raise ValueError(f"annotation {a.annotation_id!r}: {err}")
+                if not isinstance(a.annotation_id, str) or not a.annotation_id:
+                    raise ValueError("annotation with missing/empty id")
+                anns.append(a)
+        except (ValueError, TypeError, KeyError, AttributeError) as e:
+            aside = self._path.with_suffix(f".json.corrupt-{int(time.time())}")
+            # Rename failures re-raise: continuing with an empty store
+            # would let the next accepted edit os.replace() the corrupt
+            # file — destroying exactly the bytes this path promises to
+            # keep. Failing __init__ disables the API loudly instead.
+            self._path.rename(aside)
+            log.error(
+                "[scene-anno] %s failed to load (%s) — moved to %s, "
+                "starting empty", self._path, e, aside,
+            )
+            return
+        self._annotations = {a.annotation_id: a for a in anns}
+        if current_generation is None:
+            # Cannot judge staleness this session; keep the recorded epoch
+            # so a later broadcast-bound boot still can.
+            self._generation = stored_gen
+            return
+        if stored_gen is not None and stored_gen != int(current_generation):
+            reason = f"map generation {stored_gen}→{current_generation}"
+            n = self._flag_all_stale_locked(reason, new_generation=None)
+            if n:
+                log.warning(
+                    "[scene-anno] map frame epoch changed (%s) — %d "
+                    "annotation(s) marked stale for user confirmation", reason, n,
+                )
+
+    def _save_locked(self) -> None:
+        """Atomically write the current state (caller holds the lock or is
+        __init__). tmp file lands in the same directory so os.replace stays
+        on one filesystem. Raises on I/O failure — callers accepted a user
+        edit, losing it silently is worse than a 500. Synchronous file I/O
+        on the event loop is deliberate: annotation traffic is human-speed
+        and the files are a few KB."""
+        payload = {
+            "map_id": self._map_id,
+            "generation": self._generation,
+            "annotations": [a.to_json() for a in self._annotations.values()],
+        }
+        tmp = self._path.with_suffix(".json.tmp")
+        tmp.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=1), encoding="utf-8"
+        )
+        os.replace(tmp, self._path)
+
+    # ── read ─────────────────────────────────────────────────────────────
+    # list()/get() hand out the LIVE Annotation objects — treat them as
+    # read-only. Mutating them directly bypasses both the lock and
+    # persistence; go through update() instead.
+    def list(self) -> list[Annotation]:
+        with self._lock:
+            return list(self._annotations.values())
+
+    def get(self, annotation_id: str) -> Optional[Annotation]:
+        with self._lock:
+            return self._annotations.get(annotation_id)
+
+    def list_json(self) -> list[dict]:
+        """JSON-ready dump of every annotation (the `/api/state` field and
+        `GET /api/annotations` share this shape)."""
+        with self._lock:
+            return [a.to_json() for a in self._annotations.values()]
+
+    # ── mutate (each call persists before returning) ─────────────────────
+    def create(self, *, kind: str, name: str, points: list,
+               theta: Optional[float] = None) -> Annotation:
+        """Create + persist a new annotation and return it. Fields must
+        already be validated (validate_annotation_fields) — the store
+        trusts its callers and only owns id/timestamp assignment."""
+        now = time.time()
+        ann = Annotation(
+            annotation_id=f"anno.{uuid.uuid4().hex[:8]}",
+            kind=kind,
+            name=name,
+            points=[[float(x), float(y)] for x, y in points],
+            theta=None if theta is None else float(theta),
+            created_at=now,
+            updated_at=now,
+        )
+        with self._lock:
+            self._annotations[ann.annotation_id] = ann
+            self._save_locked()
+        return ann
+
+    def update(self, annotation_id: str, *, name: Optional[str] = None,
+               points: Optional[list] = None, theta: Optional[float] = None,
+               clear_stale: bool = False) -> Optional[Annotation]:
+        """Apply the provided fields to an existing annotation (None = keep),
+        bump `updated_at`, persist, and return it; None when the id is
+        unknown. `clear_stale` is the user's "confirm still valid" action —
+        it resets both the flag and the recorded reason. Redrawing the
+        points also clears staleness: new geometry is authored against the
+        CURRENT map frame, so the old epoch's doubt no longer applies."""
+        with self._lock:
+            ann = self._annotations.get(annotation_id)
+            if ann is None:
+                return None
+            if name is not None:
+                ann.name = name
+            if points is not None:
+                ann.points = [[float(x), float(y)] for x, y in points]
+                ann.stale, ann.stale_reason = False, ""
+            if theta is not None:
+                ann.theta = float(theta)
+            if clear_stale:
+                ann.stale, ann.stale_reason = False, ""
+            ann.updated_at = time.time()
+            self._save_locked()
+            return ann
+
+    def delete(self, annotation_id: str) -> bool:
+        """Remove an annotation; True when it existed. Persists on change."""
+        with self._lock:
+            if annotation_id not in self._annotations:
+                return False
+            del self._annotations[annotation_id]
+            self._save_locked()
+            return True
+
+    def _flag_all_stale_locked(self, reason: str,
+                               new_generation: Optional[int]) -> int:
+        """Shared body of the two stale-sweep entry points (caller holds
+        the lock, or is __init__/_load): flag every non-stale annotation
+        with `reason`, optionally adopt `new_generation`, persist when
+        anything changed. Returns how many annotations flipped."""
+        n = 0
+        for a in self._annotations.values():
+            if not a.stale:
+                a.stale, a.stale_reason = True, reason
+                n += 1
+        gen_changed = new_generation is not None and new_generation != self._generation
+        if gen_changed:
+            self._generation = new_generation
+        if n or gen_changed:
+            self._save_locked()
+        return n
+
+    def reconcile_generation(self, live_generation: int) -> int:
+        """Called when the map's true generation becomes known at runtime
+        (the lifecycle watcher's confirmation) — a store built under a
+        static binding (generation None) cannot judge staleness at load
+        time, so the judgement happens here instead. Adopts the epoch when
+        the store had none; when the recorded epoch differs, flags
+        everything stale (user assets are never auto-deleted, only
+        flagged). Runs decision + sweep under one lock acquisition, so a
+        concurrent create() can never be flagged by a sweep it postdates.
+        Returns how many flipped."""
+        with self._lock:
+            if self._generation is None or int(self._generation) == int(live_generation):
+                if self._generation != live_generation:
+                    self._generation = int(live_generation)
+                    self._save_locked()
+                return 0
+            reason = f"map generation {self._generation}→{live_generation}"
+            n = self._flag_all_stale_locked(reason, int(live_generation))
+        if n:
+            log.warning(
+                "[scene-anno] recorded map epoch differs from mapping's (%s) "
+                "— %d annotation(s) marked stale for user confirmation",
+                reason, n,
+            )
+        return n
+
+    def mark_all_stale(self, reason: str, *, new_generation: Optional[int] = None) -> int:
+        """Flag every non-stale annotation stale with `reason` (map frame
+        epoch changed at runtime — the _lifecycle_watch hook). Optionally
+        records the new generation so the file reflects the epoch the
+        staleness was judged against. Returns how many flipped; persists
+        when anything changed (flag or generation)."""
+        with self._lock:
+            return self._flag_all_stale_locked(reason, new_generation)

--- a/system/scene/scene_service/ingest/ros_subscribers.py
+++ b/system/scene/scene_service/ingest/ros_subscribers.py
@@ -44,6 +44,14 @@ def _import_ros():
     # transform is non-identity, and the web UI shows the robot offset
     # from where rviz (which goes through tf) shows it.
     from tf2_ros import Buffer, TransformListener  # type: ignore
+    # map/msg/MapLifecycle comes from the generated ros2_idl overlay
+    # (rbnx codegen --ros2 + colcon build), NOT the ROS distro. Import it
+    # defensively: a deploy without the overlay must lose only the
+    # lifecycle subscription, not every scene subscription.
+    try:
+        from map.msg import MapLifecycle  # type: ignore
+    except ImportError:
+        MapLifecycle = None
     return {
         "rclpy": rclpy,
         "Node": Node,
@@ -65,6 +73,9 @@ def _import_ros():
         "TransformStamped": TransformStamped,
         "Odometry": Odometry,
         "OccupancyGrid": OccupancyGrid,
+        # None when the ros2_idl overlay is missing — _subscribe skips the
+        # spec with a warning instead of crashing the hub.
+        "MapLifecycle": MapLifecycle,
         "Buffer": Buffer,
         "TransformListener": TransformListener,
     }
@@ -166,14 +177,19 @@ class SubscribersHub:
         """Add a new (kind, topic) subscription to a hub already up.
         Used by the background reconciler to absorb topics that come
         online after start(). Returns True if added, False if the
-        kind was already known."""
+        kind was already known — or if the subscription could not be
+        created (missing msg class): committing the slot anyway would
+        make has_kinds() claim a subscription that doesn't exist and
+        pair a success log with the skip warning."""
         if self._ros is None:
             return False
         if spec.kind in self._slots:
             return False
         self._slots[spec.kind] = _LatestSlot()
+        if not self._subscribe(spec):
+            del self._slots[spec.kind]
+            return False
         self.specs.append(spec)
-        self._subscribe(spec)
         log.info("[scene-ros] dynamic add: %s on %s", spec.kind, spec.topic)
         return True
 
@@ -208,9 +224,22 @@ class SubscribersHub:
                 log.debug("[scene-ros] spin tick: %s", e)
 
     # ── subscription wiring ────────────────────────────────────────────────
-    def _subscribe(self, spec: TopicSpec) -> None:
+    def _subscribe(self, spec: TopicSpec) -> bool:
+        """Create the rclpy subscription for one spec. Returns False (with
+        a warning) when the msg class is unavailable — the hub and every
+        other subscription keep running."""
         assert self._ros is not None
-        msg_cls = self._ros[spec.msg_type]
+        msg_cls = self._ros.get(spec.msg_type)
+        if msg_cls is None:
+            # Unknown or unavailable msg class (e.g. MapLifecycle without
+            # the ros2_idl overlay). One subscription degrades, the hub —
+            # and every other subscription — keeps running.
+            log.warning(
+                "[scene-ros] msg type %r unavailable — skipping %s on %s "
+                "(generated interface overlay missing?)",
+                spec.msg_type, spec.kind, spec.topic,
+            )
+            return False
         QoSProfile = self._ros["QoSProfile"]
         ReliabilityPolicy = self._ros["ReliabilityPolicy"]
         DurabilityPolicy = self._ros["DurabilityPolicy"]
@@ -266,6 +295,16 @@ class SubscribersHub:
                 history=HistoryPolicy.KEEP_LAST,
                 depth=5,
             )
+        elif spec.kind == "map_lifecycle":
+            # mapping's identity broadcast is latched (published once per
+            # lifecycle transition); TRANSIENT_LOCAL picks up the cached
+            # sample on a late start.
+            qos = QoSProfile(
+                reliability=ReliabilityPolicy.RELIABLE,
+                durability=DurabilityPolicy.TRANSIENT_LOCAL,
+                history=HistoryPolicy.KEEP_LAST,
+                depth=1,
+            )
         elif spec.kind == "camera_extrinsics":
             # Static camera mount transform (primitive/camera/extrinsics):
             # genuinely latched (published once), so TRANSIENT_LOCAL is
@@ -300,6 +339,7 @@ class SubscribersHub:
         self._node.create_subscription(msg_cls, spec.topic, _cb, qos)
         log.info("[scene-ros] subscribed: %s on %s (%s, qos=%s)",
                  spec.kind, spec.topic, spec.msg_type, spec.kind)
+        return True
 
     # ── consumer-side accessors ────────────────────────────────────────────
     def latest(self, kind: str) -> tuple[Any, float, int]:

--- a/system/scene/scene_service/map_binding.py
+++ b/system/scene/scene_service/map_binding.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+"""Map identity binding — how scene learns WHICH map it is scoped to.
+
+The mapping service broadcasts its current identity {map_id, mode,
+generation} latched on the `robonix/service/map/lifecycle` topic (see
+capabilities/service/map/lifecycle.v1.toml). At startup scene probes that
+broadcast once and, when present, binds to it — the broadcast is
+authoritative, so the deploy no longer needs to hand-copy the same map_id
+into two config blocks. Static fallbacks (manifest config / SCENE_MAP_ID
+env / "default") remain for deployments where mapping is not up yet when
+scene starts (the normal full-boot order) or does not broadcast at all.
+
+`generation` is mapping's map-frame epoch: it bumps whenever the map
+origin may have changed (mapping-mode session start, reset_map) and stays
+put across localization round-trips. P2 records it and warns on runtime
+change; acting on it (flush + re-anchor) is the P3 lifecycle linkage.
+
+Split from service.py so the pure precedence rule and the one-shot ROS
+read are unit-testable without atlas.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+log = logging.getLogger("scene.map_binding")
+
+
+@dataclass(frozen=True)
+class MapBinding:
+    """The resolved binding plus where it came from (for the startup log
+    and for the runtime mismatch watcher)."""
+    map_id: str
+    source: str                      # "lifecycle" | "config" | "env" | "default"
+    mode: str = ""                   # only set when source == "lifecycle"
+    generation: Optional[int] = None  # only set when source == "lifecycle"
+
+
+def choose_map_binding(
+    broadcast: Optional[dict],
+    config_map_id: object,
+    env_map_id: Optional[str],
+) -> MapBinding:
+    """Precedence: mapping's lifecycle broadcast (authoritative source of
+    map identity) > manifest config.map_id > SCENE_MAP_ID env > "default".
+    A broadcast with an empty map_id means mapping runs ephemeral (no named
+    map) — treated as "no broadcast", scene falls back to static binding."""
+    if broadcast and str(broadcast.get("map_id") or ""):
+        return MapBinding(
+            map_id=str(broadcast["map_id"]),
+            source="lifecycle",
+            mode=str(broadcast.get("mode") or ""),
+            generation=int(broadcast.get("generation") or 0),
+        )
+    if config_map_id:
+        return MapBinding(map_id=str(config_map_id), source="config")
+    if env_map_id:
+        return MapBinding(map_id=str(env_map_id), source="env")
+    return MapBinding(map_id="default", source="default")
+
+
+def read_latched_lifecycle(topic: str, timeout_s: float) -> Optional[dict]:
+    """One-shot read of the latched MapLifecycle sample on `topic`.
+
+    Runs on a PRIVATE rclpy context + executor so it neither initialises
+    nor disturbs the default context the ingest hub owns (the hub calls
+    rclpy.init() later and would raise on a double init). Returns
+    {map_id, mode, generation} or None on timeout. Degrades to None with
+    one warning when rclpy or the generated `map` interface package is
+    missing (ros2_idl overlay not built) — binding then falls back to
+    config/env, scene itself keeps working.
+    """
+    try:
+        import rclpy  # type: ignore
+        from rclpy.executors import SingleThreadedExecutor  # type: ignore
+        from rclpy.qos import (  # type: ignore
+            DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy,
+        )
+        from map.msg import MapLifecycle  # type: ignore  # ros2_idl overlay
+    except ImportError as e:
+        log.warning(
+            "[scene] lifecycle probe unavailable (%s) — falling back to "
+            "static map binding (is the ros2_idl overlay built + sourced?)", e,
+        )
+        return None
+
+    ctx = None
+    try:
+        # Context/init INSIDE the guard: a broken RMW env must degrade to
+        # None per the docstring promise, not escape and kill scene startup.
+        ctx = rclpy.Context()
+        rclpy.init(context=ctx, args=None)
+        node = rclpy.create_node("scene_map_binding_probe", context=ctx)
+        executor = SingleThreadedExecutor(context=ctx)
+        executor.add_node(node)
+        got: list = []
+        qos = QoSProfile(
+            reliability=ReliabilityPolicy.RELIABLE,
+            # TRANSIENT_LOCAL: the broadcast is latched; a late-joining
+            # probe must receive the cached sample.
+            durability=DurabilityPolicy.TRANSIENT_LOCAL,
+            history=HistoryPolicy.KEEP_LAST,
+            depth=1,
+        )
+        node.create_subscription(MapLifecycle, topic, got.append, qos)
+        deadline = time.monotonic() + timeout_s
+        while not got and time.monotonic() < deadline:
+            executor.spin_once(timeout_sec=0.2)
+        if not got:
+            return None
+        msg = got[0]
+        return {
+            "map_id": str(msg.map_id),
+            "mode": str(msg.mode),
+            "generation": int(msg.generation),
+        }
+    except Exception as e:  # noqa: BLE001
+        log.warning("[scene] lifecycle probe failed: %s", e)
+        return None
+    finally:
+        if ctx is not None:
+            try:
+                rclpy.shutdown(context=ctx)
+            except Exception:  # noqa: BLE001
+                pass

--- a/system/scene/scene_service/map_binding.py
+++ b/system/scene/scene_service/map_binding.py
@@ -21,11 +21,25 @@ read are unit-testable without atlas.
 from __future__ import annotations
 
 import logging
+import re
 import time
 from dataclasses import dataclass
 from typing import Optional
 
 log = logging.getLogger("scene.map_binding")
+
+# map_id is used as a milvus filter literal and as a filename, so restrict
+# it to a safe identifier charset (no quotes / spaces / separators) — keeps
+# the predicate injection-free and the path escape-free. Anything else is
+# squashed to "_"; empty falls back to "default". Every map_id-partitioned
+# store (objects, scene-graph cache, annotations) MUST key on this one rule
+# so the partitions always agree.
+_MAP_ID_UNSAFE = re.compile(r"[^A-Za-z0-9._\-]")
+
+
+def sanitize_map_id(raw: Optional[str]) -> str:
+    cleaned = _MAP_ID_UNSAFE.sub("_", (raw or "").strip())
+    return cleaned or "default"
 
 
 @dataclass(frozen=True)

--- a/system/scene/scene_service/persistence.py
+++ b/system/scene/scene_service/persistence.py
@@ -23,25 +23,16 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 from pathlib import Path
 from typing import Callable, Optional
 
+from .map_binding import sanitize_map_id as _sanitize_map_id
 from .state.object_registry import BBox3D, Pose3D, SceneObject
 
 log = logging.getLogger(__name__)
 
 _COLLECTION = "scene_objects"
 
-# map_id is interpolated into a milvus filter expression, so restrict it to a
-# safe identifier charset (no quotes / spaces) to keep the predicate injection
-# -free. Anything else is squashed to "_"; empty falls back to "default".
-_MAP_ID_UNSAFE = re.compile(r"[^A-Za-z0-9._\-]")
-
-
-def _sanitize_map_id(raw: Optional[str]) -> str:
-    cleaned = _MAP_ID_UNSAFE.sub("_", (raw or "").strip())
-    return cleaned or "default"
 # open_clip ViT-B-32 text/image features are 512-d (see
 # ingest/perception_concept_graphs.py). Object image features already live in
 # this space, so caption-text vectors are directly comparable for G3.

--- a/system/scene/scene_service/scene_graph/store.py
+++ b/system/scene/scene_service/scene_graph/store.py
@@ -45,9 +45,10 @@ class SceneGraphStore:
         (caption/relation answers are only valid within the map frame they were
         computed in — the same per-map isolation the object store gets from its
         ``"{map_id}::{object_id}"`` composite key). The id is run through
-        ``persistence._sanitize_map_id`` so it is a safe path component
-        (imported lazily — that module defers its pymilvus import, so this stays
-        importable on hosts without the milvus backend). With no ``map_id`` the
+        ``map_binding.sanitize_map_id`` (the one sanitize rule shared by every
+        map_id-partitioned store; reached via persistence's alias, imported
+        lazily so this stays importable without the milvus backend) so it is a
+        safe path component. With no ``map_id`` the
         path is unchanged (legacy/"default" behaviour)."""
         self._nodes: dict[str, SceneGraphNode] = {}
         self._geometric_edges: list[SceneGraphEdge] = []

--- a/system/scene/scene_service/service.py
+++ b/system/scene/scene_service/service.py
@@ -37,6 +37,7 @@ scene = Service(id="scene", namespace="robonix/system/scene")
 from . import mcp_tools
 from . import web as web_ui
 from .ingest.capabilities import plan_perception
+from .map_binding import MapBinding, choose_map_binding, read_latched_lifecycle
 from .ingest.perception_concept_graphs import ConceptGraphsDetector
 from .ingest.perception_vlm import VLMObjectDetector, _CamIntrinsics
 from .ingest.ros_subscribers import (
@@ -104,6 +105,12 @@ _SCENE_CONTRACTS: list[tuple[str, str, str]] = [
     ("pose",              "robonix/service/map/pose",            "PoseWithCovarianceStamped"),
     ("odom",              "robonix/service/map/odom",            "Odometry"),
     ("occupancy_grid",    "robonix/service/map/occupancy_grid",  "OccupancyGrid"),
+    # Latched {map_id, mode, generation} broadcast from mapping. Startup
+    # binding is probed separately (_discover_map_binding, before the hub
+    # exists); this hub subscription feeds the runtime mismatch watcher
+    # (_lifecycle_watch). Needs the generated `map` interface package
+    # (ros2_idl overlay) — the hub skips the row gracefully when missing.
+    ("map_lifecycle",     "robonix/service/map/lifecycle",       "MapLifecycle"),
 ]
 
 # Optional manifest opt-out: kinds listed here are dropped even if atlas
@@ -230,6 +237,46 @@ def _resolve_one_contract(
         msg_type=msg_type,
         qos_profile=qos_profile or "default",
     )
+
+
+def _discover_map_binding(wait_s: float) -> Optional[dict]:
+    """Probe mapping's latched lifecycle broadcast for the startup binding.
+
+    Adaptive cost: polls atlas for the `robonix/service/map/lifecycle`
+    contract for at most `wait_s` (the normal full-boot order starts scene
+    BEFORE mapping, so the contract is usually absent and this returns in
+    ~`wait_s`); once the contract resolves — the scene-restart-while-
+    mapping-runs case — the latched sample arrives immediately, with a 5 s
+    ceiling as safety. Returns {map_id, mode, generation} or None; blocking
+    is fine here, it runs before anything else is wired. `wait_s <= 0`
+    disables the probe (unit tests / ROS-less runs)."""
+    if wait_s <= 0:
+        return None
+    deadline = time.monotonic() + wait_s
+    while True:
+        try:
+            spec = _resolve_one_contract(
+                Transport.ROS2, "map_lifecycle",
+                "robonix/service/map/lifecycle", "MapLifecycle",
+            )
+        except Exception as e:  # noqa: BLE001
+            # Probe runs before bootstrap; if atlas isn't reachable yet a
+            # wire error must degrade to static binding, not kill startup.
+            log.warning("[scene] lifecycle probe: atlas query failed (%s) — "
+                        "falling back to static map binding", e)
+            return None
+        if spec is not None:
+            sample = read_latched_lifecycle(spec.topic, timeout_s=5.0)
+            if sample is None:
+                log.warning(
+                    "[scene] lifecycle contract resolved (%s) but no latched "
+                    "sample within 5s — falling back to static map binding",
+                    spec.topic,
+                )
+            return sample
+        if time.monotonic() >= deadline:
+            return None
+        time.sleep(0.5)
 
 
 def _resolve_explicit(
@@ -842,6 +889,71 @@ async def _ingest_detections(registry: ObjectRegistry, detections):
         )
 
 
+def _log_bg_task_exit(task: "asyncio.Task") -> None:
+    """Done-callback for scene's fire-and-forget background tasks: log any
+    exception at ERROR the moment the task dies, instead of letting asyncio
+    sit on it until interpreter shutdown."""
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        log.error("[scene] background task %r died: %r", task.get_name(), exc)
+
+
+async def _lifecycle_watch(hub: SubscribersHub, binding: MapBinding) -> None:
+    """P2 guard: scene binds its map_id ONCE at startup; when mapping's
+    broadcast later disagrees (map loaded/reset/switched at runtime), warn
+    loudly — reacting to it (flush + re-anchor the semantic state) is the
+    P3 lifecycle linkage, not guesswork here. Also confirms a static
+    binding the first time the broadcast appears and agrees."""
+    confirmed = False
+    warned_ephemeral = False
+    last_warned: Optional[tuple] = None
+    while True:
+        await asyncio.sleep(5.0)
+        msg, stamp_unix, _count = hub.latest("map_lifecycle")
+        if msg is None:
+            continue
+        live_id, live_gen = str(msg.map_id), int(msg.generation)
+        if not live_id:
+            # Ephemeral broadcast: no named identity to compare — but if
+            # scene statically bound a NAMED map, that named partition is
+            # being fed coordinates from a frame that resets every boot.
+            # Say so once instead of guarding silently forever.
+            if not warned_ephemeral and binding.source in ("config", "env"):
+                log.warning(
+                    "[scene] mapping broadcasts an EPHEMERAL session (empty "
+                    "map_id) while scene is bound to %r (source=%s) — set "
+                    "mapping's config.map_id to match", binding.map_id,
+                    binding.source,
+                )
+                warned_ephemeral = True
+            continue
+        id_ok = live_id == binding.map_id
+        gen_ok = binding.generation is None or live_gen == binding.generation
+        if id_ok and gen_ok:
+            if not confirmed:
+                log.info(
+                    "[scene] map binding confirmed by mapping lifecycle: "
+                    "id=%s gen=%d mode=%s", live_id, live_gen, str(msg.mode),
+                )
+                confirmed = True
+            last_warned = None
+            continue
+        key = (live_id, live_gen)
+        if key != last_warned:
+            log.warning(
+                "[scene] mapping's live map identity (id=%s gen=%d mode=%s) "
+                "no longer matches scene's startup binding (id=%s gen=%s "
+                "source=%s) — semantic state may be mis-anchored. Scene keeps "
+                "its startup binding until lifecycle linkage (P3) lands; "
+                "restart scene to rebind.",
+                live_id, live_gen, str(msg.mode),
+                binding.map_id, binding.generation, binding.source,
+            )
+            last_warned = key
+
+
 # ── main ───────────────────────────────────────────────────────────────────
 async def _run() -> None:
     config = _load_config()
@@ -865,14 +977,41 @@ async def _run() -> None:
     # arrive; the embedder is wired in later (only needed for writes). The
     # store is independent of SCENE_GRAPH_ENABLED — restore always runs if a
     # prior boot wrote rows — but writes are driven by the scene-graph builder.
-    # Which SLAM map this scene session belongs to. Deploy-controlled until
-    # mapping emits a real map identity — manifest `map_id` wins, else the
-    # SCENE_MAP_ID env, else "default". This is the join key against mapping
-    # and the scope key for ALL of scene's persistent state: object poses are
-    # only valid in their own map's frame, and so are the scene-graph caption/
-    # relation caches. Computed once here so the object store (below) and the
-    # scene-graph cache (further down) partition on the same value.
-    map_id = str(config.get("map_id") or os.environ.get("SCENE_MAP_ID") or "default")
+    # Which SLAM map this scene session belongs to. This is the join key
+    # against mapping and the scope key for ALL of scene's persistent state:
+    # object poses are only valid in their own map's frame, and so are the
+    # scene-graph caption/relation caches. Computed once here so the object
+    # store (below) and the scene-graph cache (further down) partition on
+    # the same value.
+    #
+    # Binding precedence (choose_map_binding): mapping's latched lifecycle
+    # broadcast — the authoritative map identity, probed briefly here —
+    # then manifest `map_id`, then SCENE_MAP_ID env, then "default". The
+    # static levers stay as fallback because the normal full-boot order
+    # starts scene BEFORE mapping (probe cost then ≈ the wait window);
+    # a scene restart while mapping runs binds from the broadcast alone.
+    broadcast = _discover_map_binding(
+        float(os.environ.get("SCENE_MAP_BINDING_WAIT_S", "3.0"))
+    )
+    binding = choose_map_binding(
+        broadcast, config.get("map_id"), os.environ.get("SCENE_MAP_ID")
+    )
+    map_id = binding.map_id
+    log.info(
+        "[scene] map binding: id=%s gen=%s source=%s",
+        binding.map_id, binding.generation, binding.source,
+    )
+    if broadcast is not None and not str(broadcast.get("map_id") or ""):
+        # mapping is provably UP but running ephemeral (no map_id) — its
+        # frame resets every boot, so the named partition scene just bound
+        # statically will never re-anchor. Likely a manifest misconfig
+        # (SCENE_MAP_ID set, mapping's config.map_id forgotten).
+        log.warning(
+            "[scene] mapping broadcasts an EPHEMERAL session (empty map_id) "
+            "while scene binds %r from %s — objects stored under this id "
+            "won't re-anchor across boots; set mapping's config.map_id to "
+            "match", binding.map_id, binding.source,
+        )
 
     obj_store = None
     if os.environ.get("SCENE_OBJECT_MEMORY_ENABLED", "true").lower() in ("true", "1", "yes"):
@@ -960,6 +1099,11 @@ async def _run() -> None:
         obj_store.set_embedder(getattr(perception, "embed_text", None))
     bg_tasks = [
         asyncio.create_task(_stale_tick(registry), name="scene-stale-tick"),
+        # P2 guard: warn when mapping's live map identity drifts from the
+        # binding scene started with (P3 will act on it instead).
+        asyncio.create_task(
+            _lifecycle_watch(hub, binding), name="scene-lifecycle-watch"
+        ),
         # Background reconciler: keeps scene's hub adding subscriptions
         # for new ROS2 topic_outs that appear on atlas after start
         # (mapping comes up after scene; same pattern for any future
@@ -975,6 +1119,11 @@ async def _run() -> None:
         ),
         *ingest_bg,
     ]
+    # These tasks are fire-and-forget: nothing awaits them, so an uncaught
+    # exception would otherwise vanish until shutdown (the failure mode of
+    # the failure-detectors themselves). Surface any death immediately.
+    for _t in bg_tasks:
+        _t.add_done_callback(_log_bg_task_exit)
 
     # ── Relation layer ───────────────────────────────────────────────
     # Fast geometric relations (contact/containment + reachable_by) are

--- a/system/scene/scene_service/service.py
+++ b/system/scene/scene_service/service.py
@@ -36,6 +36,7 @@ scene = Service(id="scene", namespace="robonix/system/scene")
 
 from . import mcp_tools
 from . import web as web_ui
+from .annotations import AnnotationStore
 from .ingest.capabilities import plan_perception
 from .map_binding import MapBinding, choose_map_binding, read_latched_lifecycle
 from .ingest.perception_concept_graphs import ConceptGraphsDetector
@@ -900,15 +901,32 @@ def _log_bg_task_exit(task: "asyncio.Task") -> None:
         log.error("[scene] background task %r died: %r", task.get_name(), exc)
 
 
-async def _lifecycle_watch(hub: SubscribersHub, binding: MapBinding) -> None:
+async def _lifecycle_watch(
+    hub: SubscribersHub,
+    binding: MapBinding,
+    anno_store: Optional[AnnotationStore] = None,
+) -> None:
     """P2 guard: scene binds its map_id ONCE at startup; when mapping's
     broadcast later disagrees (map loaded/reset/switched at runtime), warn
     loudly — reacting to it (flush + re-anchor the semantic state) is the
     P3 lifecycle linkage, not guesswork here. Also confirms a static
-    binding the first time the broadcast appears and agrees."""
+    binding the first time the broadcast appears and agrees.
+
+    One reaction IS taken already: a generation bump on the SAME map flags
+    the user's annotations stale (flag-only — user assets are never
+    deleted automatically). That is a marker write, not a flush, so it is
+    safe ahead of P3; and because it is best-effort, a failing marker
+    write must never kill this watcher — the drift WARNING itself is the
+    load-bearing part.
+
+    A static binding (config/env — the normal full-boot order, scene up
+    before mapping) carries no generation, so the epoch reference is
+    learned from the FIRST confirming broadcast: without that, `gen_ok`
+    would stay vacuously true and runtime bumps would be invisible."""
     confirmed = False
     warned_ephemeral = False
     last_warned: Optional[tuple] = None
+    ref_gen = binding.generation
     while True:
         await asyncio.sleep(5.0)
         msg, stamp_unix, _count = hub.latest("map_lifecycle")
@@ -930,7 +948,7 @@ async def _lifecycle_watch(hub: SubscribersHub, binding: MapBinding) -> None:
                 warned_ephemeral = True
             continue
         id_ok = live_id == binding.map_id
-        gen_ok = binding.generation is None or live_gen == binding.generation
+        gen_ok = ref_gen is None or live_gen == ref_gen
         if id_ok and gen_ok:
             if not confirmed:
                 log.info(
@@ -938,6 +956,21 @@ async def _lifecycle_watch(hub: SubscribersHub, binding: MapBinding) -> None:
                     "id=%s gen=%d mode=%s", live_id, live_gen, str(msg.mode),
                 )
                 confirmed = True
+                # Static bindings learn their epoch here; from now on a
+                # bump IS detectable. The annotation store gets to compare
+                # the confirmed epoch against the one its file recorded
+                # (it too may have loaded under an unknown generation).
+                ref_gen = live_gen
+                if anno_store is not None:
+                    try:
+                        anno_store.reconcile_generation(live_gen)
+                    except Exception as e:  # noqa: BLE001
+                        # Best-effort marker write (disk full / read-only
+                        # dir); the watcher itself must survive it.
+                        log.error(
+                            "[scene-anno] generation reconcile failed "
+                            "(annotation staleness may be outdated): %s", e,
+                        )
             last_warned = None
             continue
         key = (live_id, live_gen)
@@ -949,8 +982,37 @@ async def _lifecycle_watch(hub: SubscribersHub, binding: MapBinding) -> None:
                 "its startup binding until lifecycle linkage (P3) lands; "
                 "restart scene to rebind.",
                 live_id, live_gen, str(msg.mode),
-                binding.map_id, binding.generation, binding.source,
+                binding.map_id, ref_gen, binding.source,
             )
+            if anno_store is not None and id_ok and not gen_ok:
+                # Same map, new frame epoch: user-drawn geometry may no
+                # longer line up with the rebuilt map. Flag it for user
+                # confirmation (marker-only; deletion is never automatic).
+                try:
+                    n = anno_store.mark_all_stale(
+                        f"map generation {ref_gen}→{live_gen}",
+                        new_generation=live_gen,
+                    )
+                    if n:
+                        log.warning(
+                            "[scene-anno] %d annotation(s) marked stale — "
+                            "confirm or redraw them in the map UI", n,
+                        )
+                except Exception as e:  # noqa: BLE001
+                    # Losing the stale marker is recoverable (next boot's
+                    # load-time epoch check re-judges); losing this watcher
+                    # would silence ALL drift warnings for the session.
+                    log.error(
+                        "[scene-anno] stale marking failed (annotations "
+                        "may show as fresh until restart): %s", e,
+                    )
+            if id_ok:
+                # Acknowledge the new epoch so a THIRD epoch is reported
+                # against this one (accurate from→to in reason/log), and
+                # each bump warns exactly once. The registry's semantic
+                # state stays anchored to the startup binding until the
+                # lifecycle linkage (P3) actually re-anchors it.
+                ref_gen = live_gen
             last_warned = key
 
 
@@ -1040,6 +1102,34 @@ async def _run() -> None:
                 "writes): %s", e,
             )
             obj_store = None
+
+    # User annotations (rooms / POIs) — user-authored semantics on the same
+    # map_id partition rule as the object store; validity is additionally
+    # tracked against mapping's generation epoch (annotations only — the
+    # object store has no epoch concept). A failure here disables the
+    # annotation API for the session (web answers 503) but never blocks
+    # scene itself.
+    anno_store: Optional[AnnotationStore] = None
+    try:
+        anno_store = AnnotationStore(
+            os.environ.get(
+                "SCENE_ANNOTATIONS_DIR", "/data/robonix/scene_annotations"
+            ),
+            map_id=map_id,
+            generation=binding.generation,
+        )
+        anns = anno_store.list()
+        log.info(
+            "[scene-anno] annotation store ready: %d annotation(s), %d stale "
+            "(map_id=%s) at %s",
+            len(anns), sum(a.stale for a in anns), anno_store.map_id,
+            anno_store.path,
+        )
+    except Exception as e:  # noqa: BLE001
+        log.error(
+            "[scene-anno] annotation store init failed — annotation API "
+            "disabled for this session: %s", e,
+        )
     # mcp_tools v0 only needs the registry + the ROS hub (the latter is
     # supplied later in _start_ros_ingest). The geometric relation loop +
     # scene-graph store are wired further down, once the registry is live.
@@ -1102,7 +1192,8 @@ async def _run() -> None:
         # P2 guard: warn when mapping's live map identity drifts from the
         # binding scene started with (P3 will act on it instead).
         asyncio.create_task(
-            _lifecycle_watch(hub, binding), name="scene-lifecycle-watch"
+            _lifecycle_watch(hub, binding, anno_store),
+            name="scene-lifecycle-watch",
         ),
         # Background reconciler: keeps scene's hub adding subscriptions
         # for new ROS2 topic_outs that appear on atlas after start
@@ -1199,6 +1290,13 @@ async def _run() -> None:
             hub=hub,
             detector=perception,
             sg_store=sg_store,
+            anno_store=anno_store,
+            map_binding={
+                "map_id": binding.map_id,
+                "mode": binding.mode,
+                "generation": binding.generation,
+                "source": binding.source,
+            },
         )
         web_uv = uvicorn.Config(
             app=web_app,

--- a/system/scene/scene_service/web.py
+++ b/system/scene/scene_service/web.py
@@ -27,6 +27,7 @@ from starlette.responses import HTMLResponse, JSONResponse
 from starlette.routing import Mount, Route
 from starlette.staticfiles import StaticFiles
 
+from .annotations import validate_annotation_fields
 from .state import ObjectRegistry
 
 log = logging.getLogger(__name__)
@@ -371,13 +372,18 @@ def _camera_payload(hub: Any) -> dict:
 
 
 def _state_payload(registry: ObjectRegistry,
-                   hub: Any, sg_store: Any = None) -> dict:
+                   hub: Any, sg_store: Any = None,
+                   anno_store: Any = None,
+                   map_binding: Optional[dict] = None) -> dict:
     """Serialise the registry + relations + map into the small JSON
     shape the page consumes. Done in one snapshot so the page never
     sees a half-updated registry. The "relations" field shows the fast
     geometric slice (``reachable_by`` only, under the VLM-primary graph);
     the "scene_graph" field shows the full composed graph (geometric +
-    image-grounded relational/semantic edges)."""
+    image-grounded relational/semantic edges). "annotations" carries the
+    user-drawn rooms/POIs (map-frame meters, same coordinates as objects)
+    and "map_binding" the identity scene is bound to — both consumed by
+    the /user annotation page."""
     objs_dict, _surfaces = _sync_snapshot(registry)
     geo_edges = sg_store.get_geometric_edges() if sg_store is not None else []
     out_objects: list[dict[str, Any]] = []
@@ -427,6 +433,8 @@ def _state_payload(registry: ObjectRegistry,
         "scene_graph": sg_payload,
         "robot": robot_pose,
         "occupancy": _occupancy_payload(hub),
+        "annotations": anno_store.list_json() if anno_store is not None else [],
+        "map_binding": map_binding,
         "stamp_unix": time.time(),
     }
 
@@ -448,21 +456,50 @@ def _sync_snapshot(registry: ObjectRegistry):
 
 def make_app(*, registry: ObjectRegistry,
              hub: Any = None, detector: Any = None,
-             sg_store: Any = None) -> Starlette:
+             sg_store: Any = None, anno_store: Any = None,
+             map_binding: Optional[dict] = None) -> Starlette:
     """Build the Starlette ASGI app the entrypoint mounts on its own
     uvicorn server.
 
     Routes:
-      GET /                — 2D top-down map (occupancy grid + objects)
+      GET /                — combined split layout (2D map · 3D · cam)
+      GET /2d              — 2D top-down map (occupancy grid + objects)
       GET /3d              — 3D scene (point clouds + bbox; three.js)
+      GET /cam             — camera stack (live RGB + depth)
+      GET /user            — end-user map page (rooms: draw / rename /
+                             confirm-stale / delete; light object overlay)
       GET /api/state       — JSON for the 2D map
       GET /api/objects3d   — JSON for the 3D viz (per-object pcd + bbox)
+      GET /api/camera      — JSON: latest RGB + depth frames
+      /api/annotations[..] — user annotation CRUD (see below)
 
     `hub` is the SubscribersHub — passed so the JSON state can include
     the latest OccupancyGrid for the 2D canvas underlay.
     `detector` is the ConceptGraphsDetector — passed so the 3D endpoint
     can serialize its persistent MapObjectList. If None, the 3D page
     just shows an empty world.
+    `anno_store` is the AnnotationStore backing the annotation CRUD; when
+    None (store init failed / disabled) those routes answer 503.
+    `map_binding` is a static {map_id, mode, generation, source} dict shown
+    by the /user page header.
+
+    Annotation API contract (STABLE once shipped — any frontend builds on
+    it; see system/scene/README.md):
+      GET    /api/annotations       → {ok, annotations: [...]}
+      POST   /api/annotations       body {kind, name, points, theta?}
+                                    → {ok, annotation}
+      PUT    /api/annotations/{id}  body: any of {name, points, theta,
+                                    stale:false} → {ok, annotation}
+      DELETE /api/annotations/{id}  → {ok}
+    theta (heading, radians) is poi-only — a room carrying it is a 400.
+    On PUT, theta null/absent means "keep"; a set heading cannot be
+    cleared, only changed (deliberate until the poi UI exists).
+    Errors: 400 invalid body/fields, 404 unknown id, 503 store unavailable;
+    those carry {ok: false, detail}. A store write failure (disk full)
+    deliberately escapes as a plain 500 — the edit was NOT saved and hiding
+    that behind a tidy body would be worse. Coordinates are map-frame
+    meters. Same trust domain as the rest of this LAN debug/UI server —
+    no auth.
     """
 
     async def index(_request) -> HTMLResponse:
@@ -477,7 +514,91 @@ def make_app(*, registry: ObjectRegistry,
         return HTMLResponse(_INDEX_HTML)
 
     async def state(_request) -> JSONResponse:
-        return JSONResponse(_state_payload(registry, hub, sg_store))
+        return JSONResponse(
+            _state_payload(registry, hub, sg_store, anno_store, map_binding)
+        )
+
+    # ── annotation CRUD ──────────────────────────────────────────────
+    def _anno_error(status: int, detail: str) -> JSONResponse:
+        return JSONResponse({"ok": False, "detail": detail}, status_code=status)
+
+    async def _anno_body(request) -> Optional[dict]:
+        """Parse the JSON request body; None (→ caller answers 400) when
+        it is missing, malformed, or not an object."""
+        try:
+            body = await request.json()
+        except Exception:  # noqa: BLE001 — malformed body is a client error
+            return None
+        return body if isinstance(body, dict) else None
+
+    async def annotations_list(_request) -> JSONResponse:
+        if anno_store is None:
+            return _anno_error(503, "annotation store unavailable")
+        return JSONResponse({"ok": True, "annotations": anno_store.list_json()})
+
+    async def annotations_create(request) -> JSONResponse:
+        """POST /api/annotations — validate {kind, name, points, theta?}
+        and persist a new annotation (returned with its generated id)."""
+        if anno_store is None:
+            return _anno_error(503, "annotation store unavailable")
+        body = await _anno_body(request)
+        if body is None:
+            return _anno_error(400, "request body must be a JSON object")
+        kind = body.get("kind")
+        name = body.get("name", "")
+        points = body.get("points")
+        theta = body.get("theta")
+        err = validate_annotation_fields(kind, name, points, theta)
+        if err:
+            return _anno_error(400, err)
+        ann = anno_store.create(kind=kind, name=name, points=points, theta=theta)
+        return JSONResponse({"ok": True, "annotation": ann.to_json()})
+
+    async def annotations_update(request) -> JSONResponse:
+        """PUT /api/annotations/{id} — partial update: any of name /
+        points / theta / stale:false (the user's "confirm still valid").
+        Provided fields are validated against the annotation's kind."""
+        if anno_store is None:
+            return _anno_error(503, "annotation store unavailable")
+        ann_id = request.path_params["annotation_id"]
+        existing = anno_store.get(ann_id)
+        if existing is None:
+            return _anno_error(404, f"unknown annotation id {ann_id!r}")
+        body = await _anno_body(request)
+        if body is None:
+            return _anno_error(400, "request body must be a JSON object")
+        name = body.get("name")
+        points = body.get("points")
+        theta = body.get("theta")
+        # Validate the would-be merged state so a partial update can never
+        # store something a create would have rejected.
+        err = validate_annotation_fields(
+            existing.kind,
+            name if name is not None else existing.name,
+            points if points is not None else existing.points,
+            theta if theta is not None else existing.theta,
+        )
+        if err:
+            return _anno_error(400, err)
+        clear_stale = body.get("stale") is False
+        ann = anno_store.update(
+            ann_id, name=name, points=points, theta=theta,
+            clear_stale=clear_stale,
+        )
+        if ann is None:  # deleted between get and update — still a 404
+            return _anno_error(404, f"unknown annotation id {ann_id!r}")
+        return JSONResponse({"ok": True, "annotation": ann.to_json()})
+
+    async def annotations_delete(request) -> JSONResponse:
+        """DELETE /api/annotations/{id} — remove the annotation; 404 when
+        the id is unknown (delete is the user's explicit action, so unlike
+        staleness it IS allowed to drop a user asset)."""
+        if anno_store is None:
+            return _anno_error(503, "annotation store unavailable")
+        ann_id = request.path_params["annotation_id"]
+        if not anno_store.delete(ann_id):
+            return _anno_error(404, f"unknown annotation id {ann_id!r}")
+        return JSONResponse({"ok": True})
 
     async def index3d(_request) -> HTMLResponse:
         return HTMLResponse(_INDEX_3D_HTML)
@@ -489,6 +610,9 @@ def make_app(*, registry: ObjectRegistry,
 
     async def cam(_request) -> HTMLResponse:
         return HTMLResponse(_INDEX_CAM_HTML)
+
+    async def user_page(_request) -> HTMLResponse:
+        return HTMLResponse(_USER_HTML)
 
     async def camera_state(_request) -> JSONResponse:
         return JSONResponse(_camera_payload(hub))
@@ -504,9 +628,16 @@ def make_app(*, registry: ObjectRegistry,
         Route("/2d", index2d, methods=["GET"]),
         Route("/3d", index3d, methods=["GET"]),
         Route("/cam", cam, methods=["GET"]),
+        Route("/user", user_page, methods=["GET"]),
         Route("/api/state", state, methods=["GET"]),
         Route("/api/objects3d", objects3d, methods=["GET"]),
         Route("/api/camera", camera_state, methods=["GET"]),
+        Route("/api/annotations", annotations_list, methods=["GET"]),
+        Route("/api/annotations", annotations_create, methods=["POST"]),
+        Route("/api/annotations/{annotation_id}", annotations_update,
+              methods=["PUT"]),
+        Route("/api/annotations/{annotation_id}", annotations_delete,
+              methods=["DELETE"]),
     ]
     if static_dir.is_dir():
         routes.append(Mount("/static", StaticFiles(directory=str(static_dir)), name="static"))
@@ -1696,6 +1827,419 @@ _INDEX_3D_HTML = r"""<!doctype html>
     }
     requestAnimationFrame(loop);
   </script>
+</body>
+</html>
+"""
+
+
+# ── User annotation page (/user) ─────────────────────────────────────────────
+# The end-user map page: SLAM occupancy underlay + LIGHTWEIGHT object overlay
+# + user-drawn room polygons, with a draw-a-room flow talking to the
+# /api/annotations CRUD. Deliberately self-contained (own inline JS, no
+# imports from the debug pages' scripts): the two pages evolve independently
+# and a debug-UI tweak must never break the user page. Kept dependency-free
+# like every other page here (no framework, no build step).
+_USER_HTML = r"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>robonix — map & rooms</title>
+  <style>
+    :root { --fg:#e8eaed; --bg:#0e1015; --panel:#161a22; --acc:#7aa7ff;
+            --muted:#7d828b; --warn:#e6c454; --danger:#e06c75; }
+    html, body { background: var(--bg); color: var(--fg); margin: 0; height: 100%;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    #app { display: flex; flex-direction: column; height: 100vh; }
+    header { display: flex; align-items: center; gap: 14px; padding: 10px 16px;
+      background: var(--panel); border-bottom: 1px solid #232936; flex: none; }
+    header h1 { font-size: 15px; margin: 0; font-weight: 600; }
+    header .meta { font-size: 12px; color: var(--muted); }
+    header .stale-alert { font-size: 12px; color: var(--warn); display: none; }
+    #main { display: flex; flex: 1; min-height: 0; }
+    #panel { width: 260px; flex: none; background: var(--panel);
+      border-right: 1px solid #232936; display: flex; flex-direction: column; }
+    #panel .actions { padding: 12px; border-bottom: 1px solid #232936; }
+    button { background: #222a3a; color: var(--fg); border: 1px solid #33405a;
+      border-radius: 6px; padding: 6px 10px; font-size: 12px; cursor: pointer; }
+    button:hover { background: #2a3550; }
+    button.primary { background: #2b4a86; border-color: #3c62ad; }
+    button.primary.active { background: var(--acc); color: #0e1015; }
+    button.small { padding: 2px 7px; font-size: 11px; }
+    button.danger { border-color: #6b3640; color: var(--danger); }
+    #room-list { flex: 1; overflow-y: auto; padding: 8px 12px; }
+    .room { border: 1px solid #232936; border-radius: 8px; padding: 8px 10px;
+      margin-bottom: 8px; font-size: 13px; }
+    .room.selected { border-color: var(--acc); }
+    .room .name { font-weight: 600; }
+    .room .sub { color: var(--muted); font-size: 11px; margin: 3px 0 6px; }
+    .room .badge { color: #0e1015; background: var(--warn); border-radius: 4px;
+      padding: 0 5px; font-size: 10px; font-weight: 700; margin-left: 6px; }
+    .room .btns { display: flex; gap: 6px; }
+    #canvas-wrap { position: relative; flex: 1; min-width: 0; }
+    canvas { display: block; width: 100%; height: 100%; background: #14171f; }
+    #hint { position: absolute; top: 10px; left: 50%; transform: translateX(-50%);
+      background: rgba(20,23,31,.92); border: 1px solid #33405a; color: var(--fg);
+      font-size: 12px; padding: 6px 12px; border-radius: 6px; display: none; }
+    #toast { position: absolute; bottom: 14px; left: 50%; transform: translateX(-50%);
+      background: rgba(20,23,31,.95); border: 1px solid #6b3640; color: var(--danger);
+      font-size: 12px; padding: 6px 12px; border-radius: 6px; display: none; }
+    .legend { position: absolute; bottom: 8px; left: 12px; font-size: 11px;
+      color: var(--muted); background: rgba(20,23,31,.85); padding: 4px 8px;
+      border-radius: 4px; }
+    #empty { padding: 10px 2px; color: var(--muted); font-size: 12px; }
+  </style>
+</head>
+<body>
+<div id="app">
+  <header>
+    <h1>Map &amp; rooms</h1>
+    <span class="meta" id="meta">map: —</span>
+    <span class="stale-alert" id="stale-alert">⚠ map was rebuilt — review stale rooms</span>
+  </header>
+  <div id="main">
+    <div id="panel">
+      <div class="actions">
+        <button class="primary" id="btn-draw">✏ Annotate room</button>
+      </div>
+      <div id="room-list"><div id="empty">No rooms yet. Click “Annotate room”,
+        then click on the map to outline one (double-click or Enter to finish,
+        Esc to cancel).</div></div>
+    </div>
+    <div id="canvas-wrap">
+      <canvas id="c"></canvas>
+      <div id="hint"></div>
+      <div id="toast"></div>
+      <div class="legend">drag to pan · wheel to zoom · hover a dot for its label</div>
+    </div>
+  </div>
+</div>
+<script>
+const c = document.getElementById('c');
+const ctx = c.getContext('2d');
+function fit() { c.width = c.clientWidth; c.height = c.clientHeight; }
+window.addEventListener('resize', fit); fit();
+
+// ── view transform (world meters ↔ canvas px) ────────────────────────────
+// Unlike the debug page (which chases the robot) the editor keeps a STABLE
+// user-controlled view: drawing needs the map to hold still under the mouse.
+let center = [0, 0];
+let pxPerM = 40;
+let viewInit = false;
+function w2p(x, y) {
+    return [c.width / 2 + (x - center[0]) * pxPerM,
+            c.height / 2 - (y - center[1]) * pxPerM];
+}
+function p2w(px, py) {
+    return [center[0] + (px - c.width / 2) / pxPerM,
+            center[1] - (py - c.height / 2) / pxPerM];
+}
+
+// ── state ────────────────────────────────────────────────────────────────
+let state = null;          // last /api/state payload
+let occImg = null, occMeta = null, occStamp = 0, occLoading = 0;
+let drawMode = false;
+let draft = [];            // in-progress polygon vertices (world coords)
+let mouseWorld = null;     // live cursor position for the rubber-band edge
+let hoverObj = null;
+let selectedId = null;
+
+const hintEl = document.getElementById('hint');
+function setHint(text) {
+    hintEl.style.display = text ? 'block' : 'none';
+    hintEl.textContent = text || '';
+}
+let toastTimer = null;
+function toast(text) {
+    const t = document.getElementById('toast');
+    t.textContent = text; t.style.display = 'block';
+    clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => { t.style.display = 'none'; }, 4000);
+}
+
+// ── rendering ────────────────────────────────────────────────────────────
+function polyCentroid(pts) {
+    let sx = 0, sy = 0;
+    for (const [x, y] of pts) { sx += x; sy += y; }
+    return [sx / pts.length, sy / pts.length];
+}
+
+function draw() {
+    fit();
+    ctx.clearRect(0, 0, c.width, c.height);
+    if (!state) return;
+
+    // occupancy underlay (same decode/anchor math as the debug 2D page:
+    // cell [0,0] at world origin, y flipped because image y grows down).
+    // occStamp only advances on successful decode, so a corrupt frame is
+    // retried on the next poll instead of wedging the underlay.
+    if (state.occupancy && state.occupancy.stamp_ms !== occStamp
+        && state.occupancy.stamp_ms !== occLoading) {
+        occLoading = state.occupancy.stamp_ms;
+        const meta = state.occupancy;
+        const im = new Image();
+        im.onload = () => { occImg = im; occMeta = meta; occStamp = meta.stamp_ms; };
+        im.onerror = () => { occLoading = 0; console.error('occupancy PNG decode failed'); };
+        im.src = 'data:image/png;base64,' + meta.png_b64;
+    }
+    if (occImg && occMeta) {
+        if (!viewInit) {   // first grid: fit it into the viewport once
+            const wM = occMeta.width * occMeta.resolution;
+            const hM = occMeta.height * occMeta.resolution;
+            center = [occMeta.origin_x + wM / 2, occMeta.origin_y + hM / 2];
+            pxPerM = Math.min((c.width - 40) / wM, (c.height - 40) / hM, 120);
+            pxPerM = Math.max(pxPerM, 5);
+            viewInit = true;
+        }
+        const wM = occMeta.width * occMeta.resolution;
+        const hM = occMeta.height * occMeta.resolution;
+        const [x0, y0] = w2p(occMeta.origin_x, occMeta.origin_y + hM);
+        ctx.globalAlpha = 0.9;
+        ctx.imageSmoothingEnabled = false;
+        ctx.drawImage(occImg, x0, y0, wM * pxPerM, hM * pxPerM);
+        ctx.globalAlpha = 1.0;
+    } else {
+        ctx.fillStyle = '#7d828b'; ctx.font = '13px sans-serif';
+        ctx.fillText('no map yet — the SLAM map appears here once mapping publishes it', 20, 30);
+    }
+
+    // saved rooms
+    for (const a of (state.annotations || [])) {
+        if (a.kind !== 'room' || a.points.length < 3) continue;
+        const pts = a.points.map(p => w2p(p[0], p[1]));
+        ctx.beginPath();
+        pts.forEach(([x, y], i) => i ? ctx.lineTo(x, y) : ctx.moveTo(x, y));
+        ctx.closePath();
+        const sel = a.annotation_id === selectedId;
+        ctx.fillStyle = a.stale ? 'rgba(230,196,84,0.10)' : 'rgba(122,167,255,0.12)';
+        ctx.fill();
+        ctx.lineWidth = sel ? 2.5 : 1.5;
+        ctx.strokeStyle = a.stale ? '#e6c454' : (sel ? '#a8c4ff' : '#7aa7ff');
+        ctx.setLineDash(a.stale ? [6, 4] : []);
+        ctx.stroke();
+        ctx.setLineDash([]);
+        const [cx, cy] = w2p(...polyCentroid(a.points));
+        const label = (a.stale ? '⚠ ' : '') + (a.name || '(unnamed)');
+        ctx.font = 'bold 13px sans-serif'; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+        ctx.lineWidth = 3; ctx.strokeStyle = 'rgba(0,0,0,0.85)';
+        ctx.strokeText(label, cx, cy);
+        ctx.fillStyle = a.stale ? '#e6c454' : '#cfe0ff';
+        ctx.fillText(label, cx, cy);
+        ctx.textAlign = 'start';
+    }
+
+    // objects — small translucent dots; label only on hover (readability:
+    // the underlay must stay legible, objects are a light overlay).
+    for (const o of (state.objects || [])) {
+        if (o.cls === 'robot') continue;
+        const [px, py] = w2p(o.pose.x, o.pose.y);
+        ctx.globalAlpha = o.missing ? 0.25 : 0.6;
+        ctx.fillStyle = '#9ab8e8';
+        ctx.beginPath(); ctx.arc(px, py, 3.5, 0, Math.PI * 2); ctx.fill();
+        ctx.globalAlpha = 1;
+        ctx.lineWidth = 1; ctx.strokeStyle = 'rgba(14,16,21,0.9)';
+        ctx.stroke();
+    }
+    if (hoverObj) {
+        const [px, py] = w2p(hoverObj.pose.x, hoverObj.pose.y);
+        ctx.font = '12px ui-monospace, monospace'; ctx.textBaseline = 'middle';
+        ctx.lineWidth = 3; ctx.strokeStyle = 'rgba(0,0,0,0.85)';
+        ctx.strokeText(hoverObj.cls, px + 8, py);
+        ctx.fillStyle = '#cfe0ff';
+        ctx.fillText(hoverObj.cls, px + 8, py);
+    }
+
+    // robot marker (small arrow, subtle)
+    const robot = state.robot;
+    if (robot) {
+        const [rx, ry] = w2p(robot.x, robot.y);
+        const yaw = robot.yaw || 0;
+        ctx.strokeStyle = '#7aa7ff'; ctx.fillStyle = '#7aa7ff'; ctx.lineWidth = 2;
+        ctx.beginPath(); ctx.arc(rx, ry, 5, 0, Math.PI * 2); ctx.stroke();
+        ctx.beginPath();
+        ctx.moveTo(rx, ry);
+        ctx.lineTo(rx + Math.cos(yaw) * 14, ry - Math.sin(yaw) * 14);
+        ctx.stroke();
+    }
+
+    // draft polygon (draw mode)
+    if (drawMode && draft.length) {
+        const pts = draft.map(p => w2p(p[0], p[1]));
+        ctx.beginPath();
+        pts.forEach(([x, y], i) => i ? ctx.lineTo(x, y) : ctx.moveTo(x, y));
+        if (mouseWorld) { const [mx, my] = w2p(...mouseWorld); ctx.lineTo(mx, my); }
+        ctx.strokeStyle = '#8ef0b7'; ctx.lineWidth = 2; ctx.setLineDash([5, 4]);
+        ctx.stroke(); ctx.setLineDash([]);
+        ctx.fillStyle = '#8ef0b7';
+        for (const [x, y] of pts) {
+            ctx.beginPath(); ctx.arc(x, y, 3, 0, Math.PI * 2); ctx.fill();
+        }
+    }
+}
+
+// ── side panel ───────────────────────────────────────────────────────────
+function esc(s) {
+    return String(s).replace(/[&<>"']/g,
+        ch => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch]));
+}
+function renderPanel() {
+    const rooms = (state && state.annotations || []).filter(a => a.kind === 'room');
+    const list = document.getElementById('room-list');
+    const anyStale = rooms.some(a => a.stale);
+    document.getElementById('stale-alert').style.display = anyStale ? 'inline' : 'none';
+    if (!rooms.length) {
+        list.innerHTML = '<div id="empty">No rooms yet. Click “Annotate room”, ' +
+          'then click on the map to outline one (double-click or Enter to ' +
+          'finish, Esc to cancel).</div>';
+        return;
+    }
+    list.innerHTML = rooms.map(a => `
+      <div class="room ${a.annotation_id === selectedId ? 'selected' : ''}"
+           data-id="${a.annotation_id}">
+        <span class="name">${esc(a.name || '(unnamed)')}</span>
+        ${a.stale ? '<span class="badge" title="' + esc(a.stale_reason) + '">STALE</span>' : ''}
+        <div class="sub">${a.points.length} corners</div>
+        <div class="btns">
+          <button class="small" data-act="rename">Rename</button>
+          ${a.stale ? '<button class="small" data-act="confirm">Still valid</button>' : ''}
+          <button class="small danger" data-act="delete">Delete</button>
+        </div>
+      </div>`).join('');
+}
+document.getElementById('room-list').addEventListener('click', async (ev) => {
+    const roomEl = ev.target.closest('.room');
+    if (!roomEl) return;
+    const id = roomEl.dataset.id;
+    const act = ev.target.dataset && ev.target.dataset.act;
+    if (!act) { selectedId = (selectedId === id) ? null : id; renderPanel(); draw(); return; }
+    const room = (state.annotations || []).find(a => a.annotation_id === id);
+    if (!room) return;
+    if (act === 'rename') {
+        const name = prompt('Room name:', room.name);
+        if (name !== null) await api('PUT', '/api/annotations/' + id, { name });
+    } else if (act === 'confirm') {
+        await api('PUT', '/api/annotations/' + id, { stale: false });
+    } else if (act === 'delete') {
+        if (confirm(`Delete room “${room.name}”?`))
+            await api('DELETE', '/api/annotations/' + id);
+    }
+});
+
+// ── draw mode ────────────────────────────────────────────────────────────
+const btnDraw = document.getElementById('btn-draw');
+function setDrawMode(on) {
+    drawMode = on;
+    draft = [];
+    btnDraw.classList.toggle('active', on);
+    btnDraw.textContent = on ? '✕ Cancel drawing' : '✏ Annotate room';
+    c.style.cursor = on ? 'crosshair' : 'grab';
+    setHint(on ? 'Click to add corners · double-click or Enter to finish (≥3) · Esc to cancel' : '');
+    draw();
+}
+btnDraw.addEventListener('click', () => setDrawMode(!drawMode));
+
+async function finishDraft() {
+    if (draft.length < 3) { toast('A room needs at least 3 corners.'); return; }
+    const name = prompt('Room name:', '');
+    if (name === null) return;          // keep drawing
+    const body = { kind: 'room', name, points: draft };
+    if (await api('POST', '/api/annotations', body)) setDrawMode(false);
+}
+
+// ── canvas input: pan / zoom / vertex clicks / hover ─────────────────────
+let dragging = false, dragMoved = false, lastPos = null;
+c.style.cursor = 'grab';
+c.addEventListener('mousedown', (ev) => {
+    dragging = true; dragMoved = false; lastPos = [ev.offsetX, ev.offsetY];
+});
+window.addEventListener('mouseup', () => { dragging = false; });
+c.addEventListener('mousemove', (ev) => {
+    mouseWorld = p2w(ev.offsetX, ev.offsetY);
+    if (dragging && lastPos) {
+        const dx = ev.offsetX - lastPos[0], dy = ev.offsetY - lastPos[1];
+        if (Math.abs(dx) + Math.abs(dy) > 3) dragMoved = true;
+        if (dragMoved) {
+            center = [center[0] - dx / pxPerM, center[1] + dy / pxPerM];
+            lastPos = [ev.offsetX, ev.offsetY];
+        }
+    } else if (!drawMode && state) {
+        hoverObj = null;
+        for (const o of (state.objects || [])) {
+            if (o.cls === 'robot') continue;
+            const [px, py] = w2p(o.pose.x, o.pose.y);
+            if ((px - ev.offsetX) ** 2 + (py - ev.offsetY) ** 2 < 100) { hoverObj = o; break; }
+        }
+    }
+    draw();
+});
+c.addEventListener('click', (ev) => {
+    if (dragMoved) return;              // that was a pan, not a click
+    if (drawMode) { draft.push(p2w(ev.offsetX, ev.offsetY)); draw(); }
+});
+c.addEventListener('dblclick', (ev) => {
+    ev.preventDefault();
+    if (drawMode) {
+        // the dblclick's two single clicks added two duplicate corners at
+        // the same spot — drop one before closing.
+        if (draft.length > 1) draft.pop();
+        finishDraft();
+    }
+});
+window.addEventListener('keydown', (ev) => {
+    if (!drawMode) return;
+    if (ev.key === 'Escape') setDrawMode(false);
+    if (ev.key === 'Enter') finishDraft();
+});
+c.addEventListener('wheel', (ev) => {
+    ev.preventDefault();
+    const factor = ev.deltaY < 0 ? 1.15 : 1 / 1.15;
+    // zoom about the cursor so the point under the mouse stays put
+    const [wx, wy] = p2w(ev.offsetX, ev.offsetY);
+    pxPerM = Math.min(400, Math.max(3, pxPerM * factor));
+    const [nx, ny] = p2w(ev.offsetX, ev.offsetY);
+    center = [center[0] + (wx - nx), center[1] + (wy - ny)];
+    draw();
+}, { passive: false });
+
+// ── API + polling ────────────────────────────────────────────────────────
+async function api(method, path, body) {
+    try {
+        const r = await fetch(path, {
+            method,
+            headers: body !== undefined ? { 'Content-Type': 'application/json' } : {},
+            body: body !== undefined ? JSON.stringify(body) : undefined,
+        });
+        const out = await r.json().catch(() => null);
+        if (!r.ok || !out || out.ok === false) {
+            toast((out && out.detail) || (method + ' failed (' + r.status + ')'));
+            return null;
+        }
+        await refresh();
+        return out;
+    } catch (e) { toast('request failed: ' + e); return null; }
+}
+
+async function refresh() {
+    // Only the network fetch/parse is try-guarded (transient by nature);
+    // a bug thrown by the render functions must surface in the console,
+    // not be swallowed once a second forever.
+    let next = null;
+    try {
+        const r = await fetch('/api/state', { cache: 'no-store' });
+        if (!r.ok) return;
+        next = await r.json();
+    } catch (_) { return; /* transient; next poll retries */ }
+    state = next;
+    const mb = state.map_binding;
+    document.getElementById('meta').textContent = mb
+        ? `map: ${mb.map_id} · ${mb.mode || 'mode unknown'}`
+        : 'map: —';
+    renderPanel();
+    draw();
+}
+// 1 Hz is plenty for an editor page (the debug page polls at 5 Hz).
+setInterval(refresh, 1000);
+refresh();
+</script>
 </body>
 </html>
 """

--- a/system/scene/scripts/build.sh
+++ b/system/scene/scripts/build.sh
@@ -71,7 +71,13 @@ fi
 mkdir -p "$BUILD/data"
 
 # ── 1. Codegen (.proto + grpc stubs + MCP dataclasses → rbnx-build/codegen/) ─
-FLAGS=(--mcp)
+# --ros2 also emits rbnx-build/codegen/ros2_idl: the generated ROS 2
+# interface overlay carrying map/msg/MapLifecycle (mapping's latched map
+# identity broadcast, which scene's map binding subscribes to). It is
+# colcon-built inside the scene image after the docker build below and
+# sourced by docker/entrypoint.sh; without it scene falls back to static
+# map binding (SCENE_MAP_ID / config) with a warning.
+FLAGS=(--mcp --ros2)
 [[ "$CLEAN" == "1" ]] && FLAGS+=(--clean)
 
 echo "[build] rbnx codegen ${FLAGS[*]}"
@@ -369,5 +375,25 @@ esac
 
 echo "[build] docker build -f $SCENE_DOCKERFILE -t $IMG docker/  (target=$TARGET)"
 docker build "${DOCKER_BUILD_FLAGS[@]}" -f "$SCENE_DOCKERFILE" -t "$IMG" docker/
+
+# colcon-build the ros2_idl overlay (map interface package for the
+# lifecycle broadcast) inside the image we just built, so the install
+# tree lands on the host bind mount at the SAME path the runtime
+# container sees (/scene/rbnx-build/...). Skipped when codegen was
+# skipped — scene then runs with static map binding only.
+IDL="$PKG/rbnx-build/codegen/ros2_idl"
+if [[ -d "$IDL/src/map" ]]; then
+    echo "[build] colcon build ros2_idl (map interface pkg) in $IMG"
+    # --user: build/ install/ land on the HOST bind mount — as root they
+    # would survive a later non-root `rm -rf rbnx-build` (RBNX_BUILD_CLEAN).
+    # HOME=/tmp gives colcon a writable home for its metadata as that uid.
+    docker run --rm --entrypoint bash --user "$(id -u):$(id -g)" -e HOME=/tmp \
+        -v "$PKG":/scene "$IMG" -lc \
+        "source /opt/ros/\${ROS_DISTRO:-humble}/setup.bash && \
+         cd /scene/rbnx-build/codegen/ros2_idl && \
+         colcon build --packages-up-to map"
+else
+    echo "[build] WARNING: ros2_idl/src/map missing — dynamic map binding disabled"
+fi
 
 echo "[build] done."

--- a/system/scene/tests/test_annotations.py
+++ b/system/scene/tests/test_annotations.py
@@ -294,7 +294,7 @@ def test_rest_crud_roundtrip():
         assert (st, out) == (200, {"ok": True, "annotations": []})
 
         st, out = _call(app, "POST", "/api/annotations",
-                        {"kind": "room", "name": "厨房", "points": ROOM_PTS})
+                        {"kind": "room", "name": "kitchen-draft", "points": ROOM_PTS})
         assert st == 200 and out["ok"]
         ann_id = out["annotation"]["annotation_id"]
 

--- a/system/scene/tests/test_annotations.py
+++ b/system/scene/tests/test_annotations.py
@@ -1,0 +1,424 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+"""Unit tests for user annotations (scene_service.annotations) and the
+annotation CRUD REST API (scene_service.web).
+
+The store tests are pure Python + tmp dirs and always run. The web tests
+drive the Starlette app through a hand-rolled ASGI call (no httpx /
+TestClient dependency); they need starlette + the scene_service.web import
+chain and skip loudly when that is unavailable (e.g. a bare mac checkout).
+"""
+import asyncio
+import json
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from scene_service.annotations import (  # noqa: E402
+    AnnotationStore,
+    validate_annotation_fields,
+)
+
+ROOM_PTS = [[0.0, 0.0], [2.0, 0.0], [2.0, 1.5], [0.0, 1.5]]
+
+
+# ── validation ──────────────────────────────────────────────────────────────
+
+def test_validation_rules():
+    ok = validate_annotation_fields
+    assert ok("room", "kitchen", ROOM_PTS, None) is None
+    assert ok("poi", "dock", [[1.0, 2.0]], 1.57) is None
+    assert ok("no_go", "x", ROOM_PTS, None)           # unknown kind
+    assert ok("room", 7, ROOM_PTS, None)              # non-string name
+    assert ok("room", "x" * 200, ROOM_PTS, None)      # name too long
+    assert ok("room", "x", ROOM_PTS[:2], None)        # polygon < 3 points
+    assert ok("poi", "x", ROOM_PTS[:2], None)         # poi != 1 point
+    assert ok("room", "x", [[0.0, float("nan")]] * 3, None)   # NaN point
+    assert ok("room", "x", [[0.0], [1.0], [2.0]], None)       # not pairs
+    assert ok("room", "x", "not-a-list", None)
+    assert ok("poi", "x", [[0.0, 0.0]], float("inf"))         # inf theta
+    assert ok("poi", "x", [[0.0, 0.0]], "north")              # non-number theta
+    assert ok("poi", "x", [[True, 0.0]], None)                # bool is not a coord
+    assert ok("room", "x", ROOM_PTS, 1.57)                    # heading on a room
+    print("  [PASS] test_validation_rules")
+
+
+# ── store ───────────────────────────────────────────────────────────────────
+
+def test_store_roundtrip_across_reopen():
+    with tempfile.TemporaryDirectory() as base:
+        s1 = AnnotationStore(base, map_id="lab", generation=2)
+        room = s1.create(kind="room", name="kitchen", points=ROOM_PTS)
+        poi = s1.create(kind="poi", name="dock", points=[[1.0, 2.0]], theta=0.5)
+        assert room.annotation_id.startswith("anno.")
+        assert room.created_at > 0 and room.updated_at >= room.created_at
+
+        s2 = AnnotationStore(base, map_id="lab", generation=2)
+        got = {a.annotation_id: a for a in s2.list()}
+        assert got[room.annotation_id].points == ROOM_PTS
+        assert got[room.annotation_id].name == "kitchen"
+        assert got[poi.annotation_id].theta == 0.5
+        assert not any(a.stale for a in got.values())
+    print("  [PASS] test_store_roundtrip_across_reopen")
+
+
+def test_update_and_delete():
+    with tempfile.TemporaryDirectory() as base:
+        s = AnnotationStore(base, map_id="lab", generation=1)
+        a = s.create(kind="room", name="old", points=ROOM_PTS)
+        u = s.update(a.annotation_id, name="new")
+        assert u.name == "new" and u.updated_at >= a.updated_at
+        assert s.update("anno.missing", name="x") is None
+        assert s.delete(a.annotation_id) is True
+        assert s.delete(a.annotation_id) is False
+        assert s.list() == []
+    print("  [PASS] test_update_and_delete")
+
+
+def test_map_id_partition_isolation_and_sanitize():
+    with tempfile.TemporaryDirectory() as base:
+        s_a = AnnotationStore(base, map_id="lab_a", generation=1)
+        s_b = AnnotationStore(base, map_id="lab_b", generation=1)
+        s_a.create(kind="room", name="only-in-a", points=ROOM_PTS)
+        assert s_b.list() == []
+        assert AnnotationStore(base, map_id="lab_b", generation=1).list() == []
+        assert len(AnnotationStore(base, map_id="lab_a", generation=1).list()) == 1
+
+        # Hostile map_id chars are squashed to "_" — same rule as the
+        # object store, so the two partitions always agree on the key.
+        s_evil = AnnotationStore(base, map_id="we ird/../id", generation=1)
+        assert s_evil.map_id == "we_ird_.._id"
+        assert s_evil.path.parent == s_a.path.parent  # no path escape
+    print("  [PASS] test_map_id_partition_isolation_and_sanitize")
+
+
+def test_atomic_write_leaves_no_tmp():
+    with tempfile.TemporaryDirectory() as base:
+        s = AnnotationStore(base, map_id="lab", generation=1)
+        s.create(kind="room", name="r", points=ROOM_PTS)
+        s.mark_all_stale("test", new_generation=2)
+        leftovers = [p for p in os.listdir(base) if p.endswith(".tmp")]
+        assert leftovers == []
+        data = json.loads(open(os.path.join(base, "lab.json")).read())
+        assert set(data) == {"map_id", "generation", "annotations"}
+    print("  [PASS] test_atomic_write_leaves_no_tmp")
+
+
+def test_generation_mismatch_marks_stale_on_load():
+    with tempfile.TemporaryDirectory() as base:
+        s1 = AnnotationStore(base, map_id="lab", generation=2)
+        a = s1.create(kind="room", name="kitchen", points=ROOM_PTS)
+
+        # Same generation → untouched.
+        assert not AnnotationStore(base, map_id="lab", generation=2).list()[0].stale
+
+        # Bumped generation → stale + reason, and the flag is persisted.
+        s3 = AnnotationStore(base, map_id="lab", generation=3)
+        got = s3.get(a.annotation_id)
+        assert got.stale and "2→3" in got.stale_reason
+        raw = json.loads(open(s3.path).read())
+        assert raw["annotations"][0]["stale"] is True
+
+        # User confirms it is still valid → stale cleared, persisted.
+        s3.update(a.annotation_id, clear_stale=True)
+        assert not AnnotationStore(base, map_id="lab", generation=3).get(
+            a.annotation_id).stale
+    print("  [PASS] test_generation_mismatch_marks_stale_on_load")
+
+
+def test_unknown_generation_preserves_stored_epoch():
+    with tempfile.TemporaryDirectory() as base:
+        AnnotationStore(base, map_id="lab", generation=5).create(
+            kind="room", name="r", points=ROOM_PTS)
+        # A static-binding boot (no broadcast → generation None) cannot
+        # judge staleness: nothing is flagged AND the stored epoch must
+        # survive the session so a later bound boot still can.
+        s = AnnotationStore(base, map_id="lab", generation=None)
+        assert not s.list()[0].stale
+        s.update(s.list()[0].annotation_id, name="renamed")   # forces a save
+        assert json.loads(open(s.path).read())["generation"] == 5
+        assert AnnotationStore(base, map_id="lab", generation=6).list()[0].stale
+    print("  [PASS] test_unknown_generation_preserves_stored_epoch")
+
+
+def test_reconcile_generation_learns_and_flags():
+    with tempfile.TemporaryDirectory() as base:
+        AnnotationStore(base, map_id="lab", generation=None).create(
+            kind="room", name="r", points=ROOM_PTS)
+        # A file written under an unknown epoch adopts the confirmed one
+        # without flagging anything (there is nothing to disagree with).
+        s = AnnotationStore(base, map_id="lab", generation=None)
+        assert s.reconcile_generation(5) == 0
+        assert not s.list()[0].stale
+        assert json.loads(open(s.path).read())["generation"] == 5
+        assert s.reconcile_generation(5) == 0        # same epoch: no-op
+
+        # A recorded epoch that DIFFERS from the confirmed one means the
+        # map frame moved since the annotations were drawn → all stale.
+        s2 = AnnotationStore(base, map_id="lab", generation=None)
+        assert s2.reconcile_generation(7) == 1
+        got = s2.list()[0]
+        assert got.stale and "5→7" in got.stale_reason
+    print("  [PASS] test_reconcile_generation_learns_and_flags")
+
+
+def test_redraw_clears_stale_and_mark_all_stale_counts():
+    with tempfile.TemporaryDirectory() as base:
+        s = AnnotationStore(base, map_id="lab", generation=1)
+        a = s.create(kind="room", name="r", points=ROOM_PTS)
+        b = s.create(kind="poi", name="p", points=[[0.0, 0.0]])
+        assert s.mark_all_stale("epoch flip", new_generation=2) == 2
+        assert s.mark_all_stale("epoch flip", new_generation=2) == 0  # idempotent
+        # Redrawing geometry re-authors it against the CURRENT frame →
+        # staleness no longer applies.
+        assert s.update(a.annotation_id, points=ROOM_PTS).stale is False
+        assert s.get(b.annotation_id).stale is True
+    print("  [PASS] test_redraw_clears_stale_and_mark_all_stale_counts")
+
+
+def test_corrupt_file_set_aside_not_destroyed():
+    # Every bad-file shape must take the same quarantine path: parse
+    # error, valid-JSON-but-not-an-object, non-object annotation entry,
+    # non-numeric generation, and a record that fails field validation
+    # (per-map files are user-visible JSON, hand edits happen).
+    bad_files = [
+        "{not json",
+        "[1, 2, 3]",
+        '"just a string"',
+        '{"map_id": "lab", "generation": 1, "annotations": [3]}',
+        '{"map_id": "lab", "generation": "three", "annotations": []}',
+        '{"map_id": "lab", "generation": 1, "annotations": '
+        '[{"annotation_id": "anno.x", "kind": "castle", "name": "x", '
+        '"points": [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]]}]}',
+    ]
+    for content in bad_files:
+        with tempfile.TemporaryDirectory() as base:
+            path = os.path.join(base, "lab.json")
+            with open(path, "w") as f:
+                f.write(content)
+            s = AnnotationStore(base, map_id="lab", generation=1)
+            assert s.list() == [], content
+            aside = [p for p in os.listdir(base) if ".corrupt-" in p]
+            assert len(aside) == 1, content
+            assert open(os.path.join(base, aside[0])).read() == content
+    print("  [PASS] test_corrupt_file_set_aside_not_destroyed")
+
+
+def test_from_json_drops_unknown_keys():
+    from scene_service.annotations import Annotation
+    a = Annotation.from_json({
+        "annotation_id": "anno.x", "kind": "room", "name": "r",
+        "points": [[0.0, 0.0]], "written_by_future_scene": True,
+    })
+    assert a.annotation_id == "anno.x" and not hasattr(a, "written_by_future_scene")
+    print("  [PASS] test_from_json_drops_unknown_keys")
+
+
+# ── REST API (hand-rolled ASGI, no httpx needed) ────────────────────────────
+
+def _make_web_app(anno_store):
+    """Import scene_service.web lazily and build an app with only the
+    pieces the annotation routes need. When the web import chain is
+    unavailable (bare environment): under pytest the caller's test is
+    SKIPPED (visible in the report, not a hollow pass); standalone it
+    prints and returns None."""
+    try:
+        from scene_service import web as web_mod
+    except ImportError as e:
+        if os.environ.get("PYTEST_CURRENT_TEST"):
+            import pytest
+            pytest.skip(f"web deps unavailable: {e}")
+        print(f"  [SKIP] web tests unavailable: {e}")
+        return None
+
+    class _StubRegistry:  # annotation routes never touch the registry
+        _objects: dict = {}
+        _surfaces: dict = {}
+
+    return web_mod.make_app(
+        registry=_StubRegistry(), anno_store=anno_store,
+        map_binding={"map_id": "lab", "mode": "mapping",
+                     "generation": 1, "source": "lifecycle"},
+    )
+
+
+def _call(app, method: str, path: str, body=None):
+    """Drive the ASGI app directly with one JSON request; return
+    (status, parsed-body). Avoids the TestClient→httpx dependency.
+
+    Runs on a PRIVATE event loop (not asyncio.run, which unsets the
+    thread's current loop on exit and would starve later test files
+    that still use the ambient-loop pattern — the exact cross-file
+    pollution test_scene_graph._ensure_loop guards against)."""
+    raw = json.dumps(body).encode() if body is not None else b""
+    scope = {
+        "type": "http", "http_version": "1.1", "method": method,
+        "scheme": "http", "path": path, "raw_path": path.encode(),
+        "root_path": "", "query_string": b"", "client": ("test", 0),
+        "server": ("test", 80),
+        "headers": [(b"content-type", b"application/json"),
+                    (b"content-length", str(len(raw)).encode())],
+    }
+    sent, done = [], {"body": False}
+
+    async def receive():
+        if done["body"]:
+            return {"type": "http.disconnect"}
+        done["body"] = True
+        return {"type": "http.request", "body": raw, "more_body": False}
+
+    async def send(message):
+        sent.append(message)
+
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(app(scope, receive, send))
+    finally:
+        loop.close()
+    status = next(m["status"] for m in sent
+                  if m["type"] == "http.response.start")
+    payload = b"".join(m.get("body", b"") for m in sent
+                       if m["type"] == "http.response.body")
+    return status, (json.loads(payload) if payload else None)
+
+
+def test_rest_crud_roundtrip():
+    with tempfile.TemporaryDirectory() as base:
+        store = AnnotationStore(base, map_id="lab", generation=1)
+        app = _make_web_app(store)
+        if app is None:
+            return
+
+        st, out = _call(app, "GET", "/api/annotations")
+        assert (st, out) == (200, {"ok": True, "annotations": []})
+
+        st, out = _call(app, "POST", "/api/annotations",
+                        {"kind": "room", "name": "厨房", "points": ROOM_PTS})
+        assert st == 200 and out["ok"]
+        ann_id = out["annotation"]["annotation_id"]
+
+        st, out = _call(app, "PUT", f"/api/annotations/{ann_id}",
+                        {"name": "kitchen"})
+        assert st == 200 and out["annotation"]["name"] == "kitchen"
+
+        # stale confirm flow: flag via the store (what the lifecycle
+        # watcher does), clear via the API (what the UI button does).
+        store.mark_all_stale("epoch flip", new_generation=2)
+        st, out = _call(app, "PUT", f"/api/annotations/{ann_id}",
+                        {"stale": False})
+        assert st == 200 and out["annotation"]["stale"] is False
+
+        st, out = _call(app, "DELETE", f"/api/annotations/{ann_id}")
+        assert (st, out) == (200, {"ok": True})
+        assert store.list() == []
+    print("  [PASS] test_rest_crud_roundtrip")
+
+
+def test_rest_validation_and_errors():
+    with tempfile.TemporaryDirectory() as base:
+        store = AnnotationStore(base, map_id="lab", generation=1)
+        app = _make_web_app(store)
+        if app is None:
+            return
+
+        st, out = _call(app, "POST", "/api/annotations",
+                        {"kind": "castle", "name": "x", "points": ROOM_PTS})
+        assert st == 400 and not out["ok"] and "kind" in out["detail"]
+
+        st, _ = _call(app, "POST", "/api/annotations",
+                      {"kind": "room", "name": "x", "points": ROOM_PTS[:2]})
+        assert st == 400
+
+        st, out = _call(app, "POST", "/api/annotations",
+                        {"kind": "room", "name": "x", "points": ROOM_PTS,
+                         "theta": 1.57})
+        assert st == 400 and "poi" in out["detail"]  # headings are poi-only
+
+        st, _ = _call(app, "PUT", "/api/annotations/anno.nope", {"name": "x"})
+        assert st == 404
+        st, _ = _call(app, "DELETE", "/api/annotations/anno.nope")
+        assert st == 404
+
+        # A partial update may not sneak in an invalid merged state.
+        _, created = _call(app, "POST", "/api/annotations",
+                           {"kind": "room", "name": "x", "points": ROOM_PTS})
+        st, _ = _call(app, "PUT",
+                      f"/api/annotations/{created['annotation']['annotation_id']}",
+                      {"points": [[0.0, 0.0]]})
+        assert st == 400
+
+        # Store unavailable → 503 on every verb.
+        app_off = _make_web_app(None)
+        for method, path in [("GET", "/api/annotations"),
+                             ("POST", "/api/annotations"),
+                             ("PUT", "/api/annotations/x"),
+                             ("DELETE", "/api/annotations/x")]:
+            st, out = _call(app_off, method, path, {})
+            assert st == 503 and not out["ok"]
+    print("  [PASS] test_rest_validation_and_errors")
+
+
+def test_user_page_served():
+    with tempfile.TemporaryDirectory() as base:
+        app = _make_web_app(AnnotationStore(base, map_id="lab", generation=1))
+        if app is None:
+            return
+        sent = []
+
+        async def receive():
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        async def send(message):
+            sent.append(message)
+
+        scope = {"type": "http", "http_version": "1.1", "method": "GET",
+                 "scheme": "http", "path": "/user", "raw_path": b"/user",
+                 "root_path": "", "query_string": b"", "headers": [],
+                 "client": ("test", 0), "server": ("test", 80)}
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(app(scope, receive, send))
+        finally:
+            loop.close()
+        status = next(m["status"] for m in sent
+                      if m["type"] == "http.response.start")
+        body = b"".join(m.get("body", b"") for m in sent
+                        if m["type"] == "http.response.body")
+        assert status == 200
+        assert b"Annotate room" in body and b"/api/annotations" in body
+    print("  [PASS] test_user_page_served")
+
+
+def test_state_payload_carries_annotations_and_binding():
+    with tempfile.TemporaryDirectory() as base:
+        store = AnnotationStore(base, map_id="lab", generation=1)
+        store.create(kind="room", name="kitchen", points=ROOM_PTS)
+        app = _make_web_app(store)
+        if app is None:
+            return
+        st, out = _call(app, "GET", "/api/state")
+        assert st == 200
+        assert out["map_binding"]["map_id"] == "lab"
+        assert len(out["annotations"]) == 1
+        assert out["annotations"][0]["name"] == "kitchen"
+    print("  [PASS] test_state_payload_carries_annotations_and_binding")
+
+
+if __name__ == "__main__":
+    test_validation_rules()
+    test_store_roundtrip_across_reopen()
+    test_update_and_delete()
+    test_map_id_partition_isolation_and_sanitize()
+    test_atomic_write_leaves_no_tmp()
+    test_generation_mismatch_marks_stale_on_load()
+    test_unknown_generation_preserves_stored_epoch()
+    test_reconcile_generation_learns_and_flags()
+    test_redraw_clears_stale_and_mark_all_stale_counts()
+    test_corrupt_file_set_aside_not_destroyed()
+    test_from_json_drops_unknown_keys()
+    test_rest_crud_roundtrip()
+    test_rest_validation_and_errors()
+    test_user_page_served()
+    test_state_payload_carries_annotations_and_binding()
+    print("test_annotations: all tests passed")

--- a/system/scene/tests/test_map_binding.py
+++ b/system/scene/tests/test_map_binding.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+"""Unit tests for the map identity binding (scene_service.map_binding).
+
+The precedence rule is pure Python and always runs. The latched-read
+probe test exercises the graceful-degradation path: on a machine without
+rclpy / the generated `map` interface package it must return None (not
+raise); on a full ROS container it still returns None because nothing
+publishes the probe topic within the short timeout.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from scene_service.map_binding import (  # noqa: E402
+    MapBinding,
+    choose_map_binding,
+    read_latched_lifecycle,
+)
+
+
+def test_broadcast_wins_over_config_and_env():
+    b = choose_map_binding(
+        {"map_id": "lab_a", "mode": "localization", "generation": 4},
+        "cfg_map", "env_map",
+    )
+    assert b == MapBinding(
+        map_id="lab_a", source="lifecycle", mode="localization", generation=4
+    )
+    print("  [PASS] test_broadcast_wins_over_config_and_env")
+
+
+def test_empty_broadcast_map_id_falls_through():
+    # mapping running ephemeral broadcasts map_id="" — that is "no named
+    # identity", static levers must win.
+    b = choose_map_binding({"map_id": "", "mode": "mapping", "generation": 1},
+                           "cfg_map", "env_map")
+    assert (b.map_id, b.source) == ("cfg_map", "config")
+    print("  [PASS] test_empty_broadcast_map_id_falls_through")
+
+
+def test_config_beats_env_then_env_then_default():
+    assert choose_map_binding(None, "cfg_map", "env_map").source == "config"
+    b = choose_map_binding(None, None, "env_map")
+    assert (b.map_id, b.source) == ("env_map", "env")
+    b = choose_map_binding(None, None, None)
+    assert (b.map_id, b.source) == ("default", "default")
+    # static sources carry no generation — the runtime watcher treats
+    # None as "match any generation" until P3 tightens this.
+    assert b.generation is None
+    print("  [PASS] test_config_beats_env_then_env_then_default")
+
+
+def test_probe_degrades_to_none_without_publisher():
+    # No rclpy / no `map` interface package → None with a warning;
+    # with ROS available → None after the (short) timeout since nothing
+    # publishes this probe-only topic. Either way: no exception.
+    assert read_latched_lifecycle("/robonix/test/map_binding_probe",
+                                  timeout_s=0.3) is None
+    print("  [PASS] test_probe_degrades_to_none_without_publisher")
+
+
+if __name__ == "__main__":
+    test_broadcast_wins_over_config_and_env()
+    test_empty_broadcast_map_id_falls_through()
+    test_config_beats_env_then_env_then_default()
+    test_probe_degrades_to_none_without_publisher()
+    print("test_map_binding: all tests passed")

--- a/system/scene/tests/test_scene_graph.py
+++ b/system/scene/tests/test_scene_graph.py
@@ -30,6 +30,20 @@ _LLM_ENV_VARS = (
 )
 
 
+def _ensure_loop() -> asyncio.AbstractEventLoop:
+    """Current event loop, creating (and installing) one when the thread has
+    none. Bare `asyncio.get_event_loop()` is unreliable across the suite:
+    running the milvus-lite tests (test_persistence) first leaves the main
+    thread without a current loop, and the deprecated implicit-creation path
+    then raises "There is no current event loop"."""
+    try:
+        return asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        return loop
+
+
 def _pop_llm_env() -> dict:
     """Pop all LLM-related env vars and return them for restoration."""
     return {k: os.environ.pop(k, None) for k in _LLM_ENV_VARS}
@@ -156,7 +170,7 @@ def test_captioner():
     node = SceneGraphNode("obj_1", "cup", (0, 0, 0), (0.1, 0.1, 0.1))
     assert node.caption is None
 
-    result = asyncio.get_event_loop().run_until_complete(cap.caption_node(node))
+    result = _ensure_loop().run_until_complete(cap.caption_node(node))
     assert result.caption == "cup"
     assert result.caption_updated_at is not None
     print("  [PASS] test_captioner")
@@ -257,7 +271,7 @@ def test_llm_client_no_key():
         client = SceneGraphLLMClient(api_key="", base_url="")
         assert not client.available
 
-        result = asyncio.get_event_loop().run_until_complete(
+        result = _ensure_loop().run_until_complete(
             client.chat_json("system", "user")
         )
         assert result == {}
@@ -281,7 +295,7 @@ def test_relation_inferer_no_llm():
         b = SceneGraphNode("obj_2", "table", (1.0, 0.5, 0.4), (1.2, 0.8, 0.05), caption="table")
         hint = GeometryHint(0.4, 0.6, "a_above_b", "none")
 
-        edge = asyncio.get_event_loop().run_until_complete(
+        edge = _ensure_loop().run_until_complete(
             inferer.infer_relation(a, b, hint)
         )
         assert edge.relation == "unknown"
@@ -318,7 +332,7 @@ def test_builder_rebuild_no_objects():
             config=config,
         )
 
-        snap = asyncio.get_event_loop().run_until_complete(builder.rebuild_once())
+        snap = _ensure_loop().run_until_complete(builder.rebuild_once())
         assert len(snap.nodes) == 0
         assert len(snap.edges) == 0
         assert snap.updated_at > 0
@@ -346,7 +360,7 @@ def _run_builder_rebuild_with_objects_body():
     with tempfile.TemporaryDirectory() as tmpdir:
         registry = ObjectRegistry()
 
-        loop = asyncio.get_event_loop()
+        loop = _ensure_loop()
 
         async def populate():
             async with registry.lock():
@@ -619,7 +633,7 @@ def test_infer_semantic_relation():
     a = SceneGraphNode("a", "handle", (0.0, 0.0, 0.5), (0.1, 0.1, 0.1))
     b = SceneGraphNode("b", "door", (0.0, 0.0, 0.5), (1.0, 0.1, 2.0))
     hint = GeometryHint(0.0, 0.5, "same_level", "a_inside_b")
-    run = asyncio.get_event_loop().run_until_complete
+    run = _ensure_loop().run_until_complete
 
     # A spatial answer is rejected — geometry owns the spatial slot → none.
     inf = RelationInferer(_FakeClient({"relation": "on_top_of", "confidence": 0.9}))
@@ -701,7 +715,7 @@ def test_llm_client_request_body():
         k.setdefault("transport", httpx.MockTransport(handler))
         return orig(*a, **k)
 
-    run = asyncio.get_event_loop().run_until_complete
+    run = _ensure_loop().run_until_complete
     httpx.AsyncClient = patched
     try:
         c = SceneGraphLLMClient(


### PR DESCRIPTION
<h2><span>Summary</span></h2><p class="isSelectedEnd"><span>This PR adds user-authored </span><strong><span>room annotations</span></strong><span> on the SLAM map, along with the map-identity plumbing those annotations anchor to.</span></p><p class="isSelectedEnd"><span>On the scene web page (</span><code dir="ltr"><span>GET /user</span></code><span>, </span><code dir="ltr"><span>:50107</span></code><span>), a user can draw a polygon on the live occupancy map to name a room. The annotation is anchored in the map frame, partitioned by </span><code dir="ltr"><span>map_id</span></code><span>, and validated against mapping’s </span><code dir="ltr"><span>generation</span></code><span> epoch.</span></p><p class="isSelectedEnd"><span>When the map is rebuilt and a new epoch is created, the annotation is </span><strong><span>flagged as stale</span></strong><span> with a yellow dashed outline so the user can confirm or redraw it. This follows the loosely coupled semantic-layer model used by consumer floor-cleaning robots.</span></p><p class="isSelectedEnd"><span>The page also renders perceived objects as hover dots, the </span><strong><span>live robot pose and heading</span></strong><span>, and preserves annotations across a full SLAM relocalization restart. After saving a named map and rebooting mapping in </span><code dir="ltr"><span>localization</span></code><span> mode, a room’s coordinates remain bit-for-bit unchanged and still cover the same physical desk.</span></p><h2><span>What’s in This PR</span></h2>
Commit | Change
-- | --
feat(map): lifecycle topic contract | Adds new capability robonix/service/map/lifecycle and IDL map/msg/MapLifecycle {map_id, mode, generation}
feat(scene): discover map identity | Scene learns the current (map_id, generation) from mapping’s latched lifecycle broadcast, with graceful fallback to SCENE_MAP_ID / config
test(scene): tolerate missing event loop | Test-infra fix after Milvus-backed tests
feat(scene): user annotations | Adds Annotation / AnnotationStore with per-map JSON, atomic writes, corrupt-file quarantine, generation reconcile, REST /api/annotations CRUD, and /user page support

<h2><span>Validation</span></h2><h3><span>Unit Tests</span></h3><pre dir="ltr"><code dir="ltr"><span>cd system/scene &amp;&amp; pytest -q -p no:anyio</span></code></pre><p class="isSelectedEnd"><span>Result:</span></p><pre dir="ltr"><code dir="ltr"><span>71/71 passed</span></code></pre><p class="isSelectedEnd"><span>Requires a Linux runner with </span><code dir="ltr"><span>milvus_lite</span></code><span> and scene dependencies.</span></p><h3><span>REST Contract</span></h3><p class="isSelectedEnd"><span>The REST contract shape is frozen in:</span></p><pre dir="ltr"><code dir="ltr"><span>system/scene/README.md</span></code></pre><p class="isSelectedEnd"><span>Covered cases include:</span></p><ul data-spread="false"><li><code dir="ltr"><span>400</span></code><span> / </span><code dir="ltr"><span>404</span></code><span> / </span><code dir="ltr"><span>503</span></code><span> response bodies</span></li><li><span>Room rejection for theta</span></li><li><code dir="ltr"><span>PUT theta:null</span></code><span> keeps the existing theta value</span></li></ul><h3><span>E2E Validation</span></h3><p class="isSelectedEnd"><span>Environment:</span></p><pre dir="ltr"><code dir="ltr"><span>webots</span></code></pre><p class="isSelectedEnd"><span>Flow:</span></p><ol data-spread="false" start="1"><li><span>Build mapping.</span></li><li><span>Save map through </span><code dir="ltr"><span>8091 save_map(webots_lab)</span></code><span>.</span></li><li><span>Reboot mapping in </span><code dir="ltr"><span>localization</span></code><span> mode.</span></li><li><span>Scene binds to </span><code dir="ltr"><span>gen=8</span></code><span> through lifecycle.</span></li><li><span>Objects are restored.</span></li><li><code dir="ltr"><span>desk_area</span></code><span> annotation coordinates remain unchanged.</span></li><li><span>Annotation still covers the same physical desk.</span></li><li><code dir="ltr"><span>/user</span></code><span> robot dot tracks the real pose after relocalization.</span></li></ol><p class="isSelectedEnd"><span>Observed result:</span></p><pre dir="ltr"><code dir="ltr"><span>mapping build → 8091 save_map(webots_lab) → reboot localization (gen=8)
→ scene binds gen=8 via lifecycle → restored objects
→ desk_area annotation coordinates unchanged
→ annotation remains over the same desk
→ /user robot dot tracks real pose after relocalization</span></code></pre>