### PR TITLE
fix(webots): harden soma primitive lifecycle

### DIFF
--- a/.github/workflows/ci-bot.yml
+++ b/.github/workflows/ci-bot.yml
@@ -409,8 +409,16 @@ jobs:
               .slice(0, 500);
             if (summary) {
               const pct = Math.round(summary.rate * 100);
-              const icon = summary.failed === 0 ? '✅' : '❌';
-              lines.push(`### ${icon} robonix CI — ${summary.passed}/${summary.total} passed (${pct}%)`);
+              const jobFailed = outcome === 'failure' || outcome === 'cancelled';
+              const icon = summary.failed === 0 && !jobFailed ? '✅' : '❌';
+              const title = jobFailed && summary.failed === 0
+                ? `job ${outcome} after scenarios (${summary.passed}/${summary.total} scenarios passed, ${pct}%)`
+                : `${summary.passed}/${summary.total} passed (${pct}%)`;
+              lines.push(`### ${icon} robonix CI — ${title}`);
+              if (jobFailed) {
+                lines.push('');
+                lines.push(`Webots job concluded \`${outcome}\` after producing a scenario summary. Treat this as a failed CI run; inspect lifecycle, teardown, report, and raw logs in the action run.`);
+              }
               lines.push('');
               lines.push('| suite | scenario | result | rounds |');
               lines.push('|-------|----------|--------|--------|');

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -424,7 +424,12 @@ jobs:
         if: env.GIT_MIRROR_INSTEADOF == 'true'
         run: |
           set -euo pipefail
-          git config --global url."https://ghfast.top/https://github.com/".insteadOf "https://github.com/"
+          # Keep the checkout mirror scoped to this Actions job. The runner is
+          # also a developer workstation, so CI must not mutate ~/.gitconfig.
+          git_config="$RUNNER_TEMP/robonix-ci-gitconfig"
+          : > "$git_config"
+          git config --file "$git_config" url."https://ghfast.top/https://github.com/".insteadOf "https://github.com/"
+          echo "GIT_CONFIG_GLOBAL=$git_config" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@v4
         with:

--- a/examples/webots/primitives/audio_client_bridge/audio_client_bridge/main.py
+++ b/examples/webots/primitives/audio_client_bridge/audio_client_bridge/main.py
@@ -349,6 +349,11 @@ def init(cfg):
     return Ok()
 
 
+@audio_client_bridge.on_shutdown
+def shutdown():
+    return Ok()
+
+
 def main() -> int:
     audio_client_bridge.run()
     return 0

--- a/examples/webots/primitives/tiago_camera/camera_driver/driver.py
+++ b/examples/webots/primitives/tiago_camera/camera_driver/driver.py
@@ -477,5 +477,10 @@ def init(cfg):
     return Ok()
 
 
+@tiago_camera.on_shutdown
+def shutdown():
+    return Ok()
+
+
 if __name__ == "__main__":
     tiago_camera.run()

--- a/examples/webots/primitives/tiago_camera/scripts/start.sh
+++ b/examples/webots/primitives/tiago_camera/scripts/start.sh
@@ -22,14 +22,16 @@ fi
 # so the names line up. Compensation lives here (camera primitive) — never
 # in mapping/scene.
 docker exec -d "$SIM_CT" bash -lc "
-    source /opt/ros/humble/setup.bash
+    set +u
+    source /opt/ros/humble/setup.bash >/dev/null
     export RMW_IMPLEMENTATION=\"${RMW_IMPLEMENTATION:-rmw_zenoh_cpp}\"
     exec ros2 run tf2_ros static_transform_publisher \
         --x 0 --y 0 --z 0 --yaw 0 --pitch 0 --roll 0 \
         --frame-id 'Astra rgb' --child-frame-id head_front_camera_rgb_optical_frame
 " &>/dev/null
 docker exec -d "$SIM_CT" bash -lc "
-    source /opt/ros/humble/setup.bash
+    set +u
+    source /opt/ros/humble/setup.bash >/dev/null
     export RMW_IMPLEMENTATION=\"${RMW_IMPLEMENTATION:-rmw_zenoh_cpp}\"
     exec ros2 run tf2_ros static_transform_publisher \
         --x 0 --y 0 --z 0 --yaw 0 --pitch 0 --roll 0 \
@@ -72,8 +74,22 @@ exec docker exec \
   -e PYTHONPATH="/robonix_pkgs/pylib/robonix-api:/robonix_pkgs/primitives/tiago_camera/rbnx-build/codegen/proto_gen:/robonix_pkgs/primitives/tiago_camera/rbnx-build/codegen/robonix_mcp_types:/robonix_pkgs/primitives/tiago_camera/robonix_mcp_types" \
   "$SIM_CT" \
   bash -lc 'set -eo pipefail
-            source /opt/ros/humble/setup.bash
+            set +u
+            source /opt/ros/humble/setup.bash >/dev/null
             OVL=/robonix_pkgs/primitives/tiago_camera/rbnx-build/codegen/ros2_idl/install/setup.bash
-            [ -f "$OVL" ] && source "$OVL" || true
+            [ -f "$OVL" ] && source "$OVL" >/dev/null || true
             cd /robonix_pkgs/primitives/tiago_camera
-            exec python3 -m camera_driver.driver'
+            LOG=/tmp/tiago_camera_driver.log
+            : > "$LOG"
+            python3 -m camera_driver.driver >>"$LOG" 2>&1 &
+            DRIVER_PID=$!
+            tail --pid="$DRIVER_PID" -n +1 -F "$LOG" &
+            TAIL_PID=$!
+            set +e
+            wait "$DRIVER_PID"
+            STATUS=$?
+            set -e
+            kill "$TAIL_PID" 2>/dev/null || true
+            wait "$TAIL_PID" 2>/dev/null || true
+            exit "$STATUS"
+            '

--- a/examples/webots/primitives/tiago_chassis/chassis_driver/driver.py
+++ b/examples/webots/primitives/tiago_chassis/chassis_driver/driver.py
@@ -126,9 +126,10 @@ def shutdown():
         try:
             from geometry_msgs.msg import Twist  # type: ignore
             cmd_vel_pub.publish(Twist())
-        except Exception:
-            pass
-    cmd_vel_pub = None
+        except Exception as exc:
+            print(f"[tiago_chassis] shutdown zero Twist failed: {exc}", flush=True)
+        finally:
+            cmd_vel_pub = None
     return Ok()
 
 

--- a/examples/webots/primitives/tiago_chassis/scripts/start.sh
+++ b/examples/webots/primitives/tiago_chassis/scripts/start.sh
@@ -55,8 +55,22 @@ exec docker exec \
   -e PYTHONPATH="/robonix_pkgs/pylib/robonix-api:/robonix_pkgs/primitives/tiago_chassis/rbnx-build/codegen/proto_gen" \
   "$SIM_CT" \
   bash -lc 'set -eo pipefail
-            source /opt/ros/humble/setup.bash
+            set +u
+            source /opt/ros/humble/setup.bash >/dev/null
             OVL=/robonix_pkgs/primitives/tiago_chassis/rbnx-build/codegen/ros2_idl/install/setup.bash
-            [ -f "$OVL" ] && source "$OVL" || true
+            [ -f "$OVL" ] && source "$OVL" >/dev/null || true
             cd /robonix_pkgs/primitives/tiago_chassis
-            exec python3 -m chassis_driver.driver'
+            LOG=/tmp/tiago_chassis_driver.log
+            : > "$LOG"
+            python3 -m chassis_driver.driver >>"$LOG" 2>&1 &
+            DRIVER_PID=$!
+            tail --pid="$DRIVER_PID" -n +1 -F "$LOG" &
+            TAIL_PID=$!
+            set +e
+            wait "$DRIVER_PID"
+            STATUS=$?
+            set -e
+            kill "$TAIL_PID" 2>/dev/null || true
+            wait "$TAIL_PID" 2>/dev/null || true
+            exit "$STATUS"
+            '

--- a/examples/webots/primitives/tiago_lidar/lidar_driver/driver.py
+++ b/examples/webots/primitives/tiago_lidar/lidar_driver/driver.py
@@ -85,5 +85,10 @@ def init(cfg):
     return Ok()
 
 
+@tiago_lidar.on_shutdown
+def shutdown():
+    return Ok()
+
+
 if __name__ == "__main__":
     tiago_lidar.run()

--- a/examples/webots/primitives/tiago_lidar/scripts/start.sh
+++ b/examples/webots/primitives/tiago_lidar/scripts/start.sh
@@ -57,15 +57,29 @@ exec docker exec \
   -e RMW_IMPLEMENTATION="${RMW_IMPLEMENTATION:-rmw_zenoh_cpp}" \
   -e PYTHONPATH="/robonix_pkgs/pylib/robonix-api:/robonix_pkgs/primitives/tiago_lidar/rbnx-build/codegen/proto_gen:/robonix_pkgs/primitives/tiago_lidar/rbnx-build/codegen/robonix_mcp_types" \
   "$SIM_CT" \
-  bash -lc "
+  bash -lc '''
     set -eo pipefail
-    source /opt/ros/humble/setup.bash
+    set +u
+    source /opt/ros/humble/setup.bash >/dev/null
     OVL=/robonix_pkgs/primitives/tiago_lidar/rbnx-build/codegen/ros2_idl/install/setup.bash
-    [ -f \"\$OVL\" ] && source \"\$OVL\" || true
-    python3 /robonix_pkgs/primitives/tiago_lidar/scripts/scan_normalize.py \\
-        --in $RAW_TOPIC --out $OUT_TOPIC &
-    NORM_PID=\$!
-    trap 'kill -TERM \$NORM_PID 2>/dev/null || true' EXIT
+    [ -f "$OVL" ] && source "$OVL" >/dev/null || true
+    python3 /robonix_pkgs/primitives/tiago_lidar/scripts/scan_normalize.py \
+        --in "$TIAGO_SCAN_RAW_TOPIC" --out "$TIAGO_SCAN_TOPIC" &
+    NORM_PID=$!
+    trap "kill -TERM \"$NORM_PID\" 2>/dev/null || true" EXIT
     cd /robonix_pkgs/primitives/tiago_lidar
-    exec python3 -m lidar_driver.driver
-  "
+    LOG=/tmp/tiago_lidar_driver.log
+    : > "$LOG"
+    python3 -m lidar_driver.driver >>"$LOG" 2>&1 &
+    DRIVER_PID=$!
+    tail --pid="$DRIVER_PID" -n +1 -F "$LOG" &
+    TAIL_PID=$!
+    set +e
+    wait "$DRIVER_PID"
+    STATUS=$?
+    set -e
+    kill "$TAIL_PID" 2>/dev/null || true
+    wait "$TAIL_PID" 2>/dev/null || true
+    exit "$STATUS"
+  '''
+

--- a/examples/webots/robonix_manifest.yaml
+++ b/examples/webots/robonix_manifest.yaml
@@ -32,7 +32,7 @@ system:
       model: ${VLM_MODEL}
       api_format: openai
   liaison:
-    listen: 127.0.0.1:50081
+    listen: 0.0.0.0:50081
     log: info
 
 # after booted all the system components, start the devices (primitives)

--- a/system/soma/src/launcher.rs
+++ b/system/soma/src/launcher.rs
@@ -321,7 +321,7 @@ impl PackageLauncher {
         // Match rbnx deploy's provider endpoint semantics: atlas may listen on
         // 0.0.0.0, but providers need a dialable address. In-container Webots
         // drivers can still override this in their start.sh via ROBONIX_SIM_ATLAS.
-        let provider_atlas = self.atlas_endpoint.replacen("0.0.0.0", "127.0.0.1", 1);
+        let provider_atlas = self.provider_atlas_endpoint();
 
         let mut cmd = TokioCommand::new(RBNX_BIN);
         cmd.arg("start")
@@ -427,13 +427,10 @@ impl PackageLauncher {
     /// Stop all packages launched by soma and abort their
     /// pipe-forwarding tasks. Called on SIGINT/SIGTERM in main.
     pub async fn stop_all(&mut self) -> Result<()> {
+        let provider_atlas = self.provider_atlas_endpoint();
         for record in self.children.drain(..).rev() {
-            shutdown_package_runtime(
-                Some(&self.atlas_endpoint),
-                &record,
-                Duration::from_millis(500),
-            )
-            .await;
+            shutdown_package_runtime(Some(&provider_atlas), &record, Duration::from_millis(500))
+                .await;
         }
         if let Err(e) = self.manager.stop_all().await {
             warn!("stop ProcessManager-owned Soma packages: {e:#}");
@@ -449,8 +446,12 @@ impl PackageLauncher {
             "{} start -p {} --endpoint {}",
             RBNX_BIN,
             target.package_dir.display(),
-            self.atlas_endpoint.replacen("0.0.0.0", "127.0.0.1", 1)
+            self.provider_atlas_endpoint()
         )
+    }
+
+    fn provider_atlas_endpoint(&self) -> String {
+        self.atlas_endpoint.replacen("0.0.0.0", "127.0.0.1", 1)
     }
 }
 
@@ -465,6 +466,28 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let launcher =
             PackageLauncher::new(tmp.path().join("logs"), "127.0.0.1:50051").expect("launcher");
+        let target = PackageLaunchTarget {
+            kind: PackageKind::Primitive,
+            name: "demo".into(),
+            package_dir: PathBuf::from("/tmp/robonix/examples/test_ci/primitives/demo"),
+            package_manifest_path: PathBuf::from(
+                "/tmp/robonix/examples/test_ci/primitives/demo/package_manifest.yaml",
+            ),
+            manifest_override: None,
+            config: serde_yaml::Value::Null,
+        };
+
+        assert_eq!(
+            launcher.command_line(&target),
+            "rbnx start -p /tmp/robonix/examples/test_ci/primitives/demo --endpoint 127.0.0.1:50051"
+        );
+    }
+
+    #[test]
+    fn command_line_rewrites_bind_all_atlas_to_loopback_for_packages() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let launcher =
+            PackageLauncher::new(tmp.path().join("logs"), "0.0.0.0:50051").expect("launcher");
         let target = PackageLaunchTarget {
             kind: PackageKind::Primitive,
             name: "demo".into(),

--- a/tools/rbnx/src/cmd/init.rs
+++ b/tools/rbnx/src/cmd/init.rs
@@ -73,7 +73,7 @@ system:
       model: ${{VLM_MODEL}}
       api_format: openai
   liaison:
-    listen: 127.0.0.1:50081
+    listen: 0.0.0.0:50081
     log: info
   memory: []
 

--- a/tools/rbnx/src/process.rs
+++ b/tools/rbnx/src/process.rs
@@ -162,9 +162,26 @@ impl ProcessManager {
         let content = std::fs::read_to_string(&self.state_file)
             .with_context(|| format!("Failed to read state file: {}", self.state_file.display()))?;
 
-        let processes: Vec<ProcessInfo> = serde_json::from_str(&content).with_context(|| {
-            format!("Failed to parse state file: {}", self.state_file.display())
-        })?;
+        if content.trim().is_empty() {
+            warn!(
+                "Process state file {} is empty; resetting stale runtime state",
+                self.state_file.display()
+            );
+            self.save_state_internal(&HashMap::new())?;
+            return Ok(());
+        }
+
+        let processes: Vec<ProcessInfo> = match serde_json::from_str(&content) {
+            Ok(processes) => processes,
+            Err(err) => {
+                warn!(
+                    "Process state file {} is invalid ({err}); resetting stale runtime state",
+                    self.state_file.display()
+                );
+                self.save_state_internal(&HashMap::new())?;
+                return Ok(());
+            }
+        };
 
         // Verify processes are still running and filter out dead ones
         let mut valid_processes = HashMap::new();
@@ -890,3 +907,49 @@ impl ProcessManager {
 // Processes are started as daemon processes and should continue running
 // even after the CLI exits. They can be stopped explicitly using the
 // unregister command or stop_process/stop_all methods.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn unique_temp_dir(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "robonix-process-test-{label}-{}-{}",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn empty_process_state_is_reset_instead_of_fatal() {
+        let root = unique_temp_dir("empty");
+        let log_dir = root.join("rbnx-boot").join("logs");
+        fs::create_dir_all(&log_dir).unwrap();
+        let state_file = root.join("rbnx-boot").join("processes.json");
+        fs::write(&state_file, "").unwrap();
+
+        let manager = ProcessManager::new(log_dir).unwrap();
+
+        assert!(manager.processes.lock().unwrap().is_empty());
+        assert_eq!(fs::read_to_string(&state_file).unwrap(), "[]");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn invalid_process_state_is_reset_instead_of_fatal() {
+        let root = unique_temp_dir("invalid");
+        let log_dir = root.join("rbnx-boot").join("logs");
+        fs::create_dir_all(&log_dir).unwrap();
+        let state_file = root.join("rbnx-boot").join("processes.json");
+        fs::write(&state_file, "{").unwrap();
+
+        let manager = ProcessManager::new(log_dir).unwrap();
+
+        assert!(manager.processes.lock().unwrap().is_empty());
+        assert_eq!(fs::read_to_string(&state_file).unwrap(), "[]");
+        let _ = fs::remove_dir_all(root);
+    }
+}


### PR DESCRIPTION
## Summary
- make Soma use a dialable Atlas endpoint when shutting down package runtimes
- expose liaison on 0.0.0.0 in the Webots manifest/init template so remote clients can connect
- add shutdown hooks for Webots camera/lidar/audio client bridge primitives
- wrap Webots primitive driver stdout/stderr inside the sim container to avoid BrokenPipe on shutdown/log pipe closure

## Validation
- cargo fmt --all -- --check
- python3 -m py_compile for audio_client_bridge, tiago_camera, tiago_chassis, tiago_lidar drivers
- bash -n for tiago_camera/tiago_chassis/tiago_lidar start.sh
- cargo test -p robonix-soma command_line_rewrites_bind_all_atlas_to_loopback_for_packages --quiet
- cargo check -p robonix-soma --quiet