### PR TITLE
feat(scene): save and restore rooms and objects with each SLAM map

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1001,6 +1001,7 @@ jobs:
             --scene-url "http://127.0.0.1:${SCENE_WEB_PORT}" \
             --map-id "$map_id" \
             --mapping-container "${ROBONIX_MAPPING_CONTAINER:-robonix_mapping}" \
+            --maps-dir "$MAPPING_MAPS_DIR" \
             --sim-container "$ROBONIX_SIM_CONTAINER" \
             --delete-after \
             --timeout 420 | tee "$RUNNER_TEMP/sim-logs/scene-map-persistence.txt"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -330,6 +330,7 @@ jobs:
       GRPCIO_PIN: "1.80.0"
       # ── Per-run isolation (coexist with interactive users on the shared box) ──
       RUN_ID: "${{ github.run_id }}"
+      ROBONIX_HOME: "${{ runner.temp }}/robonix-home"
       # GPU selection is runner-specific. Priority:
       # workflow_call input -> repo/org variable -> runner env -> default GPU 0.
       ROBONIX_CI_GPU_ID_INPUT: ${{ inputs.gpu_id || '' }}
@@ -988,6 +989,19 @@ jobs:
             --summary-json "$GITHUB_WORKSPACE/testing/logs/summary.json" | tee "$RUNNER_TEMP/scenarios.out"
           # Surface the one-line RESULT for the reusable-workflow output / bot.
           echo "result=$(grep '^RESULT:' "$RUNNER_TEMP/scenarios.out" | tail -1)" >> "$GITHUB_OUTPUT"
+
+      - name: Verify scene map persistence
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/sim-logs"
+          map_id="ci_scene_map_${RUN_ID}"
+          python3 "$GITHUB_WORKSPACE/testing/verify_scene_map_persistence.py" \
+            --scene-url "http://127.0.0.1:${SCENE_WEB_PORT}" \
+            --map-id "$map_id" \
+            --mapping-container "${ROBONIX_MAPPING_CONTAINER:-robonix_mapping}" \
+            --sim-container "$ROBONIX_SIM_CONTAINER" \
+            --delete-after \
+            --timeout 420 | tee "$RUNNER_TEMP/sim-logs/scene-map-persistence.txt"
 
       - name: Validate boot/shutdown lifecycle
         # boot → shutdown → re-boot. Proves the runtime keeps

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -330,7 +330,6 @@ jobs:
       GRPCIO_PIN: "1.80.0"
       # ── Per-run isolation (coexist with interactive users on the shared box) ──
       RUN_ID: "${{ github.run_id }}"
-      ROBONIX_HOME: "${{ runner.temp }}/robonix-home"
       # GPU selection is runner-specific. Priority:
       # workflow_call input -> repo/org variable -> runner env -> default GPU 0.
       ROBONIX_CI_GPU_ID_INPUT: ${{ inputs.gpu_id || '' }}
@@ -369,6 +368,9 @@ jobs:
             registry-1.docker.io:443
             auth.docker.io:443
             production.cloudflare.docker.com:443
+
+      - name: Configure runner-local Robonix home
+        run: echo "ROBONIX_HOME=$RUNNER_TEMP/robonix-home" >> "$GITHUB_ENV"
 
       - name: Select runner GPU
         run: |

--- a/capabilities/lib/map/msg/MapLifecycle.msg
+++ b/capabilities/lib/map/msg/MapLifecycle.msg
@@ -1,0 +1,17 @@
+# Map identity + lifecycle broadcast from the mapping service.
+#
+# Published latched (transient_local) so late-joining consumers (e.g. the
+# scene service) learn the current map identity at startup, and re-published
+# on every lifecycle transition (init / load / reset / mode switch; save
+# does not change the live identity — its re-key semantics are a later,
+# separate design).
+#
+# The (map_id, generation) pair is the map-frame identity key: consumers
+# holding map-frame coordinates must treat a change in EITHER field as
+# "previous coordinates are no longer anchored" — reset_map keeps map_id
+# but moves the map origin, which only generation makes visible.
+string map_id      # named-map id currently bound; empty when ephemeral (no map_id configured)
+string mode        # "mapping" or "localization"
+uint64 generation  # monotonic; +1 when the map origin may have changed: mapping-mode
+                   # session start/load and reset_map. NEVER bumped by a localization
+                   # load (stable frame is the point) or by a mode switch.

--- a/capabilities/lib/semantic_map/msg/SceneAnnotation.msg
+++ b/capabilities/lib/semantic_map/msg/SceneAnnotation.msg
@@ -1,0 +1,13 @@
+# User-authored semantic annotation anchored to the SLAM map.
+# Rooms and POIs are maintained by scene, persisted per map_id, and
+# returned with the scene graph so clients/agents can reason about
+# human-provided regions as first-class scene context.
+
+string annotation_id
+string kind
+string name
+float64[] points_xy
+float64 theta
+bool stale
+string stale_reason
+float64 updated_at_unix

--- a/capabilities/lib/semantic_map/srv/GetSceneGraph.srv
+++ b/capabilities/lib/semantic_map/srv/GetSceneGraph.srv
@@ -3,4 +3,5 @@
 ---
 SceneGraphNode[] nodes
 SceneGraphEdge[] edges
+SceneAnnotation[] annotations
 float64 updated_at

--- a/capabilities/lib/semantic_map/srv/GoalNear.srv
+++ b/capabilities/lib/semantic_map/srv/GoalNear.srv
@@ -1,5 +1,6 @@
 # robonix/system/scene/goal_near — find a navigation-safe approach pose
-# near a registered scene object. Map-frame (x, y, yaw); pass to
+# near a registered physical scene object. Room annotations are rejected;
+# use robonix/system/scene/goal_room for rooms. Map-frame (x, y, yaw); pass to
 # robonix/service/navigation/navigate after.
 #
 # `reachable=false` when the occupancy grid has no free cell within

--- a/capabilities/lib/semantic_map/srv/GoalRoom.srv
+++ b/capabilities/lib/semantic_map/srv/GoalRoom.srv
@@ -1,0 +1,11 @@
+# robonix/system/scene/goal_room - find a navigation-safe pose inside
+# a user-defined room annotation. The returned map-frame pose is always
+# inside the room polygon; pass it to navigation/navigate.
+
+string room_id
+---
+bool reachable
+float64 x
+float64 y
+float64 yaw
+string reason

--- a/capabilities/service/map/lifecycle.v1.toml
+++ b/capabilities/service/map/lifecycle.v1.toml
@@ -1,0 +1,17 @@
+# Map identity + lifecycle events. The mapping service is the sole
+# authority on which named map is active; this topic broadcasts that
+# identity ({map_id, mode, generation}) latched, so consumers that key
+# state by map (e.g. scene's semantic object store) can discover the
+# current map at startup and react to init/load/reset/mode-switch
+# transitions without polling. Additive to the v0.1 surface: the four
+# original topic_out streams (occupancy_grid / pose / odom / pointcloud)
+# are unchanged.
+[contract]
+id      = "robonix/service/map/lifecycle"
+version = "1"
+kind    = "service"
+idl     = "map/msg/MapLifecycle.msg"
+description = "Latched map identity and lifecycle events ({map_id, mode, generation}) from the mapping service."
+
+[mode]
+type = "topic_out"

--- a/capabilities/system/scene/goal_near.v1.toml
+++ b/capabilities/system/scene/goal_near.v1.toml
@@ -5,7 +5,7 @@ id      = "robonix/system/scene/goal_near"
 version = "1"
 kind    = "service"
 idl     = "semantic_map/srv/GoalNear.srv"
-description = "Compute a navigation-safe approach pose near a known scene object."
+description = "Compute a navigation-safe approach pose near a known physical scene object. Room annotations are not accepted; use robonix/system/scene/goal_room for rooms or named regions."
 
 [mode]
 type = "rpc"

--- a/capabilities/system/scene/goal_room.v1.toml
+++ b/capabilities/system/scene/goal_room.v1.toml
@@ -1,0 +1,11 @@
+# Find a navigation-safe pose inside a registered room annotation.
+# Returns map-frame (x, y, yaw); pass to navigation/navigate after.
+[contract]
+id      = "robonix/system/scene/goal_room"
+version = "1"
+kind    = "service"
+idl     = "semantic_map/srv/GoalRoom.srv"
+description = "Resolve a room annotation to a navigation-safe pose inside its polygon. Use this for named rooms or regions before navigation/navigate."
+
+[mode]
+type = "rpc"

--- a/examples/webots/config/nav2_params.yaml
+++ b/examples/webots/config/nav2_params.yaml
@@ -1,0 +1,333 @@
+amcl:
+  ros__parameters:
+    use_sim_time: True
+    transform_tolerance: 0.3
+    tf_broadcast: true
+    scan_topic: /scanner_normalized
+    min_particles: 300
+    max_particles: 2000
+    odom_frame_id: "odom"
+    base_frame_id: "base_link"  # match costmap robot_base_frame
+    global_frame_id: "map"
+    laser_max_range: -1.0
+    laser_min_range: -1.0
+    update_min_d: 0.05
+    update_min_a: 0.05
+    resample_interval: 1
+    set_initial_pose: true
+    initial_pose:
+      x: 0.0
+      y: 0.0
+      z: 0.0
+      yaw: 0.0
+map_server:
+  ros__parameters:
+    use_sim_time: True
+    # Overridden in launch by the "map" launch configuration or provided default value.
+    # To use in yaml, remove the default "map" value in the tb3_simulation_launch.py file & provide full path to map below.
+    yaml_filename: ""
+bt_navigator:
+  ros__parameters:
+    use_sim_time: True
+    # map frame: rtabmap provides the map->odom TF (online SLAM), so the BT
+    # navigator plans in the same map frame as the costmaps.
+    global_frame: map
+    robot_base_frame: base_link
+    odom_topic: "__ROBONIX_ODOM_TOPIC__"
+    bt_loop_duration: 50
+    default_server_timeout: 20
+    # 'default_nav_through_poses_bt_xml' and 'default_nav_to_pose_bt_xml' are use defaults:
+    # nav2_bt_navigator/navigate_to_pose_w_replanning_and_recovery.xml
+    # nav2_bt_navigator/navigate_through_poses_w_replanning_and_recovery.xml
+    # They can be set here or via a RewrittenYaml remap from a parent launch file to Nav2.
+    plugin_lib_names:
+    - nav2_compute_path_to_pose_action_bt_node
+    - nav2_compute_path_through_poses_action_bt_node
+    - nav2_smooth_path_action_bt_node
+    - nav2_follow_path_action_bt_node
+    - nav2_spin_action_bt_node
+    - nav2_wait_action_bt_node
+    - nav2_assisted_teleop_action_bt_node
+    - nav2_back_up_action_bt_node
+    - nav2_drive_on_heading_bt_node
+    - nav2_clear_costmap_service_bt_node
+    - nav2_is_stuck_condition_bt_node
+    - nav2_goal_reached_condition_bt_node
+    - nav2_goal_updated_condition_bt_node
+    - nav2_globally_updated_goal_condition_bt_node
+    - nav2_is_path_valid_condition_bt_node
+    - nav2_initial_pose_received_condition_bt_node
+    - nav2_reinitialize_global_localization_service_bt_node
+    - nav2_rate_controller_bt_node
+    - nav2_distance_controller_bt_node
+    - nav2_speed_controller_bt_node
+    - nav2_truncate_path_action_bt_node
+    - nav2_truncate_path_local_action_bt_node
+    - nav2_goal_updater_node_bt_node
+    - nav2_recovery_node_bt_node
+    - nav2_pipeline_sequence_bt_node
+    - nav2_round_robin_node_bt_node
+    - nav2_transform_available_condition_bt_node
+    - nav2_time_expired_condition_bt_node
+    - nav2_path_expiring_timer_condition
+    - nav2_distance_traveled_condition_bt_node
+    - nav2_single_trigger_bt_node
+    - nav2_goal_updated_controller_bt_node
+    - nav2_is_battery_low_condition_bt_node
+    - nav2_navigate_through_poses_action_bt_node
+    - nav2_navigate_to_pose_action_bt_node
+    - nav2_remove_passed_goals_action_bt_node
+    - nav2_planner_selector_bt_node
+    - nav2_controller_selector_bt_node
+    - nav2_goal_checker_selector_bt_node
+    - nav2_controller_cancel_bt_node
+    - nav2_path_longer_on_approach_bt_node
+    - nav2_wait_cancel_bt_node
+    - nav2_spin_cancel_bt_node
+    - nav2_back_up_cancel_bt_node
+    - nav2_assisted_teleop_cancel_bt_node
+    - nav2_drive_on_heading_cancel_bt_node
+
+bt_navigator_navigate_through_poses_rclcpp_node:
+  ros__parameters:
+    use_sim_time: True
+
+bt_navigator_navigate_to_pose_rclcpp_node:
+  ros__parameters:
+    use_sim_time: True
+
+controller_server:
+  ros__parameters:
+    use_sim_time: True
+    controller_frequency: 20.0
+    min_x_velocity_threshold: 0.001
+    min_y_velocity_threshold: 0.5
+    min_theta_velocity_threshold: 0.001
+    failure_tolerance: 0.3
+    progress_checker_plugin: "progress_checker"
+    goal_checker_plugins: ["general_goal_checker"] # "precise_goal_checker"
+    controller_plugins: ["FollowPath"]
+
+    # Progress checker parameters
+    progress_checker:
+      plugin: "nav2_controller::SimpleProgressChecker"
+      required_movement_radius: 0.5
+      movement_time_allowance: 10.0
+    # Goal checker parameters
+    #precise_goal_checker:
+    #  plugin: "nav2_controller::SimpleGoalChecker"
+    #  xy_goal_tolerance: 0.25
+    #  yaw_goal_tolerance: 0.25
+    #  stateful: True
+    general_goal_checker:
+      stateful: True
+      plugin: "nav2_controller::SimpleGoalChecker"
+      xy_goal_tolerance: 0.25
+      yaw_goal_tolerance: 0.25
+    # DWB parameters
+    FollowPath:
+      plugin: "dwb_core::DWBLocalPlanner"
+      debug_trajectory_details: True
+      min_vel_x: 0.0
+      min_vel_y: 0.0
+      max_vel_x: 0.26
+      max_vel_y: 0.0
+      max_vel_theta: 1.0
+      min_speed_xy: 0.0
+      max_speed_xy: 0.26
+      min_speed_theta: 0.0
+      # Add high threshold velocity for turtlebot 3 issue.
+      # https://github.com/ROBOTIS-GIT/turtlebot3_simulations/issues/75
+      acc_lim_x: 2.5
+      acc_lim_y: 0.0
+      acc_lim_theta: 3.2
+      decel_lim_x: -2.5
+      decel_lim_y: 0.0
+      decel_lim_theta: -3.2
+      vx_samples: 20
+      vy_samples: 5
+      vtheta_samples: 20
+      sim_time: 1.7
+      linear_granularity: 0.05
+      angular_granularity: 0.025
+      transform_tolerance: 0.2
+      xy_goal_tolerance: 0.25
+      trans_stopped_velocity: 0.25
+      short_circuit_trajectory_evaluation: True
+      stateful: True
+      critics: ["RotateToGoal", "Oscillation", "BaseObstacle", "GoalAlign", "PathAlign", "PathDist", "GoalDist"]
+      BaseObstacle.scale: 0.02
+      PathAlign.scale: 32.0
+      PathAlign.forward_point_distance: 0.1
+      GoalAlign.scale: 24.0
+      GoalAlign.forward_point_distance: 0.1
+      PathDist.scale: 32.0
+      GoalDist.scale: 24.0
+      RotateToGoal.scale: 32.0
+      RotateToGoal.slowing_factor: 5.0
+      RotateToGoal.lookahead_time: -1.0
+
+local_costmap:
+  local_costmap:
+    ros__parameters:
+      update_frequency: 5.0
+      publish_frequency: 2.0
+      transform_tolerance: 0.3
+      # map frame: rtabmap publishes both /map and a map->odom TF, so the
+      # costmap is anchored in the SLAM map (same as the proven tiago_demo
+      # config). The rolling window crops the map around the robot.
+      global_frame: map
+      robot_base_frame: base_link
+      use_sim_time: true
+      rolling_window: true
+      width: 5
+      height: 5
+      resolution: 0.05
+      robot_radius: 0.22
+      # static_layer first: the rolling local window is cropped from the live
+      # rtabmap /map, so the local controller (DWB) sees mapped walls and
+      # avoids them reactively. obstacle_layer adds anything not yet mapped.
+      plugins: ["static_layer", "obstacle_layer", "inflation_layer"]
+      static_layer:
+        plugin: "nav2_costmap_2d::StaticLayer"
+        map_subscribe_transient_local: True
+        map_topic: "__ROBONIX_MAP_TOPIC__"
+      obstacle_layer:
+        plugin: "nav2_costmap_2d::ObstacleLayer"
+        enabled: True
+        observation_sources: scan
+        scan:
+          topic: "__ROBONIX_SCAN_TOPIC__"
+          max_obstacle_height: 2.0
+          clearing: True
+          marking: True
+          data_type: "LaserScan"
+          raytrace_max_range: 3.0
+          raytrace_min_range: 0.0
+          obstacle_max_range: 2.5
+          obstacle_min_range: 0.0
+      inflation_layer:
+        plugin: "nav2_costmap_2d::InflationLayer"
+        cost_scaling_factor: 1.0
+        inflation_radius: 1.50
+      always_send_full_costmap: True
+
+global_costmap:
+  global_costmap:
+    ros__parameters:
+      update_frequency: 1.0
+      publish_frequency: 1.0
+      # map frame, online SLAM: rtabmap publishes a live /map (growing as the
+      # robot explores) plus a map->odom TF. The static_layer tracks /map
+      # updates (map_subscribe_transient_local) so the costmap follows the
+      # map as it grows — mapping and navigating at the same time. The
+      # obstacle_layer adds anything not yet in the map; allow_unknown lets
+      # the planner route through not-yet-mapped space.
+      global_frame: map
+      robot_base_frame: base_link
+      rolling_window: false
+      width: 12
+      height: 12
+      use_sim_time: True
+      robot_radius: 0.22
+      resolution: 0.05
+      track_unknown_space: true
+      plugins: ["static_layer", "obstacle_layer", "inflation_layer"]
+      obstacle_layer:
+        plugin: "nav2_costmap_2d::ObstacleLayer"
+        enabled: True
+        observation_sources: scan
+        scan:
+          topic: "__ROBONIX_SCAN_TOPIC__"
+          max_obstacle_height: 2.0
+          clearing: True
+          marking: True
+          data_type: "LaserScan"
+          raytrace_max_range: 3.0
+          raytrace_min_range: 0.0
+          obstacle_max_range: 2.5
+          obstacle_min_range: 0.0
+      static_layer:
+        plugin: "nav2_costmap_2d::StaticLayer"
+        map_subscribe_transient_local: True
+      inflation_layer:
+        plugin: "nav2_costmap_2d::InflationLayer"
+        cost_scaling_factor: 3.0
+        inflation_radius: 0.55
+      always_send_full_costmap: True
+
+planner_server:
+  ros__parameters:
+    expected_planner_frequency: 20.0
+    use_sim_time: True
+    planner_plugins: ["GridBased"]
+    GridBased:
+      plugin: "nav2_navfn_planner/NavfnPlanner"
+      tolerance: 0.5
+      use_astar: false
+      allow_unknown: true
+
+smoother_server:
+  ros__parameters:
+    use_sim_time: True
+    smoother_plugins: ["simple_smoother"]
+    simple_smoother:
+      plugin: "nav2_smoother::SimpleSmoother"
+      tolerance: 1.0e-10
+      max_its: 1000
+      do_refinement: True
+
+behavior_server:
+  ros__parameters:
+    costmap_topic: local_costmap/costmap_raw
+    footprint_topic: local_costmap/published_footprint
+    cycle_frequency: 10.0
+    behavior_plugins: ["spin", "backup", "drive_on_heading", "assisted_teleop", "wait"]
+    spin:
+      plugin: "nav2_behaviors/Spin"
+    backup:
+      plugin: "nav2_behaviors/BackUp"
+    drive_on_heading:
+      plugin: "nav2_behaviors/DriveOnHeading"
+    wait:
+      plugin: "nav2_behaviors/Wait"
+    assisted_teleop:
+      plugin: "nav2_behaviors/AssistedTeleop"
+    global_frame: map
+    robot_base_frame: base_link
+    transform_tolerance: 0.1
+    use_sim_time: true
+    simulate_ahead_time: 2.0
+    max_rotational_vel: 1.0
+    min_rotational_vel: 0.4
+    rotational_acc_lim: 3.2
+
+robot_state_publisher:
+  ros__parameters:
+    use_sim_time: True
+
+waypoint_follower:
+  ros__parameters:
+    use_sim_time: True
+    loop_rate: 20
+    stop_on_failure: false
+    waypoint_task_executor_plugin: "wait_at_waypoint"
+    wait_at_waypoint:
+      plugin: "nav2_waypoint_follower::WaitAtWaypoint"
+      enabled: True
+      waypoint_pause_duration: 200
+
+velocity_smoother:
+  ros__parameters:
+    use_sim_time: True
+    smoothing_frequency: 20.0
+    scale_velocities: False
+    feedback: "OPEN_LOOP"
+    max_velocity: [0.26, 0.0, 1.0]
+    min_velocity: [-0.26, 0.0, -1.0]
+    max_accel: [2.5, 0.0, 3.2]
+    max_decel: [-2.5, 0.0, -3.2]
+    odom_topic: "__ROBONIX_ODOM_TOPIC__"
+    odom_duration: 0.1
+    deadband_velocity: [0.0, 0.0, 0.0]
+    velocity_timeout: 1.0

--- a/examples/webots/config/rtabmap_params.yaml
+++ b/examples/webots/config/rtabmap_params.yaml
@@ -1,0 +1,22 @@
+# Webots Tiago RTAB-Map parameters. This file is owned by this deployment.
+RGBD/CreateOccupancyGrid: true
+Grid/RangeMax: 6.0
+Grid/CellSize: 0.05
+Grid/RayTracing: true
+Grid/3D: false
+Grid/NormalsSegmentation: false
+Grid/MaxObstacleHeight: 1.0
+Grid/MaxGroundHeight: 0.1
+Reg/Strategy: 0
+Reg/Force3DoF: true
+Optimizer/Strategy: 1
+RGBD/NeighborLinkRefining: false
+RGBD/ProximityBySpace: false
+RGBD/AngularUpdate: 0.03
+RGBD/LinearUpdate: 0.03
+Mem/NotLinkedNodesKept: true
+Vis/MinInliers: 12
+Rtabmap/DetectionRate: 5.0
+Icp/MaxCorrespondenceDistance: 0.2
+Icp/MaxTranslation: 0.5
+Icp/MaxRotation: 0.78

--- a/examples/webots/primitives/audio_client_bridge/scripts/build.sh
+++ b/examples/webots/primitives/audio_client_bridge/scripts/build.sh
@@ -11,13 +11,20 @@ FLAGS=()
 
 rbnx codegen -p "$PKG" "${FLAGS[@]}"
 
-# `websockets` is the one runtime dep this package needs that ships
-# outside the robonix workspace. Install into the host Python; it's a
-# small pure-Python wheel and avoids spinning up another venv just for
-# one library.
-if ! python3 -c "import websockets" >/dev/null 2>&1; then
-    echo "[build] installing websockets (PyPI)"
-    python3 -m pip install --user --quiet websockets >/dev/null
-fi
+# Keep package dependencies independent of whichever Python environment ran
+# `rbnx build`. In particular, user-site installs are invalid when CI invokes
+# the build from a virtualenv and do not guarantee the same interpreter at
+# package start time.
+VENV="$PKG/rbnx-build/venv"
+uv venv --allow-existing --system-site-packages \
+  --python "${AUDIO_CLIENT_BRIDGE_PYTHON:-python3}" "$VENV"
+ROBONIX_API="$(rbnx path robonix-api)"
+uv pip install --python "$VENV/bin/python" --quiet "$ROBONIX_API" 'websockets>=12,<16'
+
+# Import the actual provider, not only its bridge-specific dependency.  This
+# catches missing protobuf/grpc/robonix-api runtime dependencies during build
+# instead of letting Soma discover them when the package starts.
+PYTHONPATH="$ROBONIX_API:$PKG:${PYTHONPATH:-}" \
+  "$VENV/bin/python" -c 'import audio_client_bridge.main'
 
 echo "[build] done."

--- a/examples/webots/primitives/audio_client_bridge/scripts/start.sh
+++ b/examples/webots/primitives/audio_client_bridge/scripts/start.sh
@@ -10,4 +10,10 @@ cd "$PKG_ROOT"
 
 export PYTHONPATH="$(rbnx path robonix-api):$PKG_ROOT:${PYTHONPATH:-}"
 
-exec python3 -m audio_client_bridge.main
+PYTHON="$PKG_ROOT/rbnx-build/venv/bin/python"
+if [[ ! -x "$PYTHON" ]]; then
+  echo "audio_client_bridge is not built; run 'rbnx build' first" >&2
+  exit 1
+fi
+
+exec "$PYTHON" -m audio_client_bridge.main

--- a/examples/webots/robonix_manifest.yaml
+++ b/examples/webots/robonix_manifest.yaml
@@ -33,6 +33,10 @@ system:
   liaison:
     listen: 0.0.0.0:50081
     log: info
+    # Disabled until the operator enables it from robonix-client. The client
+    # then supplies its persisted input/output provider selection; no client
+    # address is stored in this deployment.
+    handsfree_enabled: false
 
 # after booted all the system components, start the devices (primitives)
 # the robonix boot "device tree"
@@ -72,21 +76,18 @@ primitive:
       update_rate: 10
       frame_id: lidar
   # ── audio mic/speaker source ─────────────────────────────────────────────
-  # Default: local ALSA via audio_driver. liaison/speech resolve
-  # robonix/primitive/audio/{mic,speaker} from whichever single provider is
-  # active here.
+  # Local ALSA provider. It remains available for robot-local audio.
   - name: audio_driver
     path: ./primitives/audio_driver
     config: {}
-  # audio client bridge variant (opt-in): relays mic/speaker over a WebSocket from a
-  # client machine across the LAN. To use it, comment out the audio_driver block
-  # above and uncomment this one, then point host at the client machine's address
-  # and run client_audio_server/server.py (or server_web.py) on it.
-  # - name: audio_client_bridge
-  #   path: ./primitives/audio_client_bridge
-  #   config:
-  #     host: 127.0.0.1           # client machine address reachable by robonix
-  #     port: 60000
+  # Reverse bridge for a robonix-client audio route. It advertises its
+  # endpoint through Atlas and waits for the client to connect, so neither
+  # this manifest nor Liaison stores a client IP.
+  - name: audio_client_bridge
+    path: ./primitives/audio_client_bridge
+    config:
+      transport: reverse
+      listen_port: 60002
 
 # after booted all the primitives, start the services
 service:
@@ -94,18 +95,16 @@ service:
   # agent. Lives at services/memsearch in the robonix tree; pilot
   # queries it for relevant past context when planning.
   - name: memory
-    path: ../../services/memsearch
+    path: ${ROBONIX_SOURCE_PATH}/services/memsearch
     config:
       backend: sqlite
 
   # speech — ASR + TTS. Provides robonix/service/speech/asr_stream + tts that
-  # liaison's voice loop connects to. Captures mic through the
-  # robonix/primitive/audio/mic primitive, which `audio_driver` (primitive
-  # section above) provides — so voice runs fully local on this host's ALSA
-  # mic. The audio client bridge variant can be enabled in this primitive section when the mic/speaker live on a client machine.
+  # liaison's voice loop connects to. The selected audio provider is supplied
+  # by the client for F2, voice steer, and hands-free turns.
   # disable_whisper => FunASR-only (Paraformer) streaming ASR path.
   - name: speech
-    path: ../../services/speech
+    path: ${ROBONIX_SOURCE_PATH}/services/speech
     config:
       disable_whisper: true
       funasr_device: cuda
@@ -117,7 +116,7 @@ service:
   # modal enrolls/lists speakers. Config is env-driven (port 50092,
   # threshold 0.25, device auto) so the manifest block stays empty.
   - name: voiceprint
-    path: ../../services/voiceprint
+    path: ${ROBONIX_SOURCE_PATH}/services/voiceprint
     config: {}
 
   # mapping_rbnx — SLAM service. Listed FIRST because simple_nav

--- a/examples/webots/robonix_manifest.yaml
+++ b/examples/webots/robonix_manifest.yaml
@@ -109,6 +109,9 @@ service:
       disable_whisper: true
       funasr_device: cuda
       tts_voice: zh-CN-XiaoxiaoNeural
+      # CI and headless Webots have no connected reverse-audio client. Keep
+      # the bridge available, but send default speech to the local provider.
+      default_speaker_provider_id: audio_driver
 
   # voiceprint — ECAPA-TDNN speaker identification. Provides
   # robonix/service/voiceprint/{identify,enroll,list}: liaison's voice gate
@@ -119,23 +122,23 @@ service:
     path: ${ROBONIX_SOURCE_PATH}/services/voiceprint
     config: {}
 
-  # mapping_rbnx — SLAM service. Listed FIRST because simple_nav
-  # depends on `service/map/occupancy_grid` and rbnx-cli currently
-  # boots services in manifest order; until the defer-queue lands
-  # consumers must come after their providers.
+  # Mapping publishes the occupancy, point cloud, pose, and map-management
+  # contracts consumed by Navigation and Scene.
   - name: mapping
     url: https://github.com/syswonder/service-map-rbnx
     branch: main
     config:
-      algo: rtabmap
-      platform: x86_desktop
-      sensors:
-        lidar2d: true # webots do not have 3d pointcloud, so we use 2d lidar
-        lidar3d: false
-        rgb: true # color image — rtabmap fuses RGB for visual loop closure
-        depth: true # depth image — fills below-lidar-plane obstacles (rgb+depth = RGB-D)
-        imu: false
-        odom: true
+      use_sim_time: true
+      # The simulator's planar lidar is deterministic and aligned to odom.
+      # RGB-D remains available for visual SLAM without becoming an occupancy
+      # source, which avoids adding depth noise to the authoritative 2D map.
+      occupancy_sources: [lidar]
+      params_file: config/rtabmap_params.yaml
+      sensor_providers:
+        lidar2d: tiago_lidar
+        rgb: tiago_camera
+        depth: tiago_camera
+        odom: tiago_chassis
 
   # nav2_wrapper_rbnx IS the navigation service for this deploy.
   #
@@ -143,22 +146,25 @@ service:
   # (mapping/occupancy_grid), /odom (chassis/odom), /scan (lidar/lidar) —
   # and drives /cmd_vel via Nav2's navigate_to_pose action. Runs in the
   # `robonix-nav2` docker image (built by `rbnx build`, so the host needs
-  # no ROS2). The `sim` params profile navigates in the odom frame with a
-  # rolling-window costmap, so it needs only odom + a 2D scan and no SLAM
-  # map->odom TF — which is what makes it work in Webots. Listed after
+  # no ROS2). The complete simulator configuration is deployment-owned under
+  # config/. Listed after
   # mapping (its /map provider); on_init returns Deferred until mapping is
   # up, so order is a convenience, not a hard requirement.
   - name: nav2
     url: https://github.com/syswonder/service-navigation-rbnx
     branch: main
     config:
-      params_profile: sim
+      params_file: config/nav2_params.yaml
       use_sim_time: true
       action_wait_s: 240.0
       # The simulation goal checker enters at 0.25 m. Keep the terminal
       # rotation guard inside that boundary so path-alignment turns are not
       # mistaken for a stuck final-yaw correction.
       guard_terminal_xy_m: 0.20
+      provider_ids:
+        map: mapping
+        odom: tiago_chassis
+        scan: tiago_lidar
 
 # after booted all the services, register the skills (but don't activate them now)
 skill:

--- a/examples/webots/robonix_manifest.yaml
+++ b/examples/webots/robonix_manifest.yaml
@@ -1,17 +1,11 @@
 manifestVersion: 1
 name: robonix-webots-example-deploy
 
-env:
-  # FALLBACK binding of scene's semantic store to the named SLAM map of
-  # `mapping` below (the join key between geometric + semantic maps).
-  # Scene now learns the map identity from mapping's latched
-  # robonix/service/map/lifecycle broadcast (authoritative, wins over
-  # this env) — but in this boot order scene starts BEFORE mapping, so
-  # the first boot binds from this env; keep it == mapping's `map_id`.
-  # A scene restart while mapping runs binds from the broadcast alone.
-  # Propagated by `rbnx boot` into the process env, which scene's
-  # start.sh forwards as `-e SCENE_MAP_ID` into the container.
-  SCENE_MAP_ID: webots_lab
+# Default Webots boot starts a fresh live SLAM session. The map/room UI
+# names and persists that session when the operator clicks Save; clicking
+# Load later switches mapping to localization mode and binds scene objects +
+# room annotations to the selected saved map. Do not set SCENE_MAP_ID here: a
+# static default would make a first run look like a loaded map.
 
 # boot in sequence: system -> soma+scene -> execution -> interaction
 system:
@@ -136,8 +130,6 @@ service:
     config:
       algo: rtabmap
       platform: x86_desktop
-      map_id: webots_lab
-      map_mode: mapping
       sensors:
         lidar2d: true # webots do not have 3d pointcloud, so we use 2d lidar
         lidar3d: false

--- a/examples/webots/robonix_manifest.yaml
+++ b/examples/webots/robonix_manifest.yaml
@@ -2,10 +2,15 @@ manifestVersion: 1
 name: robonix-webots-example-deploy
 
 env:
-  # Bind scene's semantic store to the same named SLAM map as `mapping`
-  # below (the join key between geometric + semantic maps). Propagated by
-  # `rbnx boot` into the process env, which scene's start.sh forwards as
-  # `-e SCENE_MAP_ID` into the container. Keep this id == mapping's `map_id`.
+  # FALLBACK binding of scene's semantic store to the named SLAM map of
+  # `mapping` below (the join key between geometric + semantic maps).
+  # Scene now learns the map identity from mapping's latched
+  # robonix/service/map/lifecycle broadcast (authoritative, wins over
+  # this env) — but in this boot order scene starts BEFORE mapping, so
+  # the first boot binds from this env; keep it == mapping's `map_id`.
+  # A scene restart while mapping runs binds from the broadcast alone.
+  # Propagated by `rbnx boot` into the process env, which scene's
+  # start.sh forwards as `-e SCENE_MAP_ID` into the container.
   SCENE_MAP_ID: webots_lab
 
 # boot in sequence: system -> soma+scene -> execution -> interaction

--- a/examples/webots/sim/ros_ws/src/eaios_webots/worlds/complete_apartment.wbt
+++ b/examples/webots/sim/ros_ws/src/eaios_webots/worlds/complete_apartment.wbt
@@ -1319,53 +1319,17 @@ Wall {
   name "wall 7(3)"
   size 0.3 3.2 2.4
 }
-Door {
-  translation -6.24 -8.43 0
-  rotation 0 0 1 -1.5707953071795862
-  size 0.3 1 2.4
-  jointAtLeft FALSE
-  frameSize 0.001 0.05 0.05
-  frameAppearance BrushedAluminium {
-  }
-  doorHandle DoorLever {
-    jointAtLeft FALSE
-  }
-}
-Door {
-  translation -3.89 -3.95 0
-  name "door(6)"
-  size 0.3 1 2.4
-  frameSize 0.001 0.05 0.05
-  frameAppearance BrushedAluminium {
-  }
-}
-Door {
-  translation -4.94 -8.43 0
-  rotation 0 0 1 -1.5707953071795862
-  name "door(5)"
-  size 0.3 1 2.4
-  frameSize 0.001 0.05 0.05
-  frameAppearance BrushedAluminium {
-  }
-}
-Door {
-  translation -6.97 -7.24 0
-  rotation 0 0 1 3.14159
-  name "door(3)"
-  size 0.3 1 2.4
-  frameSize 0.001 0.05 0.05
-  frameAppearance BrushedAluminium {
-  }
-}
-Door {
-  translation -0.91 -6.6 0
-  rotation 0 0 1 1.5708
-  name "door(4)"
-  size 0.3 1 2.4
-  frameSize 0.001 0.05 0.05
-  frameAppearance BrushedAluminium {
-  }
-}
+
+# Interior door door removed for open-room apartment navigation.
+
+# Interior door door(6) removed for open-room apartment navigation.
+
+# Interior door door(5) removed for open-room apartment navigation.
+
+# Interior door door(3) removed for open-room apartment navigation.
+
+# Interior door door(4) removed for open-room apartment navigation.
+
 Door {
   translation 0 -7.49 0
   name "door(1)"
@@ -1374,15 +1338,8 @@ Door {
   frameAppearance BrushedAluminium {
   }
 }
-Door {
-  translation -2.14977 -8.43 0
-  rotation 0 0 1 -1.5707953071795862
-  name "door(2)"
-  size 0.3 1 2.4
-  frameSize 0.001 0.05 0.05
-  frameAppearance BrushedAluminium {
-  }
-}
+# Interior door door(2) removed for open-room apartment navigation.
+
 Wall {
   translation -2.93 -6.6 0
   rotation 0 0 1 1.5708

--- a/system/scene/README.md
+++ b/system/scene/README.md
@@ -257,6 +257,7 @@ plain `humble`.
 | `SCENE_OBJECT_MEMORY_DB` | `/data/robonix/scene_memory/objects.db` | milvus-lite DB path (inside container; host-mounted via `rbnx-build/data/robonix`) |
 | `SCENE_MAP_ID` | `default` | FALLBACK map binding: mapping's latched `robonix/service/map/lifecycle` broadcast wins when present at startup; this env (below manifest `map_id`) applies when mapping isn't up yet (normal full-boot order) or doesn't broadcast |
 | `SCENE_MAP_BINDING_WAIT_S` | `3.0` | how long the startup probe waits for the lifecycle contract to appear on atlas before falling back to static binding; `0` disables the probe |
+| `SCENE_ANNOTATIONS_DIR` | `/data/robonix/scene_annotations` | per-map JSON files holding user annotations (rooms / POIs); host-mounted like the object DB |
 | `VLM_REASONING_EFFORT` | `` (unset) | opt-in, forwarded to all scene VLM/LLM calls (relation inference + VLM perception): `minimal`\|`low`\|`medium`\|`high`. **Unset → the field is omitted**, so non-reasoning models and strict endpoints are unaffected. Set `minimal` (= no thinking) to keep a reasoning `VLM_MODEL` (e.g. `doubao-seed-2-1-pro`) answering in ~2 s instead of timing out |
 
 ## Object memory (warm restore)
@@ -292,6 +293,43 @@ mapping-mode session start) drifts from the startup binding, scene logs a
 warning and keeps its binding — reacting (flush + re-anchor) is the planned
 lifecycle linkage (P3).
 
+## User annotations (rooms / POIs)
+
+Scene also stores **user-authored** semantics: annotations the user draws on
+the map canvas — a `room` (named polygon) or a `poi` (named point, optional
+heading; model-ready, no UI yet). They live on the same foundation as
+perceived objects: coordinates are map-frame meters, storage partitions by
+the map binding's `map_id`, and validity follows mapping's `generation`
+epoch. Unlike perceived objects they are user assets: a map rebuild (reset /
+re-mapping) never deletes them — they are flagged `stale` (with a reason)
+for the user to confirm ("still valid" clears the flag) or redraw (new
+geometry is authored against the current frame, so redrawing also clears it).
+
+Storage is one JSON file per map under `SCENE_ANNOTATIONS_DIR`
+(`<map_id>.json`, atomic writes, no vectors — deliberately not in the milvus
+object DB). CRUD goes through the web server's REST API (same trust domain
+as the rest of this LAN debug/UI server — no auth):
+
+| Route | Body | Returns |
+|---|---|---|
+| `GET /api/annotations` | — | `{ok, annotations: [...]}` |
+| `POST /api/annotations` | `{kind, name, points, theta?}` | `{ok, annotation}` (with generated id) |
+| `PUT /api/annotations/{id}` | any of `{name, points, theta, stale: false}` | `{ok, annotation}` |
+| `DELETE /api/annotations/{id}` | — | `{ok}` |
+
+Errors: `400` invalid fields (unknown kind, room polygon < 3 points, poi ≠ 1
+point, non-finite numbers, `theta` on a room — headings are poi-only), `404`
+unknown id, `503` store unavailable — those carry `{ok: false, detail}`; a
+store write failure (e.g. disk full) surfaces as a plain `500` because the
+edit was not saved. On `PUT`, `theta: null` (or absent) means "keep the
+current heading" — a set heading can be changed but not cleared (deliberate
+until the poi UI lands). `points` are `[[x, y], ...]` map-frame
+meters. **This shape is the contract any frontend builds on; treat changes
+as breaking.** The full annotation list also rides along in `GET /api/state`
+(field `annotations`, next to `map_binding`) so map pages get everything in
+one poll. There is deliberately no atlas/MCP surface yet — exposing rooms to
+Pilot (scene-graph `in_room` edges) is a planned follow-up.
+
 ## Capabilities exposed
 
 | Contract                                       | Tool name        | What it does                                                        |
@@ -314,12 +352,14 @@ curl -s http://127.0.0.1:50106/mcp/ -H "Content-Type: application/json" \
 ## Web UI quick tour
 
 * `/` — combined 3-column layout (default): 2D map · 3D scene · cam stack
+* `/user` — **end-user map page**: SLAM map + room annotations (draw a polygon, name it, rename / delete / confirm-stale) with a lightweight object overlay; the debug pages above are untouched by it
 * `/2d` — only the 2D top-down map
 * `/3d` — only the 3D point clouds + bboxes
 * `/cam` — only the camera stack: live RGB on top, live depth below
-* `/api/state` — JSON: registry + relations + occupancy PNG + robot pose
+* `/api/state` — JSON: registry + relations + occupancy PNG + robot pose + user annotations + map binding
 * `/api/objects3d` — JSON: per-object pcd + 8 bbox corners + CLIP class
 * `/api/camera` — JSON: latest RGB + depth as base64 PNGs (5 Hz polling)
+* `/api/annotations` — user annotation CRUD (see "User annotations" above)
 
 The 3D viz draws the OccupancyGrid as a translucent floor plane at z = -0.01 (so you can read room geometry under the point clouds), each detected object as a coloured pcd + yaw-rotated wireframe bbox + class label sprite, and the robot as a composite Tiago-shaped proxy (mobile base + torso + shoulder + head + arm), all parented to a `THREE.Group` that updates from `/api/state`'s `robot` field at 4 Hz.
 
@@ -347,7 +387,7 @@ The cam panel shows the same RGB + depth frames the perception pipeline consumes
 
 ## Scope (what's NOT here)
 
-- **No write API.** No `IngestObservation`, no `UpdateTaskContext`. Per the spec, scene is a sink.
+- **No write contract.** No `IngestObservation`, no `UpdateTaskContext` on atlas/MCP — perception-wise, scene is a sink. (The web server's annotation REST is an internal UI API, not a capability contract.)
 - **No subscribe-stream.** `SubscribeUpdates` doesn't fit MCP semantics. Pilot polls.
 - **No episodic memory.** Long-term memory belongs to memory services, not scene.
 - **No direct motion control.** `goal_near` returns an approach pose; navigation is performed by `robonix/service/navigation/navigate`.

--- a/system/scene/README.md
+++ b/system/scene/README.md
@@ -255,7 +255,8 @@ plain `humble`.
 | `SCENE_PORT` / `SCENE_WEB_PORT` | `50106` / `50107` | gRPC + web UI ports |
 | `SCENE_OBJECT_MEMORY_ENABLED` | `true` | persist stable objects + warm-restore the registry on boot |
 | `SCENE_OBJECT_MEMORY_DB` | `/data/robonix/scene_memory/objects.db` | milvus-lite DB path (inside container; host-mounted via `rbnx-build/data/robonix`) |
-| `SCENE_MAP_ID` | `default` | SLAM map the persisted objects belong to; restore loads only this map's objects (manifest `map_id` overrides) |
+| `SCENE_MAP_ID` | `default` | FALLBACK map binding: mapping's latched `robonix/service/map/lifecycle` broadcast wins when present at startup; this env (below manifest `map_id`) applies when mapping isn't up yet (normal full-boot order) or doesn't broadcast |
+| `SCENE_MAP_BINDING_WAIT_S` | `3.0` | how long the startup probe waits for the lifecycle contract to appear on atlas before falling back to static binding; `0` disables the probe |
 | `VLM_REASONING_EFFORT` | `` (unset) | opt-in, forwarded to all scene VLM/LLM calls (relation inference + VLM perception): `minimal`\|`low`\|`medium`\|`high`. **Unset → the field is omitted**, so non-reasoning models and strict endpoints are unaffected. Set `minimal` (= no thinking) to keep a reasoning `VLM_MODEL` (e.g. `doubao-seed-2-1-pro`) answering in ~2 s instead of timing out |
 
 ## Object memory (warm restore)
@@ -273,13 +274,23 @@ DB — and lives under the host-mounted `/data/robonix`, which also makes the
 scene-graph JSON caches survive boots. Writes are driven by the scene-graph
 builder, so disabling `SCENE_GRAPH_ENABLED` stops new writes (restore still runs).
 
-Persistence is partitioned by `SCENE_MAP_ID` (or the manifest `map_id`): an
-object's pose is only meaningful in the `map` frame of the SLAM map it was
-observed on, so restore loads exactly the current map's objects and never mixes
-two maps. The same `object_id` may exist on different maps without colliding.
-`map_id` is a deploy-controlled string today (default `"default"`) and stays
-internal to scene — no atlas/MCP contract changes — until mapping emits a real
-map identity to wire in here.
+Persistence is partitioned by the map binding: an object's pose is only
+meaningful in the `map` frame of the SLAM map it was observed on, so restore
+loads exactly the current map's objects and never mixes two maps. The same
+`object_id` may exist on different maps without colliding.
+
+The binding itself (`scene_service/map_binding.py`) is learned at startup with
+this precedence: mapping's latched `robonix/service/map/lifecycle` broadcast
+(`{map_id, mode, generation}` — the authoritative map identity, probed for
+`SCENE_MAP_BINDING_WAIT_S`) → manifest `config.map_id` → `SCENE_MAP_ID` env →
+`"default"`. The broadcast needs the generated `map` interface package
+(`rbnx codegen --ros2` → colcon overlay, built by `scripts/build.sh`, sourced
+by the container entrypoint); without it scene falls back to static binding
+with a warning. At runtime scene only WATCHES the broadcast: if mapping's
+identity or `generation` (bumped when the map origin may have changed: reset /
+mapping-mode session start) drifts from the startup binding, scene logs a
+warning and keeps its binding — reacting (flush + re-anchor) is the planned
+lifecycle linkage (P3).
 
 ## Capabilities exposed
 

--- a/system/scene/docker/entrypoint.sh
+++ b/system/scene/docker/entrypoint.sh
@@ -16,6 +16,16 @@ set -eo pipefail
 # shellcheck disable=SC1091
 source "/opt/ros/${ROS_DISTRO:-humble}/setup.bash"
 
+# Robonix ros2_idl overlay (generated `map` interface package — mapping's
+# latched lifecycle broadcast that scene's map binding subscribes to).
+# Built by scripts/build.sh onto the bind-mounted rbnx-build/; when absent
+# scene logs a warning and falls back to static map binding.
+ROS2_IDL_SETUP=/scene/rbnx-build/codegen/ros2_idl/install/setup.bash
+if [ -f "$ROS2_IDL_SETUP" ]; then
+    # shellcheck disable=SC1090
+    source "$ROS2_IDL_SETUP"
+fi
+
 configure_zenoh_session() {
     if [ "${RMW_IMPLEMENTATION:-}" != "rmw_zenoh_cpp" ] || [ -z "${ROBONIX_ZENOH_ROUTER:-}" ]; then
         return 0

--- a/system/scene/package_manifest.jetson-docker.yaml
+++ b/system/scene/package_manifest.jetson-docker.yaml
@@ -23,6 +23,7 @@ start: ROBONIX_SCENE_FORCE=docker bash scripts/start.sh
 capabilities:
   - name: robonix/system/scene/list_objects
   - name: robonix/system/scene/goal_near
+  - name: robonix/system/scene/goal_room
   - name: robonix/system/scene/get_scene_graph
   - name: robonix/system/scene/get_object_context
   - name: robonix/system/scene/list_relations

--- a/system/scene/package_manifest.jetson-native.yaml
+++ b/system/scene/package_manifest.jetson-native.yaml
@@ -27,6 +27,7 @@ start: ROBONIX_SCENE_FORCE=native bash scripts/start.sh
 capabilities:
   - name: robonix/system/scene/list_objects
   - name: robonix/system/scene/goal_near
+  - name: robonix/system/scene/goal_room
   - name: robonix/system/scene/get_scene_graph
   - name: robonix/system/scene/get_object_context
   - name: robonix/system/scene/list_relations

--- a/system/scene/package_manifest.yaml
+++ b/system/scene/package_manifest.yaml
@@ -1,5 +1,5 @@
 # Scene MCP server — current-state semantic + geometric map of the
-# robot's environment. Exposes 5 read-only MCP tools for Pilot.
+# robot's environment. Exposes 6 read-only MCP tools for Pilot.
 #
 # Deployment shape: scene runs in its OWN docker container (image
 # `robonix-scene`, built by scripts/build.sh). Joins host network so:
@@ -33,6 +33,7 @@ stop: docker rm -f "${ROBONIX_SCENE_CONTAINER:-robonix_scene}"
 capabilities:
   - name: robonix/system/scene/list_objects
   - name: robonix/system/scene/goal_near
+  - name: robonix/system/scene/goal_room
   - name: robonix/system/scene/get_scene_graph
   - name: robonix/system/scene/get_object_context
   - name: robonix/system/scene/list_relations

--- a/system/scene/scene_service/annotations.py
+++ b/system/scene/scene_service/annotations.py
@@ -1,0 +1,354 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+"""User annotations — user-authored semantics anchored to the SLAM map.
+
+An annotation is a named geometric mark the user draws on the map canvas:
+a `room` (polygon + name) or a `poi` (single point, optional heading).
+Annotations share the same foundation as perceived objects: coordinates
+are map-frame meters, storage is partitioned by `map_id`, and validity is
+judged by mapping's `generation` epoch (see map_binding.py). Unlike
+perceived objects they are USER ASSETS: a map rebuild never deletes them —
+they are kept and flagged `stale` for the user to confirm or redraw.
+
+Storage is one JSON file per map (`<base_dir>/<map_id>.json`, atomic
+tmp+rename writes). Annotations carry no vectors, so they stay out of the
+milvus object store on purpose; the per-map JSON mirrors SceneGraphStore's
+partitioning pattern.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+import threading
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+from .map_binding import sanitize_map_id
+
+log = logging.getLogger(__name__)
+
+# The kind whitelist lives here (single source); every consumer checks it
+# through validate_annotation_fields below. `poi` is model-reserved: the
+# store handles it, the first UI iteration only draws rooms.
+VALID_KINDS = ("room", "poi")
+MAX_NAME_LEN = 128
+
+
+def validate_annotation_fields(
+    kind: str,
+    name: Any,
+    points: Any,
+    theta: Any,
+) -> Optional[str]:
+    """Validate user-supplied annotation fields; return an error string on
+    the first violation, None when everything is acceptable.
+
+    Rules: `kind` must be whitelisted; `name` a string ≤ MAX_NAME_LEN;
+    `points` a list of finite [x, y] number pairs — exactly 1 for a poi,
+    ≥3 for a room (a polygon needs three vertices); `theta` (a heading)
+    only applies to a poi and must be None or a finite number — a region
+    has no heading, so a room carrying theta is rejected rather than
+    silently stored. NaN/inf anywhere is rejected so bad JSON can never
+    poison the stored file."""
+    if kind not in VALID_KINDS:
+        return f"kind must be one of {list(VALID_KINDS)}, got {kind!r}"
+    if not isinstance(name, str):
+        return "name must be a string"
+    if len(name) > MAX_NAME_LEN:
+        return f"name too long (max {MAX_NAME_LEN} chars)"
+    if not isinstance(points, list):
+        return "points must be a list of [x, y] pairs"
+    for p in points:
+        if (
+            not isinstance(p, (list, tuple))
+            or len(p) != 2
+            or not all(isinstance(v, (int, float)) and not isinstance(v, bool) for v in p)
+            or not all(math.isfinite(float(v)) for v in p)
+        ):
+            return "each point must be a finite [x, y] number pair"
+    if kind == "poi" and len(points) != 1:
+        return "a poi takes exactly one point"
+    if kind == "room" and len(points) < 3:
+        return "a room polygon needs at least 3 points"
+    if theta is not None:
+        if kind != "poi":
+            return "theta (heading) only applies to a poi"
+        if not isinstance(theta, (int, float)) or isinstance(theta, bool) or not math.isfinite(float(theta)):
+            return "theta must be a finite number or null"
+    return None
+
+
+@dataclass
+class Annotation:
+    """One user annotation. `points` are map-frame meters; `stale` means
+    the map's generation changed after this was drawn — geometry may no
+    longer line up, and the user must confirm or redraw (never auto-deleted)."""
+    annotation_id: str
+    kind: str                       # "room" | "poi" (see VALID_KINDS)
+    name: str
+    points: list[list[float]] = field(default_factory=list)   # [[x, y], ...]
+    # Optional poi heading, radians (rooms never carry one — validated).
+    # API semantics: theta=None on update means "keep"; a set heading
+    # cannot be cleared, only changed. Revisit if/when the poi UI lands.
+    theta: Optional[float] = None
+    created_at: float = 0.0
+    updated_at: float = 0.0
+    stale: bool = False
+    stale_reason: str = ""
+
+    def to_json(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_json(cls, d: dict) -> "Annotation":
+        """Rebuild from a stored dict, dropping unknown keys so a file
+        written by a newer scene still loads (forward-tolerant)."""
+        known = set(cls.__dataclass_fields__)
+        return cls(**{k: v for k, v in d.items() if k in known})
+
+
+class AnnotationStore:
+    """Per-map JSON persistence for user annotations.
+
+    One file per map: `<base_dir>/<map_id>.json` (map_id sanitized with the
+    same rule as the object store so the two partitions always agree). The
+    file records `{map_id, generation, annotations}`; on load, a stored
+    generation that differs from the current binding's means the map frame
+    was rebuilt since the annotations were drawn — every annotation is
+    marked stale (kept, never dropped: user assets, unlike perceived
+    objects, are never cleaned up automatically). When either side
+    has no generation (static binding, pre-P2 file) staleness cannot be
+    judged and the stored value is preserved for the next boot that can.
+
+    All methods are synchronous and guarded by an internal lock; writes are
+    atomic (tmp + os.replace) and happen on every mutation — annotation
+    traffic is human-speed, so write-through is cheap and never loses an
+    accepted edit."""
+
+    def __init__(self, base_dir: str, *, map_id: str, generation: Optional[int] = None) -> None:
+        """Open (creating dirs as needed) the store for `map_id` and load
+        its file, applying the generation staleness check described on the
+        class. A corrupt file is set aside (renamed `*.corrupt-<ts>`) and
+        the store starts empty — loudly, and without destroying the bytes."""
+        self._lock = threading.Lock()
+        self._map_id = sanitize_map_id(map_id)
+        self._base = Path(base_dir).expanduser()
+        self._base.mkdir(parents=True, exist_ok=True)
+        self._path = self._base / f"{self._map_id}.json"
+        self._generation = generation
+        self._annotations: dict[str, Annotation] = {}
+        self._load(current_generation=generation)
+
+    @property
+    def map_id(self) -> str:
+        return self._map_id
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    # ── load / save ──────────────────────────────────────────────────────
+    def _load(self, current_generation: Optional[int]) -> None:
+        """Read the per-map file into memory. Missing file → empty store.
+        A file that fails to parse, has an unexpected shape, or contains a
+        record that would not pass `validate_annotation_fields` (the file
+        is a user-visible JSON asset, so hand edits happen) is treated as
+        corrupt as a whole: renamed aside + empty store — the user's bytes
+        are never dropped or overwritten by a failed load. A stored
+        generation differing from `current_generation` marks everything
+        stale and persists the flag."""
+        if not self._path.exists():
+            return
+        try:
+            data = json.loads(self._path.read_text(encoding="utf-8"))
+            if not isinstance(data, dict):
+                raise ValueError(f"top-level JSON is {type(data).__name__}, not an object")
+            stored_gen = data.get("generation")
+            if stored_gen is not None:
+                stored_gen = int(stored_gen)
+            anns = []
+            for d in data.get("annotations", []):
+                if not isinstance(d, dict):
+                    raise ValueError(f"annotation entry is {type(d).__name__}, not an object")
+                a = Annotation.from_json(d)
+                err = validate_annotation_fields(a.kind, a.name, a.points, a.theta)
+                if err:
+                    raise ValueError(f"annotation {a.annotation_id!r}: {err}")
+                if not isinstance(a.annotation_id, str) or not a.annotation_id:
+                    raise ValueError("annotation with missing/empty id")
+                anns.append(a)
+        except (ValueError, TypeError, KeyError, AttributeError) as e:
+            aside = self._path.with_suffix(f".json.corrupt-{int(time.time())}")
+            # Rename failures re-raise: continuing with an empty store
+            # would let the next accepted edit os.replace() the corrupt
+            # file — destroying exactly the bytes this path promises to
+            # keep. Failing __init__ disables the API loudly instead.
+            self._path.rename(aside)
+            log.error(
+                "[scene-anno] %s failed to load (%s) — moved to %s, "
+                "starting empty", self._path, e, aside,
+            )
+            return
+        self._annotations = {a.annotation_id: a for a in anns}
+        if current_generation is None:
+            # Cannot judge staleness this session; keep the recorded epoch
+            # so a later broadcast-bound boot still can.
+            self._generation = stored_gen
+            return
+        if stored_gen is not None and stored_gen != int(current_generation):
+            reason = f"map generation {stored_gen}→{current_generation}"
+            n = self._flag_all_stale_locked(reason, new_generation=None)
+            if n:
+                log.warning(
+                    "[scene-anno] map frame epoch changed (%s) — %d "
+                    "annotation(s) marked stale for user confirmation", reason, n,
+                )
+
+    def _save_locked(self) -> None:
+        """Atomically write the current state (caller holds the lock or is
+        __init__). tmp file lands in the same directory so os.replace stays
+        on one filesystem. Raises on I/O failure — callers accepted a user
+        edit, losing it silently is worse than a 500. Synchronous file I/O
+        on the event loop is deliberate: annotation traffic is human-speed
+        and the files are a few KB."""
+        payload = {
+            "map_id": self._map_id,
+            "generation": self._generation,
+            "annotations": [a.to_json() for a in self._annotations.values()],
+        }
+        tmp = self._path.with_suffix(".json.tmp")
+        tmp.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=1), encoding="utf-8"
+        )
+        os.replace(tmp, self._path)
+
+    # ── read ─────────────────────────────────────────────────────────────
+    # list()/get() hand out the LIVE Annotation objects — treat them as
+    # read-only. Mutating them directly bypasses both the lock and
+    # persistence; go through update() instead.
+    def list(self) -> list[Annotation]:
+        with self._lock:
+            return list(self._annotations.values())
+
+    def get(self, annotation_id: str) -> Optional[Annotation]:
+        with self._lock:
+            return self._annotations.get(annotation_id)
+
+    def list_json(self) -> list[dict]:
+        """JSON-ready dump of every annotation (the `/api/state` field and
+        `GET /api/annotations` share this shape)."""
+        with self._lock:
+            return [a.to_json() for a in self._annotations.values()]
+
+    # ── mutate (each call persists before returning) ─────────────────────
+    def create(self, *, kind: str, name: str, points: list,
+               theta: Optional[float] = None) -> Annotation:
+        """Create + persist a new annotation and return it. Fields must
+        already be validated (validate_annotation_fields) — the store
+        trusts its callers and only owns id/timestamp assignment."""
+        now = time.time()
+        ann = Annotation(
+            annotation_id=f"anno.{uuid.uuid4().hex[:8]}",
+            kind=kind,
+            name=name,
+            points=[[float(x), float(y)] for x, y in points],
+            theta=None if theta is None else float(theta),
+            created_at=now,
+            updated_at=now,
+        )
+        with self._lock:
+            self._annotations[ann.annotation_id] = ann
+            self._save_locked()
+        return ann
+
+    def update(self, annotation_id: str, *, name: Optional[str] = None,
+               points: Optional[list] = None, theta: Optional[float] = None,
+               clear_stale: bool = False) -> Optional[Annotation]:
+        """Apply the provided fields to an existing annotation (None = keep),
+        bump `updated_at`, persist, and return it; None when the id is
+        unknown. `clear_stale` is the user's "confirm still valid" action —
+        it resets both the flag and the recorded reason. Redrawing the
+        points also clears staleness: new geometry is authored against the
+        CURRENT map frame, so the old epoch's doubt no longer applies."""
+        with self._lock:
+            ann = self._annotations.get(annotation_id)
+            if ann is None:
+                return None
+            if name is not None:
+                ann.name = name
+            if points is not None:
+                ann.points = [[float(x), float(y)] for x, y in points]
+                ann.stale, ann.stale_reason = False, ""
+            if theta is not None:
+                ann.theta = float(theta)
+            if clear_stale:
+                ann.stale, ann.stale_reason = False, ""
+            ann.updated_at = time.time()
+            self._save_locked()
+            return ann
+
+    def delete(self, annotation_id: str) -> bool:
+        """Remove an annotation; True when it existed. Persists on change."""
+        with self._lock:
+            if annotation_id not in self._annotations:
+                return False
+            del self._annotations[annotation_id]
+            self._save_locked()
+            return True
+
+    def _flag_all_stale_locked(self, reason: str,
+                               new_generation: Optional[int]) -> int:
+        """Shared body of the two stale-sweep entry points (caller holds
+        the lock, or is __init__/_load): flag every non-stale annotation
+        with `reason`, optionally adopt `new_generation`, persist when
+        anything changed. Returns how many annotations flipped."""
+        n = 0
+        for a in self._annotations.values():
+            if not a.stale:
+                a.stale, a.stale_reason = True, reason
+                n += 1
+        gen_changed = new_generation is not None and new_generation != self._generation
+        if gen_changed:
+            self._generation = new_generation
+        if n or gen_changed:
+            self._save_locked()
+        return n
+
+    def reconcile_generation(self, live_generation: int) -> int:
+        """Called when the map's true generation becomes known at runtime
+        (the lifecycle watcher's confirmation) — a store built under a
+        static binding (generation None) cannot judge staleness at load
+        time, so the judgement happens here instead. Adopts the epoch when
+        the store had none; when the recorded epoch differs, flags
+        everything stale (user assets are never auto-deleted, only
+        flagged). Runs decision + sweep under one lock acquisition, so a
+        concurrent create() can never be flagged by a sweep it postdates.
+        Returns how many flipped."""
+        with self._lock:
+            if self._generation is None or int(self._generation) == int(live_generation):
+                if self._generation != live_generation:
+                    self._generation = int(live_generation)
+                    self._save_locked()
+                return 0
+            reason = f"map generation {self._generation}→{live_generation}"
+            n = self._flag_all_stale_locked(reason, int(live_generation))
+        if n:
+            log.warning(
+                "[scene-anno] recorded map epoch differs from mapping's (%s) "
+                "— %d annotation(s) marked stale for user confirmation",
+                reason, n,
+            )
+        return n
+
+    def mark_all_stale(self, reason: str, *, new_generation: Optional[int] = None) -> int:
+        """Flag every non-stale annotation stale with `reason` (map frame
+        epoch changed at runtime — the _lifecycle_watch hook). Optionally
+        records the new generation so the file reflects the epoch the
+        staleness was judged against. Returns how many flipped; persists
+        when anything changed (flag or generation)."""
+        with self._lock:
+            return self._flag_all_stale_locked(reason, new_generation)

--- a/system/scene/scene_service/annotations.py
+++ b/system/scene/scene_service/annotations.py
@@ -38,6 +38,18 @@ VALID_KINDS = ("room", "poi")
 MAX_NAME_LEN = 128
 
 
+def _annotation_identity(kind: str, name: str) -> tuple[str, str]:
+    """Stable user-facing identity for idempotent room creation.
+
+    The UI may submit the same completed polygon twice when double-click or
+    Enter events race. Rooms are named user assets, so a repeated create with
+    the same normalized name updates that room instead of minting a second UUID.
+    POIs keep append semantics.
+    """
+    normalized = " ".join(str(name).strip().split()).casefold()
+    return str(kind).strip().casefold(), normalized
+
+
 def validate_annotation_fields(
     kind: str,
     name: Any,
@@ -151,6 +163,32 @@ class AnnotationStore:
     def path(self) -> Path:
         return self._path
 
+    def rebind(self, map_id: str, *, generation: Optional[int] = None,
+               carry_current: bool = False) -> None:
+        """Switch this store to another map partition.
+
+        `carry_current=True` is used by scene's Save Map UI path: the user
+        just named the live spatial map, so the rooms they drew in the live
+        session must be written under the same map_id before future loads.
+        `carry_current=False` is used by Load Map: discard the in-memory
+        partition and load the target map's annotation JSON.
+        """
+        next_id = sanitize_map_id(map_id)
+        with self._lock:
+            if next_id == self._map_id:
+                self._generation = generation
+                if carry_current:
+                    self._save_locked()
+                return
+            self._map_id = next_id
+            self._path = self._base / f"{self._map_id}.json"
+            self._generation = generation
+            if carry_current:
+                self._save_locked()
+            else:
+                self._annotations = {}
+                self._load(current_generation=generation)
+
     # ── load / save ──────────────────────────────────────────────────────
     def _load(self, current_generation: Optional[int]) -> None:
         """Read the per-map file into memory. Missing file → empty store.
@@ -247,20 +285,40 @@ class AnnotationStore:
     # ── mutate (each call persists before returning) ─────────────────────
     def create(self, *, kind: str, name: str, points: list,
                theta: Optional[float] = None) -> Annotation:
-        """Create + persist a new annotation and return it. Fields must
-        already be validated (validate_annotation_fields) — the store
-        trusts its callers and only owns id/timestamp assignment."""
+        """Create + persist an annotation and return it.
+
+        Room creation is idempotent by normalized room name: the user page can
+        legitimately re-enter this endpoint once when double-click or Enter
+        browser events race around the async name dialog. In that case we keep
+        the existing annotation id and update its polygon instead of creating
+        two visually identical rooms. POIs remain append-style assets. Fields
+        must already be validated (validate_annotation_fields).
+        """
         now = time.time()
-        ann = Annotation(
-            annotation_id=f"anno.{uuid.uuid4().hex[:8]}",
-            kind=kind,
-            name=name,
-            points=[[float(x), float(y)] for x, y in points],
-            theta=None if theta is None else float(theta),
-            created_at=now,
-            updated_at=now,
-        )
+        norm_points = [[float(x), float(y)] for x, y in points]
+        norm_theta = None if theta is None else float(theta)
         with self._lock:
+            if kind == "room":
+                target = _annotation_identity(kind, name)
+                for existing in self._annotations.values():
+                    if _annotation_identity(existing.kind, existing.name) == target:
+                        existing.name = name
+                        existing.points = norm_points
+                        existing.theta = norm_theta
+                        existing.stale = False
+                        existing.stale_reason = ""
+                        existing.updated_at = now
+                        self._save_locked()
+                        return existing
+            ann = Annotation(
+                annotation_id=f"anno.{uuid.uuid4().hex[:8]}",
+                kind=kind,
+                name=name,
+                points=norm_points,
+                theta=norm_theta,
+                created_at=now,
+                updated_at=now,
+            )
             self._annotations[ann.annotation_id] = ann
             self._save_locked()
         return ann

--- a/system/scene/scene_service/annotations.py
+++ b/system/scene/scene_service/annotations.py
@@ -189,6 +189,25 @@ class AnnotationStore:
                 self._annotations = {}
                 self._load(current_generation=generation)
 
+    def delete_map(self, map_id: str) -> bool:
+        """Delete exactly one persisted annotation partition.
+
+        Map deletion is an explicit user action. Unlike a map-generation
+        change, it intentionally removes the matching room/POI JSON asset;
+        unrelated map partitions remain untouched. Clearing the current
+        in-memory partition keeps the user page consistent when the deleted
+        map is presently selected.
+        """
+        target = sanitize_map_id(map_id)
+        target_path = self._base / f"{target}.json"
+        with self._lock:
+            existed = target_path.exists()
+            if existed:
+                target_path.unlink()
+            if target == self._map_id:
+                self._annotations = {}
+            return existed
+
     # ── load / save ──────────────────────────────────────────────────────
     def _load(self, current_generation: Optional[int]) -> None:
         """Read the per-map file into memory. Missing file → empty store.

--- a/system/scene/scene_service/geometry.py
+++ b/system/scene/scene_service/geometry.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+"""Geometry helpers shared by Scene room rendering and navigation."""
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+Point = tuple[float, float]
+
+
+def polygon_centroid(points: Sequence[Point]) -> Point:
+    """Return the area-weighted centroid of a non-self-intersecting polygon."""
+    pts = [(float(x), float(y)) for x, y in points]
+    if not pts:
+        return 0.0, 0.0
+    if len(pts) > 1 and pts[0] == pts[-1]:
+        pts.pop()
+    if len(pts) < 3:
+        return (
+            sum(x for x, _ in pts) / len(pts),
+            sum(y for _, y in pts) / len(pts),
+        )
+
+    twice_area = 0.0
+    cx = 0.0
+    cy = 0.0
+    for (x1, y1), (x2, y2) in zip(pts, pts[1:] + pts[:1]):
+        cross = x1 * y2 - x2 * y1
+        twice_area += cross
+        cx += (x1 + x2) * cross
+        cy += (y1 + y2) * cross
+    if abs(twice_area) < 1e-9:
+        return (
+            sum(x for x, _ in pts) / len(pts),
+            sum(y for _, y in pts) / len(pts),
+        )
+    return cx / (3.0 * twice_area), cy / (3.0 * twice_area)
+
+
+def point_in_polygon(x: float, y: float, points: Sequence[Point]) -> bool:
+    """Return whether a point lies inside a polygon using even-odd crossings."""
+    pts = [(float(px), float(py)) for px, py in points]
+    if len(pts) > 1 and pts[0] == pts[-1]:
+        pts.pop()
+    if len(pts) < 3:
+        return False
+    inside = False
+    for (x1, y1), (x2, y2) in zip(pts, pts[1:] + pts[:1]):
+        if (y1 > y) != (y2 > y):
+            crossing_x = (x2 - x1) * (y - y1) / (y2 - y1) + x1
+            if x < crossing_x:
+                inside = not inside
+    return inside
+
+
+def disc_inside_polygon(
+    x: float,
+    y: float,
+    radius: float,
+    points: Sequence[Point],
+    samples: int = 16,
+) -> bool:
+    """Require a circular robot footprint, not just its centre, inside a room."""
+    if not point_in_polygon(x, y, points):
+        return False
+    return all(
+        point_in_polygon(
+            x + radius * math.cos(2.0 * math.pi * i / samples),
+            y + radius * math.sin(2.0 * math.pi * i / samples),
+            points,
+        )
+        for i in range(samples)
+    )

--- a/system/scene/scene_service/ingest/ros_subscribers.py
+++ b/system/scene/scene_service/ingest/ros_subscribers.py
@@ -44,6 +44,14 @@ def _import_ros():
     # transform is non-identity, and the web UI shows the robot offset
     # from where rviz (which goes through tf) shows it.
     from tf2_ros import Buffer, TransformListener  # type: ignore
+    # map/msg/MapLifecycle comes from the generated ros2_idl overlay
+    # (rbnx codegen --ros2 + colcon build), NOT the ROS distro. Import it
+    # defensively: a deploy without the overlay must lose only the
+    # lifecycle subscription, not every scene subscription.
+    try:
+        from map.msg import MapLifecycle  # type: ignore
+    except ImportError:
+        MapLifecycle = None
     return {
         "rclpy": rclpy,
         "Node": Node,
@@ -65,6 +73,9 @@ def _import_ros():
         "TransformStamped": TransformStamped,
         "Odometry": Odometry,
         "OccupancyGrid": OccupancyGrid,
+        # None when the ros2_idl overlay is missing — _subscribe skips the
+        # spec with a warning instead of crashing the hub.
+        "MapLifecycle": MapLifecycle,
         "Buffer": Buffer,
         "TransformListener": TransformListener,
     }
@@ -166,14 +177,19 @@ class SubscribersHub:
         """Add a new (kind, topic) subscription to a hub already up.
         Used by the background reconciler to absorb topics that come
         online after start(). Returns True if added, False if the
-        kind was already known."""
+        kind was already known — or if the subscription could not be
+        created (missing msg class): committing the slot anyway would
+        make has_kinds() claim a subscription that doesn't exist and
+        pair a success log with the skip warning."""
         if self._ros is None:
             return False
         if spec.kind in self._slots:
             return False
         self._slots[spec.kind] = _LatestSlot()
+        if not self._subscribe(spec):
+            del self._slots[spec.kind]
+            return False
         self.specs.append(spec)
-        self._subscribe(spec)
         log.info("[scene-ros] dynamic add: %s on %s", spec.kind, spec.topic)
         return True
 
@@ -208,9 +224,22 @@ class SubscribersHub:
                 log.debug("[scene-ros] spin tick: %s", e)
 
     # ── subscription wiring ────────────────────────────────────────────────
-    def _subscribe(self, spec: TopicSpec) -> None:
+    def _subscribe(self, spec: TopicSpec) -> bool:
+        """Create the rclpy subscription for one spec. Returns False (with
+        a warning) when the msg class is unavailable — the hub and every
+        other subscription keep running."""
         assert self._ros is not None
-        msg_cls = self._ros[spec.msg_type]
+        msg_cls = self._ros.get(spec.msg_type)
+        if msg_cls is None:
+            # Unknown or unavailable msg class (e.g. MapLifecycle without
+            # the ros2_idl overlay). One subscription degrades, the hub —
+            # and every other subscription — keeps running.
+            log.warning(
+                "[scene-ros] msg type %r unavailable — skipping %s on %s "
+                "(generated interface overlay missing?)",
+                spec.msg_type, spec.kind, spec.topic,
+            )
+            return False
         QoSProfile = self._ros["QoSProfile"]
         ReliabilityPolicy = self._ros["ReliabilityPolicy"]
         DurabilityPolicy = self._ros["DurabilityPolicy"]
@@ -266,6 +295,16 @@ class SubscribersHub:
                 history=HistoryPolicy.KEEP_LAST,
                 depth=5,
             )
+        elif spec.kind == "map_lifecycle":
+            # mapping's identity broadcast is latched (published once per
+            # lifecycle transition); TRANSIENT_LOCAL picks up the cached
+            # sample on a late start.
+            qos = QoSProfile(
+                reliability=ReliabilityPolicy.RELIABLE,
+                durability=DurabilityPolicy.TRANSIENT_LOCAL,
+                history=HistoryPolicy.KEEP_LAST,
+                depth=1,
+            )
         elif spec.kind == "camera_extrinsics":
             # Static camera mount transform (primitive/camera/extrinsics):
             # genuinely latched (published once), so TRANSIENT_LOCAL is
@@ -300,6 +339,7 @@ class SubscribersHub:
         self._node.create_subscription(msg_cls, spec.topic, _cb, qos)
         log.info("[scene-ros] subscribed: %s on %s (%s, qos=%s)",
                  spec.kind, spec.topic, spec.msg_type, spec.kind)
+        return True
 
     # ── consumer-side accessors ────────────────────────────────────────────
     def latest(self, kind: str) -> tuple[Any, float, int]:

--- a/system/scene/scene_service/map_binding.py
+++ b/system/scene/scene_service/map_binding.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+"""Map identity binding — how scene learns WHICH map it is scoped to.
+
+The mapping service broadcasts its current identity {map_id, mode,
+generation} latched on the `robonix/service/map/lifecycle` topic (see
+capabilities/service/map/lifecycle.v1.toml). At startup scene probes that
+broadcast once and, when present, binds to it — the broadcast is
+authoritative, so the deploy no longer needs to hand-copy the same map_id
+into two config blocks. Static fallbacks (manifest config / SCENE_MAP_ID
+env / "default") remain for deployments where mapping is not up yet when
+scene starts (the normal full-boot order) or does not broadcast at all.
+
+`generation` is mapping's map-frame epoch: it bumps whenever the map
+origin may have changed (mapping-mode session start, reset_map) and stays
+put across localization round-trips. P2 records it and warns on runtime
+change; acting on it (flush + re-anchor) is the P3 lifecycle linkage.
+
+Split from service.py so the pure precedence rule and the one-shot ROS
+read are unit-testable without atlas.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+log = logging.getLogger("scene.map_binding")
+
+
+@dataclass(frozen=True)
+class MapBinding:
+    """The resolved binding plus where it came from (for the startup log
+    and for the runtime mismatch watcher)."""
+    map_id: str
+    source: str                      # "lifecycle" | "config" | "env" | "default"
+    mode: str = ""                   # only set when source == "lifecycle"
+    generation: Optional[int] = None  # only set when source == "lifecycle"
+
+
+def choose_map_binding(
+    broadcast: Optional[dict],
+    config_map_id: object,
+    env_map_id: Optional[str],
+) -> MapBinding:
+    """Precedence: mapping's lifecycle broadcast (authoritative source of
+    map identity) > manifest config.map_id > SCENE_MAP_ID env > "default".
+    A broadcast with an empty map_id means mapping runs ephemeral (no named
+    map) — treated as "no broadcast", scene falls back to static binding."""
+    if broadcast and str(broadcast.get("map_id") or ""):
+        return MapBinding(
+            map_id=str(broadcast["map_id"]),
+            source="lifecycle",
+            mode=str(broadcast.get("mode") or ""),
+            generation=int(broadcast.get("generation") or 0),
+        )
+    if config_map_id:
+        return MapBinding(map_id=str(config_map_id), source="config")
+    if env_map_id:
+        return MapBinding(map_id=str(env_map_id), source="env")
+    return MapBinding(map_id="default", source="default")
+
+
+def read_latched_lifecycle(topic: str, timeout_s: float) -> Optional[dict]:
+    """One-shot read of the latched MapLifecycle sample on `topic`.
+
+    Runs on a PRIVATE rclpy context + executor so it neither initialises
+    nor disturbs the default context the ingest hub owns (the hub calls
+    rclpy.init() later and would raise on a double init). Returns
+    {map_id, mode, generation} or None on timeout. Degrades to None with
+    one warning when rclpy or the generated `map` interface package is
+    missing (ros2_idl overlay not built) — binding then falls back to
+    config/env, scene itself keeps working.
+    """
+    try:
+        import rclpy  # type: ignore
+        from rclpy.executors import SingleThreadedExecutor  # type: ignore
+        from rclpy.qos import (  # type: ignore
+            DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy,
+        )
+        from map.msg import MapLifecycle  # type: ignore  # ros2_idl overlay
+    except ImportError as e:
+        log.warning(
+            "[scene] lifecycle probe unavailable (%s) — falling back to "
+            "static map binding (is the ros2_idl overlay built + sourced?)", e,
+        )
+        return None
+
+    ctx = None
+    try:
+        # Context/init INSIDE the guard: a broken RMW env must degrade to
+        # None per the docstring promise, not escape and kill scene startup.
+        ctx = rclpy.Context()
+        rclpy.init(context=ctx, args=None)
+        node = rclpy.create_node("scene_map_binding_probe", context=ctx)
+        executor = SingleThreadedExecutor(context=ctx)
+        executor.add_node(node)
+        got: list = []
+        qos = QoSProfile(
+            reliability=ReliabilityPolicy.RELIABLE,
+            # TRANSIENT_LOCAL: the broadcast is latched; a late-joining
+            # probe must receive the cached sample.
+            durability=DurabilityPolicy.TRANSIENT_LOCAL,
+            history=HistoryPolicy.KEEP_LAST,
+            depth=1,
+        )
+        node.create_subscription(MapLifecycle, topic, got.append, qos)
+        deadline = time.monotonic() + timeout_s
+        while not got and time.monotonic() < deadline:
+            executor.spin_once(timeout_sec=0.2)
+        if not got:
+            return None
+        msg = got[0]
+        return {
+            "map_id": str(msg.map_id),
+            "mode": str(msg.mode),
+            "generation": int(msg.generation),
+        }
+    except Exception as e:  # noqa: BLE001
+        log.warning("[scene] lifecycle probe failed: %s", e)
+        return None
+    finally:
+        if ctx is not None:
+            try:
+                rclpy.shutdown(context=ctx)
+            except Exception:  # noqa: BLE001
+                pass

--- a/system/scene/scene_service/map_binding.py
+++ b/system/scene/scene_service/map_binding.py
@@ -21,11 +21,25 @@ read are unit-testable without atlas.
 from __future__ import annotations
 
 import logging
+import re
 import time
 from dataclasses import dataclass
 from typing import Optional
 
 log = logging.getLogger("scene.map_binding")
+
+# map_id is used as a milvus filter literal and as a filename, so restrict
+# it to a safe identifier charset (no quotes / spaces / separators) — keeps
+# the predicate injection-free and the path escape-free. Anything else is
+# squashed to "_"; empty falls back to "default". Every map_id-partitioned
+# store (objects, scene-graph cache, annotations) MUST key on this one rule
+# so the partitions always agree.
+_MAP_ID_UNSAFE = re.compile(r"[^A-Za-z0-9._\-]")
+
+
+def sanitize_map_id(raw: Optional[str]) -> str:
+    cleaned = _MAP_ID_UNSAFE.sub("_", (raw or "").strip())
+    return cleaned or "default"
 
 
 @dataclass(frozen=True)

--- a/system/scene/scene_service/mcp_tools.py
+++ b/system/scene/scene_service/mcp_tools.py
@@ -2,7 +2,8 @@
 """FastMCP tool definitions — two read-only handlers, that's it.
 
   list_objects()           → flat list of every object in the registry
-  goal_near(object_id)     → reachable approach pose for that object
+  goal_near(object_id)     → reachable approach pose for a physical object
+  goal_room(room_id)       → reachable pose inside a room polygon
 
 Writes happen on the ingest path (perception → registry); these
 handlers only read. Inputs are codegen-derived ROS dataclasses
@@ -14,12 +15,13 @@ from __future__ import annotations
 import logging
 import math
 import time
-from types import SimpleNamespace
+from difflib import SequenceMatcher
 from typing import TYPE_CHECKING
 
 from .state import ObjectRegistry, SceneObject
 from .scene_graph.store import SceneGraphStore
 from .scene_graph.types import SceneGraphSnapshot
+from .geometry import disc_inside_polygon, point_in_polygon, polygon_centroid
 
 if TYPE_CHECKING:
     from .annotations import Annotation, AnnotationStore
@@ -30,6 +32,8 @@ import semantic_map_mcp  # type: ignore
 from semantic_map_mcp import (  # type: ignore
     GoalNear_Request,
     GoalNear_Response,
+    GoalRoom_Request,
+    GoalRoom_Response,
     GetObjectContext_Request,
     GetObjectContext_Response,
     GetSceneGraph_Request,
@@ -88,13 +92,7 @@ def _to_idl(o: SceneObject) -> Object:
 
 
 def _annotation_centroid(a: "Annotation") -> tuple[float, float]:
-    pts = getattr(a, "points", []) or []
-    if not pts:
-        return 0.0, 0.0
-    sx = sum(float(p[0]) for p in pts)
-    sy = sum(float(p[1]) for p in pts)
-    n = max(1, len(pts))
-    return sx / n, sy / n
+    return polygon_centroid(getattr(a, "points", []) or [])
 
 
 def _annotation_object_id(a: "Annotation") -> str:
@@ -117,10 +115,44 @@ def _annotation_to_object(a: "Annotation") -> Object:
 def _find_annotation_target(object_id: str) -> "Annotation | None":
     if _ANNO_STORE is None:
         return None
-    for a in _ANNO_STORE.list():
-        if object_id in (a.annotation_id, _annotation_object_id(a)):
-            return a
+    for annotation in _ANNO_STORE.list():
+        if object_id == _annotation_object_id(annotation):
+            return annotation
     return None
+
+
+def _room_id_hint() -> str:
+    if _ANNO_STORE is None:
+        return "no rooms are currently registered"
+    rooms = [a for a in _ANNO_STORE.list() if a.kind == "room"]
+    if not rooms:
+        return "no rooms are currently registered"
+    candidates = ", ".join(
+        f"{room.name!r} (id={_annotation_object_id(room)})"
+        for room in rooms[:20]
+    )
+    suffix = "" if len(rooms) <= 20 else f", ... {len(rooms) - 20} more"
+    return f"available rooms: {candidates}{suffix}"
+
+
+def _object_id_hint(reference: str, objects: list[SceneObject]) -> str:
+    if not objects:
+        return "no physical objects are currently registered"
+    wanted = str(reference).strip().casefold()
+
+    def score(obj: SceneObject) -> float:
+        object_id = str(obj.object_id).casefold()
+        label = str(obj.cls).casefold()
+        return max(
+            SequenceMatcher(None, wanted, object_id).ratio(),
+            SequenceMatcher(None, wanted, label).ratio(),
+        )
+
+    nearest = sorted(objects, key=score, reverse=True)[:3]
+    candidates = ", ".join(
+        f"{obj.cls!r} (id={obj.object_id})" for obj in nearest
+    )
+    return f"did you mean one of: {candidates}"
 
 
 # ── @mcp_contract handlers ─────────────────────────────────────────────────
@@ -131,8 +163,9 @@ mcp = FastMCP("scene_provider")
 @mcp_contract(mcp, contract_id="robonix/system/scene/list_objects")
 async def list_objects(_req: ListObjects_Request) -> ListObjects_Response:
     """Return every object the scene registry currently believes
-    exists, as a flat list. The LLM filters client-side by label /
-    distance / etc. — no scoping or filter knobs in the schema.
+    exists, plus room annotations, as a flat list. Use this tool to discover
+    stable object/room IDs before goal_near or goal_room. Use get_scene_graph
+    only when object relationships are needed.
     Contract: robonix/system/scene/list_objects."""
     if _REGISTRY is None:
         raise RuntimeError("scene mcp_tools.attach_state was never called")
@@ -205,8 +238,11 @@ def _occupancy_bfs(
 
 @mcp_contract(mcp, contract_id="robonix/system/scene/goal_near")
 async def goal_near(req: GoalNear_Request) -> GoalNear_Response:
-    """Find a navigation-safe approach pose near the named object.
+    """Find a navigation-safe approach pose near a physical scene object.
     Returns map-frame (x, y, yaw); pass to navigation/navigate.
+
+    Room annotations are deliberately not accepted. Resolve those through
+    goal_room so the returned pose is constrained to the room polygon.
 
     `reachable=false` when:
       - the object_id isn't in the registry, or
@@ -217,24 +253,15 @@ async def goal_near(req: GoalNear_Request) -> GoalNear_Response:
         raise RuntimeError("scene mcp_tools.attach_state was never called")
     objs, _surfs = await _REGISTRY.snapshot()
     target = objs.get(req.object_id)
-    ann_target = None
     if target is None:
-        ann_target = _find_annotation_target(req.object_id)
-        if ann_target is None:
-            return GoalNear_Response(
-                reachable=False, x=0.0, y=0.0, yaw=0.0,
-                reason=f"unknown object_id '{req.object_id}'",
-            )
-        tx, ty = _annotation_centroid(ann_target)
-        target = SimpleNamespace(
-            pose=SimpleNamespace(
-                x=float(tx),
-                y=float(ty),
-                z=0.0,
-                yaw=float(ann_target.theta or 0.0),
+        visible = [obj for obj in objs.values() if not obj.missing]
+        return GoalNear_Response(
+            reachable=False, x=0.0, y=0.0, yaw=0.0,
+            reason=(
+                f"unknown physical object_id '{req.object_id}'; "
+                f"{_object_id_hint(req.object_id, visible)}; "
+                "use goal_room for room annotations"
             ),
-            cls=str(ann_target.name or ann_target.kind),
-            object_id=_annotation_object_id(ann_target),
         )
 
     robot = next(
@@ -288,6 +315,110 @@ async def goal_near(req: GoalNear_Request) -> GoalNear_Response:
     return GoalNear_Response(
         reachable=True, x=float(gx), y=float(gy), yaw=float(yaw),
         reason=f"approach pose for '{target.cls}' ({req.object_id})",
+    )
+
+
+def _occupancy_room_goal(grid_msg, points) -> tuple[float, float] | None:
+    """Choose the safest free grid cell nearest a room's polygon centroid."""
+    import numpy as np
+
+    polygon = [(float(x), float(y)) for x, y in points]
+    if len(polygon) < 3:
+        return None
+    info = grid_msg.info
+    width, height = int(info.width), int(info.height)
+    resolution = float(info.resolution)
+    origin_x = float(info.origin.position.x)
+    origin_y = float(info.origin.position.y)
+    grid = np.frombuffer(bytes(grid_msg.data), dtype=np.int8).reshape(height, width)
+    # A room destination must be known free space. Unknown cells are not goals.
+    blocked = (grid < 0) | (grid > 50)
+    footprint_radius = _GOAL_NEAR_ROBOT_RADIUS_M + _GOAL_NEAR_CLEARANCE_M
+    inflation_cells = max(1, int(math.ceil(footprint_radius / resolution)))
+    centroid_x, centroid_y = polygon_centroid(polygon)
+
+    min_x = max(0, int((min(x for x, _ in polygon) - origin_x) / resolution))
+    max_x = min(width - 1, int((max(x for x, _ in polygon) - origin_x) / resolution))
+    min_y = max(0, int((min(y for _, y in polygon) - origin_y) / resolution))
+    max_y = min(height - 1, int((max(y for _, y in polygon) - origin_y) / resolution))
+    candidates = []
+    for gy in range(min_y, max_y + 1):
+        wy = origin_y + (gy + 0.5) * resolution
+        for gx in range(min_x, max_x + 1):
+            wx = origin_x + (gx + 0.5) * resolution
+            if not disc_inside_polygon(wx, wy, footprint_radius, polygon):
+                continue
+            if (
+                gx - inflation_cells < 0
+                or gy - inflation_cells < 0
+                or gx + inflation_cells >= width
+                or gy + inflation_cells >= height
+            ):
+                continue
+            local = blocked[
+                gy - inflation_cells: gy + inflation_cells + 1,
+                gx - inflation_cells: gx + inflation_cells + 1,
+            ]
+            if not bool(local.any()):
+                candidates.append(((wx - centroid_x) ** 2 + (wy - centroid_y) ** 2, wx, wy))
+    if not candidates:
+        return None
+    _, x, y = min(candidates)
+    return x, y
+
+
+@mcp_contract(mcp, contract_id="robonix/system/scene/goal_room")
+async def goal_room(req: GoalRoom_Request) -> GoalRoom_Response:
+    """Resolve a room annotation to a safe map-frame pose inside its polygon.
+
+    Use this for named rooms and user-defined regions before navigation/navigate.
+    The result never falls outside the room polygon.
+    Contract: robonix/system/scene/goal_room.
+    """
+    room = _find_annotation_target(req.room_id)
+    if room is None or room.kind != "room":
+        return GoalRoom_Response(
+            reachable=False, x=0.0, y=0.0, yaw=0.0,
+            reason=(
+                f"unknown room_id '{req.room_id}'; room_id must be the exact "
+                f"stable ID returned by list_objects; {_room_id_hint()}"
+            ),
+        )
+    if _HUB is None or not _HUB.has("occupancy_grid"):
+        return GoalRoom_Response(
+            reachable=False, x=0.0, y=0.0, yaw=0.0,
+            reason="no occupancy_grid available - mapping not running",
+        )
+    try:
+        msg, _stamp, count = _HUB.latest("occupancy_grid")
+    except Exception as exc:  # noqa: BLE001
+        return GoalRoom_Response(
+            reachable=False, x=0.0, y=0.0, yaw=0.0,
+            reason=f"occupancy_grid hub error: {exc}",
+        )
+    if msg is None or count == 0 or not msg.info.width or not msg.info.height:
+        return GoalRoom_Response(
+            reachable=False, x=0.0, y=0.0, yaw=0.0,
+            reason="occupancy_grid empty - wait for mapping to publish",
+        )
+    found = _occupancy_room_goal(msg, room.points)
+    if found is None:
+        return GoalRoom_Response(
+            reachable=False, x=0.0, y=0.0, yaw=0.0,
+            reason=f"no known free pose inside room '{room.name}' ({req.room_id})",
+        )
+    x, y = found
+    if not point_in_polygon(x, y, room.points):
+        return GoalRoom_Response(
+            reachable=False, x=0.0, y=0.0, yaw=0.0,
+            reason="internal validation rejected a pose outside the room polygon",
+        )
+    return GoalRoom_Response(
+        reachable=True,
+        x=float(x),
+        y=float(y),
+        yaw=float(room.theta or 0.0),
+        reason=f"safe pose inside room '{room.name}' ({req.room_id})",
     )
 
 
@@ -442,6 +573,7 @@ __all__ = [
     "attach_annotation_store",
     "list_objects",
     "goal_near",
+    "goal_room",
     "get_scene_graph",
     "get_object_context",
     "list_relations",

--- a/system/scene/scene_service/mcp_tools.py
+++ b/system/scene/scene_service/mcp_tools.py
@@ -14,10 +14,15 @@ from __future__ import annotations
 import logging
 import math
 import time
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
 
 from .state import ObjectRegistry, SceneObject
 from .scene_graph.store import SceneGraphStore
 from .scene_graph.types import SceneGraphSnapshot
+
+if TYPE_CHECKING:
+    from .annotations import Annotation, AnnotationStore
 
 # Resolved at import time. PYTHONPATH is set by package_manifest.yaml's
 # `start:` block to include rbnx-build/codegen/{proto_gen,robonix_mcp_types}.
@@ -34,6 +39,7 @@ from semantic_map_mcp import (  # type: ignore
     ListRelations_Request,
     ListRelations_Response,
     Object,
+    SceneAnnotation as SceneAnnotationIDL,
     SceneGraphEdge as SceneGraphEdgeIDL,
     SceneGraphNode as SceneGraphNodeIDL,
 )
@@ -48,6 +54,7 @@ log = logging.getLogger(__name__)
 _REGISTRY: ObjectRegistry | None = None
 _HUB = None  # SubscribersHub, exposes .latest("occupancy_grid") for goal_near BFS
 _SG_STORE: SceneGraphStore | None = None
+_ANNO_STORE: "AnnotationStore | None" = None
 
 
 def attach_state(*, registry: ObjectRegistry, hub=None) -> None:
@@ -59,6 +66,11 @@ def attach_state(*, registry: ObjectRegistry, hub=None) -> None:
 def attach_scene_graph_store(store: SceneGraphStore) -> None:
     global _SG_STORE
     _SG_STORE = store
+
+
+def attach_annotation_store(store: "AnnotationStore | None") -> None:
+    global _ANNO_STORE
+    _ANNO_STORE = store
 
 
 # ── conversions: SceneObject → IDL Object ──────────────────────────────────
@@ -73,6 +85,42 @@ def _to_idl(o: SceneObject) -> Object:
         yaw=float(o.pose.yaw),
         last_seen_unix=float(o.last_seen),
     )
+
+
+def _annotation_centroid(a: "Annotation") -> tuple[float, float]:
+    pts = getattr(a, "points", []) or []
+    if not pts:
+        return 0.0, 0.0
+    sx = sum(float(p[0]) for p in pts)
+    sy = sum(float(p[1]) for p in pts)
+    n = max(1, len(pts))
+    return sx / n, sy / n
+
+
+def _annotation_object_id(a: "Annotation") -> str:
+    return f"scene.{a.kind}.{a.annotation_id}"
+
+
+def _annotation_to_object(a: "Annotation") -> Object:
+    x, y = _annotation_centroid(a)
+    return Object(
+        id=_annotation_object_id(a),
+        label=str(a.name or a.kind),
+        x=float(x),
+        y=float(y),
+        z=0.0,
+        yaw=float(a.theta or 0.0),
+        last_seen_unix=float(a.updated_at or 0.0),
+    )
+
+
+def _find_annotation_target(object_id: str) -> "Annotation | None":
+    if _ANNO_STORE is None:
+        return None
+    for a in _ANNO_STORE.list():
+        if object_id in (a.annotation_id, _annotation_object_id(a)):
+            return a
+    return None
 
 
 # ── @mcp_contract handlers ─────────────────────────────────────────────────
@@ -90,8 +138,11 @@ async def list_objects(_req: ListObjects_Request) -> ListObjects_Response:
         raise RuntimeError("scene mcp_tools.attach_state was never called")
     objs, _surfs = await _REGISTRY.snapshot()
     visible = [o for o in objs.values() if not o.missing]
+    objects = [_to_idl(o) for o in visible]
+    if _ANNO_STORE is not None:
+        objects.extend(_annotation_to_object(a) for a in _ANNO_STORE.list() if a.kind == "room")
     return ListObjects_Response(
-        objects=[_to_idl(o) for o in visible],
+        objects=objects,
         stamp_unix=time.time(),
     )
 
@@ -166,10 +217,24 @@ async def goal_near(req: GoalNear_Request) -> GoalNear_Response:
         raise RuntimeError("scene mcp_tools.attach_state was never called")
     objs, _surfs = await _REGISTRY.snapshot()
     target = objs.get(req.object_id)
+    ann_target = None
     if target is None:
-        return GoalNear_Response(
-            reachable=False, x=0.0, y=0.0, yaw=0.0,
-            reason=f"unknown object_id '{req.object_id}'",
+        ann_target = _find_annotation_target(req.object_id)
+        if ann_target is None:
+            return GoalNear_Response(
+                reachable=False, x=0.0, y=0.0, yaw=0.0,
+                reason=f"unknown object_id '{req.object_id}'",
+            )
+        tx, ty = _annotation_centroid(ann_target)
+        target = SimpleNamespace(
+            pose=SimpleNamespace(
+                x=float(tx),
+                y=float(ty),
+                z=0.0,
+                yaw=float(ann_target.theta or 0.0),
+            ),
+            cls=str(ann_target.name or ann_target.kind),
+            object_id=_annotation_object_id(ann_target),
         )
 
     robot = next(
@@ -258,6 +323,29 @@ def _edge_to_idl(e) -> SceneGraphEdgeIDL:
     )
 
 
+def _annotation_to_idl(a: "Annotation") -> SceneAnnotationIDL:
+    points_xy: list[float] = []
+    for point in a.points or []:
+        if len(point) >= 2:
+            points_xy.extend([float(point[0]), float(point[1])])
+    return SceneAnnotationIDL(
+        annotation_id=a.annotation_id,
+        kind=a.kind,
+        name=a.name,
+        points_xy=points_xy,
+        theta=float(a.theta) if a.theta is not None else 0.0,
+        stale=bool(a.stale),
+        stale_reason=a.stale_reason or "",
+        updated_at_unix=float(a.updated_at or 0.0),
+    )
+
+
+def _annotation_list() -> list[SceneAnnotationIDL]:
+    if _ANNO_STORE is None:
+        return []
+    return [_annotation_to_idl(a) for a in _ANNO_STORE.list()]
+
+
 @mcp_contract(mcp, contract_id="robonix/system/scene/get_scene_graph")
 async def get_scene_graph(_req: GetSceneGraph_Request) -> GetSceneGraph_Response:
     """Return the current scene graph snapshot — all stable nodes
@@ -266,11 +354,12 @@ async def get_scene_graph(_req: GetSceneGraph_Request) -> GetSceneGraph_Response
     snap = _sg_snapshot()
     if snap is None:
         return GetSceneGraph_Response(
-            nodes=[], edges=[], updated_at=0.0,
+            nodes=[], edges=[], annotations=_annotation_list(), updated_at=0.0,
         )
     return GetSceneGraph_Response(
         nodes=[_node_to_idl(n) for n in snap.nodes.values()],
         edges=[_edge_to_idl(e) for e in snap.edges],
+        annotations=_annotation_list(),
         updated_at=snap.updated_at,
     )
 
@@ -350,6 +439,7 @@ __all__ = [
     "mcp",
     "attach_state",
     "attach_scene_graph_store",
+    "attach_annotation_store",
     "list_objects",
     "goal_near",
     "get_scene_graph",

--- a/system/scene/scene_service/mcp_tools.py
+++ b/system/scene/scene_service/mcp_tools.py
@@ -121,6 +121,40 @@ def _find_annotation_target(object_id: str) -> "Annotation | None":
     return None
 
 
+def _normalize_room_reference(value: str) -> str:
+    return " ".join(str(value or "").strip().casefold().split())
+
+
+def _room_aliases(room: "Annotation") -> set[str]:
+    name = _normalize_room_reference(room.name)
+    aliases = {name}
+    for prefix in ("room ", "room-", "房间 ", "房间"):
+        if name.startswith(prefix) and name[len(prefix):].strip():
+            aliases.add(name[len(prefix):].strip())
+    return aliases
+
+
+def _resolve_room_target(reference: str) -> tuple["Annotation | None", list["Annotation"]]:
+    """Resolve stable ID first, then an exact unique room name/short alias.
+
+    The second return value contains ambiguous candidates. Fuzzy matching is
+    deliberately excluded: navigation must not guess between similar rooms.
+    """
+    exact = _find_annotation_target(reference)
+    if exact is not None and exact.kind == "room":
+        return exact, []
+    if _ANNO_STORE is None:
+        return None, []
+    needle = _normalize_room_reference(reference)
+    matches = [
+        room for room in _ANNO_STORE.list()
+        if room.kind == "room" and needle in _room_aliases(room)
+    ]
+    if len(matches) == 1:
+        return matches[0], []
+    return None, matches
+
+
 def _room_id_hint() -> str:
     if _ANNO_STORE is None:
         return "no rooms are currently registered"
@@ -375,15 +409,28 @@ async def goal_room(req: GoalRoom_Request) -> GoalRoom_Response:
     The result never falls outside the room polygon.
     Contract: robonix/system/scene/goal_room.
     """
-    room = _find_annotation_target(req.room_id)
-    if room is None or room.kind != "room":
+    room, ambiguous = _resolve_room_target(req.room_id)
+    if ambiguous:
+        candidates = ", ".join(
+            f"{item.name!r} (id={_annotation_object_id(item)})"
+            for item in ambiguous
+        )
         return GoalRoom_Response(
             reachable=False, x=0.0, y=0.0, yaw=0.0,
             reason=(
-                f"unknown room_id '{req.room_id}'; room_id must be the exact "
-                f"stable ID returned by list_objects; {_room_id_hint()}"
+                f"ambiguous room reference '{req.room_id}'; candidates: "
+                f"{candidates}; pass one exact stable ID"
             ),
         )
+    if room is None:
+        return GoalRoom_Response(
+            reachable=False, x=0.0, y=0.0, yaw=0.0,
+            reason=(
+                f"unknown room reference '{req.room_id}'; pass a stable ID or "
+                f"unique room name returned by list_objects; {_room_id_hint()}"
+            ),
+        )
+    stable_room_id = _annotation_object_id(room)
     if _HUB is None or not _HUB.has("occupancy_grid"):
         return GoalRoom_Response(
             reachable=False, x=0.0, y=0.0, yaw=0.0,
@@ -405,7 +452,7 @@ async def goal_room(req: GoalRoom_Request) -> GoalRoom_Response:
     if found is None:
         return GoalRoom_Response(
             reachable=False, x=0.0, y=0.0, yaw=0.0,
-            reason=f"no known free pose inside room '{room.name}' ({req.room_id})",
+            reason=f"no known free pose inside room '{room.name}' ({stable_room_id})",
         )
     x, y = found
     if not point_in_polygon(x, y, room.points):
@@ -418,7 +465,7 @@ async def goal_room(req: GoalRoom_Request) -> GoalRoom_Response:
         x=float(x),
         y=float(y),
         yaw=float(room.theta or 0.0),
-        reason=f"safe pose inside room '{room.name}' ({req.room_id})",
+        reason=f"safe pose inside room '{room.name}' ({stable_room_id})",
     )
 
 

--- a/system/scene/scene_service/mcp_tools.py
+++ b/system/scene/scene_service/mcp_tools.py
@@ -128,7 +128,7 @@ def _normalize_room_reference(value: str) -> str:
 def _room_aliases(room: "Annotation") -> set[str]:
     name = _normalize_room_reference(room.name)
     aliases = {name}
-    for prefix in ("room ", "room-", "房间 ", "房间"):
+    for prefix in ("room ", "room-", "房间 ", "房间"):  # i18n-ok: user room aliases
         if name.startswith(prefix) and name[len(prefix):].strip():
             aliases.add(name[len(prefix):].strip())
     return aliases

--- a/system/scene/scene_service/persistence.py
+++ b/system/scene/scene_service/persistence.py
@@ -316,6 +316,27 @@ class ObjectStore:
             )
         return objs
 
+    def delete_map(self, map_id: str) -> int:
+        """Delete persisted scene objects belonging to one map partition.
+
+        The collection is shared, so the filter is mandatory: deleting a map
+        must never affect objects captured for another spatial map.
+        """
+        target = _sanitize_map_id(map_id)
+        predicate = f'map_id == "{target}"'
+        try:
+            rows = self._client.query(
+                collection_name=_COLLECTION,
+                filter=predicate,
+                output_fields=["pk"],
+                limit=16384,
+            )
+            if rows:
+                self._client.delete(collection_name=_COLLECTION, filter=predicate)
+            return len(rows)
+        except Exception as e:  # noqa: BLE001
+            raise RuntimeError(f"delete_map({target}) failed: {e}") from e
+
     # ── lifecycle ────────────────────────────────────────────────────────
     def close(self) -> None:
         """Close the client and release the milvus-lite server so the next

--- a/system/scene/scene_service/persistence.py
+++ b/system/scene/scene_service/persistence.py
@@ -23,25 +23,16 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 from pathlib import Path
 from typing import Callable, Optional
 
+from .map_binding import sanitize_map_id as _sanitize_map_id
 from .state.object_registry import BBox3D, Pose3D, SceneObject
 
 log = logging.getLogger(__name__)
 
 _COLLECTION = "scene_objects"
 
-# map_id is interpolated into a milvus filter expression, so restrict it to a
-# safe identifier charset (no quotes / spaces) to keep the predicate injection
-# -free. Anything else is squashed to "_"; empty falls back to "default".
-_MAP_ID_UNSAFE = re.compile(r"[^A-Za-z0-9._\-]")
-
-
-def _sanitize_map_id(raw: Optional[str]) -> str:
-    cleaned = _MAP_ID_UNSAFE.sub("_", (raw or "").strip())
-    return cleaned or "default"
 # open_clip ViT-B-32 text/image features are 512-d (see
 # ingest/perception_concept_graphs.py). Object image features already live in
 # this space, so caption-text vectors are directly comparable for G3.

--- a/system/scene/scene_service/persistence.py
+++ b/system/scene/scene_service/persistence.py
@@ -77,6 +77,15 @@ class ObjectStore:
         """The sanitized map id this store is scoped to."""
         return self._map_id
 
+    def rebind(self, map_id: str) -> None:
+        """Switch subsequent reads/writes to another map partition.
+
+        The Milvus collection is shared across maps; rows are filtered by the
+        scalar ``map_id`` field and keyed by ``{map_id}::{object_id}``, so a
+        rebind only changes the partition used by ``persist`` / ``load_all``.
+        """
+        self._map_id = _sanitize_map_id(map_id)
+
     # ── schema ───────────────────────────────────────────────────────────
     def _ensure_collection(self) -> None:
         """Create the collection + index on first run; when it already exists

--- a/system/scene/scene_service/scene_graph/store.py
+++ b/system/scene/scene_service/scene_graph/store.py
@@ -45,9 +45,10 @@ class SceneGraphStore:
         (caption/relation answers are only valid within the map frame they were
         computed in — the same per-map isolation the object store gets from its
         ``"{map_id}::{object_id}"`` composite key). The id is run through
-        ``persistence._sanitize_map_id`` so it is a safe path component
-        (imported lazily — that module defers its pymilvus import, so this stays
-        importable on hosts without the milvus backend). With no ``map_id`` the
+        ``map_binding.sanitize_map_id`` (the one sanitize rule shared by every
+        map_id-partitioned store; reached via persistence's alias, imported
+        lazily so this stays importable without the milvus backend) so it is a
+        safe path component. With no ``map_id`` the
         path is unchanged (legacy/"default" behaviour)."""
         self._nodes: dict[str, SceneGraphNode] = {}
         self._geometric_edges: list[SceneGraphEdge] = []

--- a/system/scene/scene_service/service.py
+++ b/system/scene/scene_service/service.py
@@ -37,6 +37,7 @@ scene = Service(id="scene", namespace="robonix/system/scene")
 from . import mcp_tools
 from . import web as web_ui
 from .ingest.capabilities import plan_perception
+from .map_binding import MapBinding, choose_map_binding, read_latched_lifecycle
 from .ingest.perception_concept_graphs import ConceptGraphsDetector
 from .ingest.perception_vlm import VLMObjectDetector, _CamIntrinsics
 from .ingest.ros_subscribers import (
@@ -104,6 +105,12 @@ _SCENE_CONTRACTS: list[tuple[str, str, str]] = [
     ("pose",              "robonix/service/map/pose",            "PoseWithCovarianceStamped"),
     ("odom",              "robonix/service/map/odom",            "Odometry"),
     ("occupancy_grid",    "robonix/service/map/occupancy_grid",  "OccupancyGrid"),
+    # Latched {map_id, mode, generation} broadcast from mapping. Startup
+    # binding is probed separately (_discover_map_binding, before the hub
+    # exists); this hub subscription feeds the runtime mismatch watcher
+    # (_lifecycle_watch). Needs the generated `map` interface package
+    # (ros2_idl overlay) — the hub skips the row gracefully when missing.
+    ("map_lifecycle",     "robonix/service/map/lifecycle",       "MapLifecycle"),
 ]
 
 # Optional manifest opt-out: kinds listed here are dropped even if atlas
@@ -230,6 +237,46 @@ def _resolve_one_contract(
         msg_type=msg_type,
         qos_profile=qos_profile or "default",
     )
+
+
+def _discover_map_binding(wait_s: float) -> Optional[dict]:
+    """Probe mapping's latched lifecycle broadcast for the startup binding.
+
+    Adaptive cost: polls atlas for the `robonix/service/map/lifecycle`
+    contract for at most `wait_s` (the normal full-boot order starts scene
+    BEFORE mapping, so the contract is usually absent and this returns in
+    ~`wait_s`); once the contract resolves — the scene-restart-while-
+    mapping-runs case — the latched sample arrives immediately, with a 5 s
+    ceiling as safety. Returns {map_id, mode, generation} or None; blocking
+    is fine here, it runs before anything else is wired. `wait_s <= 0`
+    disables the probe (unit tests / ROS-less runs)."""
+    if wait_s <= 0:
+        return None
+    deadline = time.monotonic() + wait_s
+    while True:
+        try:
+            spec = _resolve_one_contract(
+                Transport.ROS2, "map_lifecycle",
+                "robonix/service/map/lifecycle", "MapLifecycle",
+            )
+        except Exception as e:  # noqa: BLE001
+            # Probe runs before bootstrap; if atlas isn't reachable yet a
+            # wire error must degrade to static binding, not kill startup.
+            log.warning("[scene] lifecycle probe: atlas query failed (%s) — "
+                        "falling back to static map binding", e)
+            return None
+        if spec is not None:
+            sample = read_latched_lifecycle(spec.topic, timeout_s=5.0)
+            if sample is None:
+                log.warning(
+                    "[scene] lifecycle contract resolved (%s) but no latched "
+                    "sample within 5s — falling back to static map binding",
+                    spec.topic,
+                )
+            return sample
+        if time.monotonic() >= deadline:
+            return None
+        time.sleep(0.5)
 
 
 def _resolve_explicit(
@@ -842,6 +889,71 @@ async def _ingest_detections(registry: ObjectRegistry, detections):
         )
 
 
+def _log_bg_task_exit(task: "asyncio.Task") -> None:
+    """Done-callback for scene's fire-and-forget background tasks: log any
+    exception at ERROR the moment the task dies, instead of letting asyncio
+    sit on it until interpreter shutdown."""
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        log.error("[scene] background task %r died: %r", task.get_name(), exc)
+
+
+async def _lifecycle_watch(hub: SubscribersHub, binding: MapBinding) -> None:
+    """P2 guard: scene binds its map_id ONCE at startup; when mapping's
+    broadcast later disagrees (map loaded/reset/switched at runtime), warn
+    loudly — reacting to it (flush + re-anchor the semantic state) is the
+    P3 lifecycle linkage, not guesswork here. Also confirms a static
+    binding the first time the broadcast appears and agrees."""
+    confirmed = False
+    warned_ephemeral = False
+    last_warned: Optional[tuple] = None
+    while True:
+        await asyncio.sleep(5.0)
+        msg, stamp_unix, _count = hub.latest("map_lifecycle")
+        if msg is None:
+            continue
+        live_id, live_gen = str(msg.map_id), int(msg.generation)
+        if not live_id:
+            # Ephemeral broadcast: no named identity to compare — but if
+            # scene statically bound a NAMED map, that named partition is
+            # being fed coordinates from a frame that resets every boot.
+            # Say so once instead of guarding silently forever.
+            if not warned_ephemeral and binding.source in ("config", "env"):
+                log.warning(
+                    "[scene] mapping broadcasts an EPHEMERAL session (empty "
+                    "map_id) while scene is bound to %r (source=%s) — set "
+                    "mapping's config.map_id to match", binding.map_id,
+                    binding.source,
+                )
+                warned_ephemeral = True
+            continue
+        id_ok = live_id == binding.map_id
+        gen_ok = binding.generation is None or live_gen == binding.generation
+        if id_ok and gen_ok:
+            if not confirmed:
+                log.info(
+                    "[scene] map binding confirmed by mapping lifecycle: "
+                    "id=%s gen=%d mode=%s", live_id, live_gen, str(msg.mode),
+                )
+                confirmed = True
+            last_warned = None
+            continue
+        key = (live_id, live_gen)
+        if key != last_warned:
+            log.warning(
+                "[scene] mapping's live map identity (id=%s gen=%d mode=%s) "
+                "no longer matches scene's startup binding (id=%s gen=%s "
+                "source=%s) — semantic state may be mis-anchored. Scene keeps "
+                "its startup binding until lifecycle linkage (P3) lands; "
+                "restart scene to rebind.",
+                live_id, live_gen, str(msg.mode),
+                binding.map_id, binding.generation, binding.source,
+            )
+            last_warned = key
+
+
 # ── main ───────────────────────────────────────────────────────────────────
 async def _run() -> None:
     config = _load_config()
@@ -865,14 +977,41 @@ async def _run() -> None:
     # arrive; the embedder is wired in later (only needed for writes). The
     # store is independent of SCENE_GRAPH_ENABLED — restore always runs if a
     # prior boot wrote rows — but writes are driven by the scene-graph builder.
-    # Which SLAM map this scene session belongs to. Deploy-controlled until
-    # mapping emits a real map identity — manifest `map_id` wins, else the
-    # SCENE_MAP_ID env, else "default". This is the join key against mapping
-    # and the scope key for ALL of scene's persistent state: object poses are
-    # only valid in their own map's frame, and so are the scene-graph caption/
-    # relation caches. Computed once here so the object store (below) and the
-    # scene-graph cache (further down) partition on the same value.
-    map_id = str(config.get("map_id") or os.environ.get("SCENE_MAP_ID") or "default")
+    # Which SLAM map this scene session belongs to. This is the join key
+    # against mapping and the scope key for ALL of scene's persistent state:
+    # object poses are only valid in their own map's frame, and so are the
+    # scene-graph caption/relation caches. Computed once here so the object
+    # store (below) and the scene-graph cache (further down) partition on
+    # the same value.
+    #
+    # Binding precedence (choose_map_binding): mapping's latched lifecycle
+    # broadcast — the authoritative map identity, probed briefly here —
+    # then manifest `map_id`, then SCENE_MAP_ID env, then "default". The
+    # static levers stay as fallback because the normal full-boot order
+    # starts scene BEFORE mapping (probe cost then ≈ the wait window);
+    # a scene restart while mapping runs binds from the broadcast alone.
+    broadcast = _discover_map_binding(
+        float(os.environ.get("SCENE_MAP_BINDING_WAIT_S", "3.0"))
+    )
+    binding = choose_map_binding(
+        broadcast, config.get("map_id"), os.environ.get("SCENE_MAP_ID")
+    )
+    map_id = binding.map_id
+    log.info(
+        "[scene] map binding: id=%s gen=%s source=%s",
+        binding.map_id, binding.generation, binding.source,
+    )
+    if broadcast is not None and not str(broadcast.get("map_id") or ""):
+        # mapping is provably UP but running ephemeral (no map_id) — its
+        # frame resets every boot, so the named partition scene just bound
+        # statically will never re-anchor. Likely a manifest misconfig
+        # (SCENE_MAP_ID set, mapping's config.map_id forgotten).
+        log.warning(
+            "[scene] mapping broadcasts an EPHEMERAL session (empty map_id) "
+            "while scene binds %r from %s — objects stored under this id "
+            "won't re-anchor across boots; set mapping's config.map_id to "
+            "match", binding.map_id, binding.source,
+        )
 
     obj_store = None
     if os.environ.get("SCENE_OBJECT_MEMORY_ENABLED", "true").lower() in ("true", "1", "yes"):
@@ -960,6 +1099,11 @@ async def _run() -> None:
         obj_store.set_embedder(getattr(perception, "embed_text", None))
     bg_tasks = [
         asyncio.create_task(_stale_tick(registry), name="scene-stale-tick"),
+        # P2 guard: warn when mapping's live map identity drifts from the
+        # binding scene started with (P3 will act on it instead).
+        asyncio.create_task(
+            _lifecycle_watch(hub, binding), name="scene-lifecycle-watch"
+        ),
         # Background reconciler: keeps scene's hub adding subscriptions
         # for new ROS2 topic_outs that appear on atlas after start
         # (mapping comes up after scene; same pattern for any future
@@ -975,6 +1119,11 @@ async def _run() -> None:
         ),
         *ingest_bg,
     ]
+    # These tasks are fire-and-forget: nothing awaits them, so an uncaught
+    # exception would otherwise vanish until shutdown (the failure mode of
+    # the failure-detectors themselves). Surface any death immediately.
+    for _t in bg_tasks:
+        _t.add_done_callback(_log_bg_task_exit)
 
     # ── Relation layer ───────────────────────────────────────────────
     # Fast geometric relations (contact/containment + reachable_by) are

--- a/system/scene/scene_service/service.py
+++ b/system/scene/scene_service/service.py
@@ -1150,6 +1150,7 @@ async def _run() -> None:
     for fn in (
         mcp_tools.list_objects,
         mcp_tools.goal_near,
+        mcp_tools.goal_room,
         mcp_tools.get_scene_graph,
         mcp_tools.get_object_context,
         mcp_tools.list_relations,
@@ -1168,7 +1169,7 @@ async def _run() -> None:
             description=(fn.__doc__ or "").strip(),
             input_schema_json=schema,
         )
-    log.info("scene declared 5 MCP tools at %s", scene.mcp_endpoint)
+    log.info("scene declared 6 MCP tools at %s", scene.mcp_endpoint)
 
     # ROS2 ingest hub + downstream consumers (self-pose, perception).
     # _start_ros_ingest still wants a raw atlas stub for QueryCapabilities;

--- a/system/scene/scene_service/service.py
+++ b/system/scene/scene_service/service.py
@@ -1059,9 +1059,12 @@ async def _run() -> None:
         broadcast, config.get("map_id"), os.environ.get("SCENE_MAP_ID")
     )
     map_id = binding.map_id
+    restore_on_start = os.environ.get("SCENE_RESTORE_ON_START", "false").lower() in ("true", "1", "yes")
+    scene_state_map_id = map_id if restore_on_start else f".live-{os.getpid()}-{int(time.time())}"
     log.info(
-        "[scene] map binding: id=%s gen=%s source=%s",
-        binding.map_id, binding.generation, binding.source,
+        "[scene] map binding: id=%s gen=%s source=%s mode=%s restore_on_start=%s state_partition=%s",
+        binding.map_id, binding.generation, binding.source, binding.mode,
+        restore_on_start, scene_state_map_id,
     )
     if broadcast is not None and not str(broadcast.get("map_id") or ""):
         # mapping is provably UP but running ephemeral (no map_id) — its
@@ -1083,14 +1086,15 @@ async def _run() -> None:
             "SCENE_OBJECT_MEMORY_DB", "/data/robonix/scene_memory/objects.db"
         )
         try:
-            obj_store = ObjectStore(db_path, map_id=map_id)
-            restored = obj_store.load_all()
-            async with registry.lock():
-                for o in restored:
-                    registry.restore_object(o)
+            obj_store = ObjectStore(db_path, map_id=scene_state_map_id)
+            restored = obj_store.load_all() if restore_on_start else []
+            if restored:
+                async with registry.lock():
+                    for o in restored:
+                        registry.restore_object(o)
             log.info(
-                "[scene-persist] restored %d objects (map_id=%s) from %s",
-                len(restored), obj_store.map_id, db_path,
+                "[scene-persist] object store ready: restored %d object(s) (partition=%s, restore_on_start=%s) from %s",
+                len(restored), obj_store.map_id, restore_on_start, db_path,
             )
         except Exception as e:  # noqa: BLE001
             # Object memory is opted in (default on), so a failure here is not
@@ -1115,8 +1119,8 @@ async def _run() -> None:
             os.environ.get(
                 "SCENE_ANNOTATIONS_DIR", "/data/robonix/scene_annotations"
             ),
-            map_id=map_id,
-            generation=binding.generation,
+            map_id=scene_state_map_id,
+            generation=binding.generation if restore_on_start else None,
         )
         anns = anno_store.list()
         log.info(
@@ -1134,6 +1138,7 @@ async def _run() -> None:
     # supplied later in _start_ros_ingest). The geometric relation loop +
     # scene-graph store are wired further down, once the registry is live.
     mcp_tools.attach_state(registry=registry)
+    mcp_tools.attach_annotation_store(anno_store)
 
     # Bring up atlas + lifecycle gRPC + MCP HTTP. Non-blocking; scene
     # keeps running its own asyncio event loop after this returns.
@@ -1227,9 +1232,10 @@ async def _run() -> None:
     sg_cache_dir = os.environ.get(
         "SCENE_GRAPH_CACHE_DIR", "/data/robonix/scene_graph/cache"
     )
-    # Partition the scene-graph caches by the same map_id as the object store,
-    # so caption/relation answers from one map never bleed into another.
-    sg_store = SceneGraphStore(cache_dir=sg_cache_dir, map_id=map_id)
+    # Partition the scene-graph caches by the same runtime state partition as
+    # the object store. Startup defaults to a live session; explicit Load rebinds
+    # persistent room/object state through the web map facade.
+    sg_store = SceneGraphStore(cache_dir=sg_cache_dir, map_id=scene_state_map_id)
     log.info(
         "[scene-graph] cache base=%s partitioned by map_id=%s",
         sg_cache_dir, map_id,
@@ -1291,11 +1297,12 @@ async def _run() -> None:
             detector=perception,
             sg_store=sg_store,
             anno_store=anno_store,
+            object_store=obj_store,
             map_binding={
                 "map_id": binding.map_id,
-                "mode": binding.mode,
-                "generation": binding.generation,
-                "source": binding.source,
+                "mode": binding.mode if restore_on_start else "",
+                "generation": binding.generation if restore_on_start else None,
+                "source": binding.source if restore_on_start else "default",
             },
         )
         web_uv = uvicorn.Config(

--- a/system/scene/scene_service/service.py
+++ b/system/scene/scene_service/service.py
@@ -36,6 +36,7 @@ scene = Service(id="scene", namespace="robonix/system/scene")
 
 from . import mcp_tools
 from . import web as web_ui
+from .annotations import AnnotationStore
 from .ingest.capabilities import plan_perception
 from .map_binding import MapBinding, choose_map_binding, read_latched_lifecycle
 from .ingest.perception_concept_graphs import ConceptGraphsDetector
@@ -900,15 +901,32 @@ def _log_bg_task_exit(task: "asyncio.Task") -> None:
         log.error("[scene] background task %r died: %r", task.get_name(), exc)
 
 
-async def _lifecycle_watch(hub: SubscribersHub, binding: MapBinding) -> None:
+async def _lifecycle_watch(
+    hub: SubscribersHub,
+    binding: MapBinding,
+    anno_store: Optional[AnnotationStore] = None,
+) -> None:
     """P2 guard: scene binds its map_id ONCE at startup; when mapping's
     broadcast later disagrees (map loaded/reset/switched at runtime), warn
     loudly — reacting to it (flush + re-anchor the semantic state) is the
     P3 lifecycle linkage, not guesswork here. Also confirms a static
-    binding the first time the broadcast appears and agrees."""
+    binding the first time the broadcast appears and agrees.
+
+    One reaction IS taken already: a generation bump on the SAME map flags
+    the user's annotations stale (flag-only — user assets are never
+    deleted automatically). That is a marker write, not a flush, so it is
+    safe ahead of P3; and because it is best-effort, a failing marker
+    write must never kill this watcher — the drift WARNING itself is the
+    load-bearing part.
+
+    A static binding (config/env — the normal full-boot order, scene up
+    before mapping) carries no generation, so the epoch reference is
+    learned from the FIRST confirming broadcast: without that, `gen_ok`
+    would stay vacuously true and runtime bumps would be invisible."""
     confirmed = False
     warned_ephemeral = False
     last_warned: Optional[tuple] = None
+    ref_gen = binding.generation
     while True:
         await asyncio.sleep(5.0)
         msg, stamp_unix, _count = hub.latest("map_lifecycle")
@@ -930,7 +948,7 @@ async def _lifecycle_watch(hub: SubscribersHub, binding: MapBinding) -> None:
                 warned_ephemeral = True
             continue
         id_ok = live_id == binding.map_id
-        gen_ok = binding.generation is None or live_gen == binding.generation
+        gen_ok = ref_gen is None or live_gen == ref_gen
         if id_ok and gen_ok:
             if not confirmed:
                 log.info(
@@ -938,6 +956,21 @@ async def _lifecycle_watch(hub: SubscribersHub, binding: MapBinding) -> None:
                     "id=%s gen=%d mode=%s", live_id, live_gen, str(msg.mode),
                 )
                 confirmed = True
+                # Static bindings learn their epoch here; from now on a
+                # bump IS detectable. The annotation store gets to compare
+                # the confirmed epoch against the one its file recorded
+                # (it too may have loaded under an unknown generation).
+                ref_gen = live_gen
+                if anno_store is not None:
+                    try:
+                        anno_store.reconcile_generation(live_gen)
+                    except Exception as e:  # noqa: BLE001
+                        # Best-effort marker write (disk full / read-only
+                        # dir); the watcher itself must survive it.
+                        log.error(
+                            "[scene-anno] generation reconcile failed "
+                            "(annotation staleness may be outdated): %s", e,
+                        )
             last_warned = None
             continue
         key = (live_id, live_gen)
@@ -949,8 +982,37 @@ async def _lifecycle_watch(hub: SubscribersHub, binding: MapBinding) -> None:
                 "its startup binding until lifecycle linkage (P3) lands; "
                 "restart scene to rebind.",
                 live_id, live_gen, str(msg.mode),
-                binding.map_id, binding.generation, binding.source,
+                binding.map_id, ref_gen, binding.source,
             )
+            if anno_store is not None and id_ok and not gen_ok:
+                # Same map, new frame epoch: user-drawn geometry may no
+                # longer line up with the rebuilt map. Flag it for user
+                # confirmation (marker-only; deletion is never automatic).
+                try:
+                    n = anno_store.mark_all_stale(
+                        f"map generation {ref_gen}→{live_gen}",
+                        new_generation=live_gen,
+                    )
+                    if n:
+                        log.warning(
+                            "[scene-anno] %d annotation(s) marked stale — "
+                            "confirm or redraw them in the map UI", n,
+                        )
+                except Exception as e:  # noqa: BLE001
+                    # Losing the stale marker is recoverable (next boot's
+                    # load-time epoch check re-judges); losing this watcher
+                    # would silence ALL drift warnings for the session.
+                    log.error(
+                        "[scene-anno] stale marking failed (annotations "
+                        "may show as fresh until restart): %s", e,
+                    )
+            if id_ok:
+                # Acknowledge the new epoch so a THIRD epoch is reported
+                # against this one (accurate from→to in reason/log), and
+                # each bump warns exactly once. The registry's semantic
+                # state stays anchored to the startup binding until the
+                # lifecycle linkage (P3) actually re-anchors it.
+                ref_gen = live_gen
             last_warned = key
 
 
@@ -1040,6 +1102,34 @@ async def _run() -> None:
                 "writes): %s", e,
             )
             obj_store = None
+
+    # User annotations (rooms / POIs) — user-authored semantics on the same
+    # map_id partition rule as the object store; validity is additionally
+    # tracked against mapping's generation epoch (annotations only — the
+    # object store has no epoch concept). A failure here disables the
+    # annotation API for the session (web answers 503) but never blocks
+    # scene itself.
+    anno_store: Optional[AnnotationStore] = None
+    try:
+        anno_store = AnnotationStore(
+            os.environ.get(
+                "SCENE_ANNOTATIONS_DIR", "/data/robonix/scene_annotations"
+            ),
+            map_id=map_id,
+            generation=binding.generation,
+        )
+        anns = anno_store.list()
+        log.info(
+            "[scene-anno] annotation store ready: %d annotation(s), %d stale "
+            "(map_id=%s) at %s",
+            len(anns), sum(a.stale for a in anns), anno_store.map_id,
+            anno_store.path,
+        )
+    except Exception as e:  # noqa: BLE001
+        log.error(
+            "[scene-anno] annotation store init failed — annotation API "
+            "disabled for this session: %s", e,
+        )
     # mcp_tools v0 only needs the registry + the ROS hub (the latter is
     # supplied later in _start_ros_ingest). The geometric relation loop +
     # scene-graph store are wired further down, once the registry is live.
@@ -1102,7 +1192,8 @@ async def _run() -> None:
         # P2 guard: warn when mapping's live map identity drifts from the
         # binding scene started with (P3 will act on it instead).
         asyncio.create_task(
-            _lifecycle_watch(hub, binding), name="scene-lifecycle-watch"
+            _lifecycle_watch(hub, binding, anno_store),
+            name="scene-lifecycle-watch",
         ),
         # Background reconciler: keeps scene's hub adding subscriptions
         # for new ROS2 topic_outs that appear on atlas after start
@@ -1199,6 +1290,13 @@ async def _run() -> None:
             hub=hub,
             detector=perception,
             sg_store=sg_store,
+            anno_store=anno_store,
+            map_binding={
+                "map_id": binding.map_id,
+                "mode": binding.mode,
+                "generation": binding.generation,
+                "source": binding.source,
+            },
         )
         web_uv = uvicorn.Config(
             app=web_app,

--- a/system/scene/scene_service/web.py
+++ b/system/scene/scene_service/web.py
@@ -27,6 +27,7 @@ from starlette.responses import HTMLResponse, JSONResponse
 from starlette.routing import Mount, Route
 from starlette.staticfiles import StaticFiles
 
+from .annotations import validate_annotation_fields
 from .state import ObjectRegistry
 
 log = logging.getLogger(__name__)
@@ -371,13 +372,18 @@ def _camera_payload(hub: Any) -> dict:
 
 
 def _state_payload(registry: ObjectRegistry,
-                   hub: Any, sg_store: Any = None) -> dict:
+                   hub: Any, sg_store: Any = None,
+                   anno_store: Any = None,
+                   map_binding: Optional[dict] = None) -> dict:
     """Serialise the registry + relations + map into the small JSON
     shape the page consumes. Done in one snapshot so the page never
     sees a half-updated registry. The "relations" field shows the fast
     geometric slice (``reachable_by`` only, under the VLM-primary graph);
     the "scene_graph" field shows the full composed graph (geometric +
-    image-grounded relational/semantic edges)."""
+    image-grounded relational/semantic edges). "annotations" carries the
+    user-drawn rooms/POIs (map-frame meters, same coordinates as objects)
+    and "map_binding" the identity scene is bound to — both consumed by
+    the /user annotation page."""
     objs_dict, _surfaces = _sync_snapshot(registry)
     geo_edges = sg_store.get_geometric_edges() if sg_store is not None else []
     out_objects: list[dict[str, Any]] = []
@@ -427,6 +433,8 @@ def _state_payload(registry: ObjectRegistry,
         "scene_graph": sg_payload,
         "robot": robot_pose,
         "occupancy": _occupancy_payload(hub),
+        "annotations": anno_store.list_json() if anno_store is not None else [],
+        "map_binding": map_binding,
         "stamp_unix": time.time(),
     }
 
@@ -448,21 +456,50 @@ def _sync_snapshot(registry: ObjectRegistry):
 
 def make_app(*, registry: ObjectRegistry,
              hub: Any = None, detector: Any = None,
-             sg_store: Any = None) -> Starlette:
+             sg_store: Any = None, anno_store: Any = None,
+             map_binding: Optional[dict] = None) -> Starlette:
     """Build the Starlette ASGI app the entrypoint mounts on its own
     uvicorn server.
 
     Routes:
-      GET /                — 2D top-down map (occupancy grid + objects)
+      GET /                — combined split layout (2D map · 3D · cam)
+      GET /2d              — 2D top-down map (occupancy grid + objects)
       GET /3d              — 3D scene (point clouds + bbox; three.js)
+      GET /cam             — camera stack (live RGB + depth)
+      GET /user            — end-user map page (rooms: draw / rename /
+                             confirm-stale / delete; light object overlay)
       GET /api/state       — JSON for the 2D map
       GET /api/objects3d   — JSON for the 3D viz (per-object pcd + bbox)
+      GET /api/camera      — JSON: latest RGB + depth frames
+      /api/annotations[..] — user annotation CRUD (see below)
 
     `hub` is the SubscribersHub — passed so the JSON state can include
     the latest OccupancyGrid for the 2D canvas underlay.
     `detector` is the ConceptGraphsDetector — passed so the 3D endpoint
     can serialize its persistent MapObjectList. If None, the 3D page
     just shows an empty world.
+    `anno_store` is the AnnotationStore backing the annotation CRUD; when
+    None (store init failed / disabled) those routes answer 503.
+    `map_binding` is a static {map_id, mode, generation, source} dict shown
+    by the /user page header.
+
+    Annotation API contract (STABLE once shipped — any frontend builds on
+    it; see system/scene/README.md):
+      GET    /api/annotations       → {ok, annotations: [...]}
+      POST   /api/annotations       body {kind, name, points, theta?}
+                                    → {ok, annotation}
+      PUT    /api/annotations/{id}  body: any of {name, points, theta,
+                                    stale:false} → {ok, annotation}
+      DELETE /api/annotations/{id}  → {ok}
+    theta (heading, radians) is poi-only — a room carrying it is a 400.
+    On PUT, theta null/absent means "keep"; a set heading cannot be
+    cleared, only changed (deliberate until the poi UI exists).
+    Errors: 400 invalid body/fields, 404 unknown id, 503 store unavailable;
+    those carry {ok: false, detail}. A store write failure (disk full)
+    deliberately escapes as a plain 500 — the edit was NOT saved and hiding
+    that behind a tidy body would be worse. Coordinates are map-frame
+    meters. Same trust domain as the rest of this LAN debug/UI server —
+    no auth.
     """
 
     async def index(_request) -> HTMLResponse:
@@ -477,7 +514,91 @@ def make_app(*, registry: ObjectRegistry,
         return HTMLResponse(_INDEX_HTML)
 
     async def state(_request) -> JSONResponse:
-        return JSONResponse(_state_payload(registry, hub, sg_store))
+        return JSONResponse(
+            _state_payload(registry, hub, sg_store, anno_store, map_binding)
+        )
+
+    # ── annotation CRUD ──────────────────────────────────────────────
+    def _anno_error(status: int, detail: str) -> JSONResponse:
+        return JSONResponse({"ok": False, "detail": detail}, status_code=status)
+
+    async def _anno_body(request) -> Optional[dict]:
+        """Parse the JSON request body; None (→ caller answers 400) when
+        it is missing, malformed, or not an object."""
+        try:
+            body = await request.json()
+        except Exception:  # noqa: BLE001 — malformed body is a client error
+            return None
+        return body if isinstance(body, dict) else None
+
+    async def annotations_list(_request) -> JSONResponse:
+        if anno_store is None:
+            return _anno_error(503, "annotation store unavailable")
+        return JSONResponse({"ok": True, "annotations": anno_store.list_json()})
+
+    async def annotations_create(request) -> JSONResponse:
+        """POST /api/annotations — validate {kind, name, points, theta?}
+        and persist a new annotation (returned with its generated id)."""
+        if anno_store is None:
+            return _anno_error(503, "annotation store unavailable")
+        body = await _anno_body(request)
+        if body is None:
+            return _anno_error(400, "request body must be a JSON object")
+        kind = body.get("kind")
+        name = body.get("name", "")
+        points = body.get("points")
+        theta = body.get("theta")
+        err = validate_annotation_fields(kind, name, points, theta)
+        if err:
+            return _anno_error(400, err)
+        ann = anno_store.create(kind=kind, name=name, points=points, theta=theta)
+        return JSONResponse({"ok": True, "annotation": ann.to_json()})
+
+    async def annotations_update(request) -> JSONResponse:
+        """PUT /api/annotations/{id} — partial update: any of name /
+        points / theta / stale:false (the user's "confirm still valid").
+        Provided fields are validated against the annotation's kind."""
+        if anno_store is None:
+            return _anno_error(503, "annotation store unavailable")
+        ann_id = request.path_params["annotation_id"]
+        existing = anno_store.get(ann_id)
+        if existing is None:
+            return _anno_error(404, f"unknown annotation id {ann_id!r}")
+        body = await _anno_body(request)
+        if body is None:
+            return _anno_error(400, "request body must be a JSON object")
+        name = body.get("name")
+        points = body.get("points")
+        theta = body.get("theta")
+        # Validate the would-be merged state so a partial update can never
+        # store something a create would have rejected.
+        err = validate_annotation_fields(
+            existing.kind,
+            name if name is not None else existing.name,
+            points if points is not None else existing.points,
+            theta if theta is not None else existing.theta,
+        )
+        if err:
+            return _anno_error(400, err)
+        clear_stale = body.get("stale") is False
+        ann = anno_store.update(
+            ann_id, name=name, points=points, theta=theta,
+            clear_stale=clear_stale,
+        )
+        if ann is None:  # deleted between get and update — still a 404
+            return _anno_error(404, f"unknown annotation id {ann_id!r}")
+        return JSONResponse({"ok": True, "annotation": ann.to_json()})
+
+    async def annotations_delete(request) -> JSONResponse:
+        """DELETE /api/annotations/{id} — remove the annotation; 404 when
+        the id is unknown (delete is the user's explicit action, so unlike
+        staleness it IS allowed to drop a user asset)."""
+        if anno_store is None:
+            return _anno_error(503, "annotation store unavailable")
+        ann_id = request.path_params["annotation_id"]
+        if not anno_store.delete(ann_id):
+            return _anno_error(404, f"unknown annotation id {ann_id!r}")
+        return JSONResponse({"ok": True})
 
     async def index3d(_request) -> HTMLResponse:
         return HTMLResponse(_INDEX_3D_HTML)
@@ -489,6 +610,9 @@ def make_app(*, registry: ObjectRegistry,
 
     async def cam(_request) -> HTMLResponse:
         return HTMLResponse(_INDEX_CAM_HTML)
+
+    async def user_page(_request) -> HTMLResponse:
+        return HTMLResponse(_USER_HTML)
 
     async def camera_state(_request) -> JSONResponse:
         return JSONResponse(_camera_payload(hub))
@@ -504,9 +628,16 @@ def make_app(*, registry: ObjectRegistry,
         Route("/2d", index2d, methods=["GET"]),
         Route("/3d", index3d, methods=["GET"]),
         Route("/cam", cam, methods=["GET"]),
+        Route("/user", user_page, methods=["GET"]),
         Route("/api/state", state, methods=["GET"]),
         Route("/api/objects3d", objects3d, methods=["GET"]),
         Route("/api/camera", camera_state, methods=["GET"]),
+        Route("/api/annotations", annotations_list, methods=["GET"]),
+        Route("/api/annotations", annotations_create, methods=["POST"]),
+        Route("/api/annotations/{annotation_id}", annotations_update,
+              methods=["PUT"]),
+        Route("/api/annotations/{annotation_id}", annotations_delete,
+              methods=["DELETE"]),
     ]
     if static_dir.is_dir():
         routes.append(Mount("/static", StaticFiles(directory=str(static_dir)), name="static"))
@@ -1696,6 +1827,419 @@ _INDEX_3D_HTML = r"""<!doctype html>
     }
     requestAnimationFrame(loop);
   </script>
+</body>
+</html>
+"""
+
+
+# ── User annotation page (/user) ─────────────────────────────────────────────
+# The end-user map page: SLAM occupancy underlay + LIGHTWEIGHT object overlay
+# + user-drawn room polygons, with a draw-a-room flow talking to the
+# /api/annotations CRUD. Deliberately self-contained (own inline JS, no
+# imports from the debug pages' scripts): the two pages evolve independently
+# and a debug-UI tweak must never break the user page. Kept dependency-free
+# like every other page here (no framework, no build step).
+_USER_HTML = r"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>robonix — map & rooms</title>
+  <style>
+    :root { --fg:#e8eaed; --bg:#0e1015; --panel:#161a22; --acc:#7aa7ff;
+            --muted:#7d828b; --warn:#e6c454; --danger:#e06c75; }
+    html, body { background: var(--bg); color: var(--fg); margin: 0; height: 100%;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    #app { display: flex; flex-direction: column; height: 100vh; }
+    header { display: flex; align-items: center; gap: 14px; padding: 10px 16px;
+      background: var(--panel); border-bottom: 1px solid #232936; flex: none; }
+    header h1 { font-size: 15px; margin: 0; font-weight: 600; }
+    header .meta { font-size: 12px; color: var(--muted); }
+    header .stale-alert { font-size: 12px; color: var(--warn); display: none; }
+    #main { display: flex; flex: 1; min-height: 0; }
+    #panel { width: 260px; flex: none; background: var(--panel);
+      border-right: 1px solid #232936; display: flex; flex-direction: column; }
+    #panel .actions { padding: 12px; border-bottom: 1px solid #232936; }
+    button { background: #222a3a; color: var(--fg); border: 1px solid #33405a;
+      border-radius: 6px; padding: 6px 10px; font-size: 12px; cursor: pointer; }
+    button:hover { background: #2a3550; }
+    button.primary { background: #2b4a86; border-color: #3c62ad; }
+    button.primary.active { background: var(--acc); color: #0e1015; }
+    button.small { padding: 2px 7px; font-size: 11px; }
+    button.danger { border-color: #6b3640; color: var(--danger); }
+    #room-list { flex: 1; overflow-y: auto; padding: 8px 12px; }
+    .room { border: 1px solid #232936; border-radius: 8px; padding: 8px 10px;
+      margin-bottom: 8px; font-size: 13px; }
+    .room.selected { border-color: var(--acc); }
+    .room .name { font-weight: 600; }
+    .room .sub { color: var(--muted); font-size: 11px; margin: 3px 0 6px; }
+    .room .badge { color: #0e1015; background: var(--warn); border-radius: 4px;
+      padding: 0 5px; font-size: 10px; font-weight: 700; margin-left: 6px; }
+    .room .btns { display: flex; gap: 6px; }
+    #canvas-wrap { position: relative; flex: 1; min-width: 0; }
+    canvas { display: block; width: 100%; height: 100%; background: #14171f; }
+    #hint { position: absolute; top: 10px; left: 50%; transform: translateX(-50%);
+      background: rgba(20,23,31,.92); border: 1px solid #33405a; color: var(--fg);
+      font-size: 12px; padding: 6px 12px; border-radius: 6px; display: none; }
+    #toast { position: absolute; bottom: 14px; left: 50%; transform: translateX(-50%);
+      background: rgba(20,23,31,.95); border: 1px solid #6b3640; color: var(--danger);
+      font-size: 12px; padding: 6px 12px; border-radius: 6px; display: none; }
+    .legend { position: absolute; bottom: 8px; left: 12px; font-size: 11px;
+      color: var(--muted); background: rgba(20,23,31,.85); padding: 4px 8px;
+      border-radius: 4px; }
+    #empty { padding: 10px 2px; color: var(--muted); font-size: 12px; }
+  </style>
+</head>
+<body>
+<div id="app">
+  <header>
+    <h1>Map &amp; rooms</h1>
+    <span class="meta" id="meta">map: —</span>
+    <span class="stale-alert" id="stale-alert">⚠ map was rebuilt — review stale rooms</span>
+  </header>
+  <div id="main">
+    <div id="panel">
+      <div class="actions">
+        <button class="primary" id="btn-draw">✏ Annotate room</button>
+      </div>
+      <div id="room-list"><div id="empty">No rooms yet. Click “Annotate room”,
+        then click on the map to outline one (double-click or Enter to finish,
+        Esc to cancel).</div></div>
+    </div>
+    <div id="canvas-wrap">
+      <canvas id="c"></canvas>
+      <div id="hint"></div>
+      <div id="toast"></div>
+      <div class="legend">drag to pan · wheel to zoom · hover a dot for its label</div>
+    </div>
+  </div>
+</div>
+<script>
+const c = document.getElementById('c');
+const ctx = c.getContext('2d');
+function fit() { c.width = c.clientWidth; c.height = c.clientHeight; }
+window.addEventListener('resize', fit); fit();
+
+// ── view transform (world meters ↔ canvas px) ────────────────────────────
+// Unlike the debug page (which chases the robot) the editor keeps a STABLE
+// user-controlled view: drawing needs the map to hold still under the mouse.
+let center = [0, 0];
+let pxPerM = 40;
+let viewInit = false;
+function w2p(x, y) {
+    return [c.width / 2 + (x - center[0]) * pxPerM,
+            c.height / 2 - (y - center[1]) * pxPerM];
+}
+function p2w(px, py) {
+    return [center[0] + (px - c.width / 2) / pxPerM,
+            center[1] - (py - c.height / 2) / pxPerM];
+}
+
+// ── state ────────────────────────────────────────────────────────────────
+let state = null;          // last /api/state payload
+let occImg = null, occMeta = null, occStamp = 0, occLoading = 0;
+let drawMode = false;
+let draft = [];            // in-progress polygon vertices (world coords)
+let mouseWorld = null;     // live cursor position for the rubber-band edge
+let hoverObj = null;
+let selectedId = null;
+
+const hintEl = document.getElementById('hint');
+function setHint(text) {
+    hintEl.style.display = text ? 'block' : 'none';
+    hintEl.textContent = text || '';
+}
+let toastTimer = null;
+function toast(text) {
+    const t = document.getElementById('toast');
+    t.textContent = text; t.style.display = 'block';
+    clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => { t.style.display = 'none'; }, 4000);
+}
+
+// ── rendering ────────────────────────────────────────────────────────────
+function polyCentroid(pts) {
+    let sx = 0, sy = 0;
+    for (const [x, y] of pts) { sx += x; sy += y; }
+    return [sx / pts.length, sy / pts.length];
+}
+
+function draw() {
+    fit();
+    ctx.clearRect(0, 0, c.width, c.height);
+    if (!state) return;
+
+    // occupancy underlay (same decode/anchor math as the debug 2D page:
+    // cell [0,0] at world origin, y flipped because image y grows down).
+    // occStamp only advances on successful decode, so a corrupt frame is
+    // retried on the next poll instead of wedging the underlay.
+    if (state.occupancy && state.occupancy.stamp_ms !== occStamp
+        && state.occupancy.stamp_ms !== occLoading) {
+        occLoading = state.occupancy.stamp_ms;
+        const meta = state.occupancy;
+        const im = new Image();
+        im.onload = () => { occImg = im; occMeta = meta; occStamp = meta.stamp_ms; };
+        im.onerror = () => { occLoading = 0; console.error('occupancy PNG decode failed'); };
+        im.src = 'data:image/png;base64,' + meta.png_b64;
+    }
+    if (occImg && occMeta) {
+        if (!viewInit) {   // first grid: fit it into the viewport once
+            const wM = occMeta.width * occMeta.resolution;
+            const hM = occMeta.height * occMeta.resolution;
+            center = [occMeta.origin_x + wM / 2, occMeta.origin_y + hM / 2];
+            pxPerM = Math.min((c.width - 40) / wM, (c.height - 40) / hM, 120);
+            pxPerM = Math.max(pxPerM, 5);
+            viewInit = true;
+        }
+        const wM = occMeta.width * occMeta.resolution;
+        const hM = occMeta.height * occMeta.resolution;
+        const [x0, y0] = w2p(occMeta.origin_x, occMeta.origin_y + hM);
+        ctx.globalAlpha = 0.9;
+        ctx.imageSmoothingEnabled = false;
+        ctx.drawImage(occImg, x0, y0, wM * pxPerM, hM * pxPerM);
+        ctx.globalAlpha = 1.0;
+    } else {
+        ctx.fillStyle = '#7d828b'; ctx.font = '13px sans-serif';
+        ctx.fillText('no map yet — the SLAM map appears here once mapping publishes it', 20, 30);
+    }
+
+    // saved rooms
+    for (const a of (state.annotations || [])) {
+        if (a.kind !== 'room' || a.points.length < 3) continue;
+        const pts = a.points.map(p => w2p(p[0], p[1]));
+        ctx.beginPath();
+        pts.forEach(([x, y], i) => i ? ctx.lineTo(x, y) : ctx.moveTo(x, y));
+        ctx.closePath();
+        const sel = a.annotation_id === selectedId;
+        ctx.fillStyle = a.stale ? 'rgba(230,196,84,0.10)' : 'rgba(122,167,255,0.12)';
+        ctx.fill();
+        ctx.lineWidth = sel ? 2.5 : 1.5;
+        ctx.strokeStyle = a.stale ? '#e6c454' : (sel ? '#a8c4ff' : '#7aa7ff');
+        ctx.setLineDash(a.stale ? [6, 4] : []);
+        ctx.stroke();
+        ctx.setLineDash([]);
+        const [cx, cy] = w2p(...polyCentroid(a.points));
+        const label = (a.stale ? '⚠ ' : '') + (a.name || '(unnamed)');
+        ctx.font = 'bold 13px sans-serif'; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+        ctx.lineWidth = 3; ctx.strokeStyle = 'rgba(0,0,0,0.85)';
+        ctx.strokeText(label, cx, cy);
+        ctx.fillStyle = a.stale ? '#e6c454' : '#cfe0ff';
+        ctx.fillText(label, cx, cy);
+        ctx.textAlign = 'start';
+    }
+
+    // objects — small translucent dots; label only on hover (readability:
+    // the underlay must stay legible, objects are a light overlay).
+    for (const o of (state.objects || [])) {
+        if (o.cls === 'robot') continue;
+        const [px, py] = w2p(o.pose.x, o.pose.y);
+        ctx.globalAlpha = o.missing ? 0.25 : 0.6;
+        ctx.fillStyle = '#9ab8e8';
+        ctx.beginPath(); ctx.arc(px, py, 3.5, 0, Math.PI * 2); ctx.fill();
+        ctx.globalAlpha = 1;
+        ctx.lineWidth = 1; ctx.strokeStyle = 'rgba(14,16,21,0.9)';
+        ctx.stroke();
+    }
+    if (hoverObj) {
+        const [px, py] = w2p(hoverObj.pose.x, hoverObj.pose.y);
+        ctx.font = '12px ui-monospace, monospace'; ctx.textBaseline = 'middle';
+        ctx.lineWidth = 3; ctx.strokeStyle = 'rgba(0,0,0,0.85)';
+        ctx.strokeText(hoverObj.cls, px + 8, py);
+        ctx.fillStyle = '#cfe0ff';
+        ctx.fillText(hoverObj.cls, px + 8, py);
+    }
+
+    // robot marker (small arrow, subtle)
+    const robot = state.robot;
+    if (robot) {
+        const [rx, ry] = w2p(robot.x, robot.y);
+        const yaw = robot.yaw || 0;
+        ctx.strokeStyle = '#7aa7ff'; ctx.fillStyle = '#7aa7ff'; ctx.lineWidth = 2;
+        ctx.beginPath(); ctx.arc(rx, ry, 5, 0, Math.PI * 2); ctx.stroke();
+        ctx.beginPath();
+        ctx.moveTo(rx, ry);
+        ctx.lineTo(rx + Math.cos(yaw) * 14, ry - Math.sin(yaw) * 14);
+        ctx.stroke();
+    }
+
+    // draft polygon (draw mode)
+    if (drawMode && draft.length) {
+        const pts = draft.map(p => w2p(p[0], p[1]));
+        ctx.beginPath();
+        pts.forEach(([x, y], i) => i ? ctx.lineTo(x, y) : ctx.moveTo(x, y));
+        if (mouseWorld) { const [mx, my] = w2p(...mouseWorld); ctx.lineTo(mx, my); }
+        ctx.strokeStyle = '#8ef0b7'; ctx.lineWidth = 2; ctx.setLineDash([5, 4]);
+        ctx.stroke(); ctx.setLineDash([]);
+        ctx.fillStyle = '#8ef0b7';
+        for (const [x, y] of pts) {
+            ctx.beginPath(); ctx.arc(x, y, 3, 0, Math.PI * 2); ctx.fill();
+        }
+    }
+}
+
+// ── side panel ───────────────────────────────────────────────────────────
+function esc(s) {
+    return String(s).replace(/[&<>"']/g,
+        ch => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch]));
+}
+function renderPanel() {
+    const rooms = (state && state.annotations || []).filter(a => a.kind === 'room');
+    const list = document.getElementById('room-list');
+    const anyStale = rooms.some(a => a.stale);
+    document.getElementById('stale-alert').style.display = anyStale ? 'inline' : 'none';
+    if (!rooms.length) {
+        list.innerHTML = '<div id="empty">No rooms yet. Click “Annotate room”, ' +
+          'then click on the map to outline one (double-click or Enter to ' +
+          'finish, Esc to cancel).</div>';
+        return;
+    }
+    list.innerHTML = rooms.map(a => `
+      <div class="room ${a.annotation_id === selectedId ? 'selected' : ''}"
+           data-id="${a.annotation_id}">
+        <span class="name">${esc(a.name || '(unnamed)')}</span>
+        ${a.stale ? '<span class="badge" title="' + esc(a.stale_reason) + '">STALE</span>' : ''}
+        <div class="sub">${a.points.length} corners</div>
+        <div class="btns">
+          <button class="small" data-act="rename">Rename</button>
+          ${a.stale ? '<button class="small" data-act="confirm">Still valid</button>' : ''}
+          <button class="small danger" data-act="delete">Delete</button>
+        </div>
+      </div>`).join('');
+}
+document.getElementById('room-list').addEventListener('click', async (ev) => {
+    const roomEl = ev.target.closest('.room');
+    if (!roomEl) return;
+    const id = roomEl.dataset.id;
+    const act = ev.target.dataset && ev.target.dataset.act;
+    if (!act) { selectedId = (selectedId === id) ? null : id; renderPanel(); draw(); return; }
+    const room = (state.annotations || []).find(a => a.annotation_id === id);
+    if (!room) return;
+    if (act === 'rename') {
+        const name = prompt('Room name:', room.name);
+        if (name !== null) await api('PUT', '/api/annotations/' + id, { name });
+    } else if (act === 'confirm') {
+        await api('PUT', '/api/annotations/' + id, { stale: false });
+    } else if (act === 'delete') {
+        if (confirm(`Delete room “${room.name}”?`))
+            await api('DELETE', '/api/annotations/' + id);
+    }
+});
+
+// ── draw mode ────────────────────────────────────────────────────────────
+const btnDraw = document.getElementById('btn-draw');
+function setDrawMode(on) {
+    drawMode = on;
+    draft = [];
+    btnDraw.classList.toggle('active', on);
+    btnDraw.textContent = on ? '✕ Cancel drawing' : '✏ Annotate room';
+    c.style.cursor = on ? 'crosshair' : 'grab';
+    setHint(on ? 'Click to add corners · double-click or Enter to finish (≥3) · Esc to cancel' : '');
+    draw();
+}
+btnDraw.addEventListener('click', () => setDrawMode(!drawMode));
+
+async function finishDraft() {
+    if (draft.length < 3) { toast('A room needs at least 3 corners.'); return; }
+    const name = prompt('Room name:', '');
+    if (name === null) return;          // keep drawing
+    const body = { kind: 'room', name, points: draft };
+    if (await api('POST', '/api/annotations', body)) setDrawMode(false);
+}
+
+// ── canvas input: pan / zoom / vertex clicks / hover ─────────────────────
+let dragging = false, dragMoved = false, lastPos = null;
+c.style.cursor = 'grab';
+c.addEventListener('mousedown', (ev) => {
+    dragging = true; dragMoved = false; lastPos = [ev.offsetX, ev.offsetY];
+});
+window.addEventListener('mouseup', () => { dragging = false; });
+c.addEventListener('mousemove', (ev) => {
+    mouseWorld = p2w(ev.offsetX, ev.offsetY);
+    if (dragging && lastPos) {
+        const dx = ev.offsetX - lastPos[0], dy = ev.offsetY - lastPos[1];
+        if (Math.abs(dx) + Math.abs(dy) > 3) dragMoved = true;
+        if (dragMoved) {
+            center = [center[0] - dx / pxPerM, center[1] + dy / pxPerM];
+            lastPos = [ev.offsetX, ev.offsetY];
+        }
+    } else if (!drawMode && state) {
+        hoverObj = null;
+        for (const o of (state.objects || [])) {
+            if (o.cls === 'robot') continue;
+            const [px, py] = w2p(o.pose.x, o.pose.y);
+            if ((px - ev.offsetX) ** 2 + (py - ev.offsetY) ** 2 < 100) { hoverObj = o; break; }
+        }
+    }
+    draw();
+});
+c.addEventListener('click', (ev) => {
+    if (dragMoved) return;              // that was a pan, not a click
+    if (drawMode) { draft.push(p2w(ev.offsetX, ev.offsetY)); draw(); }
+});
+c.addEventListener('dblclick', (ev) => {
+    ev.preventDefault();
+    if (drawMode) {
+        // the dblclick's two single clicks added two duplicate corners at
+        // the same spot — drop one before closing.
+        if (draft.length > 1) draft.pop();
+        finishDraft();
+    }
+});
+window.addEventListener('keydown', (ev) => {
+    if (!drawMode) return;
+    if (ev.key === 'Escape') setDrawMode(false);
+    if (ev.key === 'Enter') finishDraft();
+});
+c.addEventListener('wheel', (ev) => {
+    ev.preventDefault();
+    const factor = ev.deltaY < 0 ? 1.15 : 1 / 1.15;
+    // zoom about the cursor so the point under the mouse stays put
+    const [wx, wy] = p2w(ev.offsetX, ev.offsetY);
+    pxPerM = Math.min(400, Math.max(3, pxPerM * factor));
+    const [nx, ny] = p2w(ev.offsetX, ev.offsetY);
+    center = [center[0] + (wx - nx), center[1] + (wy - ny)];
+    draw();
+}, { passive: false });
+
+// ── API + polling ────────────────────────────────────────────────────────
+async function api(method, path, body) {
+    try {
+        const r = await fetch(path, {
+            method,
+            headers: body !== undefined ? { 'Content-Type': 'application/json' } : {},
+            body: body !== undefined ? JSON.stringify(body) : undefined,
+        });
+        const out = await r.json().catch(() => null);
+        if (!r.ok || !out || out.ok === false) {
+            toast((out && out.detail) || (method + ' failed (' + r.status + ')'));
+            return null;
+        }
+        await refresh();
+        return out;
+    } catch (e) { toast('request failed: ' + e); return null; }
+}
+
+async function refresh() {
+    // Only the network fetch/parse is try-guarded (transient by nature);
+    // a bug thrown by the render functions must surface in the console,
+    // not be swallowed once a second forever.
+    let next = null;
+    try {
+        const r = await fetch('/api/state', { cache: 'no-store' });
+        if (!r.ok) return;
+        next = await r.json();
+    } catch (_) { return; /* transient; next poll retries */ }
+    state = next;
+    const mb = state.map_binding;
+    document.getElementById('meta').textContent = mb
+        ? `map: ${mb.map_id} · ${mb.mode || 'mode unknown'}`
+        : 'map: —';
+    renderPanel();
+    draw();
+}
+// 1 Hz is plenty for an editor page (the debug page polls at 5 Hz).
+setInterval(refresh, 1000);
+refresh();
+</script>
 </body>
 </html>
 """

--- a/system/scene/scene_service/web.py
+++ b/system/scene/scene_service/web.py
@@ -844,6 +844,10 @@ def make_app(*, registry: ObjectRegistry,
             return _anno_error(400, "map_id is required")
         mode = str(body.get("mode") or "localization")
         load_timeout_s = float(os.environ.get("SCENE_MAP_LOAD_TIMEOUT_S", "240"))
+        before_stamp = 0.0
+        before_count = 0
+        if hub is not None and hub.has("occupancy_grid"):
+            _before_msg, before_stamp, before_count = hub.latest("occupancy_grid")
         out = await asyncio.to_thread(_map_rpc, "load_map", {
             "map_id": map_id,
             "mode": mode,
@@ -853,6 +857,42 @@ def make_app(*, registry: ObjectRegistry,
             "theta": float(body.get("theta") or 0.0),
         }, load_timeout_s)
         if out.get("ok"):
+            # Mapping's LoadMap response means RTAB-Map accepted the database
+            # and PublishMap request. Do not restore semantic state until Scene
+            # has actually observed the resulting occupancy grid; otherwise the
+            # first click only switches the database and a second click appears
+            # necessary to refresh rooms/objects against the loaded map.
+            ready_timeout_s = float(os.environ.get("SCENE_MAP_READY_TIMEOUT_S", "20"))
+            deadline = time.monotonic() + ready_timeout_s
+            occupancy_ready = False
+            while time.monotonic() < deadline:
+                if hub is not None and hub.has("occupancy_grid"):
+                    msg, stamp, count = hub.latest("occupancy_grid")
+                    if (
+                        msg is not None
+                        and int(getattr(msg.info, "width", 0)) > 0
+                        and int(getattr(msg.info, "height", 0)) > 0
+                        and (count > before_count or stamp > before_stamp)
+                    ):
+                        occupancy_ready = True
+                        out["occupancy"] = {
+                            "count": int(count),
+                            "stamp_unix": float(stamp),
+                            "width": int(msg.info.width),
+                            "height": int(msg.info.height),
+                        }
+                        break
+                await asyncio.sleep(0.1)
+            if not occupancy_ready:
+                out = {
+                    **out,
+                    "ok": False,
+                    "detail": (
+                        f"mapping loaded {map_id}, but Scene did not observe a new "
+                        f"occupancy grid within {ready_timeout_s:.1f}s"
+                    ),
+                }
+                return JSONResponse(out, status_code=502)
             if anno_store is not None:
                 anno_store.rebind(map_id, generation=None, carry_current=False)
             try:
@@ -2231,7 +2271,8 @@ _USER_HTML = r"""<!doctype html>
       border: 1px solid #33405a; color: var(--muted); font-size: 11px; }
     #mode-pill.localization { border-color: #3b633f; color: #8ef0b7; background: rgba(64,150,80,.12); }
     #mode-pill.mapping { border-color: #6a5630; color: var(--warn); background: rgba(230,196,84,.10); }
-    #map-list { display: grid; gap: 6px; max-height: 170px; overflow-y: auto; }
+    #map-list { display: grid; gap: 5px; max-height: min(24vh, 190px); overflow-y: auto;
+      overscroll-behavior: contain; scrollbar-gutter: stable; }
     .mapitem { border: 1px solid #232936; border-radius: 8px; padding: 7px 8px; font-size: 12px; background: #121721; cursor: pointer; }
     .mapitem.selected, .mapitem.busy { border-color: var(--acc); }
     .mapitem .name { font-weight: 700; }
@@ -2245,12 +2286,16 @@ _USER_HTML = r"""<!doctype html>
     button.primary.active { background: var(--acc); color: #0e1015; }
     button.small { padding: 2px 7px; font-size: 11px; }
     button.danger { border-color: #6b3640; color: var(--danger); }
-    #room-list { flex: 1; overflow-y: auto; padding: 8px 12px; }
-    .room { border: 1px solid #232936; border-radius: 8px; padding: 8px 10px;
-      margin-bottom: 8px; font-size: 13px; }
+    #room-list { flex: 1; min-height: 0; overflow-y: auto; padding: 7px 10px;
+      overscroll-behavior: contain; scrollbar-gutter: stable; }
+    .room { --room-color: var(--acc); border: 1px solid #232936;
+      border-left: 3px solid var(--room-color); border-radius: 7px; padding: 6px 8px;
+      margin-bottom: 6px; font-size: 12px; }
     .room.selected { border-color: var(--acc); }
-    .room .name { font-weight: 600; }
-    .room .sub { color: var(--muted); font-size: 11px; margin: 3px 0 6px; }
+    .room .name { font-weight: 650; }
+    .room .swatch { display: inline-block; width: 8px; height: 8px; margin-right: 6px;
+      border-radius: 2px; background: var(--room-color); vertical-align: 1px; }
+    .room .sub { color: var(--muted); font-size: 10px; margin: 2px 0 5px 14px; }
     .room .badge { color: #0e1015; background: var(--warn); border-radius: 4px;
       padding: 0 5px; font-size: 10px; font-weight: 700; margin-left: 6px; }
     .room .btns { display: flex; gap: 6px; }
@@ -2416,9 +2461,42 @@ function setMapItemStatus(id, text) {
 
 // ── rendering ────────────────────────────────────────────────────────────
 function polyCentroid(pts) {
-    let sx = 0, sy = 0;
-    for (const [x, y] of pts) { sx += x; sy += y; }
-    return [sx / pts.length, sy / pts.length];
+    // Area-weighted polygon centroid. Averaging vertices visibly shifts labels
+    // for irregular rooms because densely sampled edges receive extra weight.
+    let twiceArea = 0, sx = 0, sy = 0;
+    for (let i = 0; i < pts.length; i++) {
+        const [x0, y0] = pts[i];
+        const [x1, y1] = pts[(i + 1) % pts.length];
+        const cross = x0 * y1 - x1 * y0;
+        twiceArea += cross;
+        sx += (x0 + x1) * cross;
+        sy += (y0 + y1) * cross;
+    }
+    if (Math.abs(twiceArea) < 1e-9) {
+        const sum = pts.reduce(([x, y], p) => [x + p[0], y + p[1]], [0, 0]);
+        return [sum[0] / pts.length, sum[1] / pts.length];
+    }
+    return [sx / (3 * twiceArea), sy / (3 * twiceArea)];
+}
+
+const ROOM_COLORS = [
+    { stroke:'#63a7ff', fill:'rgba(99,167,255,.18)', label:'#d8e9ff' },
+    { stroke:'#5fd6a7', fill:'rgba(95,214,167,.18)', label:'#d2f8e9' },
+    { stroke:'#f0aa5d', fill:'rgba(240,170,93,.18)', label:'#ffe7cd' },
+    { stroke:'#c58cff', fill:'rgba(197,140,255,.18)', label:'#eedcff' },
+    { stroke:'#ef7f9c', fill:'rgba(239,127,156,.18)', label:'#ffd9e3' },
+    { stroke:'#55c8dd', fill:'rgba(85,200,221,.18)', label:'#d4f7fc' },
+    { stroke:'#d5c456', fill:'rgba(213,196,86,.18)', label:'#fff6bd' },
+    { stroke:'#8fcf66', fill:'rgba(143,207,102,.18)', label:'#e3f8d5' },
+];
+function roomColor(annotation) {
+    const key = String(annotation.annotation_id || annotation.name || 'room');
+    let hash = 2166136261;
+    for (let i = 0; i < key.length; i++) {
+        hash ^= key.charCodeAt(i);
+        hash = Math.imul(hash, 16777619);
+    }
+    return ROOM_COLORS[(hash >>> 0) % ROOM_COLORS.length];
 }
 
 function draw() {
@@ -2468,19 +2546,20 @@ function draw() {
         pts.forEach(([x, y], i) => i ? ctx.lineTo(x, y) : ctx.moveTo(x, y));
         ctx.closePath();
         const sel = a.annotation_id === selectedId;
-        ctx.fillStyle = a.stale ? 'rgba(230,196,84,0.10)' : 'rgba(122,167,255,0.12)';
+        const color = roomColor(a);
+        ctx.fillStyle = a.stale ? 'rgba(230,196,84,0.12)' : color.fill;
         ctx.fill();
         ctx.lineWidth = sel ? 2.5 : 1.5;
-        ctx.strokeStyle = a.stale ? '#e6c454' : (sel ? '#a8c4ff' : '#7aa7ff');
+        ctx.strokeStyle = a.stale ? '#e6c454' : color.stroke;
         ctx.setLineDash(a.stale ? [6, 4] : []);
         ctx.stroke();
         ctx.setLineDash([]);
         const [cx, cy] = w2p(...polyCentroid(a.points));
         const label = (a.stale ? '⚠ ' : '') + (a.name || '(unnamed)');
-        ctx.font = 'bold 13px sans-serif'; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
-        ctx.lineWidth = 3; ctx.strokeStyle = 'rgba(0,0,0,0.85)';
+        ctx.font = '700 15px sans-serif'; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+        ctx.lineWidth = 5; ctx.strokeStyle = 'rgba(0,0,0,0.92)';
         ctx.strokeText(label, cx, cy);
-        ctx.fillStyle = a.stale ? '#e6c454' : '#cfe0ff';
+        ctx.fillStyle = a.stale ? '#f4dc78' : color.label;
         ctx.fillText(label, cx, cy);
         ctx.textAlign = 'start';
     }
@@ -2777,8 +2856,8 @@ function renderPanel() {
     }
     list.innerHTML = rooms.map(a => `
       <div class="room ${a.annotation_id === selectedId ? 'selected' : ''}"
-           data-id="${a.annotation_id}">
-        <span class="name">${esc(a.name || '(unnamed)')}</span>
+           data-id="${a.annotation_id}" style="--room-color:${roomColor(a).stroke}">
+        <span class="swatch" aria-hidden="true"></span><span class="name">${esc(a.name || '(unnamed)')}</span>
         ${a.stale ? '<span class="badge" title="' + esc(a.stale_reason) + '">STALE</span>' : ''}
         <div class="sub">${a.points.length} corners</div>
         <div class="btns">

--- a/system/scene/scene_service/web.py
+++ b/system/scene/scene_service/web.py
@@ -870,6 +870,26 @@ def make_app(*, registry: ObjectRegistry,
         if not map_id:
             return _anno_error(400, "map_id is required")
         out = await asyncio.to_thread(_map_rpc, "delete_map", {"map_id": map_id})
+        if out.get("ok"):
+            annotations_deleted = False
+            objects_deleted = 0
+            cleanup_errors = []
+            if anno_store is not None:
+                try:
+                    annotations_deleted = bool(anno_store.delete_map(map_id))
+                except Exception as e:  # noqa: BLE001
+                    cleanup_errors.append(f"annotations: {e}")
+            if object_store is not None:
+                try:
+                    objects_deleted = int(await asyncio.to_thread(object_store.delete_map, map_id))
+                except Exception as e:  # noqa: BLE001
+                    cleanup_errors.append(f"objects: {e}")
+            out["scene_cleanup"] = {
+                "annotations_deleted": annotations_deleted,
+                "objects_deleted": objects_deleted,
+            }
+            if cleanup_errors:
+                out["scene_cleanup_error"] = "; ".join(cleanup_errors)
         return JSONResponse(out, status_code=200 if out.get("ok") else 502)
 
     async def maps_pose_estimate(request) -> JSONResponse:

--- a/system/scene/scene_service/web.py
+++ b/system/scene/scene_service/web.py
@@ -15,9 +15,13 @@ the JSON will grow an `occupancy:` field that the canvas overlays).
 """
 from __future__ import annotations
 
+import asyncio
+import math
 import base64
 import io
+import json
 import logging
+import os
 import time
 from pathlib import Path
 from typing import Any, Optional
@@ -26,6 +30,8 @@ from starlette.applications import Starlette
 from starlette.responses import HTMLResponse, JSONResponse
 from starlette.routing import Mount, Route
 from starlette.staticfiles import StaticFiles
+
+from robonix_api import ATLAS
 
 from .annotations import validate_annotation_fields
 from .state import ObjectRegistry
@@ -454,9 +460,116 @@ def _sync_snapshot(registry: ObjectRegistry):
     return dict(registry._objects), dict(registry._surfaces)  # noqa: SLF001
 
 
+_MAP_RPC = {
+    "list_maps": (
+        "robonix/service/map/list_maps",
+        "RobonixServiceMapListMapsStub",
+        "ListMaps",
+        "ListMaps_Request",
+    ),
+    "save_map": (
+        "robonix/service/map/save_map",
+        "RobonixServiceMapSaveMapStub",
+        "SaveMap",
+        "SaveMap_Request",
+    ),
+    "load_map": (
+        "robonix/service/map/load_map",
+        "RobonixServiceMapLoadMapStub",
+        "LoadMap",
+        "LoadMap_Request",
+    ),
+    "delete_map": (
+        "robonix/service/map/delete_map",
+        "RobonixServiceMapDeleteMapStub",
+        "DeleteMap",
+        "DeleteMap_Request",
+    ),
+    "pose_estimate": (
+        "robonix/service/map/pose_estimate",
+        "RobonixServiceMapPoseEstimateStub",
+        "PoseEstimate",
+        "PoseEstimate_Request",
+    ),
+    "get_pose": (
+        "robonix/service/map/get_pose",
+        "RobonixServiceMapGetPoseStub",
+        "GetPose",
+        "GetPose_Request",
+    ),
+    "get_mode": (
+        "robonix/service/map/get_mode",
+        "RobonixServiceMapGetModeStub",
+        "GetMode",
+        "GetMode_Request",
+    ),
+}
+
+
+def _pb_to_dict(resp: Any) -> dict:
+    out: dict[str, Any] = {}
+    for field, value in resp.ListFields():
+        out[field.name] = value
+    return out
+
+
+def _map_rpc(op: str, payload: Optional[dict] = None, timeout_s: float = 20.0) -> dict:
+    """Call mapping through the standard robonix/service/map capability.
+
+    The user page talks only to scene HTTP. Scene then resolves mapping via
+    Atlas + gRPC so this does not depend on mapping's debug Web UI or shared
+    container paths.
+    """
+    import grpc  # lazy: web debug imports should not fail without grpc
+    import map_pb2  # type: ignore
+    import robonix_contracts_pb2_grpc as contracts_grpc  # type: ignore
+
+    contract_id, stub_name, method_name, req_name = _MAP_RPC[op]
+    caps = ATLAS.find_capability(contract_id=contract_id, transport="grpc")
+    if not caps:
+        return {"ok": False, "detail": f"no provider for {contract_id}"}
+    cap = caps[0]
+    channel_ref = ATLAS.connect_capability(
+        consumer_id="scene",
+        provider_id=cap.provider_id,
+        contract_id=contract_id,
+        transport="grpc",
+    )
+    try:
+        endpoint = (channel_ref.endpoint or "").strip()
+        if not endpoint:
+            return {"ok": False, "detail": f"{contract_id} resolved to an empty endpoint"}
+        with grpc.insecure_channel(endpoint) as grpc_channel:
+            stub = getattr(contracts_grpc, stub_name)(grpc_channel)
+            req = getattr(map_pb2, req_name)(**(payload or {}))
+            resp = getattr(stub, method_name)(req, timeout=timeout_s)
+        return _pb_to_dict(resp)
+    except grpc.RpcError as e:
+        return {"ok": False, "detail": f"{contract_id} rpc failed: {e.code().name}: {e.details()}"}
+    except Exception as e:  # noqa: BLE001
+        log.exception("scene map rpc %s failed", contract_id)
+        return {"ok": False, "detail": str(e)}
+    finally:
+        channel_ref.close()
+
+
+def _maps_payload() -> dict:
+    out = _map_rpc("list_maps", {})
+    maps = []
+    if out.get("ok"):
+        try:
+            maps = json.loads(str(out.get("maps_json") or "[]"))
+            if not isinstance(maps, list):
+                maps = []
+        except Exception as e:  # noqa: BLE001
+            out = {"ok": False, "detail": f"invalid maps_json from mapping: {e}"}
+    return {"ok": bool(out.get("ok")), "detail": out.get("detail", ""), "maps": maps}
+
+
 def make_app(*, registry: ObjectRegistry,
              hub: Any = None, detector: Any = None,
              sg_store: Any = None, anno_store: Any = None,
+             object_store: Any = None,
              map_binding: Optional[dict] = None) -> Starlette:
     """Build the Starlette ASGI app the entrypoint mounts on its own
     uvicorn server.
@@ -472,6 +585,7 @@ def make_app(*, registry: ObjectRegistry,
       GET /api/objects3d   — JSON for the 3D viz (per-object pcd + bbox)
       GET /api/camera      — JSON: latest RGB + depth frames
       /api/annotations[..] — user annotation CRUD (see below)
+      /api/maps[..]        — scene-owned map library façade over map capabilities
 
     `hub` is the SubscribersHub — passed so the JSON state can include
     the latest OccupancyGrid for the 2D canvas underlay.
@@ -480,8 +594,10 @@ def make_app(*, registry: ObjectRegistry,
     just shows an empty world.
     `anno_store` is the AnnotationStore backing the annotation CRUD; when
     None (store init failed / disabled) those routes answer 503.
-    `map_binding` is a static {map_id, mode, generation, source} dict shown
-    by the /user page header.
+    `object_store` is the per-map scene object warm-restore store; Save/Load
+    rebinds it so perceived objects follow the same map id as rooms.
+    `map_binding` is a mutable {map_id, mode, generation, source} dict shown
+    by the /user page header and updated by Save/Load actions.
 
     Annotation API contract (STABLE once shipped — any frontend builds on
     it; see system/scene/README.md):
@@ -501,6 +617,38 @@ def make_app(*, registry: ObjectRegistry,
     meters. Same trust domain as the rest of this LAN debug/UI server —
     no auth.
     """
+    if map_binding is None:
+        map_binding = {}
+
+    async def _persist_scene_objects(map_id: str) -> int:
+        if object_store is None:
+            return 0
+        if hasattr(object_store, "rebind"):
+            object_store.rebind(map_id)
+        objs, _surfs = await registry.snapshot()
+        pairs = [(o, None) for o in objs.values() if not getattr(o, "missing", False)]
+        if not pairs:
+            return 0
+        return int(await asyncio.to_thread(object_store.persist, pairs))
+
+    async def _restore_scene_objects(map_id: str) -> int:
+        if object_store is None:
+            return 0
+        if hasattr(object_store, "rebind"):
+            object_store.rebind(map_id)
+        restored = await asyncio.to_thread(object_store.load_all)
+        async with registry.lock():
+            for o in restored:
+                registry.restore_object(o)
+        return len(restored)
+
+    def _set_map_binding(map_id: str, mode: str, source: str) -> None:
+        map_binding.update({
+            "map_id": map_id,
+            "mode": mode,
+            "generation": None,
+            "source": source,
+        })
 
     async def index(_request) -> HTMLResponse:
         # Combined split layout: 2D map left, 3D viz right, each with
@@ -600,6 +748,192 @@ def make_app(*, registry: ObjectRegistry,
             return _anno_error(404, f"unknown annotation id {ann_id!r}")
         return JSONResponse({"ok": True})
 
+    async def maps_list(_request) -> JSONResponse:
+        return JSONResponse(await asyncio.to_thread(_maps_payload))
+
+    def _map_exists_in_payload(payload: dict, map_id: str) -> tuple[bool, dict]:
+        for item in payload.get("maps", []):
+            if item.get("map_id") == map_id and item.get("has_spatial_artifact"):
+                return True, item
+        return False, {}
+
+    async def maps_save(request) -> JSONResponse:
+        body = await _anno_body(request)
+        if body is None:
+            return _anno_error(400, "request body must be a JSON object")
+        map_id = str(body.get("map_id") or "").strip()
+        if not map_id:
+            return _anno_error(400, "map_id is required")
+        note = str(body.get("note") or "")
+        before_payload = await asyncio.to_thread(_maps_payload)
+        spatial_exists, existing_map = _map_exists_in_payload(before_payload, map_id)
+        current_bound_id = str(map_binding.get("map_id") or "")
+        current_mode = str(map_binding.get("mode") or "")
+        if spatial_exists:
+            if current_bound_id and current_bound_id != map_id:
+                return _anno_error(409, f"spatial map {map_id} already exists; load it before updating scene annotations/objects")
+            out = {
+                "ok": True,
+                "map_id": map_id,
+                "detail": f"spatial map {map_id} already exists; saved scene annotations/objects only",
+                "spatial_unchanged": True,
+            }
+        else:
+            save_timeout_s = float(os.environ.get("SCENE_MAP_SAVE_TIMEOUT_S", "300"))
+            out = await asyncio.to_thread(
+                _map_rpc,
+                "save_map",
+                {"map_id": map_id, "note": note},
+                save_timeout_s,
+            )
+        object_count = 0
+        object_persist_error = None
+        if out.get("ok"):
+            if anno_store is not None:
+                anno_store.rebind(map_id, generation=None, carry_current=True)
+            try:
+                object_count = await _persist_scene_objects(map_id)
+                out["objects"] = object_count
+            except Exception as e:  # noqa: BLE001
+                object_persist_error = str(e)
+                out["object_persist_error"] = object_persist_error
+            mode_after_save = current_mode if spatial_exists and current_bound_id == map_id and current_mode else "mapping"
+            _set_map_binding(map_id, mode_after_save, "ui_save")
+
+        annotations = anno_store.list_json() if anno_store is not None else []
+        out.setdefault("annotations", len(annotations))
+        if out.get("ok"):
+            maps_payload = await asyncio.to_thread(_maps_payload)
+            saved_map = None
+            for item in maps_payload.get("maps", []):
+                if item.get("map_id") == map_id:
+                    saved_map = item
+                    break
+            validation = {
+                "map_id": map_id,
+                "spatial_ok": bool(saved_map and saved_map.get("has_spatial_artifact") and saved_map.get("spatial_ok") is not False),
+                "artifact_detail": (saved_map or {}).get("artifact_detail") or maps_payload.get("detail") or "map not found after save",
+                "artifact_size": (saved_map or {}).get("artifact_size"),
+                "has_preview": bool(saved_map and saved_map.get("has_preview")),
+                "updated": (saved_map or {}).get("updated"),
+                "object_count": int(object_count or 0),
+                "room_count": sum(1 for a in annotations if a.get("kind") == "room"),
+                "annotation_count": len(annotations),
+                "paths": {
+                    "map_artifact": (saved_map or {}).get("artifact_path") or "not exposed by map provider",
+                    "preview": (saved_map or {}).get("preview_path") or "not exposed by map provider",
+                    "scene_annotations": str(anno_store.path) if anno_store is not None else "annotation store unavailable",
+                },
+                "log": [
+                    f"save_map returned ok={bool(out.get('ok'))}: {out.get('detail') or ''}",
+                    f"map list validation ok={bool(maps_payload.get('ok'))}",
+                    f"spatial artifact check: {(saved_map or {}).get('artifact_detail') or maps_payload.get('detail') or 'unknown'}",
+                ],
+            }
+            if object_persist_error:
+                validation["log"].append(f"object persistence error: {object_persist_error}")
+            out["validation"] = validation
+        return JSONResponse(out, status_code=200 if out.get("ok") else 502)
+
+    async def maps_load(request) -> JSONResponse:
+        body = await _anno_body(request)
+        if body is None:
+            return _anno_error(400, "request body must be a JSON object")
+        map_id = str(body.get("map_id") or "").strip()
+        if not map_id:
+            return _anno_error(400, "map_id is required")
+        mode = str(body.get("mode") or "localization")
+        load_timeout_s = float(os.environ.get("SCENE_MAP_LOAD_TIMEOUT_S", "240"))
+        out = await asyncio.to_thread(_map_rpc, "load_map", {
+            "map_id": map_id,
+            "mode": mode,
+            "has_initial_pose": bool(body.get("has_initial_pose", False)),
+            "x": float(body.get("x") or 0.0),
+            "y": float(body.get("y") or 0.0),
+            "theta": float(body.get("theta") or 0.0),
+        }, load_timeout_s)
+        if out.get("ok"):
+            if anno_store is not None:
+                anno_store.rebind(map_id, generation=None, carry_current=False)
+            try:
+                out["objects_restored"] = await _restore_scene_objects(map_id)
+            except Exception as e:  # noqa: BLE001
+                out["object_restore_error"] = str(e)
+            _set_map_binding(map_id, "localization", "ui_load")
+        return JSONResponse(out, status_code=200 if out.get("ok") else 502)
+
+    async def maps_delete(request) -> JSONResponse:
+        body = await _anno_body(request)
+        if body is None:
+            return _anno_error(400, "request body must be a JSON object")
+        map_id = str(body.get("map_id") or "").strip()
+        if not map_id:
+            return _anno_error(400, "map_id is required")
+        out = await asyncio.to_thread(_map_rpc, "delete_map", {"map_id": map_id})
+        return JSONResponse(out, status_code=200 if out.get("ok") else 502)
+
+    async def maps_pose_estimate(request) -> JSONResponse:
+        body = await _anno_body(request)
+        if body is None:
+            return _anno_error(400, "request body must be a JSON object")
+        try:
+            payload = {
+                "x": float(body.get("x")),
+                "y": float(body.get("y")),
+                "theta": float(body.get("theta") or 0.0),
+                "cov_xy": float(body.get("cov_xy") or 0.0),
+                "cov_theta": float(body.get("cov_theta") or 0.0),
+            }
+            if not all(math.isfinite(float(payload[k])) for k in ("x", "y", "theta", "cov_xy", "cov_theta")):
+                raise ValueError("non-finite pose")
+        except Exception:
+            return _anno_error(400, "x/y/theta must be finite numbers")
+
+        def _pose_delta(pose: dict) -> Optional[dict]:
+            if not pose.get("ok"):
+                return None
+            dx = float(pose.get("x", 0.0)) - payload["x"]
+            dy = float(pose.get("y", 0.0)) - payload["y"]
+            dtheta = math.atan2(
+                math.sin(float(pose.get("theta", 0.0)) - payload["theta"]),
+                math.cos(float(pose.get("theta", 0.0)) - payload["theta"]),
+            )
+            return {
+                "dx": dx,
+                "dy": dy,
+                "dtheta": dtheta,
+                "distance_m": math.hypot(dx, dy),
+                "abs_yaw_rad": abs(dtheta),
+            }
+
+        mode_info = await asyncio.to_thread(_map_rpc, "get_mode", {}, 3.0)
+        before = await asyncio.to_thread(_map_rpc, "get_pose", {}, 3.0)
+        out = await asyncio.to_thread(_map_rpc, "pose_estimate", payload)
+        # RTAB-Map relocalization is not instantaneous. Give the pose adapter a
+        # short beat so the UI can show an immediate convergence hint instead
+        # of only "published".
+        await asyncio.sleep(float(os.environ.get("SCENE_POSE_ESTIMATE_FEEDBACK_DELAY_S", "1.2")))
+        after = await asyncio.to_thread(_map_rpc, "get_pose", {}, 3.0)
+        out["requested_pose"] = payload
+        out["mode"] = mode_info
+        out["pose_before"] = before
+        out["pose_after"] = after
+        out["delta_before"] = _pose_delta(before)
+        out["delta_after"] = _pose_delta(after)
+        if out.get("ok"):
+            if after.get("ok") and out["delta_after"]:
+                d = out["delta_after"]
+                mode = str(mode_info.get("mode") or "unknown") if mode_info.get("ok") else "unknown"
+                suffix = "" if mode == "localization" else f"; mode={mode}, pose estimate may not relocalize until a map is loaded in localization mode"
+                out["detail"] = (
+                    f"pose estimate sent to ({payload['x']:.2f}, {payload['y']:.2f}, {payload['theta']:.2f}); "
+                    f"current error {d['distance_m']:.2f} m, yaw {d['abs_yaw_rad']:.2f} rad"
+                    f"{suffix}"
+                )
+            else:
+                out["detail"] = (out.get("detail") or "pose estimate sent") + "; current pose not available yet"
+        return JSONResponse(out, status_code=200 if out.get("ok") else 502)
+
     async def index3d(_request) -> HTMLResponse:
         return HTMLResponse(_INDEX_3D_HTML)
 
@@ -638,6 +972,11 @@ def make_app(*, registry: ObjectRegistry,
               methods=["PUT"]),
         Route("/api/annotations/{annotation_id}", annotations_delete,
               methods=["DELETE"]),
+        Route("/api/maps", maps_list, methods=["GET"]),
+        Route("/api/maps/save", maps_save, methods=["POST"]),
+        Route("/api/maps/load", maps_load, methods=["POST"]),
+        Route("/api/maps/delete", maps_delete, methods=["POST"]),
+        Route("/api/maps/pose_estimate", maps_pose_estimate, methods=["POST"]),
     ]
     if static_dir.is_dir():
         routes.append(Mount("/static", StaticFiles(directory=str(static_dir)), name="static"))
@@ -1859,6 +2198,26 @@ _USER_HTML = r"""<!doctype html>
     #panel { width: 260px; flex: none; background: var(--panel);
       border-right: 1px solid #232936; display: flex; flex-direction: column; }
     #panel .actions { padding: 12px; border-bottom: 1px solid #232936; }
+    #map-tools { padding: 10px 12px; border-bottom: 1px solid #232936; display: grid; gap: 8px; }
+    #map-tools label { display: grid; gap: 4px; color: var(--muted); font-size: 11px; }
+    #map-id { width: 100%; box-sizing: border-box; border: 1px solid #33405a; border-radius: 6px;
+      background: #0f131b; color: var(--fg); padding: 6px 8px; font-size: 12px; }
+    #map-actions, .map-btns { display: flex; gap: 6px; flex-wrap: wrap; }
+    #map-status { min-height: 16px; color: var(--muted); font-size: 11px; overflow-wrap: anywhere; }
+    #map-status.busy { color: var(--acc); }
+    #map-status.ok { color: #8ef0b7; }
+    #map-status.err { color: var(--danger); }
+    #mode-pill { display: inline-block; margin-left: 8px; padding: 1px 6px; border-radius: 999px;
+      border: 1px solid #33405a; color: var(--muted); font-size: 11px; }
+    #mode-pill.localization { border-color: #3b633f; color: #8ef0b7; background: rgba(64,150,80,.12); }
+    #mode-pill.mapping { border-color: #6a5630; color: var(--warn); background: rgba(230,196,84,.10); }
+    #map-list { display: grid; gap: 6px; max-height: 170px; overflow-y: auto; }
+    .mapitem { border: 1px solid #232936; border-radius: 8px; padding: 7px 8px; font-size: 12px; background: #121721; cursor: pointer; }
+    .mapitem.selected, .mapitem.busy { border-color: var(--acc); }
+    .mapitem .name { font-weight: 700; }
+    .mapitem .sub { color: var(--muted); font-size: 10px; margin: 2px 0 6px; overflow-wrap: anywhere; }
+    .mapitem .map-status { color: var(--acc); font-size: 10px; min-height: 12px; margin-top: 4px; }
+    button:disabled { opacity: .55; cursor: progress; }
     button { background: #222a3a; color: var(--fg); border: 1px solid #33405a;
       border-radius: 6px; padding: 6px 10px; font-size: 12px; cursor: pointer; }
     button:hover { background: #2a3550; }
@@ -1887,6 +2246,24 @@ _USER_HTML = r"""<!doctype html>
       color: var(--muted); background: rgba(20,23,31,.85); padding: 4px 8px;
       border-radius: 4px; }
     #empty { padding: 10px 2px; color: var(--muted); font-size: 12px; }
+    dialog.modal { width: min(360px, calc(100vw - 32px)); border: 1px solid #33405a;
+      border-radius: 10px; padding: 0; background: #151a23; color: var(--fg);
+      box-shadow: 0 18px 70px rgba(0,0,0,.55); }
+    dialog.modal::backdrop { background: rgba(0,0,0,.55); }
+    .modal-body { padding: 16px; display: grid; gap: 12px; }
+    .modal-title { font-weight: 700; font-size: 14px; }
+    .modal-message { color: var(--muted); font-size: 12px; line-height: 1.45; }
+    .modal-input { width: 100%; box-sizing: border-box; border: 1px solid #33405a;
+      border-radius: 7px; background: #0f131b; color: var(--fg); padding: 8px 10px;
+      font-size: 13px; outline: none; }
+    .modal-actions { display: flex; justify-content: flex-end; gap: 8px; }
+    dialog.report-modal { width: min(720px, calc(100vw - 32px)); }
+    .save-report-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+    .save-report-preview { width: 100%; max-height: 300px; object-fit: contain; border: 1px solid #33405a; border-radius: 8px; background: #0e1015; }
+    .save-report-kv { display: grid; grid-template-columns: 120px 1fr; gap: 5px 10px; font-size: 12px; align-content: start; }
+    .save-report-kv .k { color: var(--muted); }
+    .save-report-kv .v { overflow-wrap: anywhere; }
+    .save-report-log { margin: 8px 0 0; padding: 8px; border: 1px solid #283243; border-radius: 8px; background: #0f131b; color: #c9d1d9; font: 11px/1.45 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; white-space: pre-wrap; max-height: 130px; overflow: auto; }
   </style>
 </head>
 <body>
@@ -1898,6 +2275,16 @@ _USER_HTML = r"""<!doctype html>
   </header>
   <div id="main">
     <div id="panel">
+      <div id="map-tools">
+        <label>Map ID<input id="map-id" placeholder="apartment_demo" /></label>
+        <div id="map-actions">
+          <button class="primary" id="btn-save-map">Save current</button>
+          <button id="btn-refresh-maps">Refresh</button>
+          <button id="btn-pose-estimate">Pose estimate</button>
+        </div>
+        <div id="map-status"><span id="map-status-msg">Ready.</span><span class="mode-label">Map mode:</span><span id="mode-pill">unknown</span></div>
+        <div id="map-list"><div id="empty">No saved maps listed yet.</div></div>
+      </div>
       <div class="actions">
         <button class="primary" id="btn-draw">✏ Annotate room</button>
       </div>
@@ -1913,6 +2300,30 @@ _USER_HTML = r"""<!doctype html>
     </div>
   </div>
 </div>
+<dialog class="modal" id="room-modal">
+  <form method="dialog" class="modal-body">
+    <div class="modal-title" id="room-modal-title">Room</div>
+    <div class="modal-message" id="room-modal-message"></div>
+    <input class="modal-input" id="room-modal-input" autocomplete="off" />
+    <div class="modal-actions">
+      <button id="room-modal-cancel" value="cancel">Cancel</button>
+      <button class="primary" id="room-modal-ok" value="ok">OK</button>
+    </div>
+  </form>
+</dialog>
+<dialog class="modal report-modal" id="save-modal">
+  <form method="dialog" class="modal-body">
+    <div class="modal-title" id="save-modal-title">Save report</div>
+    <div class="save-report-grid">
+      <img class="save-report-preview" id="save-report-preview" alt="saved map preview" />
+      <div class="save-report-kv" id="save-report-kv"></div>
+    </div>
+    <pre class="save-report-log" id="save-report-log"></pre>
+    <div class="modal-actions">
+      <button class="primary" value="ok">OK</button>
+    </div>
+  </form>
+</dialog>
 <script>
 const c = document.getElementById('c');
 const ctx = c.getContext('2d');
@@ -1942,6 +2353,11 @@ let draft = [];            // in-progress polygon vertices (world coords)
 let mouseWorld = null;     // live cursor position for the rubber-band edge
 let hoverObj = null;
 let selectedId = null;
+let selectedMapId = null;
+let savedMaps = [];
+let mapBusy = false;
+let poseEstimateMode = false;
+let draftSubmitting = false;
 
 const hintEl = document.getElementById('hint');
 function setHint(text) {
@@ -1954,6 +2370,28 @@ function toast(text) {
     t.textContent = text; t.style.display = 'block';
     clearTimeout(toastTimer);
     toastTimer = setTimeout(() => { t.style.display = 'none'; }, 4000);
+}
+function setMapStatus(text, kind = '') {
+    const el = document.getElementById('map-status');
+    const msg = document.getElementById('map-status-msg');
+    if (!el || !msg) return;
+    el.className = kind;
+    msg.textContent = text || 'Ready.';
+}
+function setMapBusy(on, label = '') {
+    mapBusy = on;
+    document.querySelectorAll('#map-tools button, .map-btns button').forEach(b => b.disabled = on);
+    if (label) setMapStatus(label, on ? 'busy' : '');
+}
+function mapItemFor(id) {
+    return Array.from(document.querySelectorAll('.mapitem')).find(el => el.dataset.id === id);
+}
+function setMapItemStatus(id, text) {
+    const item = mapItemFor(id);
+    if (!item) return;
+    item.classList.toggle('busy', Boolean(text));
+    const st = item.querySelector('.map-status');
+    if (st) st.textContent = text || '';
 }
 
 // ── rendering ────────────────────────────────────────────────────────────
@@ -2076,10 +2514,235 @@ function draw() {
     }
 }
 
+function showSaveReport(out, previewDataUrl) {
+    const validation = (out && out.validation) || {};
+    const modal = document.getElementById('save-modal');
+    const title = document.getElementById('save-modal-title');
+    const img = document.getElementById('save-report-preview');
+    const kv = document.getElementById('save-report-kv');
+    const log = document.getElementById('save-report-log');
+    const status = validation.spatial_ok ? 'OK' : 'FAILED';
+    title.textContent = `Save report · ${status}`;
+    img.src = previewDataUrl || '';
+    const paths = validation.paths || {};
+    const rows = [
+        ['Map ID', validation.map_id || out.map_id || '-'],
+        ['Spatial artifact', validation.spatial_ok ? 'ok' : (validation.artifact_detail || 'failed')],
+        ['Artifact size', validation.artifact_size ? `${validation.artifact_size} bytes` : '-'],
+        ['Objects', validation.object_count ?? out.objects ?? '-'],
+        ['Rooms', validation.room_count ?? '-'],
+        ['Annotations', validation.annotation_count ?? out.annotations ?? '-'],
+        ['Updated', validation.updated || '-'],
+        ['Artifact path', paths.map_artifact || '-'],
+        ['Preview path', paths.preview || '-'],
+        ['Room JSON', paths.scene_annotations || '-'],
+    ];
+    kv.innerHTML = rows.map(([k, v]) => `<div class="k">${esc(k)}</div><div class="v">${esc(v)}</div>`).join('');
+    log.textContent = (validation.log || []).join('\n') || 'no save log returned';
+    if (typeof modal.showModal === 'function') modal.showModal();
+    else modal.setAttribute('open', '');
+}
+
+// ── map library ──────────────────────────────────────────────────────────
+function preferredMapId() {
+    const input = document.getElementById('map-id');
+    const typed = input && input.value.trim();
+    const bound = state && state.map_binding && state.map_binding.map_id;
+    return typed || bound || 'default';
+}
+function renderMaps() {
+    const list = document.getElementById('map-list');
+    if (!list) return;
+    if (!savedMaps.length) {
+        list.innerHTML = '<div id="empty">No saved maps listed yet.</div>';
+        return;
+    }
+    list.innerHTML = savedMaps.map(m => {
+        const dbLabel = !m.has_spatial_artifact ? 'no spatial artifact' : (m.spatial_ok === false ? 'invalid artifact' : 'spatial artifact');
+        const dbTitle = m.artifact_detail ? ` title="${esc(m.artifact_detail)}"` : '';
+        const canLoad = m.has_spatial_artifact && m.spatial_ok !== false;
+        return `
+      <div class="mapitem ${m.map_id === selectedMapId ? 'selected' : ''} ${canLoad ? '' : 'bad'}" data-id="${esc(m.map_id)}">
+        <div class="name">${esc(m.map_id)}</div>
+        <div class="sub"${dbTitle}>${dbLabel} · ${m.has_preview ? 'preview' : 'no preview'} · ${m.updated || '-'}</div>
+        <div class="map-btns">
+          <button class="small" data-map-act="load" ${canLoad ? '' : 'disabled'}>Load</button>
+          <button class="small danger" data-map-act="delete">Delete</button>
+        </div>
+        <div class="map-status">${canLoad ? '' : esc(m.artifact_detail || 'not loadable')}</div>
+      </div>`;
+    }).join('');
+}
+async function loadMaps() {
+    try {
+        const r = await fetch('/api/maps', { cache: 'no-store' });
+        const out = await r.json();
+        if (!r.ok || !out.ok) { toast(out.detail || 'list maps failed'); return; }
+        savedMaps = out.maps || [];
+        renderMaps();
+    } catch (e) { toast('list maps failed: ' + e); }
+}
+async function saveCurrentMap() {
+    if (mapBusy) return;
+    const id = preferredMapId();
+    document.getElementById('map-id').value = id;
+    selectedMapId = id; renderMaps();
+    draw();
+    const previewDataUrl = c.toDataURL('image/png');
+    setMapBusy(true, `Saving map ${id}...`);
+    toast(`Saving map ${id}...`);
+    const out = await api('POST', '/api/maps/save', { map_id: id, note: 'saved from scene user page' });
+    setMapBusy(false);
+    if (out) {
+        const validation = out.validation || {};
+        const ok = validation.spatial_ok !== false && validation.has_preview !== false;
+        const semanticOnly = Boolean(out.spatial_unchanged);
+        setMapStatus(`${semanticOnly ? 'Updated scene data for' : 'Saved'} ${out.map_id || id}; spatial artifact ${ok ? 'ok' : 'failed'}; rooms ${validation.room_count ?? '-'}.`, ok ? 'ok' : 'err');
+        toast((semanticOnly ? 'updated scene data for ' : 'saved map ') + (out.map_id || id));
+        await loadMaps();
+        showSaveReport(out, previewDataUrl);
+    }
+    else setMapStatus(`Save ${id} failed. See toast/log for details.`, 'err');
+}
+async function loadSelectedMap(id) {
+    if (mapBusy) return;
+    selectedMapId = id;
+    document.getElementById('map-id').value = id;
+    renderMaps();
+    setMapItemStatus(id, 'loading...');
+    setMapBusy(true, `Loading ${id}; switching mapping to localization mode...`);
+    toast(`Loading ${id}; switching to localization mode...`);
+    const out = await api('POST', '/api/maps/load', { map_id: id, mode: 'localization' });
+    setMapBusy(false);
+    setMapItemStatus(id, '');
+    if (out) {
+        setMapStatus(`Loaded ${id}. Mapping requested localization mode; use Pose estimate if the robot pose is off.`, 'ok');
+        toast('loaded map ' + id + ' · localization mode requested');
+        await loadMaps();
+    } else {
+        setMapStatus(`Load ${id} failed. See toast/log for details.`, 'err');
+    }
+}
+async function deleteSelectedMap(id) {
+    if (mapBusy) return;
+    if (!(await askConfirm('Delete map', `Delete map “${id}”?`))) return;
+    setMapItemStatus(id, 'deleting...');
+    setMapBusy(true, `Deleting map ${id}...`);
+    const out = await api('POST', '/api/maps/delete', { map_id: id });
+    setMapBusy(false);
+    if (out) { setMapStatus(`Deleted ${id}.`, 'ok'); toast('deleted map ' + id); await loadMaps(); }
+    else { setMapItemStatus(id, ''); setMapStatus(`Delete ${id} failed.`, 'err'); }
+}
+function setPoseEstimateMode(on) {
+    poseEstimateMode = on;
+    const btn = document.getElementById('btn-pose-estimate');
+    if (btn) {
+        btn.classList.toggle('primary', on);
+        btn.textContent = on ? 'Click pose on map' : 'Pose estimate';
+    }
+    setHint(on ? 'Click the robot position on the map to publish /initialpose. Heading defaults to 0; refine later with orientation UI.' : '');
+    c.style.cursor = on ? 'crosshair' : (drawMode ? 'crosshair' : 'grab');
+}
+function poseDeltaText(delta) {
+    if (!delta) return 'pose feedback unavailable';
+    return `error ${Number(delta.distance_m || 0).toFixed(2)} m, yaw ${Number(delta.abs_yaw_rad || 0).toFixed(2)} rad`;
+}
+async function sendPoseEstimate(world) {
+    if (mapBusy || !world) return;
+    setPoseEstimateMode(false);
+    const x = world[0], y = world[1], theta = 0.0;
+    setMapBusy(true, `Publishing pose estimate (${x.toFixed(2)}, ${y.toFixed(2)}, ${theta.toFixed(2)})...`);
+    toast(`pose estimate: ${x.toFixed(2)}, ${y.toFixed(2)}`);
+    const out = await api('POST', '/api/maps/pose_estimate', { x, y, theta });
+    setMapBusy(false);
+    if (out) {
+        const msg = `${out.detail || 'Pose estimate sent.'}` +
+            (out.delta_before ? ` · before ${poseDeltaText(out.delta_before)}` : '') +
+            (out.delta_after ? ` · after ${poseDeltaText(out.delta_after)}` : '');
+        setMapStatus(msg, 'ok');
+        toast(out.detail || 'pose estimate sent');
+    } else setMapStatus(`Pose estimate failed for (${x.toFixed(2)}, ${y.toFixed(2)}).`, 'err');
+}
+document.getElementById('btn-save-map').addEventListener('click', saveCurrentMap);
+document.getElementById('btn-refresh-maps').addEventListener('click', async () => { setMapStatus('Refreshing maps...', 'busy'); await loadMaps(); setMapStatus('Map list refreshed.', 'ok'); });
+document.getElementById('btn-pose-estimate').addEventListener('click', () => setPoseEstimateMode(!poseEstimateMode));
+document.getElementById('map-list').addEventListener('click', (ev) => {
+    const item = ev.target.closest('.mapitem');
+    if (!item) return;
+    const id = item.dataset.id;
+    const act = ev.target.dataset && ev.target.dataset.mapAct;
+    if (!act) {
+        selectedMapId = id;
+        document.getElementById('map-id').value = id;
+        renderMaps();
+        setMapStatus(`Selected ${id}. Click Load to enter localization mode.`, 'ok');
+        return;
+    }
+    if (act === 'load') {
+        const m = savedMaps.find(x => x.map_id === id);
+        if (m && (!m.has_spatial_artifact || m.spatial_ok === false)) {
+            setMapStatus(`Map ${id} is not loadable: ${m.artifact_detail || 'invalid spatial artifact'}`, 'err');
+            return;
+        }
+        loadSelectedMap(id);
+    }
+    if (act === 'delete') deleteSelectedMap(id);
+});
+
 // ── side panel ───────────────────────────────────────────────────────────
 function esc(s) {
     return String(s).replace(/[&<>"']/g,
         ch => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch]));
+}
+
+const roomModal = document.getElementById('room-modal');
+const roomModalTitle = document.getElementById('room-modal-title');
+const roomModalMessage = document.getElementById('room-modal-message');
+const roomModalInput = document.getElementById('room-modal-input');
+const roomModalOk = document.getElementById('room-modal-ok');
+const roomModalCancel = document.getElementById('room-modal-cancel');
+
+function askModal({ title, message = '', defaultValue = '', input = true, okText = 'OK', danger = false }) {
+    return new Promise((resolve) => {
+        roomModalTitle.textContent = title;
+        roomModalMessage.textContent = message;
+        roomModalMessage.style.display = message ? 'block' : 'none';
+        roomModalInput.value = defaultValue || '';
+        roomModalInput.style.display = input ? 'block' : 'none';
+        roomModalOk.textContent = okText;
+        roomModalOk.classList.toggle('danger', danger);
+        let done = false;
+        const finish = (value) => {
+            if (done) return;
+            done = true;
+            roomModal.removeEventListener('close', onClose);
+            resolve(value);
+        };
+        const onClose = () => {
+            if (roomModal.returnValue === 'ok') {
+                finish(input ? roomModalInput.value.trim() : true);
+            } else {
+                finish(null);
+            }
+        };
+        roomModal.addEventListener('close', onClose, { once: true });
+        if (typeof roomModal.showModal === 'function') roomModal.showModal();
+        else roomModal.setAttribute('open', '');
+        if (input) {
+            roomModalInput.focus();
+            roomModalInput.select();
+        } else {
+            roomModalOk.focus();
+        }
+    });
+}
+
+function askRoomName(title, defaultValue = '') {
+    return askModal({ title, defaultValue, input: true, okText: 'Save' });
+}
+
+function askConfirm(title, message, okText = 'Delete') {
+    return askModal({ title, message, input: false, okText, danger: true });
 }
 function renderPanel() {
     const rooms = (state && state.annotations || []).filter(a => a.kind === 'room');
@@ -2114,12 +2777,12 @@ document.getElementById('room-list').addEventListener('click', async (ev) => {
     const room = (state.annotations || []).find(a => a.annotation_id === id);
     if (!room) return;
     if (act === 'rename') {
-        const name = prompt('Room name:', room.name);
-        if (name !== null) await api('PUT', '/api/annotations/' + id, { name });
+        const name = await askRoomName('Rename room', room.name);
+        if (name !== null && name) await api('PUT', '/api/annotations/' + id, { name });
     } else if (act === 'confirm') {
         await api('PUT', '/api/annotations/' + id, { stale: false });
     } else if (act === 'delete') {
-        if (confirm(`Delete room “${room.name}”?`))
+        if (await askConfirm('Delete room', `Delete room “${room.name}”?`))
             await api('DELETE', '/api/annotations/' + id);
     }
 });
@@ -2138,11 +2801,22 @@ function setDrawMode(on) {
 btnDraw.addEventListener('click', () => setDrawMode(!drawMode));
 
 async function finishDraft() {
+    if (draftSubmitting) return;
     if (draft.length < 3) { toast('A room needs at least 3 corners.'); return; }
-    const name = prompt('Room name:', '');
-    if (name === null) return;          // keep drawing
-    const body = { kind: 'room', name, points: draft };
-    if (await api('POST', '/api/annotations', body)) setDrawMode(false);
+    draftSubmitting = true;
+    try {
+        const points = draft.map(p => [p[0], p[1]]);
+        const name = await askRoomName('Create room', '');
+        if (name === null) return;          // keep drawing
+        if (!name) { toast('Room name is required.'); return; }
+        const body = { kind: 'room', name, points };
+        draft = [];
+        const created = await api('POST', '/api/annotations', body);
+        if (created) setDrawMode(false);
+        else { draft = points; draw(); }
+    } finally {
+        draftSubmitting = false;
+    }
 }
 
 // ── canvas input: pan / zoom / vertex clicks / hover ─────────────────────
@@ -2173,6 +2847,7 @@ c.addEventListener('mousemove', (ev) => {
 });
 c.addEventListener('click', (ev) => {
     if (dragMoved) return;              // that was a pan, not a click
+    if (poseEstimateMode) { sendPoseEstimate(p2w(ev.offsetX, ev.offsetY)); return; }
     if (drawMode) { draft.push(p2w(ev.offsetX, ev.offsetY)); draw(); }
 });
 c.addEventListener('dblclick', (ev) => {
@@ -2187,7 +2862,7 @@ c.addEventListener('dblclick', (ev) => {
 window.addEventListener('keydown', (ev) => {
     if (!drawMode) return;
     if (ev.key === 'Escape') setDrawMode(false);
-    if (ev.key === 'Enter') finishDraft();
+    if (ev.key === 'Enter' && !ev.repeat) finishDraft();
 });
 c.addEventListener('wheel', (ev) => {
     ev.preventDefault();
@@ -2230,15 +2905,31 @@ async function refresh() {
     } catch (_) { return; /* transient; next poll retries */ }
     state = next;
     const mb = state.map_binding;
+    const unsavedLive = mb && mb.source === 'default' && !mb.mode;
     document.getElementById('meta').textContent = mb
-        ? `map: ${mb.map_id} · ${mb.mode || 'mode unknown'}`
+        ? (unsavedLive ? 'map: live session · unsaved' : `map: ${mb.map_id} · ${mb.mode || 'mode unknown'}`)
         : 'map: —';
+    const modePill = document.getElementById('mode-pill');
+    if (modePill) {
+        const mode = unsavedLive ? 'unsaved live' : ((mb && mb.mode) || 'unknown');
+        modePill.textContent = mode;
+        modePill.className = unsavedLive ? 'mapping' : mode;
+    }
+    const msg = document.getElementById('map-status-msg');
+    if (unsavedLive && msg && (msg.textContent === 'Ready.' || msg.textContent === 'Map list refreshed.')) {
+        setMapStatus('Live mapping session is not saved yet. Enter a Map ID, then Save current.', 'busy');
+    } else if (mb && mb.mode === 'localization' && msg && (msg.textContent === 'Ready.' || msg.textContent === 'Map list refreshed.')) {
+        setMapStatus('Localization mode is active. Use Pose estimate if the robot pose is off.', 'ok');
+    }
+    const mapInput = document.getElementById('map-id');
+    if (mapInput && !mapInput.value && mb && mb.map_id && !unsavedLive) mapInput.value = mb.map_id;
     renderPanel();
     draw();
 }
 // 1 Hz is plenty for an editor page (the debug page polls at 5 Hz).
 setInterval(refresh, 1000);
 refresh();
+loadMaps();
 </script>
 </body>
 </html>

--- a/system/scene/scene_service/web.py
+++ b/system/scene/scene_service/web.py
@@ -2329,6 +2329,27 @@ _USER_HTML = r"""<!doctype html>
     .save-report-kv .k { color: var(--muted); }
     .save-report-kv .v { overflow-wrap: anywhere; }
     .save-report-log { margin: 8px 0 0; padding: 8px; border: 1px solid #283243; border-radius: 8px; background: #0f131b; color: #c9d1d9; font: 11px/1.45 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; white-space: pre-wrap; max-height: 130px; overflow: auto; }
+    dialog.operation-modal { width: min(460px, calc(100vw - 32px)); }
+    .operation-head { display: flex; align-items: center; gap: 10px; }
+    .operation-spinner { width: 16px; height: 16px; border: 2px solid #33405a;
+      border-top-color: var(--acc); border-radius: 50%; animation: operation-spin .8s linear infinite; }
+    .operation-modal.finished .operation-spinner { animation: none; border-color: #3b633f;
+      background: #8ef0b7; box-shadow: inset 0 0 0 4px #151a23; }
+    .operation-modal.failed .operation-spinner { animation: none; border-color: var(--danger);
+      background: var(--danger); box-shadow: inset 0 0 0 4px #151a23; }
+    @keyframes operation-spin { to { transform: rotate(360deg); } }
+    .operation-steps { display: grid; gap: 7px; margin: 2px 0; }
+    .operation-step { display: grid; grid-template-columns: 16px 1fr; gap: 8px;
+      align-items: center; color: var(--muted); font-size: 12px; }
+    .operation-step::before { content: '○'; color: #526078; }
+    .operation-step.active { color: var(--fg); }
+    .operation-step.active::before { content: '●'; color: var(--acc); }
+    .operation-step.done { color: #8ef0b7; }
+    .operation-step.done::before { content: '✓'; }
+    .operation-detail { margin: 0; padding: 8px; border: 1px solid #283243;
+      border-radius: 8px; background: #0f131b; color: #c9d1d9;
+      font: 11px/1.45 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      white-space: pre-wrap; max-height: 120px; overflow: auto; display: none; }
   </style>
 </head>
 <body>
@@ -2389,6 +2410,21 @@ _USER_HTML = r"""<!doctype html>
     </div>
   </form>
 </dialog>
+<dialog class="modal operation-modal" id="map-operation-modal">
+  <div class="modal-body">
+    <div class="operation-head">
+      <span class="operation-spinner" aria-hidden="true"></span>
+      <div class="modal-title" id="map-operation-title">Working...</div>
+    </div>
+    <div class="modal-message" id="map-operation-message"></div>
+    <div class="operation-steps" id="map-operation-steps"></div>
+    <pre class="operation-detail" id="map-operation-detail"></pre>
+    <div class="modal-actions">
+      <button id="map-operation-close" type="button">Close</button>
+      <button class="primary" id="map-operation-primary" type="button" disabled>Working...</button>
+    </div>
+  </div>
+</dialog>
 <script>
 const c = document.getElementById('c');
 const ctx = c.getContext('2d');
@@ -2423,6 +2459,8 @@ let savedMaps = [];
 let mapBusy = false;
 let poseEstimateMode = false;
 let draftSubmitting = false;
+let mapOperationRetry = null;
+let mapOperationDone = null;
 
 const hintEl = document.getElementById('hint');
 function setHint(text) {
@@ -2445,9 +2483,80 @@ function setMapStatus(text, kind = '') {
 }
 function setMapBusy(on, label = '') {
     mapBusy = on;
-    document.querySelectorAll('#map-tools button, .map-btns button').forEach(b => b.disabled = on);
+    document.querySelectorAll('#map-tools button, #map-tools input, .map-btns button, #btn-draw, #room-list button')
+        .forEach(el => el.disabled = on);
+    if (!on) {
+        renderMaps();
+        renderPanel();
+    }
     if (label) setMapStatus(label, on ? 'busy' : '');
 }
+const mapOperationModal = document.getElementById('map-operation-modal');
+const mapOperationTitle = document.getElementById('map-operation-title');
+const mapOperationMessage = document.getElementById('map-operation-message');
+const mapOperationSteps = document.getElementById('map-operation-steps');
+const mapOperationDetail = document.getElementById('map-operation-detail');
+const mapOperationClose = document.getElementById('map-operation-close');
+const mapOperationPrimary = document.getElementById('map-operation-primary');
+
+function beginMapOperation({ title, message, status, steps }) {
+    mapOperationRetry = null;
+    mapOperationDone = null;
+    mapOperationModal.classList.remove('finished', 'failed');
+    mapOperationTitle.textContent = title;
+    mapOperationMessage.textContent = message;
+    mapOperationSteps.innerHTML = (steps || []).map((step, index) =>
+        `<div class="operation-step ${index === 0 ? 'active' : ''}">${esc(step)}</div>`).join('');
+    mapOperationDetail.textContent = '';
+    mapOperationDetail.style.display = 'none';
+    mapOperationClose.hidden = true;
+    mapOperationPrimary.disabled = true;
+    mapOperationPrimary.textContent = 'Working...';
+    setMapBusy(true, status || message);
+    if (!mapOperationModal.open) {
+        if (typeof mapOperationModal.showModal === 'function') mapOperationModal.showModal();
+        else mapOperationModal.setAttribute('open', '');
+    }
+}
+
+function finishMapOperation({ ok, title, message, detail = '', retry = null, done = null, primaryText = '' }) {
+    setMapBusy(false);
+    mapOperationModal.classList.toggle('finished', ok);
+    mapOperationModal.classList.toggle('failed', !ok);
+    mapOperationTitle.textContent = title;
+    mapOperationMessage.textContent = message;
+    mapOperationSteps.querySelectorAll('.operation-step').forEach(step => {
+        step.classList.remove('active');
+        if (ok) step.classList.add('done');
+    });
+    mapOperationDetail.textContent = detail;
+    mapOperationDetail.style.display = detail ? 'block' : 'none';
+    mapOperationRetry = ok ? null : retry;
+    mapOperationDone = done;
+    mapOperationClose.hidden = ok;
+    mapOperationPrimary.disabled = false;
+    mapOperationPrimary.textContent = primaryText || (ok ? 'Done' : 'Retry');
+}
+
+mapOperationModal.addEventListener('cancel', ev => {
+    if (mapBusy) ev.preventDefault();
+});
+mapOperationClose.addEventListener('click', () => {
+    if (!mapBusy) mapOperationModal.close();
+});
+mapOperationPrimary.addEventListener('click', () => {
+    if (mapBusy) return;
+    if (mapOperationRetry) {
+        const retry = mapOperationRetry;
+        mapOperationRetry = null;
+        retry();
+        return;
+    }
+    const done = mapOperationDone;
+    mapOperationDone = null;
+    mapOperationModal.close();
+    if (done) done();
+});
 function mapItemFor(id) {
     return Array.from(document.querySelectorAll('.mapitem')).find(el => el.dataset.id === id);
 }
@@ -2665,8 +2774,8 @@ function renderMaps() {
         <div class="name">${esc(m.map_id)}</div>
         <div class="sub"${dbTitle}>${dbLabel} · ${m.has_preview ? 'preview' : 'no preview'} · ${m.updated || '-'}</div>
         <div class="map-btns">
-          <button class="small" data-map-act="load" ${canLoad ? '' : 'disabled'}>Load</button>
-          <button class="small danger" data-map-act="delete">Delete</button>
+          <button class="small" data-map-act="load" ${canLoad && !mapBusy ? '' : 'disabled'}>Load</button>
+          <button class="small danger" data-map-act="delete" ${mapBusy ? 'disabled' : ''}>Delete</button>
         </div>
         <div class="map-status">${canLoad ? '' : esc(m.artifact_detail || 'not loadable')}</div>
       </div>`;
@@ -2681,6 +2790,27 @@ async function loadMaps() {
         renderMaps();
     } catch (e) { toast('list maps failed: ' + e); }
 }
+async function mapRequest(path, body) {
+    try {
+        const response = await fetch(path, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        });
+        const out = await response.json().catch(() => null);
+        if (!response.ok || !out || out.ok === false) {
+            return {
+                ok: false,
+                out,
+                detail: (out && out.detail) || `request failed (${response.status})`,
+            };
+        }
+        await refresh();
+        return { ok: true, out, detail: out.detail || '' };
+    } catch (error) {
+        return { ok: false, out: null, detail: `request failed: ${error}` };
+    }
+}
 async function saveCurrentMap() {
     if (mapBusy) return;
     const id = preferredMapId();
@@ -2688,20 +2818,48 @@ async function saveCurrentMap() {
     selectedMapId = id; renderMaps();
     draw();
     const previewDataUrl = c.toDataURL('image/png');
-    setMapBusy(true, `Saving map ${id}...`);
-    toast(`Saving map ${id}...`);
-    const out = await api('POST', '/api/maps/save', { map_id: id, note: 'saved from scene user page' });
-    setMapBusy(false);
-    if (out) {
+    const existing = savedMaps.find(item => item.map_id === id && item.has_spatial_artifact);
+    beginMapOperation({
+        title: existing ? `Updating ${id}` : `Saving ${id}`,
+        message: existing
+            ? 'The spatial map already exists. Scene rooms and objects will be updated under the same Map ID.'
+            : 'Keep this page open while the spatial map and Scene data are made reusable.',
+        status: existing ? `Updating Scene data for ${id}...` : `Saving map ${id}...`,
+        steps: existing
+            ? ['Validate existing spatial artifact', 'Persist rooms and Scene objects', 'Verify reusable map entry']
+            : ['Snapshot the live spatial map', 'Persist rooms and Scene objects', 'Verify artifact and preview'],
+    });
+    const result = await mapRequest('/api/maps/save', { map_id: id, note: 'saved from scene user page' });
+    if (result.ok) {
+        const out = result.out;
         const validation = out.validation || {};
         const ok = validation.spatial_ok !== false && validation.has_preview !== false;
         const semanticOnly = Boolean(out.spatial_unchanged);
         setMapStatus(`${semanticOnly ? 'Updated scene data for' : 'Saved'} ${out.map_id || id}; spatial artifact ${ok ? 'ok' : 'failed'}; rooms ${validation.room_count ?? '-'}.`, ok ? 'ok' : 'err');
         toast((semanticOnly ? 'updated scene data for ' : 'saved map ') + (out.map_id || id));
         await loadMaps();
-        showSaveReport(out, previewDataUrl);
+        finishMapOperation({
+            ok,
+            title: ok ? (semanticOnly ? 'Scene data updated' : 'Map saved') : 'Save validation failed',
+            message: ok
+                ? `${out.map_id || id} is ready to load after a stack restart.`
+                : `${out.map_id || id} was written, but artifact validation did not pass.`,
+            detail: (validation.log || []).join('\n') || out.detail || '',
+            retry: ok ? null : saveCurrentMap,
+            done: ok ? () => showSaveReport(out, previewDataUrl) : null,
+            primaryText: ok ? 'View report' : 'Retry',
+        });
     }
-    else setMapStatus(`Save ${id} failed. See toast/log for details.`, 'err');
+    else {
+        setMapStatus(`Save ${id} failed: ${result.detail}`, 'err');
+        finishMapOperation({
+            ok: false,
+            title: 'Save failed',
+            message: `Nothing was confirmed reusable for Map ID ${id}.`,
+            detail: result.detail,
+            retry: saveCurrentMap,
+        });
+    }
 }
 async function loadSelectedMap(id) {
     if (mapBusy) return;
@@ -2709,17 +2867,40 @@ async function loadSelectedMap(id) {
     document.getElementById('map-id').value = id;
     renderMaps();
     setMapItemStatus(id, 'loading...');
-    setMapBusy(true, `Loading ${id}; switching mapping to localization mode...`);
-    toast(`Loading ${id}; switching to localization mode...`);
-    const out = await api('POST', '/api/maps/load', { map_id: id, mode: 'localization' });
-    setMapBusy(false);
+    beginMapOperation({
+        title: `Loading ${id}`,
+        message: 'The editor is locked until Mapping publishes the loaded occupancy grid and Scene restores the matching semantic data.',
+        status: `Loading ${id}; switching Mapping to localization mode...`,
+        steps: ['Validate saved spatial artifact', 'Switch Mapping to localization mode', 'Wait for a fresh occupancy grid', 'Restore rooms and Scene objects'],
+    });
+    const result = await mapRequest('/api/maps/load', { map_id: id, mode: 'localization' });
     setMapItemStatus(id, '');
-    if (out) {
+    if (result.ok) {
+        const out = result.out;
         setMapStatus(`Loaded ${id}. Mapping requested localization mode; use Pose estimate if the robot pose is off.`, 'ok');
         toast('loaded map ' + id + ' · localization mode requested');
         await loadMaps();
+        const occupancy = out.occupancy || {};
+        finishMapOperation({
+            ok: true,
+            title: 'Map loaded',
+            message: `${id} is active in localization mode. Rooms and Scene objects now use the same Map ID.`,
+            detail: [
+                out.detail || '',
+                occupancy.width ? `occupancy ${occupancy.width} × ${occupancy.height}` : '',
+                Number.isFinite(Number(out.objects_restored)) ? `objects restored: ${out.objects_restored}` : '',
+                out.object_restore_error ? `object restore warning: ${out.object_restore_error}` : '',
+            ].filter(Boolean).join('\n'),
+        });
     } else {
-        setMapStatus(`Load ${id} failed. See toast/log for details.`, 'err');
+        setMapStatus(`Load ${id} failed: ${result.detail}`, 'err');
+        finishMapOperation({
+            ok: false,
+            title: 'Load failed',
+            message: `${id} was not confirmed ready. The editor has not switched its Scene binding.`,
+            detail: result.detail,
+            retry: () => loadSelectedMap(id),
+        });
     }
 }
 async function deleteSelectedMap(id) {
@@ -2766,6 +2947,7 @@ document.getElementById('btn-save-map').addEventListener('click', saveCurrentMap
 document.getElementById('btn-refresh-maps').addEventListener('click', async () => { setMapStatus('Refreshing maps...', 'busy'); await loadMaps(); setMapStatus('Map list refreshed.', 'ok'); });
 document.getElementById('btn-pose-estimate').addEventListener('click', () => setPoseEstimateMode(!poseEstimateMode));
 document.getElementById('map-list').addEventListener('click', (ev) => {
+    if (mapBusy) return;
     const item = ev.target.closest('.mapitem');
     if (!item) return;
     const id = item.dataset.id;
@@ -2861,13 +3043,14 @@ function renderPanel() {
         ${a.stale ? '<span class="badge" title="' + esc(a.stale_reason) + '">STALE</span>' : ''}
         <div class="sub">${a.points.length} corners</div>
         <div class="btns">
-          <button class="small" data-act="rename">Rename</button>
-          ${a.stale ? '<button class="small" data-act="confirm">Still valid</button>' : ''}
-          <button class="small danger" data-act="delete">Delete</button>
+          <button class="small" data-act="rename" ${mapBusy ? 'disabled' : ''}>Rename</button>
+          ${a.stale ? `<button class="small" data-act="confirm" ${mapBusy ? 'disabled' : ''}>Still valid</button>` : ''}
+          <button class="small danger" data-act="delete" ${mapBusy ? 'disabled' : ''}>Delete</button>
         </div>
       </div>`).join('');
 }
 document.getElementById('room-list').addEventListener('click', async (ev) => {
+    if (mapBusy) return;
     const roomEl = ev.target.closest('.room');
     if (!roomEl) return;
     const id = roomEl.dataset.id;
@@ -2900,7 +3083,7 @@ function setDrawMode(on) {
 btnDraw.addEventListener('click', () => setDrawMode(!drawMode));
 
 async function finishDraft() {
-    if (draftSubmitting) return;
+    if (mapBusy || draftSubmitting) return;
     if (draft.length < 3) { toast('A room needs at least 3 corners.'); return; }
     draftSubmitting = true;
     try {
@@ -2922,6 +3105,7 @@ async function finishDraft() {
 let dragging = false, dragMoved = false, lastPos = null;
 c.style.cursor = 'grab';
 c.addEventListener('mousedown', (ev) => {
+    if (mapBusy) return;
     dragging = true; dragMoved = false; lastPos = [ev.offsetX, ev.offsetY];
 });
 window.addEventListener('mouseup', () => { dragging = false; });
@@ -2945,11 +3129,13 @@ c.addEventListener('mousemove', (ev) => {
     draw();
 });
 c.addEventListener('click', (ev) => {
+    if (mapBusy) return;
     if (dragMoved) return;              // that was a pan, not a click
     if (poseEstimateMode) { sendPoseEstimate(p2w(ev.offsetX, ev.offsetY)); return; }
     if (drawMode) { draft.push(p2w(ev.offsetX, ev.offsetY)); draw(); }
 });
 c.addEventListener('dblclick', (ev) => {
+    if (mapBusy) return;
     ev.preventDefault();
     if (drawMode) {
         // the dblclick's two single clicks added two duplicate corners at
@@ -2959,12 +3145,14 @@ c.addEventListener('dblclick', (ev) => {
     }
 });
 window.addEventListener('keydown', (ev) => {
+    if (mapBusy) return;
     if (!drawMode) return;
     if (ev.key === 'Escape') setDrawMode(false);
     if (ev.key === 'Enter' && !ev.repeat) finishDraft();
 });
 c.addEventListener('wheel', (ev) => {
     ev.preventDefault();
+    if (mapBusy) return;
     const factor = ev.deltaY < 0 ? 1.15 : 1 / 1.15;
     // zoom about the cursor so the point under the mouse stays put
     const [wx, wy] = p2w(ev.offsetX, ev.offsetY);

--- a/system/scene/scripts/build.sh
+++ b/system/scene/scripts/build.sh
@@ -71,7 +71,13 @@ fi
 mkdir -p "$BUILD/data"
 
 # ── 1. Codegen (.proto + grpc stubs + MCP dataclasses → rbnx-build/codegen/) ─
-FLAGS=(--mcp)
+# --ros2 also emits rbnx-build/codegen/ros2_idl: the generated ROS 2
+# interface overlay carrying map/msg/MapLifecycle (mapping's latched map
+# identity broadcast, which scene's map binding subscribes to). It is
+# colcon-built inside the scene image after the docker build below and
+# sourced by docker/entrypoint.sh; without it scene falls back to static
+# map binding (SCENE_MAP_ID / config) with a warning.
+FLAGS=(--mcp --ros2)
 [[ "$CLEAN" == "1" ]] && FLAGS+=(--clean)
 
 echo "[build] rbnx codegen ${FLAGS[*]}"
@@ -369,5 +375,25 @@ esac
 
 echo "[build] docker build -f $SCENE_DOCKERFILE -t $IMG docker/  (target=$TARGET)"
 docker build "${DOCKER_BUILD_FLAGS[@]}" -f "$SCENE_DOCKERFILE" -t "$IMG" docker/
+
+# colcon-build the ros2_idl overlay (map interface package for the
+# lifecycle broadcast) inside the image we just built, so the install
+# tree lands on the host bind mount at the SAME path the runtime
+# container sees (/scene/rbnx-build/...). Skipped when codegen was
+# skipped — scene then runs with static map binding only.
+IDL="$PKG/rbnx-build/codegen/ros2_idl"
+if [[ -d "$IDL/src/map" ]]; then
+    echo "[build] colcon build ros2_idl (map interface pkg) in $IMG"
+    # --user: build/ install/ land on the HOST bind mount — as root they
+    # would survive a later non-root `rm -rf rbnx-build` (RBNX_BUILD_CLEAN).
+    # HOME=/tmp gives colcon a writable home for its metadata as that uid.
+    docker run --rm --entrypoint bash --user "$(id -u):$(id -g)" -e HOME=/tmp \
+        -v "$PKG":/scene "$IMG" -lc \
+        "source /opt/ros/\${ROS_DISTRO:-humble}/setup.bash && \
+         cd /scene/rbnx-build/codegen/ros2_idl && \
+         colcon build --packages-up-to map"
+else
+    echo "[build] WARNING: ros2_idl/src/map missing — dynamic map binding disabled"
+fi
 
 echo "[build] done."

--- a/system/scene/scripts/build.sh
+++ b/system/scene/scripts/build.sh
@@ -280,8 +280,17 @@ classes = [
 model = YOLO("$WEIGHTS_DIR/yolov8l-world.pt")
 model.set_classes(classes)
 PY
-    if [[ ! -s "$UWD/clip/ViT-B-32.pt" ]]; then
-        echo "[build] warning: missing $UWD/clip/ViT-B-32.pt after ultralytics prefetch; scene start will fail fast" >&2
+    ULTRALYTICS_CLIP="$UWD/clip/ViT-B-32.pt"
+    HF_CLIP="$HFD/clip/ViT-B-32.pt"
+    if [[ ! -s "$ULTRALYTICS_CLIP" && -s "$HF_CLIP" ]]; then
+        mkdir -p "$(dirname "$ULTRALYTICS_CLIP")"
+        ln "$HF_CLIP" "$ULTRALYTICS_CLIP" 2>/dev/null \
+            || cp "$HF_CLIP" "$ULTRALYTICS_CLIP"
+        echo "[build] staged Ultralytics CLIP weight: $ULTRALYTICS_CLIP"
+    fi
+    if [[ ! -s "$ULTRALYTICS_CLIP" ]]; then
+        echo "[build] error: missing $ULTRALYTICS_CLIP after prefetch" >&2
+        exit 1
     fi
     "$PY" -c "import torch,torchvision,ultralytics; print('[build] torch',torch.__version__,'cuda',torch.cuda.is_available())" || true
     echo "[build] done (jetson-native)."

--- a/system/scene/scripts/start.sh
+++ b/system/scene/scripts/start.sh
@@ -35,8 +35,7 @@ CT="${ROBONIX_SCENE_CONTAINER:-robonix_scene}"
 IMG="${ROBONIX_SCENE_IMAGE:-robonix-scene}"
 
 cleanup() {
-    docker stop "$CT" >/dev/null 2>&1 || true
-    kill -- "-$$" 2>/dev/null || true
+    timeout 15s docker stop "$CT" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT INT TERM
 
@@ -65,6 +64,11 @@ if [[ -n "${ROBONIX_ZENOH_MODE:-}" ]]; then
 fi
 if [[ -n "${ROBONIX_ZENOH_LISTEN:-}" ]]; then
     ZENOH_ARGS+=(-e "ROBONIX_ZENOH_LISTEN=${ROBONIX_ZENOH_LISTEN}")
+fi
+
+declare -a MAP_ID_ARGS=()
+if [[ -n "${SCENE_MAP_ID:-}" ]]; then
+    MAP_ID_ARGS=(-e "SCENE_MAP_ID=${SCENE_MAP_ID}")
 fi
 
 # GPU passthrough: ConceptGraphs perception (YOLO-World + MobileSAM +
@@ -128,12 +132,13 @@ exec docker run --rm \
     -e SCENE_GRAPH_RELATION_ENABLED="${SCENE_GRAPH_RELATION_ENABLED:-true}" \
     -e SCENE_GRAPH_INTERVAL_SEC="${SCENE_GRAPH_INTERVAL_SEC:-30}" \
     -e SCENE_GRAPH_CACHE_DIR="${SCENE_GRAPH_CACHE_DIR:-/data/robonix/scene_graph/cache}" \
+    -e SCENE_MAP_LOAD_TIMEOUT_S="${SCENE_MAP_LOAD_TIMEOUT_S:-240}" \
     -e SCENE_GRAPH_MIN_OBSERVATIONS="${SCENE_GRAPH_MIN_OBSERVATIONS:-2}" \
     -e SCENE_GRAPH_MAX_OBJECTS="${SCENE_GRAPH_MAX_OBJECTS:-80}" \
     -e SCENE_GRAPH_MAX_LLM_RELATIONS_PER_CYCLE="${SCENE_GRAPH_MAX_LLM_RELATIONS_PER_CYCLE:-20}" \
     -e SCENE_OBJECT_MEMORY_ENABLED="${SCENE_OBJECT_MEMORY_ENABLED:-true}" \
     -e SCENE_OBJECT_MEMORY_DB="${SCENE_OBJECT_MEMORY_DB:-/data/robonix/scene_memory/objects.db}" \
-    -e SCENE_MAP_ID="${SCENE_MAP_ID:-default}" \
+    "${MAP_ID_ARGS[@]}" \
     -e RBNX_CONFIG_FILE="${RBNX_CONFIG_FILE:-}" \
     -e ROS_DOMAIN_ID="${ROS_DOMAIN_ID:-0}" \
     -e RMW_IMPLEMENTATION="${RMW_IMPLEMENTATION:-rmw_zenoh_cpp}" \

--- a/system/scene/scripts/start_native.sh
+++ b/system/scene/scripts/start_native.sh
@@ -59,6 +59,8 @@ done
 # Host-persisted scene state (object-memory DB + scene-graph caches).
 mkdir -p "$PKG/rbnx-build/data/robonix"
 export SCENE_GRAPH_CACHE_DIR="${SCENE_GRAPH_CACHE_DIR:-$PKG/rbnx-build/data/robonix/scene_graph/cache}"
+export SCENE_ANNOTATIONS_DIR="${SCENE_ANNOTATIONS_DIR:-$PKG/rbnx-build/data/robonix/scene_annotations}"
+mkdir -p "$SCENE_ANNOTATIONS_DIR"
 
 # Service knobs (same defaults the docker run wires via -e).
 export SCENE_WEB_PORT="${SCENE_WEB_PORT:-50107}"

--- a/system/scene/tests/test_annotations.py
+++ b/system/scene/tests/test_annotations.py
@@ -294,7 +294,7 @@ def test_rest_crud_roundtrip():
         assert (st, out) == (200, {"ok": True, "annotations": []})
 
         st, out = _call(app, "POST", "/api/annotations",
-                        {"kind": "room", "name": "厨房", "points": ROOM_PTS})
+                        {"kind": "room", "name": "kitchen-draft", "points": ROOM_PTS})
         assert st == 200 and out["ok"]
         ann_id = out["annotation"]["annotation_id"]
 

--- a/system/scene/tests/test_annotations.py
+++ b/system/scene/tests/test_annotations.py
@@ -12,6 +12,7 @@ import json
 import os
 import sys
 import tempfile
+from types import SimpleNamespace
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -246,7 +247,7 @@ def test_from_json_drops_unknown_keys():
 
 # ── REST API (hand-rolled ASGI, no httpx needed) ────────────────────────────
 
-def _make_web_app(anno_store):
+def _make_web_app(anno_store, **overrides):
     """Import scene_service.web lazily and build an app with only the
     pieces the annotation routes need. When the web import chain is
     unavailable (bare environment): under pytest the caller's test is
@@ -265,11 +266,14 @@ def _make_web_app(anno_store):
         _objects: dict = {}
         _surfaces: dict = {}
 
-    return web_mod.make_app(
-        registry=_StubRegistry(), anno_store=anno_store,
-        map_binding={"map_id": "lab", "mode": "mapping",
-                     "generation": 1, "source": "lifecycle"},
-    )
+    options = {
+        "registry": _StubRegistry(),
+        "anno_store": anno_store,
+        "map_binding": {"map_id": "lab", "mode": "mapping",
+                        "generation": 1, "source": "lifecycle"},
+    }
+    options.update(overrides)
+    return web_mod.make_app(**options)
 
 
 def _call(app, method: str, path: str, body=None):
@@ -342,6 +346,56 @@ def test_rest_crud_roundtrip():
         assert (st, out) == (200, {"ok": True})
         assert store.list() == []
     print("  [PASS] test_rest_crud_roundtrip")
+
+
+def test_map_load_waits_for_new_occupancy_before_rebinding(monkeypatch):
+    try:
+        from scene_service import web as web_mod
+    except ImportError as e:
+        import pytest
+        pytest.skip(f"web deps unavailable: {e}")
+
+    class Hub:
+        loaded = False
+
+        @staticmethod
+        def has(_name):
+            return True
+
+        def latest(self, _name):
+            count = 2 if self.loaded else 1
+            msg = SimpleNamespace(info=SimpleNamespace(width=20, height=12))
+            return msg, float(count), count
+
+    hub = Hub()
+
+    def map_rpc(op, payload, _timeout=30.0):
+        assert op == "load_map"
+        assert payload["map_id"] == "saved_lab"
+        hub.loaded = True
+        return {"ok": True, "detail": "loaded once"}
+
+    monkeypatch.setattr(web_mod, "_map_rpc", map_rpc)
+    with tempfile.TemporaryDirectory() as base:
+        AnnotationStore(base, map_id="saved_lab", generation=1).create(
+            kind="room", name="restored", points=ROOM_PTS,
+        )
+        store = AnnotationStore(base, map_id="live", generation=1)
+        binding = {"map_id": "live", "mode": "mapping",
+                   "generation": 1, "source": "lifecycle"}
+        app = _make_web_app(store, hub=hub, map_binding=binding)
+
+        status, out = _call(
+            app, "POST", "/api/maps/load",
+            {"map_id": "saved_lab", "mode": "localization"},
+        )
+
+        assert status == 200 and out["ok"] is True
+        assert out["occupancy"]["count"] == 2
+        assert binding["map_id"] == "saved_lab"
+        assert binding["mode"] == "localization"
+        assert [room.name for room in store.list()] == ["restored"]
+    print("  [PASS] test_map_load_waits_for_new_occupancy_before_rebinding")
 
 
 def test_rest_validation_and_errors():

--- a/system/scene/tests/test_annotations.py
+++ b/system/scene/tests/test_annotations.py
@@ -1,0 +1,424 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+"""Unit tests for user annotations (scene_service.annotations) and the
+annotation CRUD REST API (scene_service.web).
+
+The store tests are pure Python + tmp dirs and always run. The web tests
+drive the Starlette app through a hand-rolled ASGI call (no httpx /
+TestClient dependency); they need starlette + the scene_service.web import
+chain and skip loudly when that is unavailable (e.g. a bare mac checkout).
+"""
+import asyncio
+import json
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from scene_service.annotations import (  # noqa: E402
+    AnnotationStore,
+    validate_annotation_fields,
+)
+
+ROOM_PTS = [[0.0, 0.0], [2.0, 0.0], [2.0, 1.5], [0.0, 1.5]]
+
+
+# ── validation ──────────────────────────────────────────────────────────────
+
+def test_validation_rules():
+    ok = validate_annotation_fields
+    assert ok("room", "kitchen", ROOM_PTS, None) is None
+    assert ok("poi", "dock", [[1.0, 2.0]], 1.57) is None
+    assert ok("no_go", "x", ROOM_PTS, None)           # unknown kind
+    assert ok("room", 7, ROOM_PTS, None)              # non-string name
+    assert ok("room", "x" * 200, ROOM_PTS, None)      # name too long
+    assert ok("room", "x", ROOM_PTS[:2], None)        # polygon < 3 points
+    assert ok("poi", "x", ROOM_PTS[:2], None)         # poi != 1 point
+    assert ok("room", "x", [[0.0, float("nan")]] * 3, None)   # NaN point
+    assert ok("room", "x", [[0.0], [1.0], [2.0]], None)       # not pairs
+    assert ok("room", "x", "not-a-list", None)
+    assert ok("poi", "x", [[0.0, 0.0]], float("inf"))         # inf theta
+    assert ok("poi", "x", [[0.0, 0.0]], "north")              # non-number theta
+    assert ok("poi", "x", [[True, 0.0]], None)                # bool is not a coord
+    assert ok("room", "x", ROOM_PTS, 1.57)                    # heading on a room
+    print("  [PASS] test_validation_rules")
+
+
+# ── store ───────────────────────────────────────────────────────────────────
+
+def test_store_roundtrip_across_reopen():
+    with tempfile.TemporaryDirectory() as base:
+        s1 = AnnotationStore(base, map_id="lab", generation=2)
+        room = s1.create(kind="room", name="kitchen", points=ROOM_PTS)
+        poi = s1.create(kind="poi", name="dock", points=[[1.0, 2.0]], theta=0.5)
+        assert room.annotation_id.startswith("anno.")
+        assert room.created_at > 0 and room.updated_at >= room.created_at
+
+        s2 = AnnotationStore(base, map_id="lab", generation=2)
+        got = {a.annotation_id: a for a in s2.list()}
+        assert got[room.annotation_id].points == ROOM_PTS
+        assert got[room.annotation_id].name == "kitchen"
+        assert got[poi.annotation_id].theta == 0.5
+        assert not any(a.stale for a in got.values())
+    print("  [PASS] test_store_roundtrip_across_reopen")
+
+
+def test_update_and_delete():
+    with tempfile.TemporaryDirectory() as base:
+        s = AnnotationStore(base, map_id="lab", generation=1)
+        a = s.create(kind="room", name="old", points=ROOM_PTS)
+        u = s.update(a.annotation_id, name="new")
+        assert u.name == "new" and u.updated_at >= a.updated_at
+        assert s.update("anno.missing", name="x") is None
+        assert s.delete(a.annotation_id) is True
+        assert s.delete(a.annotation_id) is False
+        assert s.list() == []
+    print("  [PASS] test_update_and_delete")
+
+
+def test_map_id_partition_isolation_and_sanitize():
+    with tempfile.TemporaryDirectory() as base:
+        s_a = AnnotationStore(base, map_id="lab_a", generation=1)
+        s_b = AnnotationStore(base, map_id="lab_b", generation=1)
+        s_a.create(kind="room", name="only-in-a", points=ROOM_PTS)
+        assert s_b.list() == []
+        assert AnnotationStore(base, map_id="lab_b", generation=1).list() == []
+        assert len(AnnotationStore(base, map_id="lab_a", generation=1).list()) == 1
+
+        # Hostile map_id chars are squashed to "_" — same rule as the
+        # object store, so the two partitions always agree on the key.
+        s_evil = AnnotationStore(base, map_id="we ird/../id", generation=1)
+        assert s_evil.map_id == "we_ird_.._id"
+        assert s_evil.path.parent == s_a.path.parent  # no path escape
+    print("  [PASS] test_map_id_partition_isolation_and_sanitize")
+
+
+def test_atomic_write_leaves_no_tmp():
+    with tempfile.TemporaryDirectory() as base:
+        s = AnnotationStore(base, map_id="lab", generation=1)
+        s.create(kind="room", name="r", points=ROOM_PTS)
+        s.mark_all_stale("test", new_generation=2)
+        leftovers = [p for p in os.listdir(base) if p.endswith(".tmp")]
+        assert leftovers == []
+        data = json.loads(open(os.path.join(base, "lab.json")).read())
+        assert set(data) == {"map_id", "generation", "annotations"}
+    print("  [PASS] test_atomic_write_leaves_no_tmp")
+
+
+def test_generation_mismatch_marks_stale_on_load():
+    with tempfile.TemporaryDirectory() as base:
+        s1 = AnnotationStore(base, map_id="lab", generation=2)
+        a = s1.create(kind="room", name="kitchen", points=ROOM_PTS)
+
+        # Same generation → untouched.
+        assert not AnnotationStore(base, map_id="lab", generation=2).list()[0].stale
+
+        # Bumped generation → stale + reason, and the flag is persisted.
+        s3 = AnnotationStore(base, map_id="lab", generation=3)
+        got = s3.get(a.annotation_id)
+        assert got.stale and "2→3" in got.stale_reason
+        raw = json.loads(open(s3.path).read())
+        assert raw["annotations"][0]["stale"] is True
+
+        # User confirms it is still valid → stale cleared, persisted.
+        s3.update(a.annotation_id, clear_stale=True)
+        assert not AnnotationStore(base, map_id="lab", generation=3).get(
+            a.annotation_id).stale
+    print("  [PASS] test_generation_mismatch_marks_stale_on_load")
+
+
+def test_unknown_generation_preserves_stored_epoch():
+    with tempfile.TemporaryDirectory() as base:
+        AnnotationStore(base, map_id="lab", generation=5).create(
+            kind="room", name="r", points=ROOM_PTS)
+        # A static-binding boot (no broadcast → generation None) cannot
+        # judge staleness: nothing is flagged AND the stored epoch must
+        # survive the session so a later bound boot still can.
+        s = AnnotationStore(base, map_id="lab", generation=None)
+        assert not s.list()[0].stale
+        s.update(s.list()[0].annotation_id, name="renamed")   # forces a save
+        assert json.loads(open(s.path).read())["generation"] == 5
+        assert AnnotationStore(base, map_id="lab", generation=6).list()[0].stale
+    print("  [PASS] test_unknown_generation_preserves_stored_epoch")
+
+
+def test_reconcile_generation_learns_and_flags():
+    with tempfile.TemporaryDirectory() as base:
+        AnnotationStore(base, map_id="lab", generation=None).create(
+            kind="room", name="r", points=ROOM_PTS)
+        # A file written under an unknown epoch adopts the confirmed one
+        # without flagging anything (there is nothing to disagree with).
+        s = AnnotationStore(base, map_id="lab", generation=None)
+        assert s.reconcile_generation(5) == 0
+        assert not s.list()[0].stale
+        assert json.loads(open(s.path).read())["generation"] == 5
+        assert s.reconcile_generation(5) == 0        # same epoch: no-op
+
+        # A recorded epoch that DIFFERS from the confirmed one means the
+        # map frame moved since the annotations were drawn → all stale.
+        s2 = AnnotationStore(base, map_id="lab", generation=None)
+        assert s2.reconcile_generation(7) == 1
+        got = s2.list()[0]
+        assert got.stale and "5→7" in got.stale_reason
+    print("  [PASS] test_reconcile_generation_learns_and_flags")
+
+
+def test_redraw_clears_stale_and_mark_all_stale_counts():
+    with tempfile.TemporaryDirectory() as base:
+        s = AnnotationStore(base, map_id="lab", generation=1)
+        a = s.create(kind="room", name="r", points=ROOM_PTS)
+        b = s.create(kind="poi", name="p", points=[[0.0, 0.0]])
+        assert s.mark_all_stale("epoch flip", new_generation=2) == 2
+        assert s.mark_all_stale("epoch flip", new_generation=2) == 0  # idempotent
+        # Redrawing geometry re-authors it against the CURRENT frame →
+        # staleness no longer applies.
+        assert s.update(a.annotation_id, points=ROOM_PTS).stale is False
+        assert s.get(b.annotation_id).stale is True
+    print("  [PASS] test_redraw_clears_stale_and_mark_all_stale_counts")
+
+
+def test_corrupt_file_set_aside_not_destroyed():
+    # Every bad-file shape must take the same quarantine path: parse
+    # error, valid-JSON-but-not-an-object, non-object annotation entry,
+    # non-numeric generation, and a record that fails field validation
+    # (per-map files are user-visible JSON, hand edits happen).
+    bad_files = [
+        "{not json",
+        "[1, 2, 3]",
+        '"just a string"',
+        '{"map_id": "lab", "generation": 1, "annotations": [3]}',
+        '{"map_id": "lab", "generation": "three", "annotations": []}',
+        '{"map_id": "lab", "generation": 1, "annotations": '
+        '[{"annotation_id": "anno.x", "kind": "castle", "name": "x", '
+        '"points": [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]]}]}',
+    ]
+    for content in bad_files:
+        with tempfile.TemporaryDirectory() as base:
+            path = os.path.join(base, "lab.json")
+            with open(path, "w") as f:
+                f.write(content)
+            s = AnnotationStore(base, map_id="lab", generation=1)
+            assert s.list() == [], content
+            aside = [p for p in os.listdir(base) if ".corrupt-" in p]
+            assert len(aside) == 1, content
+            assert open(os.path.join(base, aside[0])).read() == content
+    print("  [PASS] test_corrupt_file_set_aside_not_destroyed")
+
+
+def test_from_json_drops_unknown_keys():
+    from scene_service.annotations import Annotation
+    a = Annotation.from_json({
+        "annotation_id": "anno.x", "kind": "room", "name": "r",
+        "points": [[0.0, 0.0]], "written_by_future_scene": True,
+    })
+    assert a.annotation_id == "anno.x" and not hasattr(a, "written_by_future_scene")
+    print("  [PASS] test_from_json_drops_unknown_keys")
+
+
+# ── REST API (hand-rolled ASGI, no httpx needed) ────────────────────────────
+
+def _make_web_app(anno_store):
+    """Import scene_service.web lazily and build an app with only the
+    pieces the annotation routes need. When the web import chain is
+    unavailable (bare environment): under pytest the caller's test is
+    SKIPPED (visible in the report, not a hollow pass); standalone it
+    prints and returns None."""
+    try:
+        from scene_service import web as web_mod
+    except ImportError as e:
+        if os.environ.get("PYTEST_CURRENT_TEST"):
+            import pytest
+            pytest.skip(f"web deps unavailable: {e}")
+        print(f"  [SKIP] web tests unavailable: {e}")
+        return None
+
+    class _StubRegistry:  # annotation routes never touch the registry
+        _objects: dict = {}
+        _surfaces: dict = {}
+
+    return web_mod.make_app(
+        registry=_StubRegistry(), anno_store=anno_store,
+        map_binding={"map_id": "lab", "mode": "mapping",
+                     "generation": 1, "source": "lifecycle"},
+    )
+
+
+def _call(app, method: str, path: str, body=None):
+    """Drive the ASGI app directly with one JSON request; return
+    (status, parsed-body). Avoids the TestClient→httpx dependency.
+
+    Runs on a PRIVATE event loop (not asyncio.run, which unsets the
+    thread's current loop on exit and would starve later test files
+    that still use the ambient-loop pattern — the exact cross-file
+    pollution test_scene_graph._ensure_loop guards against)."""
+    raw = json.dumps(body).encode() if body is not None else b""
+    scope = {
+        "type": "http", "http_version": "1.1", "method": method,
+        "scheme": "http", "path": path, "raw_path": path.encode(),
+        "root_path": "", "query_string": b"", "client": ("test", 0),
+        "server": ("test", 80),
+        "headers": [(b"content-type", b"application/json"),
+                    (b"content-length", str(len(raw)).encode())],
+    }
+    sent, done = [], {"body": False}
+
+    async def receive():
+        if done["body"]:
+            return {"type": "http.disconnect"}
+        done["body"] = True
+        return {"type": "http.request", "body": raw, "more_body": False}
+
+    async def send(message):
+        sent.append(message)
+
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(app(scope, receive, send))
+    finally:
+        loop.close()
+    status = next(m["status"] for m in sent
+                  if m["type"] == "http.response.start")
+    payload = b"".join(m.get("body", b"") for m in sent
+                       if m["type"] == "http.response.body")
+    return status, (json.loads(payload) if payload else None)
+
+
+def test_rest_crud_roundtrip():
+    with tempfile.TemporaryDirectory() as base:
+        store = AnnotationStore(base, map_id="lab", generation=1)
+        app = _make_web_app(store)
+        if app is None:
+            return
+
+        st, out = _call(app, "GET", "/api/annotations")
+        assert (st, out) == (200, {"ok": True, "annotations": []})
+
+        st, out = _call(app, "POST", "/api/annotations",
+                        {"kind": "room", "name": "厨房", "points": ROOM_PTS})
+        assert st == 200 and out["ok"]
+        ann_id = out["annotation"]["annotation_id"]
+
+        st, out = _call(app, "PUT", f"/api/annotations/{ann_id}",
+                        {"name": "kitchen"})
+        assert st == 200 and out["annotation"]["name"] == "kitchen"
+
+        # stale confirm flow: flag via the store (what the lifecycle
+        # watcher does), clear via the API (what the UI button does).
+        store.mark_all_stale("epoch flip", new_generation=2)
+        st, out = _call(app, "PUT", f"/api/annotations/{ann_id}",
+                        {"stale": False})
+        assert st == 200 and out["annotation"]["stale"] is False
+
+        st, out = _call(app, "DELETE", f"/api/annotations/{ann_id}")
+        assert (st, out) == (200, {"ok": True})
+        assert store.list() == []
+    print("  [PASS] test_rest_crud_roundtrip")
+
+
+def test_rest_validation_and_errors():
+    with tempfile.TemporaryDirectory() as base:
+        store = AnnotationStore(base, map_id="lab", generation=1)
+        app = _make_web_app(store)
+        if app is None:
+            return
+
+        st, out = _call(app, "POST", "/api/annotations",
+                        {"kind": "castle", "name": "x", "points": ROOM_PTS})
+        assert st == 400 and not out["ok"] and "kind" in out["detail"]
+
+        st, _ = _call(app, "POST", "/api/annotations",
+                      {"kind": "room", "name": "x", "points": ROOM_PTS[:2]})
+        assert st == 400
+
+        st, out = _call(app, "POST", "/api/annotations",
+                        {"kind": "room", "name": "x", "points": ROOM_PTS,
+                         "theta": 1.57})
+        assert st == 400 and "poi" in out["detail"]  # headings are poi-only
+
+        st, _ = _call(app, "PUT", "/api/annotations/anno.nope", {"name": "x"})
+        assert st == 404
+        st, _ = _call(app, "DELETE", "/api/annotations/anno.nope")
+        assert st == 404
+
+        # A partial update may not sneak in an invalid merged state.
+        _, created = _call(app, "POST", "/api/annotations",
+                           {"kind": "room", "name": "x", "points": ROOM_PTS})
+        st, _ = _call(app, "PUT",
+                      f"/api/annotations/{created['annotation']['annotation_id']}",
+                      {"points": [[0.0, 0.0]]})
+        assert st == 400
+
+        # Store unavailable → 503 on every verb.
+        app_off = _make_web_app(None)
+        for method, path in [("GET", "/api/annotations"),
+                             ("POST", "/api/annotations"),
+                             ("PUT", "/api/annotations/x"),
+                             ("DELETE", "/api/annotations/x")]:
+            st, out = _call(app_off, method, path, {})
+            assert st == 503 and not out["ok"]
+    print("  [PASS] test_rest_validation_and_errors")
+
+
+def test_user_page_served():
+    with tempfile.TemporaryDirectory() as base:
+        app = _make_web_app(AnnotationStore(base, map_id="lab", generation=1))
+        if app is None:
+            return
+        sent = []
+
+        async def receive():
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        async def send(message):
+            sent.append(message)
+
+        scope = {"type": "http", "http_version": "1.1", "method": "GET",
+                 "scheme": "http", "path": "/user", "raw_path": b"/user",
+                 "root_path": "", "query_string": b"", "headers": [],
+                 "client": ("test", 0), "server": ("test", 80)}
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(app(scope, receive, send))
+        finally:
+            loop.close()
+        status = next(m["status"] for m in sent
+                      if m["type"] == "http.response.start")
+        body = b"".join(m.get("body", b"") for m in sent
+                        if m["type"] == "http.response.body")
+        assert status == 200
+        assert b"Annotate room" in body and b"/api/annotations" in body
+    print("  [PASS] test_user_page_served")
+
+
+def test_state_payload_carries_annotations_and_binding():
+    with tempfile.TemporaryDirectory() as base:
+        store = AnnotationStore(base, map_id="lab", generation=1)
+        store.create(kind="room", name="kitchen", points=ROOM_PTS)
+        app = _make_web_app(store)
+        if app is None:
+            return
+        st, out = _call(app, "GET", "/api/state")
+        assert st == 200
+        assert out["map_binding"]["map_id"] == "lab"
+        assert len(out["annotations"]) == 1
+        assert out["annotations"][0]["name"] == "kitchen"
+    print("  [PASS] test_state_payload_carries_annotations_and_binding")
+
+
+if __name__ == "__main__":
+    test_validation_rules()
+    test_store_roundtrip_across_reopen()
+    test_update_and_delete()
+    test_map_id_partition_isolation_and_sanitize()
+    test_atomic_write_leaves_no_tmp()
+    test_generation_mismatch_marks_stale_on_load()
+    test_unknown_generation_preserves_stored_epoch()
+    test_reconcile_generation_learns_and_flags()
+    test_redraw_clears_stale_and_mark_all_stale_counts()
+    test_corrupt_file_set_aside_not_destroyed()
+    test_from_json_drops_unknown_keys()
+    test_rest_crud_roundtrip()
+    test_rest_validation_and_errors()
+    test_user_page_served()
+    test_state_payload_carries_annotations_and_binding()
+    print("test_annotations: all tests passed")

--- a/system/scene/tests/test_annotations.py
+++ b/system/scene/tests/test_annotations.py
@@ -107,6 +107,21 @@ def test_map_id_partition_isolation_and_sanitize():
     print("  [PASS] test_map_id_partition_isolation_and_sanitize")
 
 
+def test_delete_map_removes_only_target_partition():
+    with tempfile.TemporaryDirectory() as base:
+        target = AnnotationStore(base, map_id="target", generation=1)
+        other = AnnotationStore(base, map_id="other", generation=1)
+        target.create(kind="room", name="target room", points=ROOM_PTS)
+        other.create(kind="room", name="other room", points=ROOM_PTS)
+
+        assert target.delete_map("target") is True
+        assert target.list() == []
+        assert AnnotationStore(base, map_id="target", generation=1).list() == []
+        assert len(AnnotationStore(base, map_id="other", generation=1).list()) == 1
+        assert target.delete_map("target") is False
+    print("  [PASS] test_delete_map_removes_only_target_partition")
+
+
 def test_atomic_write_leaves_no_tmp():
     with tempfile.TemporaryDirectory() as base:
         s = AnnotationStore(base, map_id="lab", generation=1)
@@ -425,6 +440,7 @@ if __name__ == "__main__":
     test_room_create_is_idempotent_by_name()
     test_update_and_delete()
     test_map_id_partition_isolation_and_sanitize()
+    test_delete_map_removes_only_target_partition()
     test_atomic_write_leaves_no_tmp()
     test_generation_mismatch_marks_stale_on_load()
     test_unknown_generation_preserves_stored_epoch()

--- a/system/scene/tests/test_annotations.py
+++ b/system/scene/tests/test_annotations.py
@@ -63,6 +63,20 @@ def test_store_roundtrip_across_reopen():
     print("  [PASS] test_store_roundtrip_across_reopen")
 
 
+def test_room_create_is_idempotent_by_name():
+    with tempfile.TemporaryDirectory() as base:
+        s = AnnotationStore(base, map_id="lab", generation=1)
+        a = s.create(kind="room", name="Bathroom", points=ROOM_PTS)
+        b = s.create(kind="room", name="  bathroom  ",
+                     points=[[1.0, 1.0], [2.0, 1.0], [2.0, 2.0]])
+        assert a.annotation_id == b.annotation_id
+        assert len(s.list()) == 1
+        assert s.list()[0].points == [[1.0, 1.0], [2.0, 1.0], [2.0, 2.0]]
+        raw = json.loads(open(s.path).read())
+        assert len(raw["annotations"]) == 1
+    print("  [PASS] test_room_create_is_idempotent_by_name")
+
+
 def test_update_and_delete():
     with tempfile.TemporaryDirectory() as base:
         s = AnnotationStore(base, map_id="lab", generation=1)
@@ -408,6 +422,7 @@ def test_state_payload_carries_annotations_and_binding():
 if __name__ == "__main__":
     test_validation_rules()
     test_store_roundtrip_across_reopen()
+    test_room_create_is_idempotent_by_name()
     test_update_and_delete()
     test_map_id_partition_isolation_and_sanitize()
     test_atomic_write_leaves_no_tmp()

--- a/system/scene/tests/test_geometry.py
+++ b/system/scene/tests/test_geometry.py
@@ -1,0 +1,28 @@
+import pytest
+
+from scene_service.geometry import disc_inside_polygon, point_in_polygon, polygon_centroid
+
+
+ROOM_315 = [
+    (-4.653655402257238, 0.771744687675239),
+    (2.0362935039927557, 1.456772135591905),
+    (2.7504710560760888, -2.4201917185747583),
+    (-3.779152277257239, -3.3384199998247572),
+    (-4.609930246007238, 0.7425945835085723),
+]
+
+
+def test_room_centroid_is_area_weighted_and_inside():
+    x, y = polygon_centroid(ROOM_315)
+    assert x == pytest.approx(-0.9369215188)
+    assert y == pytest.approx(-0.8818296313)
+    assert point_in_polygon(x, y, ROOM_315)
+
+
+def test_rejects_the_goal_returned_outside_room_315():
+    assert not point_in_polygon(-0.9148793979, -3.7743059028, ROOM_315)
+
+
+def test_robot_footprint_must_remain_inside_room():
+    assert disc_inside_polygon(-0.94, -0.88, 0.3, ROOM_315)
+    assert not disc_inside_polygon(-3.75, -3.25, 0.3, ROOM_315)

--- a/system/scene/tests/test_goal_hints.py
+++ b/system/scene/tests/test_goal_hints.py
@@ -4,11 +4,14 @@ from scene_service import mcp_tools
 
 
 class _Store:
-    def list(self):
-        return [
+    def __init__(self, rooms=None):
+        self._rooms = rooms or [
             SimpleNamespace(annotation_id="anno.315", kind="room", name="room 315"),
             SimpleNamespace(annotation_id="anno.100", kind="room", name="room 100"),
         ]
+
+    def list(self):
+        return self._rooms
 
 
 def _object(object_id: str, label: str):
@@ -35,3 +38,23 @@ def test_object_hint_ranks_similar_label_first():
     )
     assert hint.index("cardboard box") < hint.index("chair")
     assert "scene.object.cardboard_box_001" in hint
+
+
+def test_room_reference_resolves_stable_id_name_and_short_alias():
+    mcp_tools.attach_annotation_store(_Store())
+    for reference in ("scene.room.anno.315", "room 315", "ROOM   315", "315"):
+        room, ambiguous = mcp_tools._resolve_room_target(reference)
+        assert room is not None
+        assert room.annotation_id == "anno.315"
+        assert ambiguous == []
+
+
+def test_room_reference_reports_ambiguous_aliases_without_guessing():
+    rooms = [
+        SimpleNamespace(annotation_id="anno.a", kind="room", name="room 315"),
+        SimpleNamespace(annotation_id="anno.b", kind="room", name="315"),
+    ]
+    mcp_tools.attach_annotation_store(_Store(rooms))
+    room, ambiguous = mcp_tools._resolve_room_target("315")
+    assert room is None
+    assert [item.annotation_id for item in ambiguous] == ["anno.a", "anno.b"]

--- a/system/scene/tests/test_goal_hints.py
+++ b/system/scene/tests/test_goal_hints.py
@@ -1,0 +1,37 @@
+from types import SimpleNamespace
+
+from scene_service import mcp_tools
+
+
+class _Store:
+    def list(self):
+        return [
+            SimpleNamespace(annotation_id="anno.315", kind="room", name="room 315"),
+            SimpleNamespace(annotation_id="anno.100", kind="room", name="room 100"),
+        ]
+
+
+def _object(object_id: str, label: str):
+    return SimpleNamespace(object_id=object_id, cls=label)
+
+
+def test_room_hint_lists_names_and_exact_ids():
+    mcp_tools.attach_annotation_store(_Store())
+    hint = mcp_tools._room_id_hint()
+    assert "room 315" in hint
+    assert "scene.room.anno.315" in hint
+    assert "room 100" in hint
+    assert "scene.room.anno.100" in hint
+
+
+def test_object_hint_ranks_similar_label_first():
+    hint = mcp_tools._object_id_hint(
+        "cardbord box",
+        [
+            _object("scene.object.chair_001", "chair"),
+            _object("scene.object.cardboard_box_001", "cardboard box"),
+            _object("scene.object.table_001", "table"),
+        ],
+    )
+    assert hint.index("cardboard box") < hint.index("chair")
+    assert "scene.object.cardboard_box_001" in hint

--- a/system/scene/tests/test_map_binding.py
+++ b/system/scene/tests/test_map_binding.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+"""Unit tests for the map identity binding (scene_service.map_binding).
+
+The precedence rule is pure Python and always runs. The latched-read
+probe test exercises the graceful-degradation path: on a machine without
+rclpy / the generated `map` interface package it must return None (not
+raise); on a full ROS container it still returns None because nothing
+publishes the probe topic within the short timeout.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from scene_service.map_binding import (  # noqa: E402
+    MapBinding,
+    choose_map_binding,
+    read_latched_lifecycle,
+)
+
+
+def test_broadcast_wins_over_config_and_env():
+    b = choose_map_binding(
+        {"map_id": "lab_a", "mode": "localization", "generation": 4},
+        "cfg_map", "env_map",
+    )
+    assert b == MapBinding(
+        map_id="lab_a", source="lifecycle", mode="localization", generation=4
+    )
+    print("  [PASS] test_broadcast_wins_over_config_and_env")
+
+
+def test_empty_broadcast_map_id_falls_through():
+    # mapping running ephemeral broadcasts map_id="" — that is "no named
+    # identity", static levers must win.
+    b = choose_map_binding({"map_id": "", "mode": "mapping", "generation": 1},
+                           "cfg_map", "env_map")
+    assert (b.map_id, b.source) == ("cfg_map", "config")
+    print("  [PASS] test_empty_broadcast_map_id_falls_through")
+
+
+def test_config_beats_env_then_env_then_default():
+    assert choose_map_binding(None, "cfg_map", "env_map").source == "config"
+    b = choose_map_binding(None, None, "env_map")
+    assert (b.map_id, b.source) == ("env_map", "env")
+    b = choose_map_binding(None, None, None)
+    assert (b.map_id, b.source) == ("default", "default")
+    # static sources carry no generation — the runtime watcher treats
+    # None as "match any generation" until P3 tightens this.
+    assert b.generation is None
+    print("  [PASS] test_config_beats_env_then_env_then_default")
+
+
+def test_probe_degrades_to_none_without_publisher():
+    # No rclpy / no `map` interface package → None with a warning;
+    # with ROS available → None after the (short) timeout since nothing
+    # publishes this probe-only topic. Either way: no exception.
+    assert read_latched_lifecycle("/robonix/test/map_binding_probe",
+                                  timeout_s=0.3) is None
+    print("  [PASS] test_probe_degrades_to_none_without_publisher")
+
+
+if __name__ == "__main__":
+    test_broadcast_wins_over_config_and_env()
+    test_empty_broadcast_map_id_falls_through()
+    test_config_beats_env_then_env_then_default()
+    test_probe_degrades_to_none_without_publisher()
+    print("test_map_binding: all tests passed")

--- a/system/scene/tests/test_map_operation_ui.py
+++ b/system/scene/tests/test_map_operation_ui.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+"""Structural checks for the blocking Save/Load operation dialog."""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def _user_html():
+    try:
+        from scene_service.web import _USER_HTML
+    except ImportError as exc:
+        pytest.skip(f"web deps unavailable: {exc}")
+    return _USER_HTML
+
+
+def test_map_operations_have_one_blocking_dialog_and_retry_path():
+    html = _user_html()
+    assert 'id="map-operation-modal"' in html
+    assert "function beginMapOperation" in html
+    assert "function finishMapOperation" in html
+    assert "if (mapBusy) ev.preventDefault()" in html
+    assert "Wait for a fresh occupancy grid" in html
+    assert "Restore rooms and Scene objects" in html
+    assert "retry: () => loadSelectedMap(id)" in html
+
+
+def test_embedded_user_script_is_valid_javascript():
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is not installed")
+    html = _user_html()
+    script = html.rsplit("<script>", 1)[1].split("</script>", 1)[0]
+    with tempfile.NamedTemporaryFile("w", suffix=".js") as handle:
+        handle.write(script)
+        handle.flush()
+        subprocess.run([node, "--check", handle.name], check=True)

--- a/system/scene/tests/test_scene_graph.py
+++ b/system/scene/tests/test_scene_graph.py
@@ -30,6 +30,20 @@ _LLM_ENV_VARS = (
 )
 
 
+def _ensure_loop() -> asyncio.AbstractEventLoop:
+    """Current event loop, creating (and installing) one when the thread has
+    none. Bare `asyncio.get_event_loop()` is unreliable across the suite:
+    running the milvus-lite tests (test_persistence) first leaves the main
+    thread without a current loop, and the deprecated implicit-creation path
+    then raises "There is no current event loop"."""
+    try:
+        return asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        return loop
+
+
 def _pop_llm_env() -> dict:
     """Pop all LLM-related env vars and return them for restoration."""
     return {k: os.environ.pop(k, None) for k in _LLM_ENV_VARS}
@@ -156,7 +170,7 @@ def test_captioner():
     node = SceneGraphNode("obj_1", "cup", (0, 0, 0), (0.1, 0.1, 0.1))
     assert node.caption is None
 
-    result = asyncio.get_event_loop().run_until_complete(cap.caption_node(node))
+    result = _ensure_loop().run_until_complete(cap.caption_node(node))
     assert result.caption == "cup"
     assert result.caption_updated_at is not None
     print("  [PASS] test_captioner")
@@ -257,7 +271,7 @@ def test_llm_client_no_key():
         client = SceneGraphLLMClient(api_key="", base_url="")
         assert not client.available
 
-        result = asyncio.get_event_loop().run_until_complete(
+        result = _ensure_loop().run_until_complete(
             client.chat_json("system", "user")
         )
         assert result == {}
@@ -281,7 +295,7 @@ def test_relation_inferer_no_llm():
         b = SceneGraphNode("obj_2", "table", (1.0, 0.5, 0.4), (1.2, 0.8, 0.05), caption="table")
         hint = GeometryHint(0.4, 0.6, "a_above_b", "none")
 
-        edge = asyncio.get_event_loop().run_until_complete(
+        edge = _ensure_loop().run_until_complete(
             inferer.infer_relation(a, b, hint)
         )
         assert edge.relation == "unknown"
@@ -318,7 +332,7 @@ def test_builder_rebuild_no_objects():
             config=config,
         )
 
-        snap = asyncio.get_event_loop().run_until_complete(builder.rebuild_once())
+        snap = _ensure_loop().run_until_complete(builder.rebuild_once())
         assert len(snap.nodes) == 0
         assert len(snap.edges) == 0
         assert snap.updated_at > 0
@@ -346,7 +360,7 @@ def _run_builder_rebuild_with_objects_body():
     with tempfile.TemporaryDirectory() as tmpdir:
         registry = ObjectRegistry()
 
-        loop = asyncio.get_event_loop()
+        loop = _ensure_loop()
 
         async def populate():
             async with registry.lock():
@@ -619,7 +633,7 @@ def test_infer_semantic_relation():
     a = SceneGraphNode("a", "handle", (0.0, 0.0, 0.5), (0.1, 0.1, 0.1))
     b = SceneGraphNode("b", "door", (0.0, 0.0, 0.5), (1.0, 0.1, 2.0))
     hint = GeometryHint(0.0, 0.5, "same_level", "a_inside_b")
-    run = asyncio.get_event_loop().run_until_complete
+    run = _ensure_loop().run_until_complete
 
     # A spatial answer is rejected — geometry owns the spatial slot → none.
     inf = RelationInferer(_FakeClient({"relation": "on_top_of", "confidence": 0.9}))
@@ -701,7 +715,7 @@ def test_llm_client_request_body():
         k.setdefault("transport", httpx.MockTransport(handler))
         return orig(*a, **k)
 
-    run = asyncio.get_event_loop().run_until_complete
+    run = _ensure_loop().run_until_complete
     httpx.AsyncClient = patched
     try:
         c = SceneGraphLLMClient(

--- a/testing/verify_scene_map_persistence.py
+++ b/testing/verify_scene_map_persistence.py
@@ -57,11 +57,16 @@ def docker_python(container: str, code: str, *, env: dict[str, str] | None = Non
     return json.loads(proc.stdout)
 
 
-def mapping_artifact(container: str, map_id: str, timeout: float) -> dict[str, Any]:
+def mapping_artifact(
+    container: str,
+    map_id: str,
+    maps_dir: str,
+    timeout: float,
+) -> dict[str, Any]:
     code = r"""
 import json, os, sqlite3, struct
 mid = os.environ["VERIFY_MAP_ID"]
-base = "/mapping/maps/" + mid
+base = os.path.join(os.environ["VERIFY_MAPS_DIR"], mid)
 png = os.path.join(base, "occupancy.png")
 meta = os.path.join(base, "meta.yaml")
 db = os.path.join(base, "rtabmap.db")
@@ -107,7 +112,12 @@ if os.path.isfile(db):
     res["counts"] = counts
 print(json.dumps(res, ensure_ascii=False))
 """
-    return docker_python(container, code, env={"VERIFY_MAP_ID": map_id}, timeout=timeout)
+    return docker_python(
+        container,
+        code,
+        env={"VERIFY_MAP_ID": map_id, "VERIFY_MAPS_DIR": maps_dir},
+        timeout=timeout,
+    )
 
 
 def live_map(container: str, timeout: float) -> dict[str, Any]:
@@ -186,6 +196,7 @@ def main() -> int:
     ap.add_argument("--map-id", default=f"verify_scene_map_{int(time.time())}")
     ap.add_argument("--note", default="scene map persistence verifier")
     ap.add_argument("--mapping-container", default="robonix_mapping")
+    ap.add_argument("--maps-dir", default="/mapping/maps")
     ap.add_argument("--sim-container", default="robonix_tiago_sim")
     ap.add_argument("--min-artifact-bytes", type=int, default=1_000_000)
     ap.add_argument("--min-nodes", type=int, default=1)
@@ -216,7 +227,12 @@ def main() -> int:
               "object_count" in validation and "room_count" in validation,
               f"objects={validation.get('object_count')} rooms={validation.get('room_count')}", results)
 
-    artifact = mapping_artifact(args.mapping_container, args.map_id, timeout=60.0)
+    artifact = mapping_artifact(
+        args.mapping_container,
+        args.map_id,
+        args.maps_dir,
+        timeout=60.0,
+    )
     print("artifact", json.dumps(artifact, ensure_ascii=False, sort_keys=True))
     check("artifact_directory_exists", bool(artifact.get("exists")), str(artifact.get("base")), results)
     check("artifact_sqlite_exists", bool(artifact.get("db_exists")), str(artifact.get("files")), results)


### PR DESCRIPTION
## Problem

Saved SLAM maps could reload without their matching rooms and objects, and the first Load click sometimes only switched RTAB-Map while Scene still showed the previous binding. Save/Load also left the editor interactive, allowing duplicate requests or room edits during a map transition.

Pilot also passed labels such as `room 315` to an API that previously accepted only stable IDs.

## Design

- Mapping remains the owner of spatial artifacts; Scene stores rooms and objects by the same `map_id`.
- Load performs one RPC, waits for a newly published occupancy grid, then rebinds and restores Scene data. If the new grid is not observed, the request fails clearly instead of requiring another click.
- Saving an existing `map_id` preserves the immutable spatial artifact and updates its Scene rooms/objects.
- Save and Load now use a blocking operation modal. While active, map actions, room editing, drawing, pose estimation, and duplicate submissions are disabled.
- The modal shows the operation phases, keeps failure details visible, and provides explicit Retry/Close. Success is shown only after validation.
- Room goals support stable IDs, unique normalized names, and short aliases without fuzzy guessing.

## Tests

Environment: Jetson AGX Orin source/runtime dependencies; map RPCs were mocked for UI/API tests, so no real map, chassis, navigation, or arm action was triggered.

- Map operation and annotation Web/API tests: **20 passed**
- One-click Load regression verifies a fresh occupancy grid is observed before Scene rebind
- Embedded UI JavaScript: `node --check` passed
- Existing Scene suite: **80 passed**
- Earlier Jetson validation loaded a 200x118 map and restored 35 objects
- Stable room ID, `room 315`, and `315` resolved consistently

## Discussion

This PR remains Draft until the cold-start sequence is repeated on the real robot: save an unannotated partial map, restart/load, add rooms, save to the same `map_id`, then restart/load again.