### PR TITLE
feat(voice): add hands-free audio and reliable task interruption

### DIFF
--- a/capabilities/lib/audio/srv/GetAudioBridgeInfo.srv
+++ b/capabilities/lib/audio/srv/GetAudioBridgeInfo.srv
@@ -1,0 +1,8 @@
+# robonix/primitive/audio/bridge_info -- return the reverse-audio listener
+# that a robonix-client should connect to. Only the client-bridge provider
+# exposes this optional contract; fixed local audio drivers do not need it.
+---
+bool reverse
+string endpoint          # ws://<robot-reachable-host>:<port>/client, or empty
+bool connected           # whether a client currently has an active session
+string detail

--- a/capabilities/lib/liaison/srv/GetHandsfreeStatus.srv
+++ b/capabilities/lib/liaison/srv/GetHandsfreeStatus.srv
@@ -1,0 +1,10 @@
+# Read the current robot-local wake-word interaction state.
+---
+bool enabled
+string state
+string keyword
+string mic_provider_id
+string speaker_provider_id
+uint64 last_wake_ms
+string last_transcript
+string last_error

--- a/capabilities/lib/liaison/srv/SetHandsfree.srv
+++ b/capabilities/lib/liaison/srv/SetHandsfree.srv
@@ -1,0 +1,9 @@
+# Enable or disable robot-local wake-word interaction.
+bool enabled
+string mic_provider_id
+string speaker_provider_id
+---
+bool ok
+bool enabled
+string state
+string detail

--- a/capabilities/lib/liaison/srv/WatchHandsfreeEvents.srv
+++ b/capabilities/lib/liaison/srv/WatchHandsfreeEvents.srv
@@ -1,0 +1,4 @@
+# Subscribe to voice events emitted by Liaison's current robot-local
+# hands-free loop. This is observational; it does not own microphone input.
+---
+liaison/VoiceEvent event

--- a/capabilities/lib/speech/srv/DetectWakeWord.srv
+++ b/capabilities/lib/speech/srv/DetectWakeWord.srv
@@ -1,0 +1,7 @@
+# Stream microphone PCM to the speech service until a configured wake phrase is detected.
+audio/msg/AudioChunk chunk
+---
+bool detected
+string keyword
+float32 confidence
+string error

--- a/capabilities/primitive/audio/bridge_info.v1.toml
+++ b/capabilities/primitive/audio/bridge_info.v1.toml
@@ -1,0 +1,12 @@
+# Optional discovery surface for an audio provider that proxies client I/O.
+# It lets a client learn the robot-side reverse WebSocket endpoint through
+# Atlas rather than hardcoding a port or placing the client address in deploy.
+[contract]
+id = "robonix/primitive/audio/bridge_info"
+version = "1"
+kind = "primitive"
+idl = "audio/srv/GetAudioBridgeInfo.srv"
+description = "Discover the reverse client-audio endpoint exposed by an audio bridge provider."
+
+[mode]
+type = "rpc"

--- a/capabilities/service/speech/wake_word.v1.toml
+++ b/capabilities/service/speech/wake_word.v1.toml
@@ -1,0 +1,9 @@
+[contract]
+id = "robonix/service/speech/wake_word"
+version = "1"
+kind = "service"
+idl = "speech/srv/DetectWakeWord.srv"
+description = "Detect a configured wake phrase from a client-streamed PCM audio source."
+
+[mode]
+type = "rpc_client_stream"

--- a/capabilities/system/liaison/handsfree/events.v1.toml
+++ b/capabilities/system/liaison/handsfree/events.v1.toml
@@ -1,0 +1,11 @@
+# Read-only observation stream for the robot-local hands-free interaction.
+# It reuses VoiceEvent so clients render it exactly like a push-to-talk turn.
+[contract]
+id = "robonix/system/liaison/handsfree/events"
+version = "1"
+kind = "service"
+idl = "liaison/srv/WatchHandsfreeEvents.srv"
+description = "Subscribe to events from Liaison's robot-local hands-free voice turns."
+
+[mode]
+type = "rpc_server_stream"

--- a/capabilities/system/liaison/handsfree/set_enabled.v1.toml
+++ b/capabilities/system/liaison/handsfree/set_enabled.v1.toml
@@ -1,0 +1,9 @@
+[contract]
+id = "robonix/system/liaison/handsfree/set_enabled"
+version = "1"
+kind = "service"
+idl = "liaison/srv/SetHandsfree.srv"
+description = "Enable or disable Liaison's robot-local wake-word interaction mode."
+
+[mode]
+type = "rpc"

--- a/capabilities/system/liaison/handsfree/status.v1.toml
+++ b/capabilities/system/liaison/handsfree/status.v1.toml
@@ -1,0 +1,9 @@
+[contract]
+id = "robonix/system/liaison/handsfree/status"
+version = "1"
+kind = "service"
+idl = "liaison/srv/GetHandsfreeStatus.srv"
+description = "Read Liaison's robot-local wake-word interaction state."
+
+[mode]
+type = "rpc"

--- a/capabilities/system/liaison/submit.v1.toml
+++ b/capabilities/system/liaison/submit.v1.toml
@@ -2,7 +2,7 @@
 [contract]
 id      = "robonix/system/liaison/submit"
 version = "1"
-kind    = "system"
+kind    = "service"
 idl     = "liaison/srv/SubmitTask.srv"
 description = "Submit a user task through Liaison and stream Pilot events back."
 

--- a/capabilities/system/liaison/voice.v1.toml
+++ b/capabilities/system/liaison/voice.v1.toml
@@ -3,7 +3,7 @@
 [contract]
 id      = "robonix/system/liaison/voice"
 version = "1"
-kind    = "system"
+kind    = "service"
 idl     = "liaison/srv/StartVoiceSession.srv"
 description = "Run a voice interaction session through Liaison."
 

--- a/examples/webots/primitives/audio_client_bridge/README.md
+++ b/examples/webots/primitives/audio_client_bridge/README.md
@@ -1,11 +1,9 @@
 # audio_client_bridge
 
-Local-only audio primitive that runs on a Linux atlas host but routes
-mic + speaker through a daemon on an client machine across the LAN. The
-manifest-side provider (`com.robonix.primitive.audio`) is identical to the
-default `audio_driver` package, so liaison / scene / pilot don't see a
-difference; the only thing that changes is where the actual ADC/DAC
-lives.
+Audio primitive that runs on the Robonix host but routes mic + speaker through
+the selected `robonix-client` device. It implements the same audio contracts
+as `audio_driver`; both providers can be registered at once, and Liaison uses
+the provider selected by the client for F2, voice-steer, and hands-free turns.
 
 Both halves (the Linux primitive package and the macOS server) live
 in this directory and are committed to the repo. The client machine just
@@ -24,67 +22,50 @@ audio_client_bridge/
 └── scripts/{build,start}.sh       # rbnx codegen + entry
 ```
 
-## Ports
+## Transport
 
-| Port | Side | Protocol | What |
-| --- | --- | --- | --- |
-| `60000` | macOS | WebSocket (`0.0.0.0`) | `/mic`, `/speaker`, `/health`, `/devices`, `/vu`, `/log`, `/set_device` |
-| `60001` | macOS | HTTP (`127.0.0.1`) | `server_web.py` debug UI — open in a browser |
+The default is a reverse WebSocket transport. During driver init the primitive
+binds `0.0.0.0:60002`, publishes its endpoint through Atlas, and waits for
+`robonix-client` to connect. The deployment never stores a client IP.
 
-`60000` listens on all interfaces so the Linux atlas host can dial it
-across LAN/Tailscale. `60001` only binds loopback by default; pass
-`--ui-host 0.0.0.0` if you want to drive the UI from another machine
-(no auth — don't expose to the public internet).
+The client discovers this endpoint through Atlas after the operator selects
+`audio_client_bridge` as an input or output route. Its Audio page owns local
+device selection, audio level display, and the reverse connection lifecycle.
 
 ## Setup (one-shot)
 
-### client side
+### Client side
 
 ```sh
-cd ~/robonix-scripts/client_audio_server          # or wherever you scp'd this dir
-python3 -m venv .venv
-. .venv/bin/activate
-pip install -r requirements.txt
-
-# Option A — headless, you already know the device ids
-python3 server.py --list-devices
-python3 server.py --port 60000 --input-device 1 --output-device 2
-
-# Option B — web UI for picking devices + watching VU + tailing log
-python3 server_web.py --port 60000        # WS 60000 + UI on 60001
-open http://localhost:60001/
+robonix-client --host <robot-host> --port 50051
 ```
 
-Leave it running. The first time, macOS will prompt for mic + network
-permission — accept both. The web UI auto-skips devices whose name
-matches `airpods|bluetooth|iphone|ipad` because BT-HFP can't open a
-16 kHz mono `RawInputStream` on Apple silicon.
+Open **Audio**, select input/output primitives and devices, then apply the
+route. The client starts its local audio endpoint and connects to the selected
+reverse bridge when needed. macOS may request microphone and local-network
+permission on first use.
 
 ### Linux side
 
-In `examples/webots/robonix_manifest.yaml` swap the audio_driver entry
-for the bridge:
+In `examples/webots/robonix_manifest.yaml`, keep both providers registered:
 
 ```yaml
 primitive:
-  # - name: audio_driver
-  #   path: ./primitives/audio_driver
+  - name: audio_driver
+    path: ./primitives/audio_driver
   - name: audio_client_bridge
     path: ./primitives/audio_client_bridge
     config:
-      host: 192.168.1.42      # macOS LAN IP
-      port: 60000
+      transport: reverse
+      listen_port: 60002
 ```
 
-Then `rbnx build && rbnx boot` as usual. Driver(CMD_INIT) probes
-`/health` on the client machine; if unreachable, this primitive defers
-instead of advertising dead mic/speaker streams.
+Then `rbnx build && rbnx boot` as usual. The bridge stays active while no
+client is connected; it is selected only when the operator chooses it.
 
 ## Wire format
 
-Both directions: 16 kHz, mono, s16le PCM. Frames are 100 ms (3200 B
-each). `/mic` is server-stream binary frames; `/speaker` is
-client-stream binary frames. `/health` is a single text JSON message.
+Both directions use 16 kHz, mono, s16le PCM. Frames are 100 ms (3200 B).
 
-No auth, no TLS — assume LAN. Don't expose `client_audio_server` on a public
-interface.
+The current bridge has no authentication or TLS. Use a trusted LAN, Tailscale,
+or an authenticated tunnel; do not expose the bridge port publicly.

--- a/examples/webots/primitives/audio_client_bridge/audio_client_bridge/main.py
+++ b/examples/webots/primitives/audio_client_bridge/audio_client_bridge/main.py
@@ -11,13 +11,12 @@ Wire format both directions: 16 kHz, mono, s16le PCM, ~100 ms chunks
 (3200 bytes each). Identical to `audio_driver` so liaison's voice
 pipeline never needs to know which backend is loaded.
 
-Config (RBNX_CAP_CONFIG_JSON or env fallbacks):
-  host:  IP / hostname of the client machine running client_audio_server
-         (env: AUDIO_CLIENT_SERVER_HOST, fallback AUDIO_BRIDGE_HOST,
-         default 127.0.0.1).
-  port:  TCP port the client audio device server listens on
-         (env: AUDIO_CLIENT_SERVER_PORT, fallback AUDIO_BRIDGE_PORT,
-         default 60000).
+Config (RBNX_CAP_CONFIG_JSON):
+  transport: reverse (default) makes this primitive listen for an outbound
+      robonix-client connection.  The deployment never stores a client IP.
+  listen_host/listen_port: reverse listener address (default 0.0.0.0:60002).
+  host/port: legacy client-owned server mode. Kept only for compatibility with
+      existing manifests; a configured ``host`` selects it automatically.
 """
 from __future__ import annotations
 
@@ -32,6 +31,7 @@ from queue import Queue
 
 from robonix_api import Primitive, Ok, Err, Deferred
 from google.protobuf.empty_pb2 import Empty
+from audio_client_bridge.reverse import ReverseAudioBridge
 
 audio_client_bridge = Primitive(
     id="audio_client_bridge",
@@ -49,6 +49,7 @@ import websockets         # type: ignore  # noqa: E402
 # discovery moment.
 bridge_host: str | None = None
 bridge_port: int | None = None
+reverse_bridge: ReverseAudioBridge | None = None
 speaker_lock = threading.Lock()
 
 # Per-100-ms PCM frame: 16000 Hz * 0.1 s * 2 bytes/sample * 1 ch.
@@ -84,6 +85,9 @@ def mic_stream(request, context):
     because robonix-api's gRPC server doesn't expose an async dispatch
     path yet, so the websockets library — which is asyncio-only — has
     to live behind a thread boundary."""
+    if reverse_bridge is not None:
+        yield from reverse_bridge.mic_stream(context, audio_pb2)
+        return
     if bridge_host is None:
         context.abort(__import__("grpc").StatusCode.UNAVAILABLE,
                       "audio client bridge not initialized — Driver(CMD_INIT) failed or never ran")
@@ -149,6 +153,8 @@ def speaker_stream(request_iterator, context):
     macOS playback continues asynchronously inside sounddevice. Holding the
     speaker lock for the estimated PCM duration keeps consecutive TTS
     utterances serialized even when Liaison speaks sentence by sentence."""
+    if reverse_bridge is not None:
+        return reverse_bridge.speaker_stream(request_iterator, context, Empty)
     if bridge_host is None:
         context.abort(__import__("grpc").StatusCode.UNAVAILABLE,
                       "audio client bridge not initialized")
@@ -231,12 +237,16 @@ def _ws_request(path: str, body: object | None = None, timeout_s: float = 3.0):
 
 @audio_client_bridge.grpc("robonix/primitive/audio/list_devices")
 def list_devices(request, context):
-    if bridge_host is None:
+    if reverse_bridge is None and bridge_host is None:
         context.abort(__import__("grpc").StatusCode.UNAVAILABLE,
                       "audio client bridge not initialized")
         return audio_pb2.ListAudioDevices_Response()
     try:
-        payload = _ws_request("/devices")
+        payload = (
+            reverse_bridge.control_request("list_devices")
+            if reverse_bridge is not None
+            else _ws_request("/devices")
+        )
     except Exception as e:  # noqa: BLE001
         context.abort(__import__("grpc").StatusCode.UNAVAILABLE,
                       f"client_audio_server /devices unreachable: {e}")
@@ -280,7 +290,7 @@ def list_devices(request, context):
 
 @audio_client_bridge.grpc("robonix/primitive/audio/select_device")
 def select_device(request, context):
-    if bridge_host is None:
+    if reverse_bridge is None and bridge_host is None:
         context.abort(__import__("grpc").StatusCode.UNAVAILABLE,
                       "audio client bridge not initialized")
         return audio_pb2.SelectAudioDevice_Response()
@@ -300,7 +310,11 @@ def select_device(request, context):
             sent_id = raw_id  # forward as string; client_audio_server will reject if bad
     body = {kind: sent_id}
     try:
-        payload = _ws_request("/set_device", body)
+        payload = (
+            reverse_bridge.control_request("select_device", body)
+            if reverse_bridge is not None
+            else _ws_request("/set_device", body)
+        )
     except Exception as e:  # noqa: BLE001
         return audio_pb2.SelectAudioDevice_Response(ok=False, error=f"ws: {e}")
     return audio_pb2.SelectAudioDevice_Response(
@@ -316,11 +330,20 @@ def init(cfg):
     endpoint once. Refuse to come up if it's unreachable — atlas defers
     instead of advertising dead interfaces, and consumers see a clear
     error rather than mysteriously empty mic streams."""
-    global bridge_host, bridge_port
+    global bridge_host, bridge_port, reverse_bridge
+
+    transport = str(cfg.get("transport") or "").strip().lower()
+    legacy_host = cfg.get("host") or os.environ.get("AUDIO_CLIENT_SERVER_HOST") or os.environ.get("AUDIO_BRIDGE_HOST")
+    if transport == "reverse" or (not transport and not legacy_host):
+        listen_host = str(cfg.get("listen_host") or os.environ.get("AUDIO_CLIENT_LISTEN_HOST", "0.0.0.0"))
+        listen_port = int(cfg.get("listen_port") or os.environ.get("AUDIO_CLIENT_LISTEN_PORT", "60002"))
+        reverse_bridge = ReverseAudioBridge(listen_host, listen_port, CHUNK_BYTES)
+        reverse_bridge.start()
+        log.info("reverse client audio transport enabled on ws://%s:%d/client", listen_host, listen_port)
+        return Ok()
 
     bridge_host = (
-        cfg.get("host")
-        or os.environ.get("AUDIO_CLIENT_SERVER_HOST")
+        legacy_host
         or os.environ.get("AUDIO_BRIDGE_HOST", "127.0.0.1")
     ).strip()
     bridge_port = int(
@@ -351,6 +374,10 @@ def init(cfg):
 
 @audio_client_bridge.on_shutdown
 def shutdown():
+    global reverse_bridge
+    if reverse_bridge is not None:
+        reverse_bridge.stop()
+        reverse_bridge = None
     return Ok()
 
 

--- a/examples/webots/primitives/audio_client_bridge/audio_client_bridge/main.py
+++ b/examples/webots/primitives/audio_client_bridge/audio_client_bridge/main.py
@@ -50,6 +50,7 @@ import websockets         # type: ignore  # noqa: E402
 bridge_host: str | None = None
 bridge_port: int | None = None
 reverse_bridge: ReverseAudioBridge | None = None
+reverse_endpoint: str = ""
 speaker_lock = threading.Lock()
 
 # Per-100-ms PCM frame: 16000 Hz * 0.1 s * 2 bytes/sample * 1 ch.
@@ -71,6 +72,24 @@ def _ws_connect(path: str, **kwargs):
     "timed out during opening handshake" on every connect. Passing proxy=None
     forces a direct connection regardless of the ambient proxy env."""
     return websockets.connect(_ws_url(path), proxy=None, **kwargs)
+
+
+@audio_client_bridge.grpc("robonix/primitive/audio/bridge_info")
+def bridge_info(request, context):
+    """Return the client-facing reverse endpoint through Atlas discovery."""
+    if reverse_bridge is None:
+        return audio_pb2.GetAudioBridgeInfo_Response(
+            reverse=False,
+            endpoint="",
+            connected=False,
+            detail="provider is using legacy client-owned transport",
+        )
+    return audio_pb2.GetAudioBridgeInfo_Response(
+        reverse=True,
+        endpoint=reverse_endpoint,
+        connected=reverse_bridge.is_connected(),
+        detail="connected" if reverse_bridge.is_connected() else "waiting for robonix-client",
+    )
 
 
 # ── streaming handlers ─────────────────────────────────────────────────────
@@ -330,7 +349,7 @@ def init(cfg):
     endpoint once. Refuse to come up if it's unreachable — atlas defers
     instead of advertising dead interfaces, and consumers see a clear
     error rather than mysteriously empty mic streams."""
-    global bridge_host, bridge_port, reverse_bridge
+    global bridge_host, bridge_port, reverse_bridge, reverse_endpoint
 
     transport = str(cfg.get("transport") or "").strip().lower()
     legacy_host = cfg.get("host") or os.environ.get("AUDIO_CLIENT_SERVER_HOST") or os.environ.get("AUDIO_BRIDGE_HOST")
@@ -339,7 +358,8 @@ def init(cfg):
         listen_port = int(cfg.get("listen_port") or os.environ.get("AUDIO_CLIENT_LISTEN_PORT", "60002"))
         reverse_bridge = ReverseAudioBridge(listen_host, listen_port, CHUNK_BYTES)
         reverse_bridge.start()
-        log.info("reverse client audio transport enabled on ws://%s:%d/client", listen_host, listen_port)
+        reverse_endpoint = f"ws://{audio_client_bridge._advertise_host()}:{listen_port}/client"
+        log.info("reverse client audio transport enabled on %s", reverse_endpoint)
         return Ok()
 
     bridge_host = (
@@ -374,10 +394,11 @@ def init(cfg):
 
 @audio_client_bridge.on_shutdown
 def shutdown():
-    global reverse_bridge
+    global reverse_bridge, reverse_endpoint
     if reverse_bridge is not None:
         reverse_bridge.stop()
         reverse_bridge = None
+    reverse_endpoint = ""
     return Ok()
 
 

--- a/examples/webots/primitives/audio_client_bridge/audio_client_bridge/reverse.py
+++ b/examples/webots/primitives/audio_client_bridge/audio_client_bridge/reverse.py
@@ -213,6 +213,7 @@ class ReverseAudioBridge:
     def mic_stream(self, context, audio_pb2):
         if not self._require_client(context):
             return
+        log.info("client microphone stream requested")
         while True:
             try:
                 self._mic_frames.get_nowait()
@@ -229,7 +230,10 @@ class ReverseAudioBridge:
                 except queue.Empty:
                     continue
                 if frame is None:
+                    log.info("client microphone stream ended before frame %d", sequence)
                     break
+                if sequence == 0:
+                    log.info("client microphone first PCM frame: %d bytes", len(frame))
                 yield audio_pb2.AudioChunk(
                     timestamp_ns=time.time_ns(),
                     data=frame,
@@ -239,6 +243,7 @@ class ReverseAudioBridge:
                 sequence += 1
         finally:
             self._send(json.dumps({"type": "mic_stop"}))
+            log.info("client microphone stream stopped after %d frame(s)", sequence)
 
     def speaker_stream(self, request_iterator, context, empty_type):
         if not self._require_client(context):

--- a/examples/webots/primitives/audio_client_bridge/audio_client_bridge/reverse.py
+++ b/examples/webots/primitives/audio_client_bridge/audio_client_bridge/reverse.py
@@ -36,7 +36,8 @@ class ReverseAudioBridge:
         self._session: _ClientSession | None = None
         self._lock = threading.Lock()
         self._connected = threading.Event()
-        self._mic_frames: queue.Queue[bytes | None] = queue.Queue(maxsize=128)
+        self._mic_streams: dict[str, queue.Queue[bytes | None]] = {}
+        self._active_mic_id: str | None = None
         self._pending_controls: dict[str, queue.Queue[dict]] = {}
         self._pending_lock = threading.Lock()
         self._speaker_lock = threading.Lock()
@@ -63,7 +64,7 @@ class ReverseAudioBridge:
             self._thread.join(timeout=5.0)
         self._thread = None
         self._connected.clear()
-        self._put_mic(None)
+        self._end_all_mics()
 
     def is_connected(self) -> bool:
         """Whether a robonix-client currently owns this reverse session."""
@@ -106,32 +107,49 @@ class ReverseAudioBridge:
         try:
             async for message in ws:
                 if isinstance(message, bytes):
-                    self._put_mic(message)
+                    self._put_active_mic(message)
                     continue
                 self._handle_control(message)
         except Exception as exc:  # noqa: BLE001
             log.warning("client reverse-audio session closed: %s", exc)
         finally:
+            owns_session = False
             with self._lock:
                 if self._session and self._session.ws is ws:
                     self._session = None
                     self._connected.clear()
-                    self._put_mic(None)
+                    owns_session = True
+            if owns_session:
+                self._end_all_mics()
             self._fail_pending_controls("client audio session disconnected")
             log.info("client reverse-audio session disconnected")
 
-    def _put_mic(self, frame: bytes | None) -> None:
+    @staticmethod
+    def _put_mic(target: queue.Queue[bytes | None], frame: bytes | None) -> None:
         try:
-            self._mic_frames.put_nowait(frame)
+            target.put_nowait(frame)
         except queue.Full:
             try:
-                self._mic_frames.get_nowait()
+                target.get_nowait()
             except queue.Empty:
                 pass
             try:
-                self._mic_frames.put_nowait(frame)
+                target.put_nowait(frame)
             except queue.Full:
                 pass
+
+    def _put_active_mic(self, frame: bytes) -> None:
+        with self._lock:
+            target = self._mic_streams.get(self._active_mic_id or "")
+        if target is not None:
+            self._put_mic(target, frame)
+
+    def _end_all_mics(self) -> None:
+        with self._lock:
+            targets = list(self._mic_streams.values())
+            self._active_mic_id = None
+        for target in targets:
+            self._put_mic(target, None)
 
     def _handle_control(self, raw: str) -> None:
         try:
@@ -139,7 +157,11 @@ class ReverseAudioBridge:
         except json.JSONDecodeError:
             return
         if body.get("type") == "mic_end":
-            self._put_mic(None)
+            stream_id = str(body.get("stream_id") or "")
+            with self._lock:
+                target = self._mic_streams.get(stream_id or self._active_mic_id or "")
+            if target is not None:
+                self._put_mic(target, None)
             return
         if body.get("type") != "control_response":
             return
@@ -225,25 +247,37 @@ class ReverseAudioBridge:
         if not self._require_client(context):
             return
         log.info("client microphone stream requested")
-        while True:
-            try:
-                self._mic_frames.get_nowait()
-            except queue.Empty:
-                break
+        stream_id = uuid.uuid4().hex
+        frames: queue.Queue[bytes | None] = queue.Queue(maxsize=128)
+        with self._lock:
+            previous = self._mic_streams.get(self._active_mic_id or "")
+            self._mic_streams[stream_id] = frames
+            self._active_mic_id = stream_id
+        if previous is not None:
+            self._put_mic(previous, None)
         metadata = {item.key: item.value for item in context.invocation_metadata()}
         if metadata.get("x-robonix-barge-in", "").lower() in {"1", "true", "yes"}:
             # Explicit F2 / steer capture clears client-local TTS before PCM
             # starts.  The persistent wake-word listener does not carry this
             # metadata and therefore never mutes normal replies.
             self._interrupt_speaker()
-        if not self._send(json.dumps({"type": "mic_start", "sample_rate": 16000, "channels": 1})):
-            context.abort(__import__("grpc").StatusCode.UNAVAILABLE, "client audio session disconnected")
-            return
         sequence = 0
         try:
+            start = {
+                "type": "mic_start",
+                "stream_id": stream_id,
+                "sample_rate": 16000,
+                "channels": 1,
+            }
+            if not self._send(json.dumps(start)):
+                context.abort(
+                    __import__("grpc").StatusCode.UNAVAILABLE,
+                    "client audio session disconnected",
+                )
+                return
             while context.is_active():
                 try:
-                    frame = self._mic_frames.get(timeout=0.5)
+                    frame = frames.get(timeout=0.5)
                 except queue.Empty:
                     continue
                 if frame is None:
@@ -259,7 +293,11 @@ class ReverseAudioBridge:
                 )
                 sequence += 1
         finally:
-            self._send(json.dumps({"type": "mic_stop"}))
+            self._send(json.dumps({"type": "mic_stop", "stream_id": stream_id}))
+            with self._lock:
+                self._mic_streams.pop(stream_id, None)
+                if self._active_mic_id == stream_id:
+                    self._active_mic_id = None
             log.info("client microphone stream stopped after %d frame(s)", sequence)
 
     def speaker_stream(self, request_iterator, context, empty_type):

--- a/examples/webots/primitives/audio_client_bridge/audio_client_bridge/reverse.py
+++ b/examples/webots/primitives/audio_client_bridge/audio_client_bridge/reverse.py
@@ -39,6 +39,8 @@ class ReverseAudioBridge:
         self._mic_frames: queue.Queue[bytes | None] = queue.Queue(maxsize=128)
         self._pending_controls: dict[str, queue.Queue[dict]] = {}
         self._pending_lock = threading.Lock()
+        self._speaker_lock = threading.Lock()
+        self._speaker_epoch = 0
         self._thread: threading.Thread | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
         self._stop_async: asyncio.Event | None = None
@@ -164,6 +166,15 @@ class ReverseAudioBridge:
             session = self._session
         if session is None:
             return False
+
+    def _interrupt_speaker(self) -> None:
+        with self._speaker_lock:
+            self._speaker_epoch += 1
+        self._send(json.dumps({"type": "speaker_stop"}))
+
+    def _current_speaker_epoch(self) -> int:
+        with self._speaker_lock:
+            return self._speaker_epoch
         try:
             future = asyncio.run_coroutine_threadsafe(session.ws.send(payload), session.loop)
             future.result(timeout=3.0)
@@ -219,6 +230,12 @@ class ReverseAudioBridge:
                 self._mic_frames.get_nowait()
             except queue.Empty:
                 break
+        metadata = {item.key: item.value for item in context.invocation_metadata()}
+        if metadata.get("x-robonix-barge-in", "").lower() in {"1", "true", "yes"}:
+            # Explicit F2 / steer capture clears client-local TTS before PCM
+            # starts.  The persistent wake-word listener does not carry this
+            # metadata and therefore never mutes normal replies.
+            self._interrupt_speaker()
         if not self._send(json.dumps({"type": "mic_start", "sample_rate": 16000, "channels": 1})):
             context.abort(__import__("grpc").StatusCode.UNAVAILABLE, "client audio session disconnected")
             return
@@ -249,16 +266,24 @@ class ReverseAudioBridge:
         if not self._require_client(context):
             return empty_type()
         total = 0
-        for chunk in request_iterator:
-            if chunk.data:
-                data = bytes(chunk.data)
-                total += len(data)
-                if not self._send(data):
-                    context.abort(__import__("grpc").StatusCode.UNAVAILABLE, "client audio session disconnected")
-                    return empty_type()
-        self._send(json.dumps({"type": "speaker_end"}))
+        epoch = self._current_speaker_epoch()
+        completed = False
+        try:
+            for chunk in request_iterator:
+                if epoch != self._current_speaker_epoch():
+                    log.info("speaker stream superseded by voice barge-in")
+                    break
+                if chunk.data:
+                    data = bytes(chunk.data)
+                    total += len(data)
+                    if not self._send(data):
+                        context.abort(__import__("grpc").StatusCode.UNAVAILABLE, "client audio session disconnected")
+                        return empty_type()
+            completed = context.is_active() and epoch == self._current_speaker_epoch()
+        finally:
+            self._send(json.dumps({"type": "speaker_end" if completed else "speaker_stop"}))
         # Preserve serialised speaker semantics without sleeping for a full long
         # utterance in the gRPC worker.
-        if total:
+        if completed and total:
             time.sleep(min(total / 32000.0 + 0.1, 5.0))
         return empty_type()

--- a/examples/webots/primitives/audio_client_bridge/audio_client_bridge/reverse.py
+++ b/examples/webots/primitives/audio_client_bridge/audio_client_bridge/reverse.py
@@ -166,6 +166,13 @@ class ReverseAudioBridge:
             session = self._session
         if session is None:
             return False
+        try:
+            future = asyncio.run_coroutine_threadsafe(session.ws.send(payload), session.loop)
+            future.result(timeout=3.0)
+            return True
+        except Exception as exc:  # noqa: BLE001
+            log.warning("reverse client send failed: %s", exc)
+            return False
 
     def _interrupt_speaker(self) -> None:
         with self._speaker_lock:
@@ -175,13 +182,6 @@ class ReverseAudioBridge:
     def _current_speaker_epoch(self) -> int:
         with self._speaker_lock:
             return self._speaker_epoch
-        try:
-            future = asyncio.run_coroutine_threadsafe(session.ws.send(payload), session.loop)
-            future.result(timeout=3.0)
-            return True
-        except Exception as exc:  # noqa: BLE001
-            log.warning("reverse client send failed: %s", exc)
-            return False
 
     def control_request(self, op: str, payload: dict | None = None, timeout_s: float = 3.0) -> dict:
         """Ask the connected client to perform a small local audio operation."""

--- a/examples/webots/primitives/audio_client_bridge/audio_client_bridge/reverse.py
+++ b/examples/webots/primitives/audio_client_bridge/audio_client_bridge/reverse.py
@@ -1,0 +1,255 @@
+"""Reverse client-audio transport for the robot-side audio primitive.
+
+The client opens one outbound WebSocket to this server.  That keeps the
+network ownership simple: the user only enters the Robonix host in the client;
+the robot never needs a client IP address or an exposed client-side port.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import queue
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+
+import websockets
+
+log = logging.getLogger("audio-client-bridge.reverse")
+
+
+@dataclass
+class _ClientSession:
+    ws: object
+    loop: asyncio.AbstractEventLoop
+
+
+class ReverseAudioBridge:
+    """Expose one connected client as PCM mic/speaker streams."""
+
+    def __init__(self, host: str, port: int, frame_bytes: int) -> None:
+        self.host = host
+        self.port = port
+        self.frame_bytes = frame_bytes
+        self._session: _ClientSession | None = None
+        self._lock = threading.Lock()
+        self._connected = threading.Event()
+        self._mic_frames: queue.Queue[bytes | None] = queue.Queue(maxsize=128)
+        self._pending_controls: dict[str, queue.Queue[dict]] = {}
+        self._pending_lock = threading.Lock()
+        self._thread: threading.Thread | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._stop_async: asyncio.Event | None = None
+        self._started = threading.Event()
+
+    def start(self) -> None:
+        if self._thread and self._thread.is_alive():
+            return
+        self._thread = threading.Thread(target=self._run, name="audio-client-reverse", daemon=True)
+        self._thread.start()
+        if not self._started.wait(timeout=5.0):
+            raise RuntimeError(f"reverse audio listener did not start on {self.host}:{self.port}")
+
+    def stop(self) -> None:
+        loop = self._loop
+        stop_async = self._stop_async
+        if loop is not None and stop_async is not None and loop.is_running():
+            loop.call_soon_threadsafe(stop_async.set)
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=5.0)
+        self._thread = None
+        self._connected.clear()
+        self._put_mic(None)
+
+    def _run(self) -> None:
+        asyncio.run(self._serve())
+
+    async def _serve(self) -> None:
+        self._loop = asyncio.get_running_loop()
+        self._stop_async = asyncio.Event()
+        async with websockets.serve(self._handler, self.host, self.port, max_size=None):
+            log.info("reverse client bridge listening on ws://%s:%d/client", self.host, self.port)
+            self._started.set()
+            await self._stop_async.wait()
+            with self._lock:
+                session = self._session
+            if session is not None:
+                await session.ws.close(code=1001, reason="audio provider shutting down")
+        self._loop = None
+        self._stop_async = None
+        self._started.clear()
+
+    async def _handler(self, ws) -> None:
+        path = ws.request.path if hasattr(ws, "request") else getattr(ws, "path", "")
+        if path != "/client":
+            await ws.close(code=1008, reason="expected /client")
+            return
+
+        with self._lock:
+            previous = self._session
+            self._session = _ClientSession(ws=ws, loop=asyncio.get_running_loop())
+            self._connected.set()
+        if previous is not None:
+            try:
+                await previous.ws.close(code=1012, reason="replaced by newer client")
+            except Exception:  # noqa: BLE001
+                pass
+        log.info("client reverse-audio session connected: %s", getattr(ws, "remote_address", "unknown"))
+        try:
+            async for message in ws:
+                if isinstance(message, bytes):
+                    self._put_mic(message)
+                    continue
+                self._handle_control(message)
+        except Exception as exc:  # noqa: BLE001
+            log.warning("client reverse-audio session closed: %s", exc)
+        finally:
+            with self._lock:
+                if self._session and self._session.ws is ws:
+                    self._session = None
+                    self._connected.clear()
+                    self._put_mic(None)
+            self._fail_pending_controls("client audio session disconnected")
+            log.info("client reverse-audio session disconnected")
+
+    def _put_mic(self, frame: bytes | None) -> None:
+        try:
+            self._mic_frames.put_nowait(frame)
+        except queue.Full:
+            try:
+                self._mic_frames.get_nowait()
+            except queue.Empty:
+                pass
+            try:
+                self._mic_frames.put_nowait(frame)
+            except queue.Full:
+                pass
+
+    def _handle_control(self, raw: str) -> None:
+        try:
+            body = json.loads(raw)
+        except json.JSONDecodeError:
+            return
+        if body.get("type") == "mic_end":
+            self._put_mic(None)
+            return
+        if body.get("type") != "control_response":
+            return
+        request_id = str(body.get("id") or "")
+        if not request_id:
+            return
+        with self._pending_lock:
+            response = self._pending_controls.get(request_id)
+        if response is not None:
+            response.put_nowait(body)
+
+    def _fail_pending_controls(self, message: str) -> None:
+        with self._pending_lock:
+            pending = list(self._pending_controls.values())
+            self._pending_controls.clear()
+        for response in pending:
+            try:
+                response.put_nowait({"ok": False, "error": message})
+            except queue.Full:
+                pass
+
+    def _send(self, payload: str | bytes) -> bool:
+        with self._lock:
+            session = self._session
+        if session is None:
+            return False
+        try:
+            future = asyncio.run_coroutine_threadsafe(session.ws.send(payload), session.loop)
+            future.result(timeout=3.0)
+            return True
+        except Exception as exc:  # noqa: BLE001
+            log.warning("reverse client send failed: %s", exc)
+            return False
+
+    def control_request(self, op: str, payload: dict | None = None, timeout_s: float = 3.0) -> dict:
+        """Ask the connected client to perform a small local audio operation."""
+        request_id = uuid.uuid4().hex
+        response: queue.Queue[dict] = queue.Queue(maxsize=1)
+        with self._pending_lock:
+            self._pending_controls[request_id] = response
+        try:
+            sent = self._send(
+                json.dumps(
+                    {
+                        "type": "control_request",
+                        "id": request_id,
+                        "op": op,
+                        "payload": payload or {},
+                    }
+                )
+            )
+            if not sent:
+                raise RuntimeError("client audio session disconnected")
+            result = response.get(timeout=timeout_s)
+            if not isinstance(result, dict):
+                raise RuntimeError("invalid client audio control response")
+            return result
+        except queue.Empty as exc:
+            raise RuntimeError(f"client audio control {op} timed out") from exc
+        finally:
+            with self._pending_lock:
+                self._pending_controls.pop(request_id, None)
+
+    def _require_client(self, context) -> bool:
+        if self._connected.wait(timeout=3.0):
+            return True
+        context.abort(
+            __import__("grpc").StatusCode.UNAVAILABLE,
+            "no client audio session connected; start robonix-client and connect it to this robot",
+        )
+        return False
+
+    def mic_stream(self, context, audio_pb2):
+        if not self._require_client(context):
+            return
+        while True:
+            try:
+                self._mic_frames.get_nowait()
+            except queue.Empty:
+                break
+        if not self._send(json.dumps({"type": "mic_start", "sample_rate": 16000, "channels": 1})):
+            context.abort(__import__("grpc").StatusCode.UNAVAILABLE, "client audio session disconnected")
+            return
+        sequence = 0
+        try:
+            while context.is_active():
+                try:
+                    frame = self._mic_frames.get(timeout=0.5)
+                except queue.Empty:
+                    continue
+                if frame is None:
+                    break
+                yield audio_pb2.AudioChunk(
+                    timestamp_ns=time.time_ns(),
+                    data=frame,
+                    sequence=sequence,
+                    duration_s=len(frame) / 32000.0,
+                )
+                sequence += 1
+        finally:
+            self._send(json.dumps({"type": "mic_stop"}))
+
+    def speaker_stream(self, request_iterator, context, empty_type):
+        if not self._require_client(context):
+            return empty_type()
+        total = 0
+        for chunk in request_iterator:
+            if chunk.data:
+                data = bytes(chunk.data)
+                total += len(data)
+                if not self._send(data):
+                    context.abort(__import__("grpc").StatusCode.UNAVAILABLE, "client audio session disconnected")
+                    return empty_type()
+        self._send(json.dumps({"type": "speaker_end"}))
+        # Preserve serialised speaker semantics without sleeping for a full long
+        # utterance in the gRPC worker.
+        if total:
+            time.sleep(min(total / 32000.0 + 0.1, 5.0))
+        return empty_type()

--- a/examples/webots/primitives/audio_client_bridge/audio_client_bridge/reverse.py
+++ b/examples/webots/primitives/audio_client_bridge/audio_client_bridge/reverse.py
@@ -63,6 +63,10 @@ class ReverseAudioBridge:
         self._connected.clear()
         self._put_mic(None)
 
+    def is_connected(self) -> bool:
+        """Whether a robonix-client currently owns this reverse session."""
+        return self._connected.is_set()
+
     def _run(self) -> None:
         asyncio.run(self._serve())
 

--- a/examples/webots/primitives/audio_client_bridge/package_manifest.yaml
+++ b/examples/webots/primitives/audio_client_bridge/package_manifest.yaml
@@ -2,11 +2,10 @@
 # default ALSA `audio_driver` package when you want robonix's audio I/O
 # physically on a macOS machine while atlas/pilot/liaison run on Linux.
 #
-# Pairs with the `client_audio_server/server.py` script — that one runs on the
-# client machine and exposes mic capture + speaker playback over a tiny
-# WebSocket protocol; this package runs on the Linux host, registers
-# the usual `robonix/primitive/audio/{mic,speaker,driver}` contracts
-# with atlas, and just relays PCM frames to/from that WebSocket.
+# The client opens one outbound WebSocket to this package on the Linux host.
+# The robot therefore does not store a client IP address. This package
+# registers the usual `robonix/primitive/audio/{mic,speaker,driver}` contracts
+# with Atlas and relays the connected client's PCM frames.
 #
 # Toggle by commenting one line in `examples/webots/robonix_manifest.yaml`:
 #
@@ -16,8 +15,8 @@
 #     - name: audio_client_bridge
 #       path: ./primitives/audio_client_bridge
 #       config:
-#         host: 192.168.1.42      # macOS LAN address running client_audio_server
-#         port: 60000             # default
+#         transport: reverse
+#         listen_port: 60002
 #
 # Same wire format as audio_driver (16 kHz / mono / s16le PCM in
 # AudioChunk frames) so liaison / scene / TTS see no difference.
@@ -26,7 +25,6 @@ manifestVersion: 1
 package:
   name: com.robonix.example.audio_client_bridge
   version: 0.1.0
-  vendor: robonix
   description: Audio primitive that proxies mic/speaker over WebSocket to an client audio device server.
   license: MulanPSL-2.0
 

--- a/examples/webots/primitives/audio_client_bridge/package_manifest.yaml
+++ b/examples/webots/primitives/audio_client_bridge/package_manifest.yaml
@@ -53,3 +53,4 @@ capabilities:
   - name: robonix/primitive/audio/driver
   - name: robonix/primitive/audio/list_devices
   - name: robonix/primitive/audio/select_device
+  - name: robonix/primitive/audio/bridge_info

--- a/examples/webots/primitives/audio_client_bridge/tests/test_reverse_barge_in.py
+++ b/examples/webots/primitives/audio_client_bridge/tests/test_reverse_barge_in.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import queue
 from types import SimpleNamespace
 
 from audio_client_bridge.reverse import ReverseAudioBridge, _ClientSession
@@ -65,3 +66,18 @@ def test_send_reports_disconnected_client() -> None:
     bridge = ReverseAudioBridge("127.0.0.1", 0, 3200)
 
     assert bridge._send('{"type":"mic_start"}') is False
+
+
+def test_stale_mic_end_does_not_terminate_new_stream() -> None:
+    bridge = ReverseAudioBridge("127.0.0.1", 0, 3200)
+    old_frames: queue.Queue[bytes | None] = queue.Queue()
+    new_frames: queue.Queue[bytes | None] = queue.Queue()
+    bridge._mic_streams = {"old": old_frames, "new": new_frames}
+    bridge._active_mic_id = "new"
+
+    bridge._handle_control('{"type":"mic_end","stream_id":"old"}')
+    bridge._put_active_mic(b"new-pcm")
+
+    assert old_frames.get_nowait() is None
+    assert new_frames.get_nowait() == b"new-pcm"
+    assert new_frames.empty()

--- a/examples/webots/primitives/audio_client_bridge/tests/test_reverse_barge_in.py
+++ b/examples/webots/primitives/audio_client_bridge/tests/test_reverse_barge_in.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from types import SimpleNamespace
 
-from audio_client_bridge.reverse import ReverseAudioBridge
+from audio_client_bridge.reverse import ReverseAudioBridge, _ClientSession
 
 
 class ActiveContext:
@@ -29,3 +30,38 @@ def test_barge_in_supersedes_inflight_speaker_generation() -> None:
     assert b"old-audio-2" not in sent
     controls = [json.loads(item) for item in sent if isinstance(item, str)]
     assert {control["type"] for control in controls} == {"speaker_stop"}
+
+
+def test_send_forwards_payload_to_connected_client(monkeypatch) -> None:
+    bridge = ReverseAudioBridge("127.0.0.1", 0, 3200)
+    delivered: list[str | bytes] = []
+    marker_loop = object()
+
+    class FakeWebSocket:
+        async def send(self, payload: str | bytes) -> None:
+            delivered.append(payload)
+
+    class FakeFuture:
+        @staticmethod
+        def result(timeout: float) -> None:
+            assert timeout == 3.0
+
+    def run_coroutine(coro, loop):
+        assert loop is marker_loop
+        asyncio.run(coro)
+        return FakeFuture()
+
+    bridge._session = _ClientSession(ws=FakeWebSocket(), loop=marker_loop)
+    monkeypatch.setattr(
+        "audio_client_bridge.reverse.asyncio.run_coroutine_threadsafe",
+        run_coroutine,
+    )
+
+    assert bridge._send('{"type":"mic_start"}') is True
+    assert delivered == ['{"type":"mic_start"}']
+
+
+def test_send_reports_disconnected_client() -> None:
+    bridge = ReverseAudioBridge("127.0.0.1", 0, 3200)
+
+    assert bridge._send('{"type":"mic_start"}') is False

--- a/examples/webots/primitives/audio_client_bridge/tests/test_reverse_barge_in.py
+++ b/examples/webots/primitives/audio_client_bridge/tests/test_reverse_barge_in.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from audio_client_bridge.reverse import ReverseAudioBridge
+
+
+class ActiveContext:
+    @staticmethod
+    def is_active() -> bool:
+        return True
+
+
+def test_barge_in_supersedes_inflight_speaker_generation() -> None:
+    bridge = ReverseAudioBridge("127.0.0.1", 0, 3200)
+    sent: list[str | bytes] = []
+    bridge._require_client = lambda _context: True  # type: ignore[method-assign]
+    bridge._send = lambda payload: (sent.append(payload), True)[1]  # type: ignore[method-assign]
+
+    def chunks():
+        yield SimpleNamespace(data=b"old-audio-1")
+        bridge._interrupt_speaker()
+        yield SimpleNamespace(data=b"old-audio-2")
+
+    bridge.speaker_stream(chunks(), ActiveContext(), lambda: object())
+
+    assert b"old-audio-1" in sent
+    assert b"old-audio-2" not in sent
+    controls = [json.loads(item) for item in sent if isinstance(item, str)]
+    assert {control["type"] for control in controls} == {"speaker_stop"}

--- a/examples/webots/primitives/audio_driver/audio_driver/main.py
+++ b/examples/webots/primitives/audio_driver/audio_driver/main.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 
 from robonix_api import Primitive, Ok, Err, Deferred
 
@@ -47,24 +48,40 @@ speaker_driver: SpeakerDriver | None = None
 # read back by ListAudioDevices.current_*_id.
 current_input_id: str = ""
 current_output_id: str = ""
+configured_input_id: str = ""
+configured_output_id: str = ""
+_mic_stream_lock = threading.Lock()
 
 
 # ── streaming handlers ─────────────────────────────────────────────────────
 @audio_driver.grpc("robonix/primitive/audio/mic")
 def mic_stream(request, context):
-    """Server-streaming mic capture. Drives one arecord subprocess per
-    open client; ALSA only allows one capture handle so concurrent clients
-    share the stream (driver is started by the first call, kept alive
-    while any context is active)."""
-    if mic_driver is None:
-        context.abort(__import__("grpc").StatusCode.UNAVAILABLE,
-                      "mic driver not initialized — Driver(CMD_INIT) failed or never ran")
+    """Server-streaming mic capture with exclusive ALSA ownership.
+
+    One ``MicDriver`` owns one ``arecord`` process. Reject overlapping clients
+    explicitly instead of replacing the shared process handle and leaking the
+    previous recorder.
+    """
+    grpc = __import__("grpc")
+    if not _mic_stream_lock.acquire(blocking=False):
+        context.abort(
+            grpc.StatusCode.RESOURCE_EXHAUSTED,
+            "microphone is already in use by another stream",
+        )
         return
-    log.info("mic stream client connected")
-    mic_driver.start()
+    driver = None
     try:
+        driver = mic_driver
+        if driver is None:
+            context.abort(
+                grpc.StatusCode.UNAVAILABLE,
+                "mic driver not initialized — Driver(CMD_INIT) failed or never ran",
+            )
+            return
+        log.info("mic stream client connected")
+        driver.start()
         while context.is_active():
-            chunk = mic_driver.read_chunk()
+            chunk = driver.read_chunk()
             if chunk is None:
                 break
             yield audio_pb2.AudioChunk(
@@ -74,8 +91,12 @@ def mic_stream(request, context):
                 duration_s=chunk["duration_s"],
             )
     finally:
-        mic_driver.stop()
-        log.info("mic stream client disconnected")
+        try:
+            if driver is not None:
+                driver.stop()
+                log.info("mic stream client disconnected")
+        finally:
+            _mic_stream_lock.release()
 
 
 @audio_driver.grpc("robonix/primitive/audio/speaker")
@@ -129,27 +150,33 @@ def _scan_audio_devices_proto():
             note="",
         ))
     ids = {d.id for d in devs}
-    configured_mic = os.environ.get("AUDIO_MIC_DEVICE", "").strip()
-    if configured_mic and configured_mic not in ids:
+    # ALSA plugin devices such as plughw:0,0 are intentionally absent from
+    # arecord/aplay -l. Expose the *active* deployment selections as first-class
+    # choices so a client refresh does not silently replace them with hw:0,0.
+    configured: dict[str, set[str]] = {}
+    for device_id, kind in (
+        (current_input_id, "input"),
+        (current_output_id, "output"),
+        (configured_input_id, "input"),
+        (configured_output_id, "output"),
+        (os.environ.get("AUDIO_MIC_DEVICE", "").strip(), "input"),
+        (os.environ.get("AUDIO_SPEAKER_DEVICE", "").strip(), "output"),
+    ):
+        if device_id:
+            configured.setdefault(device_id, set()).add(kind)
+    for device_id, kinds in configured.items():
+        if device_id in ids:
+            continue
+        kind = "duplex" if kinds == {"input", "output"} else next(iter(kinds))
         devs.append(audio_pb2.AudioDevice(
-            id=configured_mic,
-            name="Configured ALSA input device",
-            kind="input",
+            id=device_id,
+            name="Configured ALSA device",
+            kind=kind,
             is_default=False,
             channels=1,
-            note="configured via AUDIO_MIC_DEVICE",
+            note="active deployment selection",
         ))
-        ids.add(configured_mic)
-    configured_spk = os.environ.get("AUDIO_SPEAKER_DEVICE", "").strip()
-    if configured_spk and configured_spk not in ids:
-        devs.append(audio_pb2.AudioDevice(
-            id=configured_spk,
-            name="Configured ALSA output device",
-            kind="output",
-            is_default=False,
-            channels=1,
-            note="configured via AUDIO_SPEAKER_DEVICE",
-        ))
+        ids.add(device_id)
     return devs
 
 
@@ -183,6 +210,12 @@ def select_device(request, context):
         ).strip()
         if configured:
             valid.add(configured)
+        current = current_input_id if kind == "input" else current_output_id
+        if current:
+            valid.add(current)
+        deployment_configured = configured_input_id if kind == "input" else configured_output_id
+        if deployment_configured:
+            valid.add(deployment_configured)
         if requested not in valid:
             return audio_pb2.SelectAudioDevice_Response(
                 ok=False, error=f"unknown {kind} id '{requested}'")
@@ -199,27 +232,60 @@ def select_device(request, context):
         new_id = info.device_id
 
     if kind == "input":
-        if mic_driver is not None:
-            try:
-                mic_driver.stop()
-            except Exception:  # noqa: BLE001
-                pass
-        # Auto-probe hardware sample rate unless explicitly overridden
-        mic_rate = int(os.environ["AUDIO_MIC_SAMPLE_RATE"]) if "AUDIO_MIC_SAMPLE_RATE" in os.environ else probe_mic_sample_rate(new_id)
-        mic_driver = MicDriver(
-            device_id=new_id,
-            sample_rate=mic_rate,
-            channels=int(os.environ.get("AUDIO_MIC_CHANNELS", "1")),
-            bits_per_sample=int(os.environ.get("AUDIO_MIC_BITS", "16")),
-            chunk_duration_s=int(os.environ.get("AUDIO_MIC_CHUNK_MS", "100")) / 1000.0,
-        )
-        current_input_id = new_id
+        if not _mic_stream_lock.acquire(blocking=False):
+            return audio_pb2.SelectAudioDevice_Response(
+                ok=False,
+                error="cannot change input device while microphone is streaming",
+            )
+        try:
+            previous = mic_driver
+            if previous is not None:
+                try:
+                    previous.stop()
+                except Exception:  # noqa: BLE001
+                    pass
+            # Auto-probe hardware sample rate unless explicitly overridden
+            mic_rate = (
+                int(os.environ["AUDIO_MIC_SAMPLE_RATE"])
+                if "AUDIO_MIC_SAMPLE_RATE" in os.environ
+                else previous.sample_rate if previous is not None
+                else probe_mic_sample_rate(new_id)
+            )
+            mic_driver = MicDriver(
+                device_id=new_id,
+                sample_rate=mic_rate,
+                channels=int(os.environ.get(
+                    "AUDIO_MIC_CHANNELS",
+                    str(previous.channels if previous is not None else 1),
+                )),
+                bits_per_sample=int(os.environ.get(
+                    "AUDIO_MIC_BITS",
+                    str(previous.bits_per_sample if previous is not None else 16),
+                )),
+                chunk_duration_s=int(os.environ.get(
+                    "AUDIO_MIC_CHUNK_MS",
+                    str(round((previous.chunk_duration_s if previous is not None else 0.1) * 1000)),
+                )) / 1000.0,
+            )
+            current_input_id = new_id
+        finally:
+            _mic_stream_lock.release()
     else:
+        previous = speaker_driver
         speaker_driver = SpeakerDriver(
             device_id=new_id,
-            sample_rate=int(os.environ.get("AUDIO_SPEAKER_SAMPLE_RATE", "24000")),
-            channels=int(os.environ.get("AUDIO_SPEAKER_CHANNELS", "1")),
-            bits_per_sample=int(os.environ.get("AUDIO_SPEAKER_BITS", "16")),
+            sample_rate=int(os.environ.get(
+                "AUDIO_SPEAKER_SAMPLE_RATE",
+                str(previous.sample_rate if previous is not None else 24000),
+            )),
+            channels=int(os.environ.get(
+                "AUDIO_SPEAKER_CHANNELS",
+                str(previous.channels if previous is not None else 1),
+            )),
+            bits_per_sample=int(os.environ.get(
+                "AUDIO_SPEAKER_BITS",
+                str(previous.bits_per_sample if previous is not None else 16),
+            )),
         )
         current_output_id = new_id
     return audio_pb2.SelectAudioDevice_Response(ok=True, error="")
@@ -235,6 +301,7 @@ def init(cfg):
     compatible operator override for older manifests.
     """
     global mic_driver, speaker_driver, current_input_id, current_output_id
+    global configured_input_id, configured_output_id
 
     devices = scan_alsa_devices()
     for d in devices:
@@ -281,6 +348,7 @@ def init(cfg):
             chunk_duration_s=int(cfg.get("mic_chunk_ms") or os.environ.get("AUDIO_MIC_CHUNK_MS", "100")) / 1000.0,
         )
         current_input_id = mic_dev_id
+        configured_input_id = mic_dev_id
 
     if spk_dev_id is not None:
         speaker_driver = SpeakerDriver(
@@ -290,6 +358,7 @@ def init(cfg):
             bits_per_sample=int(cfg.get("speaker_bits") or os.environ.get("AUDIO_SPEAKER_BITS", "16")),
         )
         current_output_id = spk_dev_id
+        configured_output_id = spk_dev_id
     return Ok()
 
 

--- a/examples/webots/robonix_manifest.yaml
+++ b/examples/webots/robonix_manifest.yaml
@@ -159,6 +159,10 @@ service:
       params_profile: sim
       use_sim_time: true
       action_wait_s: 240.0
+      # The simulation goal checker enters at 0.25 m. Keep the terminal
+      # rotation guard inside that boundary so path-alignment turns are not
+      # mistaken for a stuck final-yaw correction.
+      guard_terminal_xy_m: 0.20
 
 # after booted all the services, register the skills (but don't activate them now)
 skill:

--- a/examples/webots/sim/stop.sh
+++ b/examples/webots/sim/stop.sh
@@ -29,8 +29,9 @@ echo "[sim/stop] killing host-side python service zombies (speech / memsearch / 
 pkill -9 -f "speech_service\\.service" 2>/dev/null || true
 pkill -9 -f "memsearch_service\\.service" 2>/dev/null || true
 pkill -9 -f "scene_service\\.service" 2>/dev/null || true
-pkill -9 -f "audio_driver\\.node" 2>/dev/null || true
-pkill -9 -f "audio_client_bridge\\.node" 2>/dev/null || true
+pkill -9 -f "audio_driver\\.main|audio_driver\\.node" 2>/dev/null || true
+pkill -9 -f "audio_client_bridge\\.main|audio_client_bridge\\.node" 2>/dev/null || true
+pkill -9 -f "voiceprint_service\\.service" 2>/dev/null || true
 pkill -9 -f "simple_nav\\.atlas_bridge" 2>/dev/null || true
 pkill -9 -f "mapping_service\\.service" 2>/dev/null || true
 

--- a/services/speech/README.md
+++ b/services/speech/README.md
@@ -16,22 +16,63 @@ Tencent Cloud mode:
 2. Open CAM / Access Management -> Access Key -> API Key Management and create
    an API key. Save `SecretKey` immediately; Tencent Cloud only shows it when
    the key is created. The same page/account information provides the AppID.
-3. Export the credentials on the operator machine before `rbnx boot`:
+3. Select the backend in the deployment manifest so `rbnx build` also knows
+   that no local model or GPU dependencies are needed:
+
+```yaml
+env:
+  SPEECH_BACKEND: tencent
+
+service:
+  - name: speech
+    path: ${ROBONIX_SOURCE_PATH}/services/speech
+    config:
+      speech_backend: tencent
+      tencent_asr_appid: "1234567890"
+      tencent_asr_engine: 16k_zh_en
+      tencent_tts_voice_type: 502003
+      tencent_tts_region: ap-guangzhou
+```
+
+4. Export only the credentials on the operator machine before `rbnx boot`:
 
 ```bash
-export SPEECH_BACKEND=tencent
-export TENCENT_ASR_APPID=...
 export TENCENTCLOUD_SECRET_ID=...
 export TENCENTCLOUD_SECRET_KEY=...
 ```
 
 Do not commit Tencent credentials. Put them in the operator shell, a local
-ignored env file, or a machine-local boot wrapper. Useful optional knobs:
+ignored env file, or a machine-local boot wrapper. The AppID and non-secret
+backend settings belong in the deployment manifest. Useful optional knobs:
 `TENCENT_ASR_ENGINE` (default `16k_zh_en`), `TENCENT_TTS_VOICE_TYPE` (default
 `1001`), and `TENCENT_TTS_REGION` (default `ap-guangzhou`).
 
+With `SPEECH_BACKEND=tencent`, the build installs only the cloud client and
+audio adaptation dependencies. It does not install or warm FunASR, Whisper,
+Torch, CUDA, or Edge TTS. The `local` backend keeps those dependencies in the
+`local` optional dependency set and preloads its models during build.
+
 The TTS contract returns 16 kHz mono `pcm_s16le` bytes in both local and Tencent
 modes so existing audio speaker primitives can play the response directly.
+
+## Wake word
+
+Wake-word recognition is part of the Speech package, not Liaison. The default
+phrase is `罗伯特`; it is selected because the bundled KWS model recognizes it
+from a 16 kHz Tencent TTS test stream. A deployment can replace it without
+changing code:
+
+```yaml
+service:
+  - name: speech
+    config:
+      wake_words: ["罗伯特"]
+      wake_word_boost: 2.0
+      wake_word_threshold: 0.45
+```
+
+`SPEECH_WAKE_WORDS` is the environment equivalent (comma-separated). The
+Speech build downloads the KWS model; runtime does not download model weights.
 
 ## Adding a new ASR/TTS algorithm
 

--- a/services/speech/README.md
+++ b/services/speech/README.md
@@ -58,15 +58,16 @@ modes so existing audio speaker primitives can play the response directly.
 ## Wake word
 
 Wake-word recognition is part of the Speech package, not Liaison. The default
-phrase is `罗伯特`; it is selected because the bundled KWS model recognizes it
-from a 16 kHz Tencent TTS test stream. A deployment can replace it without
+phrase is the bundled Mandarin wake phrase (YAML `\u7f57\u4f2f\u7279`); it is
+selected because the bundled KWS model recognizes it from a 16 kHz Tencent TTS
+test stream. A deployment can replace it without
 changing code:
 
 ```yaml
 service:
   - name: speech
     config:
-      wake_words: ["罗伯特"]
+      wake_words: ["\u7f57\u4f2f\u7279"]
       wake_word_boost: 2.0
       wake_word_threshold: 0.45
 ```

--- a/services/speech/package_manifest.yaml
+++ b/services/speech/package_manifest.yaml
@@ -60,6 +60,7 @@ capabilities:
   - name: robonix/service/speech/driver
   - name: robonix/service/speech/asr
   - name: robonix/service/speech/asr_stream
+  - name: robonix/service/speech/wake_word
   - name: robonix/service/speech/tts
   - name: robonix/service/speech/tts_stream
   - name: robonix/service/speech/dialog

--- a/services/speech/package_manifest.yaml
+++ b/services/speech/package_manifest.yaml
@@ -44,7 +44,7 @@ package:
 build: bash scripts/build.sh
 
 start: |
-  export PYTHONPATH="$(pwd)/rbnx-build/codegen/proto_gen:${PYTHONPATH:-}"
+  export PYTHONPATH="$(pwd)/rbnx-build/codegen/proto_gen:$(pwd)/rbnx-build/codegen/robonix_mcp_types:${PYTHONPATH:-}"
   # Don't redirect stdout/stderr — `rbnx boot` already captures both
   # into rbnx-boot/logs/system_speech.log. A second redirect here would
   # split the log in half and leave the boot-side log empty, which is

--- a/services/speech/pyproject.toml
+++ b/services/speech/pyproject.toml
@@ -7,23 +7,32 @@
 [project]
 name = "robonix-system-speech"
 version = "0.1.0"
-description = "Robonix Speech Service — ASR (Whisper / FunASR) + TTS (Edge TTS) + Dialog Manager."
+description = "Robonix Speech Service — pluggable local or cloud ASR/TTS backends."
 requires-python = ">=3.10"
 dependencies = [
-    "torch>=2.0",
-    "torchaudio>=2.0",
-    "transformers>=4.30",
-    "funasr>=1.0",
-    "edge-tts>=6.1",
     "requests>=2.31",
     "websockets>=16.0",
-    "opencc-python-reimplemented>=0.1.7",
     "grpcio>=1.60",
     "grpcio-tools>=1.60",
     "protobuf>=4.24",
+    "pypinyin>=0.55",
+    "sentencepiece>=0.2",
+    "sherpa-onnx>=1.13.2,<1.14",
     "scipy>=1.10",
     "numpy>=1.24,<2",
     "robonix-api",
+]
+
+[project.optional-dependencies]
+# Local inference is deliberately optional. Cloud deployments must not pull
+# Torch, FunASR, Transformers, or model weights merely to use Tencent ASR/TTS.
+local = [
+    "torch>=2.0; platform_machine != 'aarch64'",
+    "torchaudio>=2.0; platform_machine != 'aarch64'",
+    "transformers>=4.30",
+    "funasr>=1.0",
+    "edge-tts>=6.1",
+    "opencc-python-reimplemented>=0.1.7",
 ]
 
 [tool.uv]

--- a/services/speech/scripts/build.sh
+++ b/services/speech/scripts/build.sh
@@ -25,6 +25,21 @@ cd "$PKG"
 BUILD="rbnx-build"
 VENV="$BUILD/venv"
 CLEAN="${RBNX_BUILD_CLEAN:-}"
+IS_JETSON=0
+[[ -f /etc/nv_tegra_release ]] && IS_JETSON=1
+BACKEND="${SPEECH_BACKEND:-local}"
+case "$BACKEND" in
+    local|tencent|custom|mock) ;;
+    *)
+        echo "[build] error: unsupported SPEECH_BACKEND=$BACKEND" >&2
+        exit 1
+        ;;
+esac
+USE_JETSON_TORCH=0
+if [[ "$IS_JETSON" == "1" && "$BACKEND" == "local" ]]; then
+    USE_JETSON_TORCH=1
+fi
+echo "[build] speech backend: $BACKEND"
 
 if [[ "$CLEAN" == "1" ]]; then
     echo "[build] clean: removing $BUILD"
@@ -37,9 +52,25 @@ if ! command -v uv >/dev/null 2>&1; then
     echo "[build] error: 'uv' not found on PATH. Install: https://docs.astral.sh/uv/" >&2
     exit 1
 fi
+if [[ -d "$VENV" ]]; then
+    has_system_site=0
+    grep -q '^include-system-site-packages = true$' "$VENV/pyvenv.cfg" \
+        && has_system_site=1
+    if [[ "$USE_JETSON_TORCH" == "1" && "$has_system_site" == "0" ]]; then
+        echo "[build] Jetson local backend: recreating venv with host CUDA packages"
+        rm -rf "$VENV"
+    elif [[ "$USE_JETSON_TORCH" == "0" && "$has_system_site" == "1" ]]; then
+        echo "[build] $BACKEND backend: recreating isolated venv"
+        rm -rf "$VENV"
+    fi
+fi
 if [[ ! -d "$VENV" ]]; then
     echo "[build] uv venv → $VENV"
-    uv venv "$VENV"
+    if [[ "$USE_JETSON_TORCH" == "1" ]]; then
+        uv venv --system-site-packages "$VENV"
+    else
+        uv venv "$VENV"
+    fi
 fi
 
 # This venv's site-packages (robust to the python minor version).
@@ -49,7 +80,7 @@ SITEPKG="$("$VENV/bin/python" -c 'import sysconfig; print(sysconfig.get_path("pu
 # SYMLINKS in this venv. Remove them BEFORE uv sync — otherwise uv, seeing the
 # deleted dist-info, reinstalls torch and writes THROUGH the symlink into the
 # host's shared JetPack torch tree, corrupting the system torch. Re-linked below.
-if [[ -f /etc/nv_tegra_release ]]; then
+if [[ "$USE_JETSON_TORCH" == "1" ]]; then
     for _m in torch torchaudio torchvision torchgen functorch torio; do
         [[ -L "$SITEPKG/$_m" ]] && rm -f "$SITEPKG/$_m"
     done
@@ -57,7 +88,25 @@ fi
 
 # ── 2. uv sync (deps from pyproject.toml + workspace uv.lock) ──────────────
 echo "[build] uv sync (pyproject.toml → $VENV)"
-VIRTUAL_ENV="$PKG/$VENV" uv sync --active --no-managed-python
+SYNC_ARGS=(--active --no-managed-python)
+if [[ "$BACKEND" == "local" ]]; then
+    SYNC_ARGS+=(--extra local)
+fi
+if [[ "$USE_JETSON_TORCH" == "1" ]]; then
+    SYNC_ARGS+=(
+        --no-install-package torch
+        --no-install-package torchaudio
+        --no-install-package torchvision
+    )
+fi
+VIRTUAL_ENV="$PKG/$VENV" uv sync "${SYNC_ARGS[@]}"
+
+# Wake-word detection is a core Speech capability, independent of whether ASR
+# and TTS use local models or Tencent. The runtime libraries are published on
+# sherpa-onnx's wheel index rather than PyPI.
+uv pip install --python "$VENV/bin/python" --no-index \
+    --find-links "${SHERPA_ONNX_WHEEL_INDEX:-https://k2-fsa.github.io/sherpa/onnx/cpu-cn.html}" \
+    sherpa-onnx-bin==1.13.4 sherpa-onnx-core==1.13.4
 
 # ── 2b. Jetson: use the host's JetPack CUDA torch, not PyPI's ──────────────
 # On Jetson (aarch64), PyPI ships a torch built against a CUDA version that
@@ -69,7 +118,7 @@ VIRTUAL_ENV="$PKG/$VENV" uv sync --active --no-managed-python
 # Generalised: resolve each module's dir from the host python, so it works
 # regardless of where JetPack / editable installs place them.
 # Disable with SPEECH_SKIP_JETSON_TORCH=1.
-if [[ -f /etc/nv_tegra_release && "${SPEECH_SKIP_JETSON_TORCH:-}" != "1" ]]; then
+if [[ "$USE_JETSON_TORCH" == "1" && "${SPEECH_SKIP_JETSON_TORCH:-}" != "1" ]]; then
     SP="$SITEPKG"
     if ! "$VENV/bin/python" -c 'import torch,sys; sys.exit(0 if torch.cuda.is_available() else 1)' 2>/dev/null; then
         HOSTPY="${SPEECH_HOST_PYTHON:-python3}"
@@ -90,17 +139,41 @@ if [[ -f /etc/nv_tegra_release && "${SPEECH_SKIP_JETSON_TORCH:-}" != "1" ]]; the
 fi
 
 # ── 3. Codegen (.proto + grpc stubs → rbnx-build/codegen/) ──────────────────
-FLAGS=(--mcp)
-[[ "$CLEAN" == "1" ]] && FLAGS+=(--clean)
-echo "[build] rbnx codegen ${FLAGS[*]}"
-rbnx codegen -p "$PKG" "${FLAGS[@]}"
+echo "[build] rbnx codegen"
+rbnx codegen -p "$PKG"
 
 # ── 4. Pre-download models (skip with SKIP_MODEL_DOWNLOAD=1) ────────────────
 # Default HF_ENDPOINT to hf-mirror.com for runners where direct model downloads
 # are slow or unreliable. Override by exporting HF_ENDPOINT before invoking build.sh.
 : "${HF_ENDPOINT:=https://hf-mirror.com}"
 export HF_ENDPOINT
+
 if [[ "${SKIP_MODEL_DOWNLOAD:-}" != "1" ]]; then
+    PY="$VENV/bin/python"
+    MODEL_NAME=sherpa-onnx-kws-zipformer-zh-en-3M-2025-12-20
+    MODEL_DIR="$BUILD/models/$MODEL_NAME"
+    ARCHIVE="$BUILD/models/$MODEL_NAME.tar.bz2"
+    OFFICIAL_URL="https://github.com/k2-fsa/sherpa-onnx/releases/download/kws-models/$MODEL_NAME.tar.bz2"
+    MIRROR_URL="https://ghfast.top/$OFFICIAL_URL"
+    mkdir -p "$BUILD/models"
+    if [[ ! -f "$MODEL_DIR/tokens.txt" ]]; then
+        echo "[build] downloading Speech wake-word model ($MODEL_NAME)"
+        rm -f "$ARCHIVE"
+        if ! curl -fL --retry 3 --connect-timeout 15 -o "$ARCHIVE" \
+            "${SHERPA_KWS_MODEL_URL:-$MIRROR_URL}"; then
+            rm -f "$ARCHIVE"
+            curl -fL --retry 3 --connect-timeout 15 -o "$ARCHIVE" "$OFFICIAL_URL"
+        fi
+        bzip2 -t "$ARCHIVE"
+        tar -xjf "$ARCHIVE" -C "$BUILD/models"
+        rm -f "$ARCHIVE"
+    fi
+    "$PY" -c 'import sherpa_onnx; print("[build] sherpa-onnx", sherpa_onnx.__version__)'
+else
+    echo "[build] skipping wake-word model download (SKIP_MODEL_DOWNLOAD=1)."
+fi
+
+if [[ "$BACKEND" == "local" && "${SKIP_MODEL_DOWNLOAD:-}" != "1" ]]; then
     PY="$VENV/bin/python"
     # Whisper is opt-in: it's a 20+ GB pull (whisper-large-v3) that only
     # the one-shot `robonix/system/speech/asr` contract uses. The default
@@ -114,16 +187,26 @@ if [[ "${SKIP_MODEL_DOWNLOAD:-}" != "1" ]]; then
         # transformers (TypeError: got multiple values). `snapshot_download`
         # is more direct for "just fetch the weights into the HF cache"
         # intent and avoids spinning up the full pipeline.
-        "$PY" -c "from huggingface_hub import snapshot_download; snapshot_download('openai/whisper-large-v3')" \
-            || echo "[build] WARNING: Whisper model download failed; ASR backend will fail at runtime."
+        "$PY" -c "from huggingface_hub import snapshot_download; snapshot_download('openai/whisper-large-v3')"
     else
         echo "[build] skipping Whisper download (set DOWNLOAD_WHISPER=1 to pull the 20 GB one-shot ASR weights)."
     fi
     echo "[build] downloading FunASR model (paraformer-zh-streaming)…"
-    "$PY" -c "from funasr import AutoModel; AutoModel(model='paraformer-zh-streaming')" \
-        || echo "[build] WARNING: FunASR model download failed; streaming ASR backend will fail at runtime."
-else
+    "$PY" -c "from funasr import AutoModel; AutoModel(model='paraformer-zh-streaming')"
+elif [[ "$BACKEND" == "tencent" ]]; then
+    echo "[build] Tencent backend: validating lightweight cloud dependencies"
+    "$VENV/bin/python" - <<'PY'
+from speech_service.tencent_cloud import TencentRealtimeASRBackend, TencentTTSBackend
+import requests
+from websockets.sync.client import connect
+
+assert TencentRealtimeASRBackend and TencentTTSBackend and requests and connect
+print("[build]   Tencent ASR/TTS imports OK; no local model or GPU required")
+PY
+elif [[ "$BACKEND" == "local" ]]; then
     echo "[build] skipping model download (SKIP_MODEL_DOWNLOAD=1)."
+else
+    echo "[build] $BACKEND backend: no bundled model download"
 fi
 
 echo "[build] done."

--- a/services/speech/scripts/build.sh
+++ b/services/speech/scripts/build.sh
@@ -140,7 +140,20 @@ fi
 
 # ── 3. Codegen (.proto + grpc stubs → rbnx-build/codegen/) ──────────────────
 echo "[build] rbnx codegen"
-rbnx codegen -p "$PKG"
+PATH="$PKG/$VENV/bin:$PATH" rbnx codegen -p "$PKG"
+
+# The service imports both gRPC stubs (`speech_pb2*`) and MCP dataclasses
+# (`speech_mcp`) at startup. Verify both generated Python roots now so a
+# missing runtime PYTHONPATH cannot degrade into a 60-second Atlas
+# registration timeout during `rbnx boot`.
+CODEGEN_PYTHONPATH="$PKG/$BUILD/codegen/proto_gen:$PKG/$BUILD/codegen/robonix_mcp_types"
+PYTHONPATH="$CODEGEN_PYTHONPATH:${PYTHONPATH:-}" "$VENV/bin/python" - <<'PY'
+import speech_mcp
+import speech_pb2
+import speech_pb2_grpc
+
+print("[build] generated Speech gRPC and MCP imports OK")
+PY
 
 # ── 4. Pre-download models (skip with SKIP_MODEL_DOWNLOAD=1) ────────────────
 # Default HF_ENDPOINT to hf-mirror.com for runners where direct model downloads

--- a/services/speech/scripts/build.sh
+++ b/services/speech/scripts/build.sh
@@ -140,7 +140,7 @@ fi
 
 # ── 3. Codegen (.proto + grpc stubs → rbnx-build/codegen/) ──────────────────
 echo "[build] rbnx codegen"
-PATH="$PKG/$VENV/bin:$PATH" rbnx codegen -p "$PKG"
+PATH="$PKG/$VENV/bin:$PATH" rbnx codegen --mcp -p "$PKG"
 
 # The service imports both gRPC stubs (`speech_pb2*`) and MCP dataclasses
 # (`speech_mcp`) at startup. Verify both generated Python roots now so a

--- a/services/speech/speech_service/service.py
+++ b/services/speech/speech_service/service.py
@@ -63,6 +63,7 @@ import time
 import uuid
 import asyncio
 import logging
+import threading
 import wave
 import importlib
 from concurrent import futures
@@ -140,6 +141,10 @@ SpeechAsrBase = _grpc_class(
 SpeechAsrStreamBase = _grpc_class(
     "RobonixServiceSpeechAsrStreamServicer",
     "RobonixSystemSpeechAsrStreamServicer",
+)
+SpeechWakeWordBase = _grpc_class(
+    "RobonixServiceSpeechWakeWordServicer",
+    "RobonixSystemSpeechWakeWordServicer",
 )
 SpeechTtsBase = _grpc_class(
     "RobonixServiceSpeechTtsServicer",
@@ -878,6 +883,30 @@ class SpeechAsrStreamServicer(SpeechAsrStreamBase):
         )
 
 
+class SpeechWakeWordServicer(SpeechWakeWordBase):
+    """Client-streaming wake-word inference owned by the Speech service."""
+
+    def __init__(self, backend):
+        self.backend = backend
+
+    def DetectWakeWord(self, request_iterator, context):
+        if self.backend is None:
+            context.set_code(grpc.StatusCode.UNAVAILABLE)
+            context.set_details("wake-word backend is unavailable; run the speech package build")
+            return speech_pb2.DetectWakeWord_Response(error="wake-word backend unavailable")
+        try:
+            keyword = self.backend.detect(bytes(chunk.data) for chunk in request_iterator if chunk.data)
+            return speech_pb2.DetectWakeWord_Response(
+                detected=bool(keyword),
+                keyword=keyword,
+                confidence=1.0 if keyword else 0.0,
+                error="",
+            )
+        except Exception as exc:
+            log.exception("wake-word stream failed")
+            return speech_pb2.DetectWakeWord_Response(error=str(exc))
+
+
 class SpeechTtsServicer(SpeechTtsBase):
     """TTS gRPC servicer -- handles the Call RPC for one-shot text-to-speech.
 
@@ -890,6 +919,39 @@ class SpeechTtsServicer(SpeechTtsBase):
 
     def __init__(self, tts_backend):
         self.tts_backend = tts_backend
+        self._cache: dict[tuple[str, str, float], bytes] = {}
+        self._cache_lock = threading.Lock()
+
+    def configure_backend(self, tts_backend) -> None:
+        with self._cache_lock:
+            self.tts_backend = tts_backend
+            self._cache.clear()
+
+    def _synthesize_cached(self, text: str, voice: str, speed: float) -> bytes:
+        key = (text, voice, speed)
+        with self._cache_lock:
+            cached = self._cache.get(key)
+        if cached is not None:
+            return cached
+        audio_data = asyncio.run(self.tts_backend.synthesize(text, voice, speed))
+        with self._cache_lock:
+            self._cache[key] = audio_data
+            while len(self._cache) > 16:
+                self._cache.pop(next(iter(self._cache)))
+        return audio_data
+
+    def prewarm(self, phrases: Iterable[str]) -> None:
+        if self.tts_backend is None:
+            return
+        for phrase in phrases:
+            text = str(phrase).strip()
+            if not text:
+                continue
+            try:
+                self._synthesize_cached(text, "", 1.0)
+                log.info("TTS cache prewarmed for %d-character prompt", len(text))
+            except Exception:
+                log.exception("TTS cache prewarm failed for %d-character prompt", len(text))
 
     def Synthesize(self, request, context):
         """Handle one-shot TTS: receive text, return complete MP3 audio.
@@ -916,7 +978,7 @@ class SpeechTtsServicer(SpeechTtsBase):
         speed = request.speed or 1.0
 
         try:
-            audio_data = asyncio.run(self.tts_backend.synthesize(text, voice, speed))
+            audio_data = self._synthesize_cached(text, voice, speed)
             return tts_pb2.Synthesize_Response(
                 audio_data=audio_data,
                 encoding=os.environ.get("SPEECH_TTS_OUTPUT_ENCODING", "pcm_s16le"),
@@ -1093,11 +1155,13 @@ log.info("Starting speech service (mock_mode=%s)", MOCK_MODE)
 _dialog_manager = DialogManager()
 _asr_servicer        = SpeechAsrServicer(None)
 _asr_stream_servicer = SpeechAsrStreamServicer(None)
+_wake_word_servicer   = SpeechWakeWordServicer(None)
 _tts_servicer        = SpeechTtsServicer(None)
 _tts_stream_servicer = SpeechTtsStreamServicer(None)
 _dialog_servicer     = SpeechDialogServicer(_dialog_manager)
 speech.attach_grpc_servicer("robonix/service/speech/asr",        _asr_servicer)
 speech.attach_grpc_servicer("robonix/service/speech/asr_stream", _asr_stream_servicer)
+speech.attach_grpc_servicer("robonix/service/speech/wake_word",  _wake_word_servicer)
 speech.attach_grpc_servicer("robonix/service/speech/tts",        _tts_servicer)
 speech.attach_grpc_servicer("robonix/service/speech/tts_stream", _tts_stream_servicer)
 speech.attach_grpc_servicer("robonix/service/speech/dialog",     _dialog_servicer)
@@ -1227,6 +1291,24 @@ _CFG_ENV_MAP = {
 }
 
 
+def _configured_strings(value, env_name: str, default: list[str]) -> list[str]:
+    raw = value if value is not None else os.environ.get(env_name, "")
+    if not raw:
+        return list(default)
+    if isinstance(raw, str):
+        stripped = raw.strip()
+        if stripped.startswith("["):
+            raw = json.loads(stripped)
+        else:
+            raw = [item.strip() for item in stripped.replace("\n", ",").split(",")]
+    if not isinstance(raw, (list, tuple)):
+        raise ValueError(f"{env_name} must be a JSON list or comma-separated string")
+    values = [str(item).strip() for item in raw if str(item).strip()]
+    if not values:
+        raise ValueError(f"{env_name} must contain at least one non-empty value")
+    return values
+
+
 def _apply_cfg_to_env(cfg: dict) -> None:
     for key, env in _CFG_ENV_MAP.items():
         if key not in cfg:
@@ -1303,8 +1385,44 @@ def init(cfg):
 
     _asr_servicer.asr_backend = asr
     _asr_stream_servicer.stream_asr_backend = asr_stream
-    _tts_servicer.tts_backend = tts
+    try:
+        from speech_service.wake_word import WakeWordBackend, prepare_keywords_file
+
+        package_root = Path(__file__).resolve().parents[1]
+        model_dir = Path(cfg.get("wake_word_model_dir") or package_root / "rbnx-build" / "models" / "sherpa-onnx-kws-zipformer-zh-en-3M-2025-12-20")
+        # The default is a distinctive phrase validated with the bundled KWS
+        # model and Tencent 16 kHz TTS. Deployments can replace it without
+        # modifying Liaison through `wake_words` or `SPEECH_WAKE_WORDS`.
+        wake_words = _configured_strings(cfg.get("wake_words"), "SPEECH_WAKE_WORDS", ["罗伯特"])
+        configured_keywords = cfg.get("wake_word_keywords_file")
+        if configured_keywords:
+            keywords_file = Path(configured_keywords)
+        else:
+            keywords_file = prepare_keywords_file(
+                model_dir,
+                package_root / "rbnx-build" / "runtime" / "wake_word",
+                wake_words,
+                boost=float(cfg.get("wake_word_boost") or 2.0),
+                threshold=float(cfg.get("wake_word_threshold") or 0.45),
+            )
+        _wake_word_servicer.backend = WakeWordBackend(
+            model_dir,
+            keywords_file,
+            max(1, int(cfg.get("wake_word_num_threads") or 2)),
+        )
+        log.info("wake-word backend ready: phrases=%s", wake_words)
+    except Exception as exc:
+        _wake_word_servicer.backend = None
+        log.exception("wake-word backend unavailable: %s", exc)
+    _tts_servicer.configure_backend(tts)
     _tts_stream_servicer.tts_backend = tts
+    if tts is not None:
+        warm_phrases = _configured_strings(
+            cfg.get("tts_warm_phrases"),
+            "SPEECH_TTS_WARM_PHRASES",
+            ["我在"],
+        )
+        _tts_servicer.prewarm(warm_phrases)
 
     log.info(
         "Backend status: mode=%s asr=%s (%s) asr_stream=%s (%s) tts=%s (%s)",

--- a/services/speech/speech_service/service.py
+++ b/services/speech/speech_service/service.py
@@ -895,7 +895,12 @@ class SpeechWakeWordServicer(SpeechWakeWordBase):
             context.set_details("wake-word backend is unavailable; run the speech package build")
             return speech_pb2.DetectWakeWord_Response(error="wake-word backend unavailable")
         try:
-            keyword = self.backend.detect(bytes(chunk.data) for chunk in request_iterator if chunk.data)
+            # Robonix codegen unwraps the sole request field for a client-stream
+            # RPC. gRPC therefore yields bare audio.AudioChunk messages here,
+            # not DetectWakeWord_Request wrappers.
+            keyword = self.backend.detect(
+                bytes(chunk.data) for chunk in request_iterator if chunk.data
+            )
             return speech_pb2.DetectWakeWord_Response(
                 detected=bool(keyword),
                 keyword=keyword,

--- a/services/speech/speech_service/service.py
+++ b/services/speech/speech_service/service.py
@@ -1393,7 +1393,11 @@ def init(cfg):
         # The default is a distinctive phrase validated with the bundled KWS
         # model and Tencent 16 kHz TTS. Deployments can replace it without
         # modifying Liaison through `wake_words` or `SPEECH_WAKE_WORDS`.
-        wake_words = _configured_strings(cfg.get("wake_words"), "SPEECH_WAKE_WORDS", ["罗伯特"])
+        wake_words = _configured_strings(
+            cfg.get("wake_words"),
+            "SPEECH_WAKE_WORDS",
+            ["\u7f57\u4f2f\u7279"],
+        )
         configured_keywords = cfg.get("wake_word_keywords_file")
         if configured_keywords:
             keywords_file = Path(configured_keywords)
@@ -1420,7 +1424,7 @@ def init(cfg):
         warm_phrases = _configured_strings(
             cfg.get("tts_warm_phrases"),
             "SPEECH_TTS_WARM_PHRASES",
-            ["我在"],
+            ["\u6211\u5728"],
         )
         _tts_servicer.prewarm(warm_phrases)
 

--- a/services/speech/speech_service/wake_word.py
+++ b/services/speech/speech_service/wake_word.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import numpy as np
+import sherpa_onnx
+
+
+def prepare_keywords_file(
+    model_dir: Path,
+    output_dir: Path,
+    wake_words: Sequence[str],
+    *,
+    boost: float = 2.0,
+    threshold: float = 0.45,
+) -> Path:
+    """Compile configured phrases into sherpa-onnx tokens without network I/O."""
+    phrases = []
+    for raw in wake_words:
+        phrase = str(raw).strip()
+        if not phrase:
+            continue
+        if any(char in phrase for char in "\r\n:@#"):
+            raise ValueError(f"invalid wake phrase: {phrase!r}")
+        if phrase not in phrases:
+            phrases.append(phrase)
+    if not phrases:
+        raise ValueError("wake_words must contain at least one non-empty phrase")
+    if boost <= 0:
+        raise ValueError("wake_word_boost must be positive")
+    if not 0 < threshold <= 1:
+        raise ValueError("wake_word_threshold must be in (0, 1]")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    raw_file = output_dir / "keywords_raw.txt"
+    token_file = output_dir / "keywords.txt"
+    raw_file.write_text(
+        "".join(f"{phrase} :{boost:g} #{threshold:g} @{phrase}\n" for phrase in phrases),
+        encoding="utf-8",
+    )
+
+    cli = Path(sys.executable).with_name("sherpa-onnx-cli")
+    if not cli.is_file():
+        resolved = shutil.which("sherpa-onnx-cli")
+        if not resolved:
+            raise RuntimeError("sherpa-onnx-cli is unavailable; rebuild the Speech package")
+        cli = Path(resolved)
+    subprocess.run(
+        [
+            str(cli),
+            "text2token",
+            "--tokens",
+            str(model_dir / "tokens.txt"),
+            "--tokens-type",
+            "phone+ppinyin",
+            "--lexicon",
+            str(model_dir / "en.phone"),
+            str(raw_file),
+            str(token_file),
+        ],
+        check=True,
+    )
+    return token_file
+
+
+class WakeWordBackend:
+    """Streaming open-vocabulary KWS implemented inside the Speech service."""
+
+    def __init__(self, model_dir: Path, keywords_file: Path, num_threads: int = 2) -> None:
+        self._spotter = sherpa_onnx.KeywordSpotter(
+            tokens=str(model_dir / "tokens.txt"),
+            encoder=str(model_dir / "encoder-epoch-13-avg-2-chunk-8-left-64.int8.onnx"),
+            decoder=str(model_dir / "decoder-epoch-13-avg-2-chunk-8-left-64.onnx"),
+            joiner=str(model_dir / "joiner-epoch-13-avg-2-chunk-8-left-64.int8.onnx"),
+            num_threads=num_threads,
+            keywords_file=str(keywords_file),
+            provider="cpu",
+        )
+
+    def detect(self, pcm_chunks: Iterable[bytes]) -> str:
+        stream = self._spotter.create_stream()
+        for pcm in pcm_chunks:
+            if not pcm:
+                continue
+            samples = np.frombuffer(pcm, dtype=np.int16).astype(np.float32) / 32768.0
+            stream.accept_waveform(16_000, samples)
+            while self._spotter.is_ready(stream):
+                self._spotter.decode_stream(stream)
+                result = self._spotter.get_result(stream)
+                if result:
+                    return str(result)
+        return ""

--- a/system/liaison/src/handsfree.rs
+++ b/system/liaison/src/handsfree.rs
@@ -1,0 +1,317 @@
+// SPDX-License-Identifier: MulanPSL-2.0
+// Robot-local voice mode orchestration. This module contains no speech
+// algorithm: Audio provides PCM, Speech performs KWS/ASR/TTS, Voiceprint
+// identifies the speaker, and Liaison only connects those capabilities.
+
+use anyhow::{Context, Result, anyhow};
+use robonix_atlas::client::AtlasClient;
+use robonix_scribe::{info, warn};
+use serde::Deserialize;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::sync::{Mutex, Notify, mpsc};
+use tokio_stream::{StreamExt, wrappers::ReceiverStream};
+use tonic::Request;
+
+use crate::access::AccessControlConfig;
+use crate::pb::contracts::{
+    robonix_primitive_audio_mic_client::RobonixPrimitiveAudioMicClient,
+    robonix_service_speech_wake_word_client::RobonixServiceSpeechWakeWordClient,
+};
+use crate::pb::liaison::{GetHandsfreeStatusResponse, StartVoiceSessionRequest};
+use crate::{voice, voice::KIND_ASR_FINAL};
+
+const MIC_CONTRACT: &str = "robonix/primitive/audio/mic";
+const WAKE_WORD_CONTRACT: &str = "robonix/service/speech/wake_word";
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(default)]
+pub struct HandsfreeConfig {
+    pub handsfree_enabled: bool,
+    pub handsfree_ack_text: String,
+    pub handsfree_mic_provider_id: String,
+    pub handsfree_speech_provider_id: String,
+    pub handsfree_voiceprint_provider_id: String,
+    pub handsfree_speaker_provider_id: String,
+    pub handsfree_session_id: String,
+    pub handsfree_record_seconds: u32,
+}
+
+impl Default for HandsfreeConfig {
+    fn default() -> Self {
+        Self {
+            handsfree_enabled: false,
+            handsfree_ack_text: "我在".to_string(),
+            handsfree_mic_provider_id: String::new(),
+            handsfree_speech_provider_id: "speech".to_string(),
+            handsfree_voiceprint_provider_id: "voiceprint".to_string(),
+            handsfree_speaker_provider_id: String::new(),
+            handsfree_session_id: "handsfree".to_string(),
+            handsfree_record_seconds: 20,
+        }
+    }
+}
+
+#[derive(Default)]
+struct RuntimeState {
+    state: String,
+    keyword: String,
+    last_wake_ms: u64,
+    last_transcript: String,
+    last_error: String,
+}
+
+pub struct HandsfreeController {
+    enabled: AtomicBool,
+    config: Mutex<HandsfreeConfig>,
+    state: Mutex<RuntimeState>,
+    changed: Notify,
+    atlas: Arc<Mutex<AtlasClient>>,
+    pilot_endpoint_default: String,
+    access: Arc<AccessControlConfig>,
+}
+
+impl HandsfreeController {
+    pub fn new(
+        config: HandsfreeConfig,
+        atlas: Arc<Mutex<AtlasClient>>,
+        pilot_endpoint_default: String,
+        access: Arc<AccessControlConfig>,
+    ) -> Arc<Self> {
+        let enabled = config.handsfree_enabled
+            && !config.handsfree_mic_provider_id.is_empty()
+            && !config.handsfree_speaker_provider_id.is_empty();
+        Arc::new(Self {
+            enabled: AtomicBool::new(enabled),
+            config: Mutex::new(config),
+            state: Mutex::new(RuntimeState {
+                state: if enabled { "starting" } else { "disabled" }.to_string(),
+                ..RuntimeState::default()
+            }),
+            changed: Notify::new(),
+            atlas,
+            pilot_endpoint_default,
+            access,
+        })
+    }
+
+    pub fn spawn(self: &Arc<Self>) {
+        let controller = Arc::clone(self);
+        tokio::spawn(async move { controller.run().await });
+    }
+
+    pub async fn set_enabled(
+        &self,
+        enabled: bool,
+        mic_provider_id: String,
+        speaker_provider_id: String,
+    ) -> Result<GetHandsfreeStatusResponse> {
+        {
+            let mut config = self.config.lock().await;
+            if !mic_provider_id.trim().is_empty() {
+                config.handsfree_mic_provider_id = mic_provider_id;
+            }
+            if !speaker_provider_id.trim().is_empty() {
+                config.handsfree_speaker_provider_id = speaker_provider_id;
+            }
+            if enabled
+                && (config.handsfree_mic_provider_id.trim().is_empty()
+                    || config.handsfree_speaker_provider_id.trim().is_empty())
+            {
+                anyhow::bail!(
+                    "select both an input and an output audio primitive before enabling hands-free mode"
+                );
+            }
+        }
+        self.enabled.store(enabled, Ordering::Release);
+        self.set_state(if enabled { "starting" } else { "disabled" }, None)
+            .await;
+        self.changed.notify_waiters();
+        Ok(self.snapshot().await)
+    }
+
+    pub async fn snapshot(&self) -> GetHandsfreeStatusResponse {
+        let config = self.config.lock().await.clone();
+        let state = self.state.lock().await;
+        GetHandsfreeStatusResponse {
+            enabled: self.enabled.load(Ordering::Acquire),
+            state: state.state.clone(),
+            keyword: state.keyword.clone(),
+            mic_provider_id: config.handsfree_mic_provider_id,
+            speaker_provider_id: config.handsfree_speaker_provider_id,
+            last_wake_ms: state.last_wake_ms,
+            last_transcript: state.last_transcript.clone(),
+            last_error: state.last_error.clone(),
+        }
+    }
+
+    async fn set_state(&self, value: &str, error: Option<String>) {
+        let mut state = self.state.lock().await;
+        state.state = value.to_string();
+        if let Some(error) = error {
+            state.last_error = error;
+        }
+    }
+
+    async fn run(self: Arc<Self>) {
+        loop {
+            if !self.enabled.load(Ordering::Acquire) {
+                self.set_state("disabled", None).await;
+                self.changed.notified().await;
+                continue;
+            }
+
+            self.set_state("listening", None).await;
+            let wait = self.wait_for_wake();
+            tokio::pin!(wait);
+            let wake_result = tokio::select! {
+                result = &mut wait => Some(result),
+                _ = self.changed.notified() => None,
+            };
+            let Some(wake_result) = wake_result else {
+                continue;
+            };
+
+            match wake_result {
+                Ok(Some(keyword)) => {
+                    {
+                        let mut state = self.state.lock().await;
+                        state.state = "triggered".to_string();
+                        state.keyword = keyword.clone();
+                        state.last_wake_ms = now_ms();
+                        state.last_error.clear();
+                    }
+                    info!("[liaison/handsfree] wake phrase detected: {keyword}");
+                    if let Err(error) = self.run_voice_turn().await {
+                        let message = format!("{error:#}");
+                        warn!("[liaison/handsfree] voice turn failed: {message}");
+                        self.set_state("error", Some(message)).await;
+                        tokio::time::sleep(Duration::from_secs(1)).await;
+                    }
+                }
+                Ok(None) => {
+                    self.set_state("listening", None).await;
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+                }
+                Err(error) => {
+                    let message = format!("{error:#}");
+                    warn!("[liaison/handsfree] wake listener failed: {message}");
+                    self.set_state("error", Some(message)).await;
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                }
+            }
+        }
+    }
+
+    async fn wait_for_wake(&self) -> Result<Option<String>> {
+        let config = self.config.lock().await.clone();
+        let mic_endpoint =
+            voice::resolve_endpoint(&self.atlas, MIC_CONTRACT, &config.handsfree_mic_provider_id)
+                .await
+                .ok_or_else(|| anyhow!("no mic provider '{}'", config.handsfree_mic_provider_id))?;
+        let wake_endpoint = voice::resolve_endpoint(
+            &self.atlas,
+            WAKE_WORD_CONTRACT,
+            &config.handsfree_speech_provider_id,
+        )
+        .await
+        .ok_or_else(|| {
+            anyhow!(
+                "no speech wake-word provider '{}'",
+                config.handsfree_speech_provider_id
+            )
+        })?;
+
+        let mut mic = RobonixPrimitiveAudioMicClient::connect(mic_endpoint.clone())
+            .await
+            .with_context(|| format!("connect mic at {mic_endpoint}"))?;
+        let mut wake = RobonixServiceSpeechWakeWordClient::connect(wake_endpoint.clone())
+            .await
+            .with_context(|| format!("connect wake-word service at {wake_endpoint}"))?;
+        let mut mic_stream = mic.mic(Request::new(())).await?.into_inner();
+        let (tx, rx) = mpsc::channel(64);
+        let pump = tokio::spawn(async move {
+            while let Ok(Some(chunk)) = mic_stream.message().await {
+                if tx.send(chunk).await.is_err() {
+                    break;
+                }
+            }
+        });
+        let response = wake
+            .detect_wake_word(Request::new(ReceiverStream::new(rx)))
+            .await;
+        pump.abort();
+        let response = response?.into_inner();
+        if !response.error.is_empty() {
+            return Err(anyhow!(response.error));
+        }
+        Ok(response.detected.then_some(response.keyword))
+    }
+
+    async fn run_voice_turn(&self) -> Result<()> {
+        let config = self.config.lock().await.clone();
+        let ack = config.handsfree_ack_text.trim();
+        if !ack.is_empty() {
+            self.set_state("acknowledging", None).await;
+            if let Err(error) = voice::play_prompt(
+                &self.atlas,
+                &config.handsfree_speech_provider_id,
+                &config.handsfree_speaker_provider_id,
+                "",
+                ack,
+                &config.handsfree_session_id,
+            )
+            .await
+            {
+                let message = format!("wake acknowledgement failed: {error:#}");
+                warn!("[liaison/handsfree] {message}");
+                self.state.lock().await.last_error = message;
+            }
+        }
+        self.set_state("in_voice", None).await;
+        let request = StartVoiceSessionRequest {
+            session_id: config.handsfree_session_id.clone(),
+            client_user_id: "voice:anyone".to_string(),
+            record_seconds: config.handsfree_record_seconds,
+            language: String::new(),
+            tts_enabled: true,
+            mic_node_id: config.handsfree_mic_provider_id.clone(),
+            asr_node_id: config.handsfree_speech_provider_id.clone(),
+            voiceprint_node_id: config.handsfree_voiceprint_provider_id.clone(),
+            tts_node_id: config.handsfree_speech_provider_id.clone(),
+            speaker_node_id: config.handsfree_speaker_provider_id.clone(),
+            context_json:
+                r#"{"client":"robot-handsfree","interaction_mode":"auto","handsfree":true}"#
+                    .to_string(),
+        };
+        let mut stream = voice::start_voice_session(
+            request,
+            Arc::clone(&self.atlas),
+            self.pilot_endpoint_default.clone(),
+            Arc::clone(&self.access),
+        )
+        .await
+        .map_err(|status| anyhow!(status.to_string()))?;
+        while let Some(event) = stream.next().await {
+            let event = event.map_err(|status| anyhow!(status.to_string()))?;
+            if event.event_kind == KIND_ASR_FINAL {
+                self.state.lock().await.last_transcript = event.text;
+            }
+            if !event.error.is_empty() {
+                return Err(anyhow!(event.error));
+            }
+        }
+        if self.enabled.load(Ordering::Acquire) {
+            self.set_state("listening", None).await;
+        }
+        Ok(())
+    }
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}

--- a/system/liaison/src/handsfree.rs
+++ b/system/liaison/src/handsfree.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use tokio::sync::{Mutex, Notify, mpsc};
+use tokio::sync::{Mutex, Notify, broadcast, mpsc};
 use tokio_stream::{StreamExt, wrappers::ReceiverStream};
 use tonic::Request;
 
@@ -19,8 +19,11 @@ use crate::pb::contracts::{
     robonix_primitive_audio_mic_client::RobonixPrimitiveAudioMicClient,
     robonix_service_speech_wake_word_client::RobonixServiceSpeechWakeWordClient,
 };
-use crate::pb::liaison::{GetHandsfreeStatusResponse, StartVoiceSessionRequest};
-use crate::{voice, voice::KIND_ASR_FINAL};
+use crate::pb::liaison::{GetHandsfreeStatusResponse, StartVoiceSessionRequest, VoiceEvent};
+use crate::{
+    voice,
+    voice::{KIND_ASR_FINAL, KIND_ERROR},
+};
 
 const MIC_CONTRACT: &str = "robonix/primitive/audio/mic";
 const WAKE_WORD_CONTRACT: &str = "robonix/service/speech/wake_word";
@@ -70,6 +73,7 @@ pub struct HandsfreeController {
     atlas: Arc<Mutex<AtlasClient>>,
     pilot_endpoint_default: String,
     access: Arc<AccessControlConfig>,
+    events: broadcast::Sender<VoiceEvent>,
 }
 
 impl HandsfreeController {
@@ -82,6 +86,7 @@ impl HandsfreeController {
         let enabled = config.handsfree_enabled
             && !config.handsfree_mic_provider_id.is_empty()
             && !config.handsfree_speaker_provider_id.is_empty();
+        let (events, _) = broadcast::channel(256);
         Arc::new(Self {
             enabled: AtomicBool::new(enabled),
             config: Mutex::new(config),
@@ -93,6 +98,7 @@ impl HandsfreeController {
             atlas,
             pilot_endpoint_default,
             access,
+            events,
         })
     }
 
@@ -146,6 +152,35 @@ impl HandsfreeController {
         }
     }
 
+    /// Subscribe to the existing VoiceEvent model rather than inventing a
+    /// hands-free-specific client protocol. This stream is observational and
+    /// never drives microphone ownership or task execution.
+    pub fn subscribe_events(&self) -> ReceiverStream<Result<VoiceEvent, tonic::Status>> {
+        let mut source = self.events.subscribe();
+        let (tx, rx) = mpsc::channel(64);
+        tokio::spawn(async move {
+            loop {
+                match source.recv().await {
+                    Ok(event) => {
+                        if tx.send(Ok(event)).await.is_err() {
+                            break;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                        warn!("[liaison/handsfree] event observer lagged by {skipped} event(s)");
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        });
+        ReceiverStream::new(rx)
+    }
+
+    fn publish(&self, event: VoiceEvent) {
+        // A disconnected UI must never block the robot-local interaction.
+        let _ = self.events.send(event);
+    }
+
     async fn set_state(&self, value: &str, error: Option<String>) {
         let mut state = self.state.lock().await;
         state.state = value.to_string();
@@ -190,6 +225,18 @@ impl HandsfreeController {
                     if let Err(error) = self.run_voice_turn().await {
                         let message = format!("{error:#}");
                         warn!("[liaison/handsfree] voice turn failed: {message}");
+                        let session_id = self.config.lock().await.handsfree_session_id.clone();
+                        self.publish(VoiceEvent {
+                            event_kind: KIND_ERROR,
+                            session_id,
+                            text: String::new(),
+                            user_id: String::new(),
+                            confidence: 0.0,
+                            pilot: None,
+                            error: message.clone(),
+                            status_message: String::new(),
+                            timestamp_ms: now_ms(),
+                        });
                         self.set_state("error", Some(message)).await;
                         tokio::time::sleep(Duration::from_secs(1)).await;
                     }
@@ -300,8 +347,9 @@ impl HandsfreeController {
         while let Some(event) = stream.next().await {
             let event = event.map_err(|status| anyhow!(status.to_string()))?;
             if event.event_kind == KIND_ASR_FINAL {
-                self.state.lock().await.last_transcript = event.text;
+                self.state.lock().await.last_transcript = event.text.clone();
             }
+            self.publish(event.clone());
             if !event.error.is_empty() {
                 return Err(anyhow!(event.error));
             }

--- a/system/liaison/src/handsfree.rs
+++ b/system/liaison/src/handsfree.rs
@@ -8,9 +8,10 @@ use robonix_atlas::client::AtlasClient;
 use robonix_scribe::{info, warn};
 use serde::Deserialize;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::{Mutex, Notify, broadcast, mpsc};
+use tokio::task::JoinHandle;
 use tokio_stream::{StreamExt, wrappers::ReceiverStream};
 use tonic::Request;
 
@@ -67,6 +68,7 @@ struct RuntimeState {
 
 pub struct HandsfreeController {
     enabled: AtomicBool,
+    suspended: AtomicUsize,
     config: Mutex<HandsfreeConfig>,
     state: Mutex<RuntimeState>,
     changed: Notify,
@@ -74,6 +76,7 @@ pub struct HandsfreeController {
     pilot_endpoint_default: String,
     access: Arc<AccessControlConfig>,
     events: broadcast::Sender<VoiceEvent>,
+    active_turns: Mutex<Vec<JoinHandle<()>>>,
 }
 
 impl HandsfreeController {
@@ -89,6 +92,7 @@ impl HandsfreeController {
         let (events, _) = broadcast::channel(256);
         Arc::new(Self {
             enabled: AtomicBool::new(enabled),
+            suspended: AtomicUsize::new(0),
             config: Mutex::new(config),
             state: Mutex::new(RuntimeState {
                 state: if enabled { "starting" } else { "disabled" }.to_string(),
@@ -99,6 +103,7 @@ impl HandsfreeController {
             pilot_endpoint_default,
             access,
             events,
+            active_turns: Mutex::new(Vec::new()),
         })
     }
 
@@ -131,6 +136,12 @@ impl HandsfreeController {
             }
         }
         self.enabled.store(enabled, Ordering::Release);
+        if !enabled {
+            let mut turns = self.active_turns.lock().await;
+            for turn in turns.drain(..) {
+                turn.abort();
+            }
+        }
         self.set_state(if enabled { "starting" } else { "disabled" }, None)
             .await;
         self.changed.notify_waiters();
@@ -149,6 +160,33 @@ impl HandsfreeController {
             last_wake_ms: state.last_wake_ms,
             last_transcript: state.last_transcript.clone(),
             last_error: state.last_error.clone(),
+        }
+    }
+
+    /// Pause only wake-word microphone ownership while an explicit voice
+    /// capture is active.  Enabled state is preserved and listening resumes
+    /// automatically at ASR final (or on any failed/disconnected capture).
+    pub async fn suspend_capture(&self) {
+        self.suspended.fetch_add(1, Ordering::AcqRel);
+        self.set_state("suspended", None).await;
+        self.changed.notify_waiters();
+    }
+
+    pub async fn resume_capture(&self) {
+        let mut current = self.suspended.load(Ordering::Acquire);
+        while current > 0 {
+            match self.suspended.compare_exchange_weak(
+                current,
+                current - 1,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => break,
+                Err(actual) => current = actual,
+            }
+        }
+        if self.suspended.load(Ordering::Acquire) == 0 {
+            self.changed.notify_waiters();
         }
     }
 
@@ -197,6 +235,11 @@ impl HandsfreeController {
         loop {
             if !self.enabled.load(Ordering::Acquire) {
                 self.set_state("disabled", None).await;
+                self.changed.notified().await;
+                continue;
+            }
+            if self.suspended.load(Ordering::Acquire) > 0 {
+                self.set_state("suspended", None).await;
                 self.changed.notified().await;
                 continue;
             }
@@ -300,10 +343,14 @@ impl HandsfreeController {
         Ok(response.detected.then_some(response.keyword))
     }
 
-    async fn run_voice_turn(&self) -> Result<()> {
+    async fn run_voice_turn(self: &Arc<Self>) -> Result<()> {
         let config = self.config.lock().await.clone();
+        let is_steer = self.has_active_turn().await;
         let ack = config.handsfree_ack_text.trim();
-        if !ack.is_empty() {
+        // A mid-task wake phrase is itself the acknowledgement.  Starting a
+        // second prompt here would queue behind the reply the user is trying
+        // to interrupt and delay capture by several seconds.
+        if !is_steer && !ack.is_empty() {
             self.set_state("acknowledging", None).await;
             if let Err(error) = voice::play_prompt(
                 &self.atlas,
@@ -332,9 +379,11 @@ impl HandsfreeController {
             voiceprint_node_id: config.handsfree_voiceprint_provider_id.clone(),
             tts_node_id: config.handsfree_speech_provider_id.clone(),
             speaker_node_id: config.handsfree_speaker_provider_id.clone(),
-            context_json:
-                r#"{"client":"robot-handsfree","interaction_mode":"auto","handsfree":true}"#
-                    .to_string(),
+            context_json: if is_steer {
+                r#"{"client":"robot-handsfree","interaction_mode":"steer","steer":true,"barge_in":true,"handsfree":true}"#.to_string()
+            } else {
+                r#"{"client":"robot-handsfree","interaction_mode":"auto","barge_in":false,"handsfree":true}"#.to_string()
+            },
         };
         let mut stream = voice::start_voice_session(
             request,
@@ -353,11 +402,49 @@ impl HandsfreeController {
             if !event.error.is_empty() {
                 return Err(anyhow!(event.error));
             }
+            if event.event_kind == KIND_ASR_FINAL {
+                // Recording ownership ends at ASR final, not when Pilot and
+                // TTS eventually finish.  Continue relaying that turn in the
+                // background and immediately restore wake-word listening so
+                // the user can steer a long-running action.
+                let controller = Arc::clone(self);
+                let handle = tokio::spawn(async move {
+                    while let Some(item) = stream.next().await {
+                        match item {
+                            Ok(event) => {
+                                let failed = !event.error.is_empty();
+                                controller.publish(event.clone());
+                                if failed {
+                                    warn!(
+                                        "[liaison/handsfree] background voice turn failed: {}",
+                                        event.error
+                                    );
+                                    break;
+                                }
+                            }
+                            Err(status) => {
+                                warn!(
+                                    "[liaison/handsfree] background voice stream failed: {status}"
+                                );
+                                break;
+                            }
+                        }
+                    }
+                });
+                self.active_turns.lock().await.push(handle);
+                if self.enabled.load(Ordering::Acquire) {
+                    self.set_state("listening", None).await;
+                }
+                return Ok(());
+            }
         }
-        if self.enabled.load(Ordering::Acquire) {
-            self.set_state("listening", None).await;
-        }
-        Ok(())
+        Err(anyhow!("voice session ended before ASR final"))
+    }
+
+    async fn has_active_turn(&self) -> bool {
+        let mut turns = self.active_turns.lock().await;
+        turns.retain(|turn| !turn.is_finished());
+        !turns.is_empty()
     }
 }
 

--- a/system/liaison/src/handsfree.rs
+++ b/system/liaison/src/handsfree.rs
@@ -151,6 +151,10 @@ impl HandsfreeController {
         state.state = value.to_string();
         if let Some(error) = error {
             state.last_error = error;
+        } else if value == "listening" {
+            // A connected microphone and a fresh wake listener mean an older
+            // reconnect failure is no longer actionable in the client UI.
+            state.last_error.clear();
         }
     }
 

--- a/system/liaison/src/handsfree.rs
+++ b/system/liaison/src/handsfree.rs
@@ -42,7 +42,7 @@ impl Default for HandsfreeConfig {
     fn default() -> Self {
         Self {
             handsfree_enabled: false,
-            handsfree_ack_text: "我在".to_string(),
+            handsfree_ack_text: "\u{6211}\u{5728}".to_string(),
             handsfree_mic_provider_id: String::new(),
             handsfree_speech_provider_id: "speech".to_string(),
             handsfree_voiceprint_provider_id: "voiceprint".to_string(),

--- a/system/liaison/src/main.rs
+++ b/system/liaison/src/main.rs
@@ -288,14 +288,44 @@ impl RobonixSystemLiaisonVoice for LiaisonServiceImpl {
         request: Request<StartVoiceSessionRequest>,
     ) -> Result<Response<Self::StartVoiceSessionStream>, Status> {
         let req = request.into_inner();
-        let stream = voice::start_voice_session(
+        self.handsfree.suspend_capture().await;
+        let stream = match voice::start_voice_session(
             req,
             Arc::clone(&self.atlas),
             self.pilot_endpoint_default.clone(),
             Arc::clone(&self.access),
         )
-        .await?;
-        let boxed: Self::StartVoiceSessionStream = Box::pin(stream);
+        .await
+        {
+            Ok(stream) => stream,
+            Err(status) => {
+                self.handsfree.resume_capture().await;
+                return Err(status);
+            }
+        };
+        let (tx, rx) = mpsc::channel(64);
+        let handsfree = Arc::clone(&self.handsfree);
+        tokio::spawn(async move {
+            let mut stream = Box::pin(stream);
+            let mut capture_suspended = true;
+            while let Some(item) = stream.next().await {
+                if capture_suspended
+                    && item
+                        .as_ref()
+                        .is_ok_and(|event| event.event_kind == voice::KIND_ASR_FINAL)
+                {
+                    handsfree.resume_capture().await;
+                    capture_suspended = false;
+                }
+                if tx.send(item).await.is_err() {
+                    break;
+                }
+            }
+            if capture_suspended {
+                handsfree.resume_capture().await;
+            }
+        });
+        let boxed: Self::StartVoiceSessionStream = Box::pin(ReceiverStream::new(rx));
         Ok(Response::new(boxed))
     }
 }

--- a/system/liaison/src/main.rs
+++ b/system/liaison/src/main.rs
@@ -30,6 +30,9 @@ use access::{AccessControlConfig, AccessDecision};
 use anyhow::{Context, Result, anyhow};
 use clap::Parser;
 use pb::contracts::{
+    robonix_system_liaison_handsfree_events_server::{
+        RobonixSystemLiaisonHandsfreeEvents, RobonixSystemLiaisonHandsfreeEventsServer,
+    },
     robonix_system_liaison_handsfree_set_enabled_server::{
         RobonixSystemLiaisonHandsfreeSetEnabled, RobonixSystemLiaisonHandsfreeSetEnabledServer,
     },
@@ -46,7 +49,7 @@ use pb::contracts::{
 };
 use pb::liaison::{
     GetHandsfreeStatusRequest, GetHandsfreeStatusResponse, SetHandsfreeRequest,
-    SetHandsfreeResponse, StartVoiceSessionRequest, VoiceEvent,
+    SetHandsfreeResponse, StartVoiceSessionRequest, VoiceEvent, WatchHandsfreeEventsRequest,
 };
 use pb::pilot::rtdl_node_state::RtdlNodeStateEnum;
 use pb::pilot::{CapabilityCall, PilotEvent, Plan, Task};
@@ -67,11 +70,13 @@ const LIAISON_SUBMIT_CONTRACT: &str = "robonix/system/liaison/submit";
 const LIAISON_VOICE_CONTRACT: &str = "robonix/system/liaison/voice";
 const LIAISON_HANDSFREE_SET_CONTRACT: &str = "robonix/system/liaison/handsfree/set_enabled";
 const LIAISON_HANDSFREE_STATUS_CONTRACT: &str = "robonix/system/liaison/handsfree/status";
+const LIAISON_HANDSFREE_EVENTS_CONTRACT: &str = "robonix/system/liaison/handsfree/events";
 const LIAISON_SUBMIT_TOML: &str = "capabilities/system/liaison/submit.v1.toml";
 const LIAISON_VOICE_TOML: &str = "capabilities/system/liaison/voice.v1.toml";
 const LIAISON_HANDSFREE_SET_TOML: &str =
     "capabilities/system/liaison/handsfree/set_enabled.v1.toml";
 const LIAISON_HANDSFREE_STATUS_TOML: &str = "capabilities/system/liaison/handsfree/status.v1.toml";
+const LIAISON_HANDSFREE_EVENTS_TOML: &str = "capabilities/system/liaison/handsfree/events.v1.toml";
 
 /// `lib/system/pilot/msg/Task.msg` source: TEXT=0 AUDIO=1
 const INTENT_SOURCE_TEXT: u32 = 0;
@@ -327,6 +332,18 @@ impl RobonixSystemLiaisonHandsfreeStatus for LiaisonServiceImpl {
         _request: Request<GetHandsfreeStatusRequest>,
     ) -> Result<Response<GetHandsfreeStatusResponse>, Status> {
         Ok(Response::new(self.handsfree.snapshot().await))
+    }
+}
+
+#[tonic::async_trait]
+impl RobonixSystemLiaisonHandsfreeEvents for LiaisonServiceImpl {
+    type WatchHandsfreeEventsStream = ReceiverStream<Result<VoiceEvent, Status>>;
+
+    async fn watch_handsfree_events(
+        &self,
+        _request: Request<WatchHandsfreeEventsRequest>,
+    ) -> Result<Response<Self::WatchHandsfreeEventsStream>, Status> {
+        Ok(Response::new(self.handsfree.subscribe_events()))
     }
 }
 
@@ -610,6 +627,20 @@ async fn main() -> Result<()> {
         )
         .await
         .context("declare liaison hands-free status gRPC capability")?;
+    atlas
+        .declare_capability(
+            LIAISON_PROVIDER_ID,
+            LIAISON_HANDSFREE_EVENTS_CONTRACT,
+            atlas_pb::Transport::Grpc,
+            &advertised,
+            atlas_client::grpc_params(
+                LIAISON_HANDSFREE_EVENTS_TOML,
+                "robonix.contracts.RobonixSystemLiaisonHandsfreeEvents",
+                "/robonix.contracts.RobonixSystemLiaisonHandsfreeEvents/WatchHandsfreeEvents",
+            ),
+        )
+        .await
+        .context("declare liaison hands-free events gRPC capability")?;
     // Liaison has no Driver(CMD_INIT/CMD_ACTIVATE) handshake — it's a Rust binary
     // that's fully ready as soon as the gRPC server is listening. Push the
     // state explicitly so `rbnx caps` shows ACTIVE instead of stopping at
@@ -690,7 +721,10 @@ async fn main() -> Result<()> {
         .add_service(RobonixSystemLiaisonHandsfreeSetEnabledServer::from_arc(
             Arc::clone(&svc),
         ))
-        .add_service(RobonixSystemLiaisonHandsfreeStatusServer::from_arc(svc))
+        .add_service(RobonixSystemLiaisonHandsfreeStatusServer::from_arc(
+            Arc::clone(&svc),
+        ))
+        .add_service(RobonixSystemLiaisonHandsfreeEventsServer::from_arc(svc))
         .serve(listen_addr);
 
     if let Some(handle) = text_handle {

--- a/system/liaison/src/main.rs
+++ b/system/liaison/src/main.rs
@@ -22,6 +22,7 @@
 // and called via gRPC — same pattern as the VLM service in Pilot.
 
 mod access;
+mod handsfree;
 mod pb;
 mod voice;
 
@@ -29,6 +30,12 @@ use access::{AccessControlConfig, AccessDecision};
 use anyhow::{Context, Result, anyhow};
 use clap::Parser;
 use pb::contracts::{
+    robonix_system_liaison_handsfree_set_enabled_server::{
+        RobonixSystemLiaisonHandsfreeSetEnabled, RobonixSystemLiaisonHandsfreeSetEnabledServer,
+    },
+    robonix_system_liaison_handsfree_status_server::{
+        RobonixSystemLiaisonHandsfreeStatus, RobonixSystemLiaisonHandsfreeStatusServer,
+    },
     robonix_system_liaison_submit_server::{
         RobonixSystemLiaisonSubmit, RobonixSystemLiaisonSubmitServer,
     },
@@ -37,7 +44,10 @@ use pb::contracts::{
     },
     robonix_system_pilot_client::RobonixSystemPilotClient,
 };
-use pb::liaison::{StartVoiceSessionRequest, VoiceEvent};
+use pb::liaison::{
+    GetHandsfreeStatusRequest, GetHandsfreeStatusResponse, SetHandsfreeRequest,
+    SetHandsfreeResponse, StartVoiceSessionRequest, VoiceEvent,
+};
 use pb::pilot::rtdl_node_state::RtdlNodeStateEnum;
 use pb::pilot::{CapabilityCall, PilotEvent, Plan, Task};
 use robonix_atlas::client::{self as atlas_client, AtlasClient};
@@ -55,8 +65,13 @@ const LIAISON_PROVIDER_ID: &str = "liaison";
 const LIAISON_NAMESPACE: &str = "robonix/system/liaison";
 const LIAISON_SUBMIT_CONTRACT: &str = "robonix/system/liaison/submit";
 const LIAISON_VOICE_CONTRACT: &str = "robonix/system/liaison/voice";
+const LIAISON_HANDSFREE_SET_CONTRACT: &str = "robonix/system/liaison/handsfree/set_enabled";
+const LIAISON_HANDSFREE_STATUS_CONTRACT: &str = "robonix/system/liaison/handsfree/status";
 const LIAISON_SUBMIT_TOML: &str = "capabilities/system/liaison/submit.v1.toml";
 const LIAISON_VOICE_TOML: &str = "capabilities/system/liaison/voice.v1.toml";
+const LIAISON_HANDSFREE_SET_TOML: &str =
+    "capabilities/system/liaison/handsfree/set_enabled.v1.toml";
+const LIAISON_HANDSFREE_STATUS_TOML: &str = "capabilities/system/liaison/handsfree/status.v1.toml";
 
 /// `lib/system/pilot/msg/Task.msg` source: TEXT=0 AUDIO=1
 const INTENT_SOURCE_TEXT: u32 = 0;
@@ -237,6 +252,7 @@ struct LiaisonServiceImpl {
     atlas: Arc<Mutex<AtlasClient>>,
     pilot_endpoint_default: String,
     access: Arc<AccessControlConfig>,
+    handsfree: Arc<handsfree::HandsfreeController>,
 }
 
 #[tonic::async_trait]
@@ -276,6 +292,41 @@ impl RobonixSystemLiaisonVoice for LiaisonServiceImpl {
         .await?;
         let boxed: Self::StartVoiceSessionStream = Box::pin(stream);
         Ok(Response::new(boxed))
+    }
+}
+
+#[tonic::async_trait]
+impl RobonixSystemLiaisonHandsfreeSetEnabled for LiaisonServiceImpl {
+    async fn set_handsfree(
+        &self,
+        request: Request<SetHandsfreeRequest>,
+    ) -> Result<Response<SetHandsfreeResponse>, Status> {
+        let request = request.into_inner();
+        let status = self
+            .handsfree
+            .set_enabled(
+                request.enabled,
+                request.mic_provider_id,
+                request.speaker_provider_id,
+            )
+            .await
+            .map_err(|error| Status::invalid_argument(error.to_string()))?;
+        Ok(Response::new(SetHandsfreeResponse {
+            ok: true,
+            enabled: status.enabled,
+            state: status.state,
+            detail: String::new(),
+        }))
+    }
+}
+
+#[tonic::async_trait]
+impl RobonixSystemLiaisonHandsfreeStatus for LiaisonServiceImpl {
+    async fn get_handsfree_status(
+        &self,
+        _request: Request<GetHandsfreeStatusRequest>,
+    ) -> Result<Response<GetHandsfreeStatusResponse>, Status> {
+        Ok(Response::new(self.handsfree.snapshot().await))
     }
 }
 
@@ -531,6 +582,34 @@ async fn main() -> Result<()> {
         )
         .await
         .context("declare liaison voice gRPC capability")?;
+    atlas
+        .declare_capability(
+            LIAISON_PROVIDER_ID,
+            LIAISON_HANDSFREE_SET_CONTRACT,
+            atlas_pb::Transport::Grpc,
+            &advertised,
+            atlas_client::grpc_params(
+                LIAISON_HANDSFREE_SET_TOML,
+                "robonix.contracts.RobonixSystemLiaisonHandsfreeSetEnabled",
+                "/robonix.contracts.RobonixSystemLiaisonHandsfreeSetEnabled/SetHandsfree",
+            ),
+        )
+        .await
+        .context("declare liaison hands-free set gRPC capability")?;
+    atlas
+        .declare_capability(
+            LIAISON_PROVIDER_ID,
+            LIAISON_HANDSFREE_STATUS_CONTRACT,
+            atlas_pb::Transport::Grpc,
+            &advertised,
+            atlas_client::grpc_params(
+                LIAISON_HANDSFREE_STATUS_TOML,
+                "robonix.contracts.RobonixSystemLiaisonHandsfreeStatus",
+                "/robonix.contracts.RobonixSystemLiaisonHandsfreeStatus/GetHandsfreeStatus",
+            ),
+        )
+        .await
+        .context("declare liaison hands-free status gRPC capability")?;
     // Liaison has no Driver(CMD_INIT/CMD_ACTIVATE) handshake — it's a Rust binary
     // that's fully ready as soon as the gRPC server is listening. Push the
     // state explicitly so `rbnx caps` shows ACTIVE instead of stopping at
@@ -575,6 +654,20 @@ async fn main() -> Result<()> {
         Arc::clone(&atlas),
         Arc::clone(&access),
     ));
+    let handsfree_config = args
+        .config_json
+        .as_deref()
+        .map(serde_json::from_str::<handsfree::HandsfreeConfig>)
+        .transpose()
+        .context("parse liaison hands-free config")?
+        .unwrap_or_default();
+    let handsfree = handsfree::HandsfreeController::new(
+        handsfree_config,
+        Arc::clone(&atlas),
+        pilot_http.clone(),
+        Arc::clone(&access),
+    );
+    handsfree.spawn();
 
     let source = std::env::var("ROBONIX_LIAISON_SOURCE").unwrap_or_default();
     let text_handle: Option<tokio::task::JoinHandle<Result<()>>> = if source == "text" {
@@ -589,10 +682,15 @@ async fn main() -> Result<()> {
         atlas: Arc::clone(&atlas),
         pilot_endpoint_default: pilot_http,
         access,
+        handsfree,
     });
     let server = tonic::transport::Server::builder()
         .add_service(RobonixSystemLiaisonSubmitServer::from_arc(Arc::clone(&svc)))
-        .add_service(RobonixSystemLiaisonVoiceServer::from_arc(svc))
+        .add_service(RobonixSystemLiaisonVoiceServer::from_arc(Arc::clone(&svc)))
+        .add_service(RobonixSystemLiaisonHandsfreeSetEnabledServer::from_arc(
+            Arc::clone(&svc),
+        ))
+        .add_service(RobonixSystemLiaisonHandsfreeStatusServer::from_arc(svc))
         .serve(listen_addr);
 
     if let Some(handle) = text_handle {

--- a/system/liaison/src/voice.rs
+++ b/system/liaison/src/voice.rs
@@ -99,7 +99,7 @@ const DEFAULT_AUDIO_SAMPLE_RATE: u32 = 16_000;
 /// `ConnectCapability` against the chosen one to actually receive the
 /// endpoint string. Atlas hides endpoints from `query_capabilities` on
 /// purpose; consumers must commit a channel before they can dial.
-async fn resolve_endpoint(
+pub(crate) async fn resolve_endpoint(
     atlas: &Arc<Mutex<AtlasClient>>,
     contract_id: &str,
     pin_provider_id: &str,
@@ -123,10 +123,10 @@ async fn resolve_endpoint(
     let pick: Option<&atlas_pb::CapabilityProvider> = if pin_provider_id.is_empty() {
         auto_pick()
     } else {
-        // Try the pinned provider first; if it isn't in atlas anymore (stale chat
-        // config / pin pointed at a provider that's not in this deploy), fall back
-        // to auto-pick rather than failing hard. The pin is a hint, not a
-        // hard requirement.
+        // A caller that explicitly names a provider is selecting a physical I/O
+        // boundary, not merely expressing a preference. Falling back from a
+        // client bridge to the robot device would silently capture or play on
+        // the wrong machine, so an explicit pin is a hard requirement.
         match providers
             .iter()
             .find(|r| r.id == pin_provider_id || r.namespace == pin_provider_id)
@@ -135,10 +135,10 @@ async fn resolve_endpoint(
             None => {
                 warn!(
                     "[voice] pinned provider '{pin_provider_id}' for {contract_id} not in atlas; \
-                     falling back to auto-pick. Available providers: {:?}",
+                     refusing implicit fallback. Available providers: {:?}",
                     providers.iter().map(|r| r.id.as_str()).collect::<Vec<_>>()
                 );
-                auto_pick()
+                None
             }
         }
     };
@@ -438,12 +438,14 @@ async fn run_session(
                             seg.push_str(&ev.text_chunk);
                         }
                         let is_boundary = matches!(kind, 1 | 2 | 4);
-                        let say = if is_boundary && req.tts_enabled && !seg.trim().is_empty() {
-                            Some(std::mem::take(&mut seg))
-                        } else {
-                            if is_boundary {
-                                seg.clear();
+                        let say = if is_boundary {
+                            let streamed = std::mem::take(&mut seg);
+                            if req.tts_enabled {
+                                tts_boundary_text(kind, streamed, &ev.final_text)
+                            } else {
+                                None
                             }
+                        } else {
                             None
                         };
                         let _ = tx
@@ -1001,6 +1003,18 @@ async fn synthesize_and_play(
     Ok(())
 }
 
+pub(crate) async fn play_prompt(
+    atlas: &Arc<Mutex<AtlasClient>>,
+    tts_pin: &str,
+    speaker_pin: &str,
+    language: &str,
+    text: &str,
+    session_id: &str,
+) -> Result<()> {
+    let (tx, _rx) = mpsc::channel(2);
+    synthesize_and_play(atlas, tts_pin, speaker_pin, language, text, session_id, &tx).await
+}
+
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 fn build_task(
@@ -1054,6 +1068,19 @@ fn accumulate_text(ev: &PilotEvent, into: &mut String) {
         }
         _ => {}
     }
+}
+
+/// Pick the narration for a completed Pilot stream segment.
+///
+/// FINAL_TEXT is authoritative: some providers emit it without preceding
+/// TEXT_CHUNK events. Returning it here ensures voice sessions do not lose
+/// their final spoken response while text sessions remain unaffected.
+fn tts_boundary_text(kind: u32, streamed: String, final_text: &str) -> Option<String> {
+    const EVT_FINAL_TEXT: u32 = 4;
+    if kind == EVT_FINAL_TEXT && !final_text.trim().is_empty() {
+        return Some(final_text.trim().to_string());
+    }
+    (!streamed.trim().is_empty()).then_some(streamed)
 }
 
 fn event_status(kind: u32, session_id: &str, message: &str) -> VoiceEvent {
@@ -1276,5 +1303,13 @@ mod tests {
             &mut buf,
         );
         assert_eq!(buf, "hello world");
+    }
+
+    #[test]
+    fn final_text_is_spoken_without_text_chunks() {
+        assert_eq!(
+            tts_boundary_text(4, String::new(), "final answer"),
+            Some("final answer".to_string())
+        );
     }
 }

--- a/system/liaison/src/voice.rs
+++ b/system/liaison/src/voice.rs
@@ -33,8 +33,10 @@ use robonix_atlas::client::AtlasClient;
 use robonix_atlas::pb as atlas_pb;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
+use std::task::{Context, Poll};
 use std::time::Duration;
 use tokio::sync::{Mutex, mpsc};
 use tokio_stream::{StreamExt, wrappers::ReceiverStream};
@@ -85,9 +87,37 @@ const DEFAULT_RECORD_SECONDS: u32 = 10;
 /// background noise sits around 50–300, so 500 is a comfortable gap.
 const VAD_SPEECH_RMS: f32 = 500.0;
 const VAD_END_SILENCE_SECS: f32 = 1.2;
+const VAD_NO_SPEECH_TIMEOUT_SECS: u64 = 5;
 const DEFAULT_ASR_LANGUAGE: &str = "";
 const DEFAULT_AUDIO_ENCODING: &str = "pcm_s16le";
 const DEFAULT_AUDIO_SAMPLE_RATE: u32 = 16_000;
+
+struct AbortOnDrop(tokio::task::AbortHandle);
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+struct VoiceSessionStream {
+    inner: ReceiverStream<Result<VoiceEvent, Status>>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl Stream for VoiceSessionStream {
+    type Item = Result<VoiceEvent, Status>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.inner).poll_next(cx)
+    }
+}
+
+impl Drop for VoiceSessionStream {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
 
 // ── Discovery helpers ────────────────────────────────────────────────────────
 //
@@ -199,7 +229,7 @@ pub async fn start_voice_session(
             KIND_SESSION_STARTED,
             &session_id,
             &format!(
-                "voice session started (vad, record≤{record_seconds}s, tts={}, lang={})",
+                "voice session started (vad, record≤{record_seconds}s, no-speech≤{VAD_NO_SPEECH_TIMEOUT_SECS}s, tts={}, lang={})",
                 req.tts_enabled,
                 if language.is_empty() {
                     "auto"
@@ -211,7 +241,7 @@ pub async fn start_voice_session(
         .await;
 
     let session_id_for_task = session_id.clone();
-    tokio::spawn(async move {
+    let task = tokio::spawn(async move {
         let outcome = run_session(
             req,
             session_id_for_task.clone(),
@@ -242,7 +272,10 @@ pub async fn start_voice_session(
         }
     });
 
-    Ok(ReceiverStream::new(rx))
+    Ok(VoiceSessionStream {
+        inner: ReceiverStream::new(rx),
+        task,
+    })
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -627,6 +660,7 @@ async fn stream_capture_and_recognize(
         // the audio-source startup (e.g. audio client bridge over the network); the
         // chunk count + total audio vs wall time shows transfer throughput.
         let t_pump = tokio::time::Instant::now();
+        let no_speech_deadline = t_pump + Duration::from_secs(VAD_NO_SPEECH_TIMEOUT_SECS);
         let mut n_chunks: u32 = 0u32;
         let mut audio_s: f32 = 0.0;
         let mut logged_first = false;
@@ -634,10 +668,15 @@ async fn stream_capture_and_recognize(
         let mut silence_secs: f32 = 0.0;
         let mut first_chunk = true;
         loop {
-            if tokio::time::Instant::now() >= deadline {
+            let active_deadline = if has_spoken {
+                deadline
+            } else {
+                deadline.min(no_speech_deadline)
+            };
+            if tokio::time::Instant::now() >= active_deadline {
                 break;
             }
-            let remaining = deadline - tokio::time::Instant::now();
+            let remaining = active_deadline - tokio::time::Instant::now();
             match tokio::time::timeout(remaining, mic_stream.message()).await {
                 Ok(Ok(Some(chunk))) => {
                     if !logged_first {
@@ -691,6 +730,7 @@ async fn stream_capture_and_recognize(
             (wall as f32 / 1000.0) / audio_s.max(0.001)
         );
     });
+    let _pump_abort_guard = AbortOnDrop(pump_handle.abort_handle());
 
     // FunASR docs: AsrAudioChunk + ASR backend reads its own audio_config
     // defaults (16 kHz mono pcm_s16le); language hint is on the bidi
@@ -1311,5 +1351,29 @@ mod tests {
             tts_boundary_text(4, String::new(), "final answer"),
             Some("final answer".to_string())
         );
+    }
+
+    #[tokio::test]
+    async fn dropping_voice_stream_aborts_session_task() {
+        let (_tx, rx) = mpsc::channel(1);
+        let task = tokio::spawn(std::future::pending::<()>());
+        let abort = task.abort_handle();
+        let stream = VoiceSessionStream {
+            inner: ReceiverStream::new(rx),
+            task,
+        };
+        drop(stream);
+        tokio::task::yield_now().await;
+        assert!(abort.is_finished());
+    }
+
+    #[tokio::test]
+    async fn dropping_abort_guard_aborts_nested_mic_pump() {
+        let task = tokio::spawn(std::future::pending::<()>());
+        let abort = task.abort_handle();
+        drop(AbortOnDrop(abort.clone()));
+        tokio::task::yield_now().await;
+        assert!(abort.is_finished());
+        let _ = task.await;
     }
 }

--- a/system/liaison/src/voice.rs
+++ b/system/liaison/src/voice.rs
@@ -336,6 +336,7 @@ async fn run_session(
             max_seconds,
             &session_id,
             &tx,
+            context_flag(&req.context_json, "barge_in"),
         )
         .await?
     };
@@ -597,6 +598,7 @@ async fn stream_capture_and_recognize(
     max_seconds: u32,
     session_id: &str,
     tx: &mpsc::Sender<Result<VoiceEvent, Status>>,
+    barge_in: bool,
 ) -> Result<(Vec<u8>, String)> {
     let mic_endpoint = resolve_endpoint(atlas, "robonix/primitive/audio/mic", mic_pin)
         .await
@@ -624,8 +626,15 @@ async fn stream_capture_and_recognize(
         )))
         .await;
 
+    let mut mic_request = Request::new(());
+    if barge_in {
+        mic_request.metadata_mut().insert(
+            "x-robonix-barge-in",
+            "true".parse().expect("static metadata value"),
+        );
+    }
     let mut mic_stream = mic_client
-        .mic(Request::new(()))
+        .mic(mic_request)
         .await
         .map_err(|e| anyhow::anyhow!("mic rpc failed: {e}"))?
         .into_inner();
@@ -1098,6 +1107,13 @@ fn build_task(
     }
 }
 
+fn context_flag(raw: &str, key: &str) -> bool {
+    serde_json::from_str::<serde_json::Value>(raw)
+        .ok()
+        .and_then(|value| value.get(key).and_then(serde_json::Value::as_bool))
+        .unwrap_or(false)
+}
+
 fn accumulate_text(ev: &PilotEvent, into: &mut String) {
     const EVT_TEXT_CHUNK: u32 = 0;
     const EVT_FINAL_TEXT: u32 = 4;
@@ -1351,6 +1367,13 @@ mod tests {
             tts_boundary_text(4, String::new(), "final answer"),
             Some("final answer".to_string())
         );
+    }
+
+    #[test]
+    fn barge_in_metadata_is_explicit_not_inferred_from_voice_mode() {
+        assert!(context_flag(r#"{"barge_in":true}"#, "barge_in"));
+        assert!(!context_flag(r#"{"interaction_mode":"voice"}"#, "barge_in"));
+        assert!(!context_flag("not json", "barge_in"));
     }
 
     #[tokio::test]

--- a/system/pilot/src/service.rs
+++ b/system/pilot/src/service.rs
@@ -4,9 +4,11 @@
 // `RobonixSystemPilot` gRPC handler (contract `robonix/system/pilot`).
 
 use crate::pb::contracts::{
+    robonix_system_executor_cancel_all_plans_client::RobonixSystemExecutorCancelAllPlansClient,
     robonix_system_executor_execute_client::RobonixSystemExecutorExecuteClient,
     robonix_system_pilot_server::RobonixSystemPilot,
 };
+use crate::pb::executor::CancelAllRequest;
 use crate::pb::pilot::{
     BatchResult, PilotEvent, Plan, RtdlNodeState, SessionStatusEvent, Task, TaskStateEvent,
 };
@@ -179,14 +181,38 @@ impl RobonixSystemPilot for PilotServiceImpl {
 
         if task_is_abort_turn(&task) {
             let id = task.session_id.clone();
-            let ok = if let Some(tx) = self.cancels.lock().await.get(&id) {
+            let turn_signaled = if let Some(tx) = self.cancels.lock().await.get(&id) {
                 let _ = tx.send(true);
                 true
             } else {
                 false
             };
-            debug!("[pilot] abort_turn task for session {id} (signaled={ok})");
-            let (_tx, rx) = tokio::sync::mpsc::channel::<Result<PilotEvent, Status>>(1);
+            let executor_cancelled =
+                cancel_all_executor_plans(self.atlas.clone(), &self.provider_id).await;
+            debug!(
+                "[pilot] abort_turn session {id} (turn_signaled={turn_signaled}, executor={executor_cancelled:?})"
+            );
+            let (tx, rx) = tokio::sync::mpsc::channel::<Result<PilotEvent, Status>>(1);
+            let message = match executor_cancelled {
+                Ok(true) => "stop completed",
+                Ok(false) => "stop reached Executor but cancellation was not accepted",
+                Err(ref error) => error.as_str(),
+            };
+            let state = if executor_cancelled == Ok(true) {
+                SessionState::Completed
+            } else {
+                SessionState::Failed
+            };
+            let _ = tx
+                .send(Ok(pack(
+                    &id,
+                    PilotStreamBody::Status(SessionStatusEvent {
+                        session_id: id.clone(),
+                        state: state as u32,
+                        message: message.to_string(),
+                    }),
+                )))
+                .await;
             return Ok(Response::new(ReceiverStream::new(rx)));
         }
 
@@ -293,6 +319,25 @@ impl RobonixSystemPilot for PilotServiceImpl {
 
         Ok(Response::new(ReceiverStream::new(rx)))
     }
+}
+
+async fn cancel_all_executor_plans(
+    mut atlas: AtlasClient,
+    consumer_id: &str,
+) -> Result<bool, String> {
+    let (_, _, channel) = atlas_client::connect_to_capability(
+        &mut atlas,
+        consumer_id,
+        "robonix/system/executor/cancel_all_plans",
+    )
+    .await
+    .map_err(|error| format!("stop could not reach Executor: {error:#}"))?;
+    let mut client = RobonixSystemExecutorCancelAllPlansClient::new(channel);
+    client
+        .cancel_all(CancelAllRequest::default())
+        .await
+        .map(|response| response.into_inner().success)
+        .map_err(|error| format!("Executor cancellation failed: {error}"))
 }
 
 /// Connect to executor's Execute RPC. Capability discovery (what's available


### PR DESCRIPTION
## Problem

Voice interaction was not interruptible in practice:

- hands-free stayed `in_voice` until Pilot and TTS finished, so saying “Robert” during a task was ignored;
- F2 was blocked whenever hands-free was enabled, and remained “recording” after ASR had already finished;
- closing the local speaker stream drained queued audio, so cancelled TTS kept playing;
- the old audio route also required a client IP in the robot manifest.

Example: after asking the robot to count down, both a wake-word cancel and F2 produced “Voice recording is already active” instead of steering the running turn.

## Design

- Liaison releases microphone ownership at ASR final and relays Pilot/TTS events in the background.
- Wake-word listening resumes while the task is still running; a second wake is submitted as an explicit steer.
- F2 temporarily suspends wake-word capture only until its ASR final, then hands-free resumes automatically.
- Barge-in capture carries explicit metadata. The reverse audio bridge stops the current speaker generation and the client discards unplayed PCM.
- Disabling hands-free aborts its outstanding voice producers.
- The reverse client-audio connection remains Atlas-discovered, so the manifest does not store a client IP.

## Connection model

Here, `reverse` describes connection ownership, not audio direction: the macOS client opens the connection to the robot. The resulting WebSocket is bidirectional.

Control and events use Liaison directly. The client discovers Liaison through Atlas, then calls its gRPC contracts for text submission, F2 voice sessions, hands-free enable/status, and the hands-free event stream.

Audio uses a separate path:

```text
macOS CoreAudio
  <-> client-local audio service
  <-> client-initiated WebSocket
  <-> robot audio_client_bridge
  <-> standard audio/mic and audio/speaker contracts
  <-> Liaison -> Speech / Pilot / TTS
```

The selected `audio_client_bridge` exposes the optional `GetAudioBridgeInfo` contract. The client discovers that contract through Atlas, obtains the robot-side WebSocket endpoint, and connects to it. Robot-local ALSA/USB audio providers do not need this contract.

Liaison does not know whether the selected audio provider uses ALSA or the reverse bridge. It only consumes the standard mic/speaker contracts, so no client IP or bridge-specific logic is stored in Liaison or the robot manifest.

## Tests

Environment: macOS client and Jetson AGX Orin robot stack; no chassis, navigation, exploration, or arm command was sent.

- `cargo test -p robonix-liaison`: **14 passed**
- client-side playback/capture tests: **7 passed** in the client PR
- Rust formatting, Python compilation, and JS syntax checks passed
- existing field checks covered wake → ASR → Pilot → TTS, voice steer delivery, mic contention, and voice-stream cancellation

## Discussion

- Immediate interruption is deterministic for F2 and for the configured wake phrase. Arbitrary speech-only barge-in still needs echo-aware VAD/AEC; raw volume thresholds would falsely trigger on the robot’s own TTS.
- The bridge currently supports one connected client and assumes a trusted LAN/Tailscale path.

Closes #122
