### PR TITLE
feat: standardize core arm primitive contracts

### DIFF
--- a/capabilities/primitive/arm/driver.v1.toml
+++ b/capabilities/primitive/arm/driver.v1.toml
@@ -1,0 +1,10 @@
+# Lifecycle interface every arm primitive implementation must declare.
+[contract]
+id = "robonix/primitive/arm/driver"
+version = "1"
+kind = "primitive"
+idl = "lifecycle/srv/Driver.srv"
+description = "Lifecycle control interface for arm primitive providers."
+
+[mode]
+type = "rpc"

--- a/capabilities/primitive/arm/end_pose.v1.toml
+++ b/capabilities/primitive/arm/end_pose.v1.toml
@@ -1,0 +1,12 @@
+# Legacy-compatible unstamped end-effector pose. The provider documents the
+# frame in its package capability guide. A future stamped contract can add an
+# explicit frame without changing this deployed v1 wire shape.
+[contract]
+id = "robonix/primitive/arm/end_pose"
+version = "1"
+kind = "primitive"
+idl = "common_interfaces/geometry_msgs/msg/Pose.msg"
+description = "Measured end-effector pose in the arm provider's documented base frame."
+
+[mode]
+type = "topic_out"

--- a/capabilities/primitive/arm/joint_command.v1.toml
+++ b/capabilities/primitive/arm/joint_command.v1.toml
@@ -1,0 +1,11 @@
+# Standard joint command input. Providers may support a subset of JointState
+# fields, but names and positions must use the same units as joint_states.
+[contract]
+id = "robonix/primitive/arm/joint_command"
+version = "1"
+kind = "primitive"
+idl = "common_interfaces/sensor_msgs/msg/JointState.msg"
+description = "Named arm and gripper joint command input using standard JointState units."
+
+[mode]
+type = "topic_in"

--- a/capabilities/primitive/arm/joint_states.v1.toml
+++ b/capabilities/primitive/arm/joint_states.v1.toml
@@ -1,0 +1,11 @@
+# Standard joint feedback. Grippers that are part of the arm expose their
+# measured opening as a named joint in this same JointState stream.
+[contract]
+id = "robonix/primitive/arm/joint_states"
+version = "1"
+kind = "primitive"
+idl = "common_interfaces/sensor_msgs/msg/JointState.msg"
+description = "Measured arm and gripper joint positions, velocities, and efforts."
+
+[mode]
+type = "topic_out"


### PR DESCRIPTION
## Problem

Arm providers currently define common lifecycle, joint-state, command, and end-pose contracts inside individual packages. This makes basic arm state discovery vendor-specific and prevents Soma from consuming a stable embodiment interface.

## Change

Add standard core contracts for:

- arm driver lifecycle
- joint-state output
- joint command input
- end-pose output

Vendor-specific status and command messages remain provider extensions. The end-pose contract intentionally preserves the deployed Piper v1 `geometry_msgs/Pose` wire type.

## Impact

Arm providers can implement shared Robonix contracts while remaining independently identifiable by provider ID. Existing package-local declarations remain compatible.

## Validation

- Proto, MCP, ROS 2, and documentation code generation passed.
- `cargo test -q -p robonix-codegen` passed.
- Merged code generation with the deployed Piper package-local capabilities passed without duplicate-contract conflicts.

## Discussion

Soma runtime aggregation of joint states is intentionally excluded and will be proposed in a separate draft PR.
