### PR TITLE
feat(atlas): make provider namespaces advisory

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,8 +234,11 @@ Dive deeper:
 ## Ecosystem
 
 Robonix is built from small, swappable **packages**, each implementing one or
-more capability contracts under a `robonix/<kind>/<area>/*` namespace. The
-contract definitions are documented in the
+more capability contracts normally grouped under a primary
+`robonix/<kind>/<area>/*` namespace. Shared framework contracts may be
+implemented across those provider namespaces. Namespace mismatches are
+diagnostic rather than a runtime authorization boundary. The contract
+definitions are documented in the
 [interface catalog](https://github.com/syswonder/robonix-book/blob/main/src/interface-catalog/index.md).
 
 This repository contains the core runtime, built-in reference services, and

--- a/pylib/robonix-api/README.md
+++ b/pylib/robonix-api/README.md
@@ -46,6 +46,17 @@ if __name__ == "__main__":
 
 That's a complete Robonix primitive — registers with Atlas, serves the Driver lifecycle, waits for the upstream topic, declares a ROS 2 capability for downstream consumers, and blocks on SIGTERM.
 
+`namespace` declares the provider's primary contract grouping. Regular
+contracts normally use that prefix. Declaring another contract is allowed;
+robonix-api and Atlas emit a visible warning unless the contract TOML marks it
+as `cross_namespace = true`. The warning is diagnostic and never blocks boot,
+discovery, or calls.
+
+Existing package-local `*/driver` contracts remain supported. A later
+framework migration will provide one built-in lifecycle contract so new
+packages do not need to copy a driver TOML; that migration will retain the
+current form as a compatibility path.
+
 ## What's in the box
 
 - **`ATLAS`** — module-level singleton client (`ATLAS.register`, `ATLAS.find_primitive`, `ATLAS.connect`, ...)

--- a/pylib/robonix-api/robonix_api/atlas_types.py
+++ b/pylib/robonix-api/robonix_api/atlas_types.py
@@ -75,6 +75,7 @@ class Capability:
     contract_id: str
     transport: Transport
     description: str = ""
+    namespace_mismatch: bool = False
     params: GrpcParams | Ros2Params | McpParams | None = None
 
 
@@ -106,6 +107,7 @@ class ContractDescriptor:
     io_srv_type: str = ""
     source_toml_path: str = ""
     description: str = ""
+    cross_namespace: bool = False
     msg_fields: tuple[FieldSpec, ...] = ()
     srv_request_fields: tuple[FieldSpec, ...] = ()
     srv_response_fields: tuple[FieldSpec, ...] = ()
@@ -182,6 +184,7 @@ def from_pb_capability(pb_cap) -> Capability:
         contract_id=pb_cap.contract_id,
         transport=transport,
         description=pb_cap.description,
+        namespace_mismatch=getattr(pb_cap, "namespace_mismatch", False),
         params=from_pb_params(transport, pb_cap.params),
     )
 
@@ -215,6 +218,7 @@ def from_pb_contract(pb_c) -> ContractDescriptor:
         io_srv_type=pb_c.io_srv_type,
         source_toml_path=pb_c.source_toml_path,
         description=pb_c.description,
+        cross_namespace=getattr(pb_c, "cross_namespace", False),
         msg_fields=tuple(from_pb_field_spec(f) for f in pb_c.msg_fields),
         srv_request_fields=tuple(from_pb_field_spec(f) for f in pb_c.srv_request_fields),
         srv_response_fields=tuple(from_pb_field_spec(f) for f in pb_c.srv_response_fields),

--- a/pylib/robonix-api/robonix_api/capability.py
+++ b/pylib/robonix-api/robonix_api/capability.py
@@ -77,9 +77,10 @@ class _ProviderBase:
     Args:
         id:        stable provider id (e.g. "webots_tiago_camera_front").
                    Convention: matches `name:` in package_manifest.yaml.
-        namespace: contract_id prefix this provider claims, e.g.
-                   "robonix/primitive/camera". Every declare_capability
-                   call MUST carry a contract_id under this prefix.
+        namespace: primary contract grouping for this provider, e.g.
+                   "robonix/primitive/camera". Domain contracts normally
+                   use this prefix. Shared contracts may opt out; other
+                   mismatches produce diagnostics but remain callable.
         pkg_root:  package root directory; auto-detected from the
                    caller's __file__ when omitted.
         md_path:   absolute path to CAPABILITY.md; defaults to
@@ -231,7 +232,24 @@ class _ProviderBase:
         `description` is the instance-specific natural-language string
         Pilot/LLM sees; empty means "use the contract's generic
         description from the TOML at consume time" (the two are merged,
-        not picked-one-of)."""
+        not picked-one-of). Namespace alignment is advisory: a regular
+        contract outside this provider's primary namespace emits a warning
+        but is still declared; contracts marked `cross_namespace` do not."""
+        contract = ATLAS.query_contract(contract_id)
+        cross_namespace = bool(contract and contract.cross_namespace)
+        namespace = self.namespace.strip("/")
+        normalized_contract = contract_id.strip("/")
+        namespace_matches = normalized_contract == namespace or normalized_contract.startswith(
+            f"{namespace}/"
+        )
+        if not namespace_matches and not cross_namespace:
+            log.warning(
+                "[%s] namespace mismatch: declaring '%s' outside primary "
+                "namespace '%s'; Atlas will accept it and expose a diagnostic",
+                self.id,
+                contract_id,
+                self.namespace,
+            )
         return ATLAS.declare_capability(
             provider_id=self.id,
             contract_id=contract_id,

--- a/system/atlas/README.md
+++ b/system/atlas/README.md
@@ -27,6 +27,20 @@ each one provides.
 
 The wire schema lives in [`proto/atlas.proto`](proto/atlas.proto).
 
+## Namespace diagnostics
+
+A provider's namespace is its primary grouping for discovery and operator
+output. Domain contracts normally use that prefix, but namespace is not an
+authorization boundary: Atlas accepts and serves a capability whose contract
+id is outside the provider namespace.
+
+Contract TOMLs may set `cross_namespace = true` for shared framework contracts
+that are intentionally implemented across provider domains. Other mismatches
+are logged and returned as `Capability.namespace_mismatch`; `rbnx caps -v`
+shows the warning without changing provider lifecycle state or callability.
+Existing per-namespace contracts, including current `*/driver` contracts,
+remain supported.
+
 ## Build
 
 From the repo root:

--- a/system/atlas/proto/atlas.proto
+++ b/system/atlas/proto/atlas.proto
@@ -59,7 +59,7 @@ package robonix.atlas;
 //
 // Why two-step registration?
 //   1) RegisterPrimitive / RegisterService / RegisterSkill announces
-//      identity + namespace; heartbeat starts. The provider is on
+//      identity + its primary namespace; heartbeat starts. The provider is on
 //      the registry but cannot yet be called.
 //   2) DeclareCapability, called once per (contract, transport),
 //      late-binds the wire endpoint for that pair. Late so the
@@ -123,9 +123,11 @@ message RegisterRequest {
   // assigns "ephemeral-<uuid>". Convention: id matches `name:` in
   // package_manifest.yaml.
   string id = 1;
-  // Grouping namespace, e.g. "robonix/primitive/camera". Every later
-  // DeclareCapability MUST carry a contract_id under this prefix;
-  // otherwise Atlas rejects with InvalidArgument.
+  // Primary grouping namespace, e.g. "robonix/primitive/camera". This is
+  // classification and diagnostics metadata, not an authorization boundary.
+  // Contracts normally live under this prefix. A contract may explicitly
+  // opt into cross-namespace use; any other mismatch is accepted with a
+  // warning so metadata mistakes remain visible without blocking startup.
   string namespace = 2;
   // Absolute path to the package's CAPABILITY.md, in the *provider's own*
   // filesystem namespace. Recorded for debugging only -- it is NOT
@@ -210,9 +212,8 @@ message TransportParams {
 // gRPC errors:
 //   * NotFound          -- `provider_id` is not registered with Atlas.
 //   * InvalidArgument   -- `transport` is TRANSPORT_UNSPECIFIED;
-//                         `contract_id` is not under the provider's
-//                         declared namespace; `params.kind` does
-//                         not match `transport`; or the conflict-
+//                         `params.kind` does not match `transport`;
+//                         or the conflict-
 //                         resolution rules below resolve to it.
 //   * AlreadyExists     -- duplicate (provider_id, contract_id, transport)
 //                         or a non-mintable endpoint collision.
@@ -302,6 +303,10 @@ message Capability {
   TransportParams params = 5;
   // Natural-language description (see DeclareCapabilityRequest.description).
   string description = 6;
+  // True when this contract sits outside the provider's primary namespace
+  // and its ContractDescriptor does not opt into cross-namespace use. Atlas
+  // still accepts and serves the capability; this is diagnostic only.
+  bool namespace_mismatch = 7;
 }
 
 // -- CapabilityProvider lifecycle --------------------------------------------
@@ -509,6 +514,10 @@ message ContractDescriptor {
   // are complementary (generic + instance-specific), not
   // alternatives.
   string description = 11;
+  // Allow providers from any primary namespace to implement this contract
+  // without a namespace-mismatch diagnostic. Intended for shared framework
+  // contracts such as lifecycle and health. Defaults to false.
+  bool cross_namespace = 12;
 }
 
 message FieldSpec {

--- a/system/atlas/src/contract_registry.rs
+++ b/system/atlas/src/contract_registry.rs
@@ -8,8 +8,8 @@
 // truth for "what contracts exist and what's their wire shape".
 //
 // Scope is deliberately small: only the fields current TOMLs actually
-// carry (`[contract]` id/version/kind, `[mode]` type, `[io.msg].msg`,
-// `[io.srv].srv`). Richer metadata (summary / examples / safety /
+// carry (`[contract]` id/version/kind/cross_namespace, `[mode]` type,
+// `[io.msg].msg`, `[io.srv].srv`). Richer metadata (summary / examples / safety /
 // capability-card-style fields) waits until the TOML schema grows.
 
 use anyhow::Context;
@@ -55,6 +55,10 @@ struct ContractSection {
     /// alternatives.
     #[serde(default)]
     description: Option<String>,
+    /// Shared framework contracts can be implemented by providers whose
+    /// primary namespace differs from this contract's id prefix.
+    #[serde(default)]
+    cross_namespace: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -323,6 +327,7 @@ fn load_one(path: &Path) -> anyhow::Result<pb::ContractDescriptor> {
         io_srv_type,
         source_toml_path: path.to_string_lossy().into_owned(),
         description,
+        cross_namespace: parsed.contract.cross_namespace,
         // Filled later by attach_idl_fields() after every TOML has
         // been loaded. Empty here is the right default.
         msg_fields: Vec::new(),
@@ -505,4 +510,37 @@ pub fn resolve_capabilities_roots(explicit: &[String]) -> Vec<PathBuf> {
         }
     }
     Vec::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cross_namespace_is_explicit_and_defaults_to_false() {
+        let shared: RawContract = toml::from_str(
+            r#"
+                [contract]
+                id = "robonix/primitive/health/stream"
+                cross_namespace = true
+
+                [mode]
+                type = "topic_out"
+            "#,
+        )
+        .expect("shared contract TOML");
+        assert!(shared.contract.cross_namespace);
+
+        let regular: RawContract = toml::from_str(
+            r#"
+                [contract]
+                id = "robonix/primitive/camera/rgb"
+
+                [mode]
+                type = "topic_out"
+            "#,
+        )
+        .expect("regular contract TOML");
+        assert!(!regular.contract.cross_namespace);
+    }
 }

--- a/system/atlas/src/service.rs
+++ b/system/atlas/src/service.rs
@@ -87,6 +87,9 @@ struct DeclaredEndpoint {
     /// Provider-supplied natural-language description for this
     /// Capability. Empty means "fall back to contract default".
     description: String,
+    /// Diagnostic only: this endpoint's contract is outside the provider's
+    /// primary namespace without an explicit cross-namespace opt-in.
+    namespace_mismatch: bool,
 }
 
 fn serialize_transport<S: serde::Serializer>(t: &Transport, ser: S) -> Result<S::Ok, S::Error> {
@@ -139,6 +142,7 @@ impl CapabilityProviderState {
             transport: e.transport as i32,
             params: Some((&e.params).into()),
             description: e.description.clone(),
+            namespace_mismatch: e.namespace_mismatch,
         }
     }
 }
@@ -211,6 +215,20 @@ fn is_driver_contract(contract_id: &str) -> bool {
     // `capabilities/{primitive,service}/driver.v1.toml` is concretised by
     // the provider to its area at DeclareCapability time.
     contract_id.ends_with("/driver")
+}
+
+/// Return whether a declared contract should carry a namespace diagnostic.
+/// Namespace is advisory: a mismatch never rejects registration or calling.
+fn has_namespace_mismatch(namespace: &str, contract_id: &str, cross_namespace: bool) -> bool {
+    if cross_namespace {
+        return false;
+    }
+    let namespace = namespace.trim_matches('/');
+    let contract_id = contract_id.trim_matches('/');
+    contract_id != namespace
+        && !contract_id
+            .strip_prefix(namespace)
+            .is_some_and(|suffix| suffix.starts_with('/'))
 }
 
 /// One open consumer→provider edge. Allocated by `ConnectCapability`,
@@ -472,11 +490,18 @@ impl AtlasRegistry {
             .providers
             .get(provider_id)
             .ok_or_else(|| Status::not_found(format!("unknown provider_id: {provider_id}")))?;
-        if !contract_id.starts_with(&provider.namespace) {
-            return Err(Status::invalid_argument(format!(
-                "contract_id '{contract_id}' is not under namespace '{}' of capability '{provider_id}'",
+        let cross_namespace = self
+            .contracts
+            .get(&contract_id)
+            .is_some_and(|contract| contract.cross_namespace);
+        let namespace_mismatch =
+            has_namespace_mismatch(&provider.namespace, &contract_id, cross_namespace);
+        if namespace_mismatch {
+            warn!(
+                "[atlas] namespace mismatch: provider '{provider_id}' declares '{contract_id}' \
+                 outside primary namespace '{}'; accepting capability",
                 provider.namespace
-            )));
+            );
         }
         if provider
             .endpoints
@@ -499,6 +524,7 @@ impl AtlasRegistry {
             endpoint: endpoint.clone(),
             params,
             description: description.to_string(),
+            namespace_mismatch,
         });
         info!("[atlas] declare {provider_id} {contract_id} via {transport:?} -> {endpoint}");
         Ok(endpoint)
@@ -836,6 +862,208 @@ fn resolve_endpoint(
 mod endpoint_tests {
     use super::*;
 
+    fn ros2_params() -> pb::TransportParams {
+        pb::TransportParams {
+            kind: Some(pb::transport_params::Kind::Ros2(pb::Ros2Params {
+                qos_profile: String::new(),
+            })),
+        }
+    }
+
+    #[test]
+    fn namespace_mismatch_is_advisory_and_shared_contracts_are_exempt() {
+        assert!(!has_namespace_mismatch(
+            "robonix/primitive/camera",
+            "robonix/primitive/camera/rgb",
+            false
+        ));
+        assert!(has_namespace_mismatch(
+            "robonix/primitive/camera",
+            "robonix/primitive/health/stream",
+            false
+        ));
+        assert!(!has_namespace_mismatch(
+            "robonix/primitive/camera",
+            "robonix/primitive/health/stream",
+            true
+        ));
+    }
+
+    #[tokio::test]
+    async fn declare_accepts_namespace_mismatch_and_surfaces_diagnostic() {
+        let registry = AtlasRegistry::default();
+        registry
+            .register(
+                "front_camera",
+                pb::Kind::Primitive,
+                "robonix/primitive/camera",
+                "",
+                "",
+            )
+            .await
+            .expect("provider registration");
+
+        registry
+            .declare(
+                "front_camera",
+                "robonix/primitive/health/stream",
+                Transport::Ros2,
+                "/camera_health",
+                ros2_params(),
+                "",
+            )
+            .await
+            .expect("namespace mismatch must not block declaration");
+
+        let providers = registry
+            .query(
+                "front_camera",
+                pb::Kind::Primitive,
+                "robonix/primitive/health/stream",
+                Transport::Ros2,
+            )
+            .await;
+        assert_eq!(providers.len(), 1);
+        assert_eq!(providers[0].capabilities.len(), 1);
+        assert!(providers[0].capabilities[0].namespace_mismatch);
+    }
+
+    #[tokio::test]
+    async fn legacy_namespaced_driver_contract_remains_clean() {
+        let registry = AtlasRegistry::default();
+        registry
+            .register(
+                "front_camera",
+                pb::Kind::Primitive,
+                "robonix/primitive/camera",
+                "",
+                "",
+            )
+            .await
+            .expect("provider registration");
+
+        registry
+            .declare(
+                "front_camera",
+                "robonix/primitive/camera/driver",
+                Transport::Ros2,
+                "/camera_driver",
+                ros2_params(),
+                "",
+            )
+            .await
+            .expect("legacy namespaced driver declaration");
+
+        let providers = registry
+            .query(
+                "front_camera",
+                pb::Kind::Primitive,
+                "robonix/primitive/camera/driver",
+                Transport::Ros2,
+            )
+            .await;
+        assert_eq!(providers.len(), 1);
+        assert!(!providers[0].capabilities[0].namespace_mismatch);
+    }
+
+    #[tokio::test]
+    async fn multiple_providers_can_implement_the_same_contract() {
+        let registry = AtlasRegistry::default();
+        for (provider_id, endpoint) in [
+            ("front_camera", "/front_camera_driver"),
+            ("rear_camera", "/rear_camera_driver"),
+        ] {
+            registry
+                .register(
+                    provider_id,
+                    pb::Kind::Primitive,
+                    "robonix/primitive/camera",
+                    "",
+                    "",
+                )
+                .await
+                .expect("provider registration");
+            registry
+                .declare(
+                    provider_id,
+                    "robonix/primitive/camera/driver",
+                    Transport::Ros2,
+                    endpoint,
+                    ros2_params(),
+                    "",
+                )
+                .await
+                .expect("shared contract declaration");
+        }
+
+        let providers = registry
+            .query(
+                "",
+                pb::Kind::Primitive,
+                "robonix/primitive/camera/driver",
+                Transport::Ros2,
+            )
+            .await;
+        assert_eq!(providers.len(), 2);
+        assert!(providers.iter().all(|provider| {
+            provider.capabilities.len() == 1 && !provider.capabilities[0].namespace_mismatch
+        }));
+    }
+
+    #[tokio::test]
+    async fn cross_namespace_contract_suppresses_the_diagnostic() {
+        let root = std::env::temp_dir().join(format!(
+            "robonix-atlas-cross-namespace-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&root).expect("create temporary capability root");
+        std::fs::write(
+            root.join("health.toml"),
+            r#"[contract]
+id = "robonix/primitive/health/stream"
+cross_namespace = true
+"#,
+        )
+        .expect("write shared contract fixture");
+        let contracts = ContractRegistry::load_from_capabilities_dir(&root)
+            .expect("load shared contract fixture");
+        std::fs::remove_dir_all(&root).expect("remove temporary capability root");
+
+        let registry = AtlasRegistry::with_contracts(contracts);
+        registry
+            .register(
+                "front_camera",
+                pb::Kind::Primitive,
+                "robonix/primitive/camera",
+                "",
+                "",
+            )
+            .await
+            .expect("provider registration");
+        registry
+            .declare(
+                "front_camera",
+                "robonix/primitive/health/stream",
+                Transport::Ros2,
+                "/camera_health",
+                ros2_params(),
+                "",
+            )
+            .await
+            .expect("cross-namespace contract declaration");
+
+        let providers = registry
+            .query(
+                "front_camera",
+                pb::Kind::Primitive,
+                "robonix/primitive/health/stream",
+                Transport::Ros2,
+            )
+            .await;
+        assert_eq!(providers.len(), 1);
+        assert!(!providers[0].capabilities[0].namespace_mismatch);
+    }
+
     #[test]
     fn ros2_collision_rewrite_never_appends_private_name_marker() {
         let mut state = State::default();
@@ -856,6 +1084,7 @@ mod endpoint_tests {
                         qos_profile: "reliable".to_string(),
                     },
                     description: String::new(),
+                    namespace_mismatch: false,
                 }],
                 pushed_state: None,
                 state_detail: String::new(),

--- a/tools/rbnx/src/cmd/inspect.rs
+++ b/tools/rbnx/src/cmd/inspect.rs
@@ -72,6 +72,7 @@ pub async fn providers(endpoint: &str, json: bool, verbose: bool) -> Result<()> 
                     "capabilities":     r.capabilities.iter().map(|i| serde_json::json!({
                         "contract_id": i.contract_id,
                         "transport":   transport_name(i.transport),
+                        "namespace_mismatch": i.namespace_mismatch,
                     })).collect::<Vec<_>>(),
                 })
             })
@@ -99,22 +100,38 @@ pub async fn providers(endpoint: &str, json: bool, verbose: bool) -> Result<()> 
                 .dimmed()
                 .to_string()
         };
+        let namespace_hint = if provider
+            .capabilities
+            .iter()
+            .any(|cap| cap.namespace_mismatch)
+        {
+            " [namespace mismatch]".yellow().to_string()
+        } else {
+            String::new()
+        };
         println!(
-            "{} {} {} {}{}{}",
+            "{} {} {} {}{}{}{}",
             "●".green(),
             provider.id.bold(),
             state_tag(provider.state),
             provider.namespace.dimmed(),
             cap_count_hint,
+            namespace_hint,
             detail.dimmed()
         );
         if verbose {
             for cap in &provider.capabilities {
+                let mismatch = if cap.namespace_mismatch {
+                    " [namespace mismatch]".yellow().to_string()
+                } else {
+                    String::new()
+                };
                 println!(
-                    "    {} {} {}",
+                    "    {} {} {}{}",
                     "└─".dimmed(),
                     cap.contract_id,
-                    format!("({})", transport_name(cap.transport)).dimmed()
+                    format!("({})", transport_name(cap.transport)).dimmed(),
+                    mismatch
                 );
             }
         }
@@ -155,6 +172,7 @@ pub async fn describe(endpoint: &str, provider_id: Option<&str>, json: bool) -> 
                 "capabilities":      provider.capabilities.iter().map(|i| serde_json::json!({
                     "contract_id": i.contract_id,
                     "transport":   transport_name(i.transport),
+                    "namespace_mismatch": i.namespace_mismatch,
                 })).collect::<Vec<_>>(),
                 "capability_md":   md,
             });
@@ -167,11 +185,17 @@ pub async fn describe(endpoint: &str, provider_id: Option<&str>, json: bool) -> 
                 state_tag(provider.state)
             );
             for cap in &provider.capabilities {
+                let mismatch = if cap.namespace_mismatch {
+                    " [namespace mismatch]".yellow().to_string()
+                } else {
+                    String::new()
+                };
                 println!(
-                    "    {} {} ({})",
+                    "    {} {} ({}){}",
                     "└─".dimmed(),
                     cap.contract_id,
-                    transport_name(cap.transport)
+                    transport_name(cap.transport),
+                    mismatch
                 );
             }
             if !md.is_empty() {
@@ -314,6 +338,7 @@ pub async fn contracts(
                     "mode": c.mode,
                     "io_msg_type": c.io_msg_type,
                     "io_srv_type": c.io_srv_type,
+                    "cross_namespace": c.cross_namespace,
                     "source_toml_path": c.source_toml_path,
                     "msg_fields": c.msg_fields.iter().map(|f| serde_json::json!({
                         "name": f.name, "type_name": f.type_name,
@@ -356,11 +381,16 @@ pub async fn contracts(
             "(none)".dimmed().to_string()
         };
         println!(
-            "● {}  {} {} {}",
+            "● {}  {} {} {}{}",
             c.id.bold(),
             format!("[{}]", c.kind).dimmed(),
             format!("mode={}", c.mode).cyan(),
             format!("idl={io}").dimmed(),
+            if c.cross_namespace {
+                " cross-namespace".dimmed().to_string()
+            } else {
+                String::new()
+            },
         );
         if verbose {
             if !c.msg_fields.is_empty() {


### PR DESCRIPTION
## Problem

Atlas treated a provider namespace as an authorization boundary and rejected every contract outside that prefix. This prevents one provider from implementing shared contracts: for example, a camera provider could not expose a standard health contract without creating a separate shadow provider.

The provider is already identified by `provider_id`; multiple providers are expected to implement the same `contract_id`.

## Design

- Keep `namespace` as the provider's primary grouping for discovery and diagnostics.
- Add `cross_namespace = true` to contract metadata for intentionally shared contracts.
- Accept other namespace mismatches, log a warning, and expose `Capability.namespace_mismatch` instead of blocking startup.
- Emit the same advisory warning from robonix-api and show it in `rbnx caps -v`, `describe`, and JSON output.

## Compatibility and migration

This is an additive wire change. Existing providers and per-namespace `*/driver` TOMLs continue to work unchanged.

After merge, Vitals #111 can mark its shared health contract as cross-namespace and let the existing hardware provider expose health directly. A later PR can add one built-in lifecycle contract and one built-in optional health contract; legacy package-local driver/health contracts must remain supported with migration notices.

## Validation

- GitHub CI: Rust, English-only docs, security preflight, and Webots report checks passed.
- macOS: workspace formatting, clippy, and all-target tests passed.
- Jetson AGX Orin (aarch64): Atlas and `rbnx` clippy/tests passed; release binaries were installed.
- robonix-api: sdist and wheel were rebuilt from the updated proto, installed, and verified to expose both additive fields.
- Isolated Atlas process on `127.0.0.1:54051` with the installed Python API:
  - two camera providers exposed the same legacy camera driver contract;
  - a shared health contract produced no namespace diagnostic;
  - an unmarked cross-namespace contract remained callable and produced exactly one diagnostic.

No robot stack or motion component was started during this validation.

## Related

- Vitals: #111
- Documentation: syswonder/robonix-book#8
