### PR TITLE
feat(pilot, soma, scene): plan from live robot and environment state

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -330,6 +330,7 @@ jobs:
       GRPCIO_PIN: "1.80.0"
       # ── Per-run isolation (coexist with interactive users on the shared box) ──
       RUN_ID: "${{ github.run_id }}"
+      ROBONIX_HOME: "${{ runner.temp }}/robonix-home"
       # GPU selection is runner-specific. Priority:
       # workflow_call input -> repo/org variable -> runner env -> default GPU 0.
       ROBONIX_CI_GPU_ID_INPUT: ${{ inputs.gpu_id || '' }}
@@ -919,6 +920,19 @@ jobs:
             --summary-json "$GITHUB_WORKSPACE/testing/logs/summary.json" | tee "$RUNNER_TEMP/scenarios.out"
           # Surface the one-line RESULT for the reusable-workflow output / bot.
           echo "result=$(grep '^RESULT:' "$RUNNER_TEMP/scenarios.out" | tail -1)" >> "$GITHUB_OUTPUT"
+
+      - name: Verify scene map persistence
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/sim-logs"
+          map_id="ci_scene_map_${RUN_ID}"
+          python3 "$GITHUB_WORKSPACE/testing/verify_scene_map_persistence.py" \
+            --scene-url "http://127.0.0.1:${SCENE_WEB_PORT}" \
+            --map-id "$map_id" \
+            --mapping-container "${ROBONIX_MAPPING_CONTAINER:-robonix_mapping}" \
+            --sim-container "$ROBONIX_SIM_CONTAINER" \
+            --delete-after \
+            --timeout 420 | tee "$RUNNER_TEMP/sim-logs/scene-map-persistence.txt"
 
       - name: Validate boot/shutdown lifecycle
         # boot → shutdown → re-boot. Proves the runtime keeps

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2934,6 +2934,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "nix 0.31.2",
  "prost",
  "protoc-bin-vendored",
  "rmcp",

--- a/capabilities/lib/liaison/srv/WatchHandsfreeEvents.srv
+++ b/capabilities/lib/liaison/srv/WatchHandsfreeEvents.srv
@@ -1,0 +1,4 @@
+# Subscribe to voice events emitted by Liaison's current robot-local
+# hands-free loop. This is observational; it does not own microphone input.
+---
+liaison/VoiceEvent event

--- a/capabilities/lib/map/msg/MapLifecycle.msg
+++ b/capabilities/lib/map/msg/MapLifecycle.msg
@@ -1,0 +1,17 @@
+# Map identity + lifecycle broadcast from the mapping service.
+#
+# Published latched (transient_local) so late-joining consumers (e.g. the
+# scene service) learn the current map identity at startup, and re-published
+# on every lifecycle transition (init / load / reset / mode switch; save
+# does not change the live identity — its re-key semantics are a later,
+# separate design).
+#
+# The (map_id, generation) pair is the map-frame identity key: consumers
+# holding map-frame coordinates must treat a change in EITHER field as
+# "previous coordinates are no longer anchored" — reset_map keeps map_id
+# but moves the map origin, which only generation makes visible.
+string map_id      # named-map id currently bound; empty when ephemeral (no map_id configured)
+string mode        # "mapping" or "localization"
+uint64 generation  # monotonic; +1 when the map origin may have changed: mapping-mode
+                   # session start/load and reset_map. NEVER bumped by a localization
+                   # load (stable frame is the point) or by a mode switch.

--- a/capabilities/lib/semantic_map/msg/SceneAnnotation.msg
+++ b/capabilities/lib/semantic_map/msg/SceneAnnotation.msg
@@ -1,0 +1,13 @@
+# User-authored semantic annotation anchored to the SLAM map.
+# Rooms and POIs are maintained by scene, persisted per map_id, and
+# returned with the scene graph so clients/agents can reason about
+# human-provided regions as first-class scene context.
+
+string annotation_id
+string kind
+string name
+float64[] points_xy
+float64 theta
+bool stale
+string stale_reason
+float64 updated_at_unix

--- a/capabilities/lib/semantic_map/srv/GetRobotContext.srv
+++ b/capabilities/lib/semantic_map/srv/GetRobotContext.srv
@@ -1,0 +1,17 @@
+# Return the current spatial context used by Pilot before planning.
+---
+bool pose_known
+string map_id
+float64 x
+float64 y
+float64 z
+float64 yaw
+string room_id
+string room_name
+string[] containing_area_ids
+string[] containing_area_names
+Object[] nearby_objects
+float64 observed_at_unix
+float64 snapshot_at_unix
+bool stale
+string reason

--- a/capabilities/lib/semantic_map/srv/GetSceneGraph.srv
+++ b/capabilities/lib/semantic_map/srv/GetSceneGraph.srv
@@ -3,4 +3,5 @@
 ---
 SceneGraphNode[] nodes
 SceneGraphEdge[] edges
+SceneAnnotation[] annotations
 float64 updated_at

--- a/capabilities/lib/semantic_map/srv/GoalNear.srv
+++ b/capabilities/lib/semantic_map/srv/GoalNear.srv
@@ -1,5 +1,6 @@
 # robonix/system/scene/goal_near — find a navigation-safe approach pose
-# near a registered scene object. Map-frame (x, y, yaw); pass to
+# near a registered physical scene object. Room annotations are rejected;
+# use robonix/system/scene/goal_room for rooms. Map-frame (x, y, yaw); pass to
 # robonix/service/navigation/navigate after.
 #
 # `reachable=false` when the occupancy grid has no free cell within

--- a/capabilities/lib/semantic_map/srv/GoalRoom.srv
+++ b/capabilities/lib/semantic_map/srv/GoalRoom.srv
@@ -1,0 +1,11 @@
+# robonix/system/scene/goal_room - find a navigation-safe pose inside
+# a user-defined room annotation. The returned map-frame pose is always
+# inside the room polygon; pass it to navigation/navigate.
+
+string room_id
+---
+bool reachable
+float64 x
+float64 y
+float64 yaw
+string reason

--- a/capabilities/lib/soma/msg/ActuatorState.msg
+++ b/capabilities/lib/soma/msg/ActuatorState.msg
@@ -1,0 +1,18 @@
+string component_id
+string joint_name
+
+Scalar position
+Scalar velocity
+Scalar effort
+Scalar current
+Scalar voltage
+Scalar motor_temp
+Scalar driver_temp
+
+bool torque_enabled
+bool brake_engaged
+bool communication_ok
+
+uint32 vendor_mode
+uint32 vendor_error_code
+uint32 status_flags

--- a/capabilities/lib/soma/msg/ComponentStatus.msg
+++ b/capabilities/lib/soma/msg/ComponentStatus.msg
@@ -1,0 +1,41 @@
+uint8 HEALTH_OK=0
+uint8 HEALTH_WARN=1
+uint8 HEALTH_ERROR=2
+uint8 HEALTH_STALE=3
+uint8 HEALTH_UNKNOWN=4
+
+uint8 KIND_UNKNOWN=0
+uint8 KIND_BODY=1
+uint8 KIND_ARM=2
+uint8 KIND_LEG=3
+uint8 KIND_JOINT=4
+uint8 KIND_WHEEL=5
+uint8 KIND_GRIPPER=6
+uint8 KIND_BATTERY=7
+uint8 KIND_COMPUTER=8
+uint8 KIND_SENSOR=9
+uint8 KIND_CONTROLLER=10
+uint8 KIND_END_EFFECTOR=11
+
+uint8 OP_UNKNOWN=0
+uint8 OP_OFFLINE=1
+uint8 OP_POWERED_OFF=2
+uint8 OP_IDLE=3
+uint8 OP_ACTIVE=4
+uint8 OP_DEGRADED=5
+uint8 OP_PROTECTIVE_STOP=6
+uint8 OP_ESTOP=7
+uint8 OP_FAULT=8
+
+string id
+string parent_id
+uint8 kind
+string name
+string frame_id
+string model
+string serial
+uint8 health
+uint8 operational_state
+bool present
+bool online
+string detail

--- a/capabilities/lib/soma/msg/FaultState.msg
+++ b/capabilities/lib/soma/msg/FaultState.msg
@@ -1,0 +1,17 @@
+uint8 INFO=0
+uint8 WARN=1
+uint8 ERROR=2
+uint8 CRITICAL=3
+
+string component_id
+string fault_id
+uint8 severity
+bool active
+bool clearable
+int64 onset_ts_ns
+
+uint32 vendor_code
+string vendor_code_text
+string message
+string[] attributes
+string vendor_raw_json

--- a/capabilities/lib/soma/msg/Metric.msg
+++ b/capabilities/lib/soma/msg/Metric.msg
@@ -1,0 +1,4 @@
+string component_id
+string name
+Scalar value
+string source_key

--- a/capabilities/lib/soma/msg/PowerSourceState.msg
+++ b/capabilities/lib/soma/msg/PowerSourceState.msg
@@ -1,0 +1,12 @@
+string component_id
+
+Scalar soc_percent
+Scalar soh_percent
+Scalar voltage
+Scalar current
+Scalar temperature
+Scalar remaining_s
+
+uint32 cycle_count
+Scalar[] cell_voltages
+uint32 vendor_status_code

--- a/capabilities/lib/soma/msg/SafetyEndpointState.msg
+++ b/capabilities/lib/soma/msg/SafetyEndpointState.msg
@@ -1,0 +1,13 @@
+uint8 TYPE_UNKNOWN=0
+uint8 TYPE_HARDWARE=1
+uint8 TYPE_SOFTWARE=2
+uint8 TYPE_REMOTE=3
+uint8 TYPE_PAYLOAD=4
+
+uint8 RELEASED=0
+uint8 ACTIVE=1
+
+string name
+uint8 type
+uint8 state
+string detail

--- a/capabilities/lib/soma/msg/SafetyState.msg
+++ b/capabilities/lib/soma/msg/SafetyState.msg
@@ -1,0 +1,11 @@
+uint8 UNKNOWN=0
+uint8 NORMAL=1
+uint8 REDUCED=2
+uint8 PROTECTIVE_STOP=3
+uint8 ESTOP=4
+uint8 FAULT=5
+
+bool motion_allowed
+bool motor_power_allowed
+uint8 aggregate_state
+string detail

--- a/capabilities/lib/soma/msg/Scalar.msg
+++ b/capabilities/lib/soma/msg/Scalar.msg
@@ -1,0 +1,8 @@
+uint8 VALID=0
+uint8 STALE=1
+uint8 UNAVAILABLE=2
+uint8 INVALID=3
+
+float64 value
+string unit
+uint8 quality

--- a/capabilities/lib/soma/msg/SomaHealthSnapshot.msg
+++ b/capabilities/lib/soma/msg/SomaHealthSnapshot.msg
@@ -1,0 +1,14 @@
+uint32 schema_version
+string body_id
+uint64 seq
+int64 source_ts_ns
+int64 soma_ts_ns
+uint32 ttl_ms
+
+ComponentStatus[] components
+ActuatorState[] actuators
+PowerSourceState[] power_sources
+SafetyState safety
+SafetyEndpointState[] safety_endpoints
+FaultState[] faults
+Metric[] metrics

--- a/capabilities/lib/soma/srv/GetHealth.srv
+++ b/capabilities/lib/soma/srv/GetHealth.srv
@@ -1,0 +1,2 @@
+---
+SomaHealthSnapshot snapshot

--- a/capabilities/lib/soma/srv/StreamHealth.srv
+++ b/capabilities/lib/soma/srv/StreamHealth.srv
@@ -1,0 +1,2 @@
+---
+SomaHealthSnapshot snapshot

--- a/capabilities/primitive/arm/driver.v1.toml
+++ b/capabilities/primitive/arm/driver.v1.toml
@@ -1,0 +1,10 @@
+# Lifecycle interface every arm primitive implementation must declare.
+[contract]
+id = "robonix/primitive/arm/driver"
+version = "1"
+kind = "primitive"
+idl = "lifecycle/srv/Driver.srv"
+description = "Lifecycle control interface for arm primitive providers."
+
+[mode]
+type = "rpc"

--- a/capabilities/primitive/arm/end_pose.v1.toml
+++ b/capabilities/primitive/arm/end_pose.v1.toml
@@ -1,0 +1,12 @@
+# Legacy-compatible unstamped end-effector pose. The provider documents the
+# frame in its package capability guide. A future stamped contract can add an
+# explicit frame without changing this deployed v1 wire shape.
+[contract]
+id = "robonix/primitive/arm/end_pose"
+version = "1"
+kind = "primitive"
+idl = "common_interfaces/geometry_msgs/msg/Pose.msg"
+description = "Measured end-effector pose in the arm provider's documented base frame."
+
+[mode]
+type = "topic_out"

--- a/capabilities/primitive/arm/joint_command.v1.toml
+++ b/capabilities/primitive/arm/joint_command.v1.toml
@@ -1,0 +1,11 @@
+# Standard joint command input. Providers may support a subset of JointState
+# fields, but names and positions must use the same units as joint_states.
+[contract]
+id = "robonix/primitive/arm/joint_command"
+version = "1"
+kind = "primitive"
+idl = "common_interfaces/sensor_msgs/msg/JointState.msg"
+description = "Named arm and gripper joint command input using standard JointState units."
+
+[mode]
+type = "topic_in"

--- a/capabilities/primitive/arm/joint_states.v1.toml
+++ b/capabilities/primitive/arm/joint_states.v1.toml
@@ -1,0 +1,11 @@
+# Standard joint feedback. Grippers that are part of the arm expose their
+# measured opening as a named joint in this same JointState stream.
+[contract]
+id = "robonix/primitive/arm/joint_states"
+version = "1"
+kind = "primitive"
+idl = "common_interfaces/sensor_msgs/msg/JointState.msg"
+description = "Measured arm and gripper joint positions, velocities, and efforts."
+
+[mode]
+type = "topic_out"

--- a/capabilities/service/map/lifecycle.v1.toml
+++ b/capabilities/service/map/lifecycle.v1.toml
@@ -1,0 +1,17 @@
+# Map identity + lifecycle events. The mapping service is the sole
+# authority on which named map is active; this topic broadcasts that
+# identity ({map_id, mode, generation}) latched, so consumers that key
+# state by map (e.g. scene's semantic object store) can discover the
+# current map at startup and react to init/load/reset/mode-switch
+# transitions without polling. Additive to the v0.1 surface: the four
+# original topic_out streams (occupancy_grid / pose / odom / pointcloud)
+# are unchanged.
+[contract]
+id      = "robonix/service/map/lifecycle"
+version = "1"
+kind    = "service"
+idl     = "map/msg/MapLifecycle.msg"
+description = "Latched map identity and lifecycle events ({map_id, mode, generation}) from the mapping service."
+
+[mode]
+type = "topic_out"

--- a/capabilities/system/liaison/handsfree/events.v1.toml
+++ b/capabilities/system/liaison/handsfree/events.v1.toml
@@ -1,0 +1,11 @@
+# Read-only observation stream for the robot-local hands-free interaction.
+# It reuses VoiceEvent so clients render it exactly like a push-to-talk turn.
+[contract]
+id = "robonix/system/liaison/handsfree/events"
+version = "1"
+kind = "service"
+idl = "liaison/srv/WatchHandsfreeEvents.srv"
+description = "Subscribe to events from Liaison's robot-local hands-free voice turns."
+
+[mode]
+type = "rpc_server_stream"

--- a/capabilities/system/scene/get_robot_context.v1.toml
+++ b/capabilities/system/scene/get_robot_context.v1.toml
@@ -1,0 +1,9 @@
+[contract]
+id = "robonix/system/scene/get_robot_context"
+version = "1"
+kind = "service"
+idl = "semantic_map/srv/GetRobotContext.srv"
+description = "Return the robot pose, containing room and areas, and nearby objects as one current Scene snapshot."
+
+[mode]
+type = "rpc"

--- a/capabilities/system/scene/goal_near.v1.toml
+++ b/capabilities/system/scene/goal_near.v1.toml
@@ -5,7 +5,7 @@ id      = "robonix/system/scene/goal_near"
 version = "1"
 kind    = "service"
 idl     = "semantic_map/srv/GoalNear.srv"
-description = "Compute a navigation-safe approach pose near a known scene object."
+description = "Compute a navigation-safe approach pose near a known physical scene object. Room annotations are not accepted; use robonix/system/scene/goal_room for rooms or named regions."
 
 [mode]
 type = "rpc"

--- a/capabilities/system/scene/goal_room.v1.toml
+++ b/capabilities/system/scene/goal_room.v1.toml
@@ -1,0 +1,11 @@
+# Find a navigation-safe pose inside a registered room annotation.
+# Returns map-frame (x, y, yaw); pass to navigation/navigate after.
+[contract]
+id      = "robonix/system/scene/goal_room"
+version = "1"
+kind    = "service"
+idl     = "semantic_map/srv/GoalRoom.srv"
+description = "Resolve a room annotation to a navigation-safe pose inside its polygon. Use this for named rooms or regions before navigation/navigate."
+
+[mode]
+type = "rpc"

--- a/capabilities/system/soma/get_health.v1.toml
+++ b/capabilities/system/soma/get_health.v1.toml
@@ -1,0 +1,8 @@
+[contract]
+id      = "robonix/system/soma/get_health"
+version = "1"
+kind    = "service"
+idl     = "soma/srv/GetHealth.srv"
+
+[mode]
+type = "rpc"

--- a/capabilities/system/soma/health.v1.toml
+++ b/capabilities/system/soma/health.v1.toml
@@ -1,0 +1,8 @@
+[contract]
+id      = "robonix/system/soma/health"
+version = "1"
+kind    = "service"
+idl     = "soma/srv/StreamHealth.srv"
+
+[mode]
+type = "rpc_server_stream"

--- a/examples/webots/primitives/audio_client_bridge/README.md
+++ b/examples/webots/primitives/audio_client_bridge/README.md
@@ -1,11 +1,9 @@
 # audio_client_bridge
 
-Local-only audio primitive that runs on a Linux atlas host but routes
-mic + speaker through a daemon on an client machine across the LAN. The
-manifest-side provider (`com.robonix.primitive.audio`) is identical to the
-default `audio_driver` package, so liaison / scene / pilot don't see a
-difference; the only thing that changes is where the actual ADC/DAC
-lives.
+Audio primitive that runs on the Robonix host but routes mic + speaker through
+the selected `robonix-client` device. It implements the same audio contracts
+as `audio_driver`; both providers can be registered at once, and Liaison uses
+the provider selected by the client for F2, voice-steer, and hands-free turns.
 
 Both halves (the Linux primitive package and the macOS server) live
 in this directory and are committed to the repo. The client machine just
@@ -24,67 +22,50 @@ audio_client_bridge/
 └── scripts/{build,start}.sh       # rbnx codegen + entry
 ```
 
-## Ports
+## Transport
 
-| Port | Side | Protocol | What |
-| --- | --- | --- | --- |
-| `60000` | macOS | WebSocket (`0.0.0.0`) | `/mic`, `/speaker`, `/health`, `/devices`, `/vu`, `/log`, `/set_device` |
-| `60001` | macOS | HTTP (`127.0.0.1`) | `server_web.py` debug UI — open in a browser |
+The default is a reverse WebSocket transport. During driver init the primitive
+binds `0.0.0.0:60002`, publishes its endpoint through Atlas, and waits for
+`robonix-client` to connect. The deployment never stores a client IP.
 
-`60000` listens on all interfaces so the Linux atlas host can dial it
-across LAN/Tailscale. `60001` only binds loopback by default; pass
-`--ui-host 0.0.0.0` if you want to drive the UI from another machine
-(no auth — don't expose to the public internet).
+The client discovers this endpoint through Atlas after the operator selects
+`audio_client_bridge` as an input or output route. Its Audio page owns local
+device selection, audio level display, and the reverse connection lifecycle.
 
 ## Setup (one-shot)
 
-### client side
+### Client side
 
 ```sh
-cd ~/robonix-scripts/client_audio_server          # or wherever you scp'd this dir
-python3 -m venv .venv
-. .venv/bin/activate
-pip install -r requirements.txt
-
-# Option A — headless, you already know the device ids
-python3 server.py --list-devices
-python3 server.py --port 60000 --input-device 1 --output-device 2
-
-# Option B — web UI for picking devices + watching VU + tailing log
-python3 server_web.py --port 60000        # WS 60000 + UI on 60001
-open http://localhost:60001/
+robonix-client --host <robot-host> --port 50051
 ```
 
-Leave it running. The first time, macOS will prompt for mic + network
-permission — accept both. The web UI auto-skips devices whose name
-matches `airpods|bluetooth|iphone|ipad` because BT-HFP can't open a
-16 kHz mono `RawInputStream` on Apple silicon.
+Open **Audio**, select input/output primitives and devices, then apply the
+route. The client starts its local audio endpoint and connects to the selected
+reverse bridge when needed. macOS may request microphone and local-network
+permission on first use.
 
 ### Linux side
 
-In `examples/webots/robonix_manifest.yaml` swap the audio_driver entry
-for the bridge:
+In `examples/webots/robonix_manifest.yaml`, keep both providers registered:
 
 ```yaml
 primitive:
-  # - name: audio_driver
-  #   path: ./primitives/audio_driver
+  - name: audio_driver
+    path: ./primitives/audio_driver
   - name: audio_client_bridge
     path: ./primitives/audio_client_bridge
     config:
-      host: 192.168.1.42      # macOS LAN IP
-      port: 60000
+      transport: reverse
+      listen_port: 60002
 ```
 
-Then `rbnx build && rbnx boot` as usual. Driver(CMD_INIT) probes
-`/health` on the client machine; if unreachable, this primitive defers
-instead of advertising dead mic/speaker streams.
+Then `rbnx build && rbnx boot` as usual. The bridge stays active while no
+client is connected; it is selected only when the operator chooses it.
 
 ## Wire format
 
-Both directions: 16 kHz, mono, s16le PCM. Frames are 100 ms (3200 B
-each). `/mic` is server-stream binary frames; `/speaker` is
-client-stream binary frames. `/health` is a single text JSON message.
+Both directions use 16 kHz, mono, s16le PCM. Frames are 100 ms (3200 B).
 
-No auth, no TLS — assume LAN. Don't expose `client_audio_server` on a public
-interface.
+The current bridge has no authentication or TLS. Use a trusted LAN, Tailscale,
+or an authenticated tunnel; do not expose the bridge port publicly.

--- a/examples/webots/primitives/audio_client_bridge/audio_client_bridge/reverse.py
+++ b/examples/webots/primitives/audio_client_bridge/audio_client_bridge/reverse.py
@@ -213,6 +213,7 @@ class ReverseAudioBridge:
     def mic_stream(self, context, audio_pb2):
         if not self._require_client(context):
             return
+        log.info("client microphone stream requested")
         while True:
             try:
                 self._mic_frames.get_nowait()
@@ -229,7 +230,10 @@ class ReverseAudioBridge:
                 except queue.Empty:
                     continue
                 if frame is None:
+                    log.info("client microphone stream ended before frame %d", sequence)
                     break
+                if sequence == 0:
+                    log.info("client microphone first PCM frame: %d bytes", len(frame))
                 yield audio_pb2.AudioChunk(
                     timestamp_ns=time.time_ns(),
                     data=frame,
@@ -239,6 +243,7 @@ class ReverseAudioBridge:
                 sequence += 1
         finally:
             self._send(json.dumps({"type": "mic_stop"}))
+            log.info("client microphone stream stopped after %d frame(s)", sequence)
 
     def speaker_stream(self, request_iterator, context, empty_type):
         if not self._require_client(context):

--- a/examples/webots/primitives/audio_client_bridge/audio_client_bridge/reverse.py
+++ b/examples/webots/primitives/audio_client_bridge/audio_client_bridge/reverse.py
@@ -36,7 +36,8 @@ class ReverseAudioBridge:
         self._session: _ClientSession | None = None
         self._lock = threading.Lock()
         self._connected = threading.Event()
-        self._mic_frames: queue.Queue[bytes | None] = queue.Queue(maxsize=128)
+        self._mic_streams: dict[str, queue.Queue[bytes | None]] = {}
+        self._active_mic_id: str | None = None
         self._pending_controls: dict[str, queue.Queue[dict]] = {}
         self._pending_lock = threading.Lock()
         self._speaker_lock = threading.Lock()
@@ -63,7 +64,7 @@ class ReverseAudioBridge:
             self._thread.join(timeout=5.0)
         self._thread = None
         self._connected.clear()
-        self._put_mic(None)
+        self._end_all_mics()
 
     def is_connected(self) -> bool:
         """Whether a robonix-client currently owns this reverse session."""
@@ -106,32 +107,49 @@ class ReverseAudioBridge:
         try:
             async for message in ws:
                 if isinstance(message, bytes):
-                    self._put_mic(message)
+                    self._put_active_mic(message)
                     continue
                 self._handle_control(message)
         except Exception as exc:  # noqa: BLE001
             log.warning("client reverse-audio session closed: %s", exc)
         finally:
+            owns_session = False
             with self._lock:
                 if self._session and self._session.ws is ws:
                     self._session = None
                     self._connected.clear()
-                    self._put_mic(None)
+                    owns_session = True
+            if owns_session:
+                self._end_all_mics()
             self._fail_pending_controls("client audio session disconnected")
             log.info("client reverse-audio session disconnected")
 
-    def _put_mic(self, frame: bytes | None) -> None:
+    @staticmethod
+    def _put_mic(target: queue.Queue[bytes | None], frame: bytes | None) -> None:
         try:
-            self._mic_frames.put_nowait(frame)
+            target.put_nowait(frame)
         except queue.Full:
             try:
-                self._mic_frames.get_nowait()
+                target.get_nowait()
             except queue.Empty:
                 pass
             try:
-                self._mic_frames.put_nowait(frame)
+                target.put_nowait(frame)
             except queue.Full:
                 pass
+
+    def _put_active_mic(self, frame: bytes) -> None:
+        with self._lock:
+            target = self._mic_streams.get(self._active_mic_id or "")
+        if target is not None:
+            self._put_mic(target, frame)
+
+    def _end_all_mics(self) -> None:
+        with self._lock:
+            targets = list(self._mic_streams.values())
+            self._active_mic_id = None
+        for target in targets:
+            self._put_mic(target, None)
 
     def _handle_control(self, raw: str) -> None:
         try:
@@ -139,7 +157,11 @@ class ReverseAudioBridge:
         except json.JSONDecodeError:
             return
         if body.get("type") == "mic_end":
-            self._put_mic(None)
+            stream_id = str(body.get("stream_id") or "")
+            with self._lock:
+                target = self._mic_streams.get(stream_id or self._active_mic_id or "")
+            if target is not None:
+                self._put_mic(target, None)
             return
         if body.get("type") != "control_response":
             return
@@ -225,25 +247,37 @@ class ReverseAudioBridge:
         if not self._require_client(context):
             return
         log.info("client microphone stream requested")
-        while True:
-            try:
-                self._mic_frames.get_nowait()
-            except queue.Empty:
-                break
+        stream_id = uuid.uuid4().hex
+        frames: queue.Queue[bytes | None] = queue.Queue(maxsize=128)
+        with self._lock:
+            previous = self._mic_streams.get(self._active_mic_id or "")
+            self._mic_streams[stream_id] = frames
+            self._active_mic_id = stream_id
+        if previous is not None:
+            self._put_mic(previous, None)
         metadata = {item.key: item.value for item in context.invocation_metadata()}
         if metadata.get("x-robonix-barge-in", "").lower() in {"1", "true", "yes"}:
             # Explicit F2 / steer capture clears client-local TTS before PCM
             # starts.  The persistent wake-word listener does not carry this
             # metadata and therefore never mutes normal replies.
             self._interrupt_speaker()
-        if not self._send(json.dumps({"type": "mic_start", "sample_rate": 16000, "channels": 1})):
-            context.abort(__import__("grpc").StatusCode.UNAVAILABLE, "client audio session disconnected")
-            return
         sequence = 0
         try:
+            start = {
+                "type": "mic_start",
+                "stream_id": stream_id,
+                "sample_rate": 16000,
+                "channels": 1,
+            }
+            if not self._send(json.dumps(start)):
+                context.abort(
+                    __import__("grpc").StatusCode.UNAVAILABLE,
+                    "client audio session disconnected",
+                )
+                return
             while context.is_active():
                 try:
-                    frame = self._mic_frames.get(timeout=0.5)
+                    frame = frames.get(timeout=0.5)
                 except queue.Empty:
                     continue
                 if frame is None:
@@ -259,7 +293,11 @@ class ReverseAudioBridge:
                 )
                 sequence += 1
         finally:
-            self._send(json.dumps({"type": "mic_stop"}))
+            self._send(json.dumps({"type": "mic_stop", "stream_id": stream_id}))
+            with self._lock:
+                self._mic_streams.pop(stream_id, None)
+                if self._active_mic_id == stream_id:
+                    self._active_mic_id = None
             log.info("client microphone stream stopped after %d frame(s)", sequence)
 
     def speaker_stream(self, request_iterator, context, empty_type):

--- a/examples/webots/primitives/audio_client_bridge/audio_client_bridge/reverse.py
+++ b/examples/webots/primitives/audio_client_bridge/audio_client_bridge/reverse.py
@@ -39,6 +39,8 @@ class ReverseAudioBridge:
         self._mic_frames: queue.Queue[bytes | None] = queue.Queue(maxsize=128)
         self._pending_controls: dict[str, queue.Queue[dict]] = {}
         self._pending_lock = threading.Lock()
+        self._speaker_lock = threading.Lock()
+        self._speaker_epoch = 0
         self._thread: threading.Thread | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
         self._stop_async: asyncio.Event | None = None
@@ -164,6 +166,15 @@ class ReverseAudioBridge:
             session = self._session
         if session is None:
             return False
+
+    def _interrupt_speaker(self) -> None:
+        with self._speaker_lock:
+            self._speaker_epoch += 1
+        self._send(json.dumps({"type": "speaker_stop"}))
+
+    def _current_speaker_epoch(self) -> int:
+        with self._speaker_lock:
+            return self._speaker_epoch
         try:
             future = asyncio.run_coroutine_threadsafe(session.ws.send(payload), session.loop)
             future.result(timeout=3.0)
@@ -219,6 +230,12 @@ class ReverseAudioBridge:
                 self._mic_frames.get_nowait()
             except queue.Empty:
                 break
+        metadata = {item.key: item.value for item in context.invocation_metadata()}
+        if metadata.get("x-robonix-barge-in", "").lower() in {"1", "true", "yes"}:
+            # Explicit F2 / steer capture clears client-local TTS before PCM
+            # starts.  The persistent wake-word listener does not carry this
+            # metadata and therefore never mutes normal replies.
+            self._interrupt_speaker()
         if not self._send(json.dumps({"type": "mic_start", "sample_rate": 16000, "channels": 1})):
             context.abort(__import__("grpc").StatusCode.UNAVAILABLE, "client audio session disconnected")
             return
@@ -249,16 +266,24 @@ class ReverseAudioBridge:
         if not self._require_client(context):
             return empty_type()
         total = 0
-        for chunk in request_iterator:
-            if chunk.data:
-                data = bytes(chunk.data)
-                total += len(data)
-                if not self._send(data):
-                    context.abort(__import__("grpc").StatusCode.UNAVAILABLE, "client audio session disconnected")
-                    return empty_type()
-        self._send(json.dumps({"type": "speaker_end"}))
+        epoch = self._current_speaker_epoch()
+        completed = False
+        try:
+            for chunk in request_iterator:
+                if epoch != self._current_speaker_epoch():
+                    log.info("speaker stream superseded by voice barge-in")
+                    break
+                if chunk.data:
+                    data = bytes(chunk.data)
+                    total += len(data)
+                    if not self._send(data):
+                        context.abort(__import__("grpc").StatusCode.UNAVAILABLE, "client audio session disconnected")
+                        return empty_type()
+            completed = context.is_active() and epoch == self._current_speaker_epoch()
+        finally:
+            self._send(json.dumps({"type": "speaker_end" if completed else "speaker_stop"}))
         # Preserve serialised speaker semantics without sleeping for a full long
         # utterance in the gRPC worker.
-        if total:
+        if completed and total:
             time.sleep(min(total / 32000.0 + 0.1, 5.0))
         return empty_type()

--- a/examples/webots/primitives/audio_client_bridge/audio_client_bridge/reverse.py
+++ b/examples/webots/primitives/audio_client_bridge/audio_client_bridge/reverse.py
@@ -166,6 +166,13 @@ class ReverseAudioBridge:
             session = self._session
         if session is None:
             return False
+        try:
+            future = asyncio.run_coroutine_threadsafe(session.ws.send(payload), session.loop)
+            future.result(timeout=3.0)
+            return True
+        except Exception as exc:  # noqa: BLE001
+            log.warning("reverse client send failed: %s", exc)
+            return False
 
     def _interrupt_speaker(self) -> None:
         with self._speaker_lock:
@@ -175,13 +182,6 @@ class ReverseAudioBridge:
     def _current_speaker_epoch(self) -> int:
         with self._speaker_lock:
             return self._speaker_epoch
-        try:
-            future = asyncio.run_coroutine_threadsafe(session.ws.send(payload), session.loop)
-            future.result(timeout=3.0)
-            return True
-        except Exception as exc:  # noqa: BLE001
-            log.warning("reverse client send failed: %s", exc)
-            return False
 
     def control_request(self, op: str, payload: dict | None = None, timeout_s: float = 3.0) -> dict:
         """Ask the connected client to perform a small local audio operation."""

--- a/examples/webots/primitives/audio_client_bridge/tests/test_reverse_barge_in.py
+++ b/examples/webots/primitives/audio_client_bridge/tests/test_reverse_barge_in.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import queue
 from types import SimpleNamespace
 
 from audio_client_bridge.reverse import ReverseAudioBridge, _ClientSession
@@ -65,3 +66,18 @@ def test_send_reports_disconnected_client() -> None:
     bridge = ReverseAudioBridge("127.0.0.1", 0, 3200)
 
     assert bridge._send('{"type":"mic_start"}') is False
+
+
+def test_stale_mic_end_does_not_terminate_new_stream() -> None:
+    bridge = ReverseAudioBridge("127.0.0.1", 0, 3200)
+    old_frames: queue.Queue[bytes | None] = queue.Queue()
+    new_frames: queue.Queue[bytes | None] = queue.Queue()
+    bridge._mic_streams = {"old": old_frames, "new": new_frames}
+    bridge._active_mic_id = "new"
+
+    bridge._handle_control('{"type":"mic_end","stream_id":"old"}')
+    bridge._put_active_mic(b"new-pcm")
+
+    assert old_frames.get_nowait() is None
+    assert new_frames.get_nowait() == b"new-pcm"
+    assert new_frames.empty()

--- a/examples/webots/primitives/audio_client_bridge/tests/test_reverse_barge_in.py
+++ b/examples/webots/primitives/audio_client_bridge/tests/test_reverse_barge_in.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from types import SimpleNamespace
 
-from audio_client_bridge.reverse import ReverseAudioBridge
+from audio_client_bridge.reverse import ReverseAudioBridge, _ClientSession
 
 
 class ActiveContext:
@@ -29,3 +30,38 @@ def test_barge_in_supersedes_inflight_speaker_generation() -> None:
     assert b"old-audio-2" not in sent
     controls = [json.loads(item) for item in sent if isinstance(item, str)]
     assert {control["type"] for control in controls} == {"speaker_stop"}
+
+
+def test_send_forwards_payload_to_connected_client(monkeypatch) -> None:
+    bridge = ReverseAudioBridge("127.0.0.1", 0, 3200)
+    delivered: list[str | bytes] = []
+    marker_loop = object()
+
+    class FakeWebSocket:
+        async def send(self, payload: str | bytes) -> None:
+            delivered.append(payload)
+
+    class FakeFuture:
+        @staticmethod
+        def result(timeout: float) -> None:
+            assert timeout == 3.0
+
+    def run_coroutine(coro, loop):
+        assert loop is marker_loop
+        asyncio.run(coro)
+        return FakeFuture()
+
+    bridge._session = _ClientSession(ws=FakeWebSocket(), loop=marker_loop)
+    monkeypatch.setattr(
+        "audio_client_bridge.reverse.asyncio.run_coroutine_threadsafe",
+        run_coroutine,
+    )
+
+    assert bridge._send('{"type":"mic_start"}') is True
+    assert delivered == ['{"type":"mic_start"}']
+
+
+def test_send_reports_disconnected_client() -> None:
+    bridge = ReverseAudioBridge("127.0.0.1", 0, 3200)
+
+    assert bridge._send('{"type":"mic_start"}') is False

--- a/examples/webots/primitives/audio_client_bridge/tests/test_reverse_barge_in.py
+++ b/examples/webots/primitives/audio_client_bridge/tests/test_reverse_barge_in.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from audio_client_bridge.reverse import ReverseAudioBridge
+
+
+class ActiveContext:
+    @staticmethod
+    def is_active() -> bool:
+        return True
+
+
+def test_barge_in_supersedes_inflight_speaker_generation() -> None:
+    bridge = ReverseAudioBridge("127.0.0.1", 0, 3200)
+    sent: list[str | bytes] = []
+    bridge._require_client = lambda _context: True  # type: ignore[method-assign]
+    bridge._send = lambda payload: (sent.append(payload), True)[1]  # type: ignore[method-assign]
+
+    def chunks():
+        yield SimpleNamespace(data=b"old-audio-1")
+        bridge._interrupt_speaker()
+        yield SimpleNamespace(data=b"old-audio-2")
+
+    bridge.speaker_stream(chunks(), ActiveContext(), lambda: object())
+
+    assert b"old-audio-1" in sent
+    assert b"old-audio-2" not in sent
+    controls = [json.loads(item) for item in sent if isinstance(item, str)]
+    assert {control["type"] for control in controls} == {"speaker_stop"}

--- a/examples/webots/primitives/audio_driver/audio_driver/main.py
+++ b/examples/webots/primitives/audio_driver/audio_driver/main.py
@@ -51,6 +51,7 @@ current_output_id: str = ""
 configured_input_id: str = ""
 configured_output_id: str = ""
 _mic_stream_lock = threading.Lock()
+_speaker_stream_lock = threading.Lock()
 
 
 # ── streaming handlers ─────────────────────────────────────────────────────
@@ -104,17 +105,33 @@ def speaker_stream(request_iterator, context):
     """Client-streaming playback. Pipes received PCM chunks into aplay;
     SpeakerDriver lazy-starts the subprocess and auto-restarts after
     underruns. Returns Empty on stream close."""
-    if speaker_driver is None:
-        context.abort(__import__("grpc").StatusCode.UNAVAILABLE,
-                      "speaker driver not initialized")
+    grpc = __import__("grpc")
+    if not _speaker_stream_lock.acquire(blocking=False):
+        context.abort(
+            grpc.StatusCode.RESOURCE_EXHAUSTED,
+            "speaker is already in use by another stream",
+        )
         return std_msgs_pb2.Empty()
-    log.info("speaker stream client connected")
+    driver = None
     try:
+        driver = speaker_driver
+        if driver is None:
+            context.abort(
+                grpc.StatusCode.UNAVAILABLE,
+                "speaker driver not initialized",
+            )
+            return std_msgs_pb2.Empty()
+        log.info("speaker stream client connected")
         for chunk in request_iterator:
             if chunk.data:
-                speaker_driver.play_chunk(bytes(chunk.data))
+                driver.play_chunk(bytes(chunk.data))
     finally:
-        log.info("speaker stream client disconnected")
+        try:
+            if driver is not None:
+                driver.stop()
+                log.info("speaker stream client disconnected")
+        finally:
+            _speaker_stream_lock.release()
     return std_msgs_pb2.Empty()
 
 
@@ -271,23 +288,36 @@ def select_device(request, context):
         finally:
             _mic_stream_lock.release()
     else:
-        previous = speaker_driver
-        speaker_driver = SpeakerDriver(
-            device_id=new_id,
-            sample_rate=int(os.environ.get(
-                "AUDIO_SPEAKER_SAMPLE_RATE",
-                str(previous.sample_rate if previous is not None else 24000),
-            )),
-            channels=int(os.environ.get(
-                "AUDIO_SPEAKER_CHANNELS",
-                str(previous.channels if previous is not None else 1),
-            )),
-            bits_per_sample=int(os.environ.get(
-                "AUDIO_SPEAKER_BITS",
-                str(previous.bits_per_sample if previous is not None else 16),
-            )),
-        )
-        current_output_id = new_id
+        if not _speaker_stream_lock.acquire(blocking=False):
+            return audio_pb2.SelectAudioDevice_Response(
+                ok=False,
+                error="cannot change output device while speaker is streaming",
+            )
+        try:
+            previous = speaker_driver
+            if previous is not None:
+                try:
+                    previous.stop()
+                except Exception:  # noqa: BLE001
+                    pass
+            speaker_driver = SpeakerDriver(
+                device_id=new_id,
+                sample_rate=int(os.environ.get(
+                    "AUDIO_SPEAKER_SAMPLE_RATE",
+                    str(previous.sample_rate if previous is not None else 24000),
+                )),
+                channels=int(os.environ.get(
+                    "AUDIO_SPEAKER_CHANNELS",
+                    str(previous.channels if previous is not None else 1),
+                )),
+                bits_per_sample=int(os.environ.get(
+                    "AUDIO_SPEAKER_BITS",
+                    str(previous.bits_per_sample if previous is not None else 16),
+                )),
+            )
+            current_output_id = new_id
+        finally:
+            _speaker_stream_lock.release()
     return audio_pb2.SelectAudioDevice_Response(ok=True, error="")
 
 

--- a/examples/webots/primitives/audio_driver/audio_driver/main.py
+++ b/examples/webots/primitives/audio_driver/audio_driver/main.py
@@ -129,27 +129,31 @@ def _scan_audio_devices_proto():
             note="",
         ))
     ids = {d.id for d in devs}
-    configured_mic = os.environ.get("AUDIO_MIC_DEVICE", "").strip()
-    if configured_mic and configured_mic not in ids:
+    # ALSA plugin devices such as plughw:0,0 are intentionally absent from
+    # arecord/aplay -l. Expose the *active* deployment selections as first-class
+    # choices so a client refresh does not silently replace them with hw:0,0.
+    configured: dict[str, set[str]] = {}
+    for device_id, kind in (
+        (current_input_id, "input"),
+        (current_output_id, "output"),
+        (os.environ.get("AUDIO_MIC_DEVICE", "").strip(), "input"),
+        (os.environ.get("AUDIO_SPEAKER_DEVICE", "").strip(), "output"),
+    ):
+        if device_id:
+            configured.setdefault(device_id, set()).add(kind)
+    for device_id, kinds in configured.items():
+        if device_id in ids:
+            continue
+        kind = "duplex" if kinds == {"input", "output"} else next(iter(kinds))
         devs.append(audio_pb2.AudioDevice(
-            id=configured_mic,
-            name="Configured ALSA input device",
-            kind="input",
+            id=device_id,
+            name="Configured ALSA device",
+            kind=kind,
             is_default=False,
             channels=1,
-            note="configured via AUDIO_MIC_DEVICE",
+            note="active deployment selection",
         ))
-        ids.add(configured_mic)
-    configured_spk = os.environ.get("AUDIO_SPEAKER_DEVICE", "").strip()
-    if configured_spk and configured_spk not in ids:
-        devs.append(audio_pb2.AudioDevice(
-            id=configured_spk,
-            name="Configured ALSA output device",
-            kind="output",
-            is_default=False,
-            channels=1,
-            note="configured via AUDIO_SPEAKER_DEVICE",
-        ))
+        ids.add(device_id)
     return devs
 
 
@@ -183,6 +187,9 @@ def select_device(request, context):
         ).strip()
         if configured:
             valid.add(configured)
+        current = current_input_id if kind == "input" else current_output_id
+        if current:
+            valid.add(current)
         if requested not in valid:
             return audio_pb2.SelectAudioDevice_Response(
                 ok=False, error=f"unknown {kind} id '{requested}'")
@@ -199,27 +206,52 @@ def select_device(request, context):
         new_id = info.device_id
 
     if kind == "input":
+        previous = mic_driver
         if mic_driver is not None:
             try:
                 mic_driver.stop()
             except Exception:  # noqa: BLE001
                 pass
         # Auto-probe hardware sample rate unless explicitly overridden
-        mic_rate = int(os.environ["AUDIO_MIC_SAMPLE_RATE"]) if "AUDIO_MIC_SAMPLE_RATE" in os.environ else probe_mic_sample_rate(new_id)
+        mic_rate = (
+            int(os.environ["AUDIO_MIC_SAMPLE_RATE"])
+            if "AUDIO_MIC_SAMPLE_RATE" in os.environ
+            else previous.sample_rate if previous is not None
+            else probe_mic_sample_rate(new_id)
+        )
         mic_driver = MicDriver(
             device_id=new_id,
             sample_rate=mic_rate,
-            channels=int(os.environ.get("AUDIO_MIC_CHANNELS", "1")),
-            bits_per_sample=int(os.environ.get("AUDIO_MIC_BITS", "16")),
-            chunk_duration_s=int(os.environ.get("AUDIO_MIC_CHUNK_MS", "100")) / 1000.0,
+            channels=int(os.environ.get(
+                "AUDIO_MIC_CHANNELS",
+                str(previous.channels if previous is not None else 1),
+            )),
+            bits_per_sample=int(os.environ.get(
+                "AUDIO_MIC_BITS",
+                str(previous.bits_per_sample if previous is not None else 16),
+            )),
+            chunk_duration_s=int(os.environ.get(
+                "AUDIO_MIC_CHUNK_MS",
+                str(round((previous.chunk_duration_s if previous is not None else 0.1) * 1000)),
+            )) / 1000.0,
         )
         current_input_id = new_id
     else:
+        previous = speaker_driver
         speaker_driver = SpeakerDriver(
             device_id=new_id,
-            sample_rate=int(os.environ.get("AUDIO_SPEAKER_SAMPLE_RATE", "24000")),
-            channels=int(os.environ.get("AUDIO_SPEAKER_CHANNELS", "1")),
-            bits_per_sample=int(os.environ.get("AUDIO_SPEAKER_BITS", "16")),
+            sample_rate=int(os.environ.get(
+                "AUDIO_SPEAKER_SAMPLE_RATE",
+                str(previous.sample_rate if previous is not None else 24000),
+            )),
+            channels=int(os.environ.get(
+                "AUDIO_SPEAKER_CHANNELS",
+                str(previous.channels if previous is not None else 1),
+            )),
+            bits_per_sample=int(os.environ.get(
+                "AUDIO_SPEAKER_BITS",
+                str(previous.bits_per_sample if previous is not None else 16),
+            )),
         )
         current_output_id = new_id
     return audio_pb2.SelectAudioDevice_Response(ok=True, error="")

--- a/examples/webots/primitives/audio_driver/audio_driver/main.py
+++ b/examples/webots/primitives/audio_driver/audio_driver/main.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 
 from robonix_api import Primitive, Ok, Err, Deferred
 
@@ -47,24 +48,40 @@ speaker_driver: SpeakerDriver | None = None
 # read back by ListAudioDevices.current_*_id.
 current_input_id: str = ""
 current_output_id: str = ""
+configured_input_id: str = ""
+configured_output_id: str = ""
+_mic_stream_lock = threading.Lock()
 
 
 # ── streaming handlers ─────────────────────────────────────────────────────
 @audio_driver.grpc("robonix/primitive/audio/mic")
 def mic_stream(request, context):
-    """Server-streaming mic capture. Drives one arecord subprocess per
-    open client; ALSA only allows one capture handle so concurrent clients
-    share the stream (driver is started by the first call, kept alive
-    while any context is active)."""
-    if mic_driver is None:
-        context.abort(__import__("grpc").StatusCode.UNAVAILABLE,
-                      "mic driver not initialized — Driver(CMD_INIT) failed or never ran")
+    """Server-streaming mic capture with exclusive ALSA ownership.
+
+    One ``MicDriver`` owns one ``arecord`` process. Reject overlapping clients
+    explicitly instead of replacing the shared process handle and leaking the
+    previous recorder.
+    """
+    grpc = __import__("grpc")
+    if not _mic_stream_lock.acquire(blocking=False):
+        context.abort(
+            grpc.StatusCode.RESOURCE_EXHAUSTED,
+            "microphone is already in use by another stream",
+        )
         return
-    log.info("mic stream client connected")
-    mic_driver.start()
+    driver = None
     try:
+        driver = mic_driver
+        if driver is None:
+            context.abort(
+                grpc.StatusCode.UNAVAILABLE,
+                "mic driver not initialized — Driver(CMD_INIT) failed or never ran",
+            )
+            return
+        log.info("mic stream client connected")
+        driver.start()
         while context.is_active():
-            chunk = mic_driver.read_chunk()
+            chunk = driver.read_chunk()
             if chunk is None:
                 break
             yield audio_pb2.AudioChunk(
@@ -74,8 +91,12 @@ def mic_stream(request, context):
                 duration_s=chunk["duration_s"],
             )
     finally:
-        mic_driver.stop()
-        log.info("mic stream client disconnected")
+        try:
+            if driver is not None:
+                driver.stop()
+                log.info("mic stream client disconnected")
+        finally:
+            _mic_stream_lock.release()
 
 
 @audio_driver.grpc("robonix/primitive/audio/speaker")
@@ -136,6 +157,8 @@ def _scan_audio_devices_proto():
     for device_id, kind in (
         (current_input_id, "input"),
         (current_output_id, "output"),
+        (configured_input_id, "input"),
+        (configured_output_id, "output"),
         (os.environ.get("AUDIO_MIC_DEVICE", "").strip(), "input"),
         (os.environ.get("AUDIO_SPEAKER_DEVICE", "").strip(), "output"),
     ):
@@ -190,6 +213,9 @@ def select_device(request, context):
         current = current_input_id if kind == "input" else current_output_id
         if current:
             valid.add(current)
+        deployment_configured = configured_input_id if kind == "input" else configured_output_id
+        if deployment_configured:
+            valid.add(deployment_configured)
         if requested not in valid:
             return audio_pb2.SelectAudioDevice_Response(
                 ok=False, error=f"unknown {kind} id '{requested}'")
@@ -206,36 +232,44 @@ def select_device(request, context):
         new_id = info.device_id
 
     if kind == "input":
-        previous = mic_driver
-        if mic_driver is not None:
-            try:
-                mic_driver.stop()
-            except Exception:  # noqa: BLE001
-                pass
-        # Auto-probe hardware sample rate unless explicitly overridden
-        mic_rate = (
-            int(os.environ["AUDIO_MIC_SAMPLE_RATE"])
-            if "AUDIO_MIC_SAMPLE_RATE" in os.environ
-            else previous.sample_rate if previous is not None
-            else probe_mic_sample_rate(new_id)
-        )
-        mic_driver = MicDriver(
-            device_id=new_id,
-            sample_rate=mic_rate,
-            channels=int(os.environ.get(
-                "AUDIO_MIC_CHANNELS",
-                str(previous.channels if previous is not None else 1),
-            )),
-            bits_per_sample=int(os.environ.get(
-                "AUDIO_MIC_BITS",
-                str(previous.bits_per_sample if previous is not None else 16),
-            )),
-            chunk_duration_s=int(os.environ.get(
-                "AUDIO_MIC_CHUNK_MS",
-                str(round((previous.chunk_duration_s if previous is not None else 0.1) * 1000)),
-            )) / 1000.0,
-        )
-        current_input_id = new_id
+        if not _mic_stream_lock.acquire(blocking=False):
+            return audio_pb2.SelectAudioDevice_Response(
+                ok=False,
+                error="cannot change input device while microphone is streaming",
+            )
+        try:
+            previous = mic_driver
+            if previous is not None:
+                try:
+                    previous.stop()
+                except Exception:  # noqa: BLE001
+                    pass
+            # Auto-probe hardware sample rate unless explicitly overridden
+            mic_rate = (
+                int(os.environ["AUDIO_MIC_SAMPLE_RATE"])
+                if "AUDIO_MIC_SAMPLE_RATE" in os.environ
+                else previous.sample_rate if previous is not None
+                else probe_mic_sample_rate(new_id)
+            )
+            mic_driver = MicDriver(
+                device_id=new_id,
+                sample_rate=mic_rate,
+                channels=int(os.environ.get(
+                    "AUDIO_MIC_CHANNELS",
+                    str(previous.channels if previous is not None else 1),
+                )),
+                bits_per_sample=int(os.environ.get(
+                    "AUDIO_MIC_BITS",
+                    str(previous.bits_per_sample if previous is not None else 16),
+                )),
+                chunk_duration_s=int(os.environ.get(
+                    "AUDIO_MIC_CHUNK_MS",
+                    str(round((previous.chunk_duration_s if previous is not None else 0.1) * 1000)),
+                )) / 1000.0,
+            )
+            current_input_id = new_id
+        finally:
+            _mic_stream_lock.release()
     else:
         previous = speaker_driver
         speaker_driver = SpeakerDriver(
@@ -267,6 +301,7 @@ def init(cfg):
     compatible operator override for older manifests.
     """
     global mic_driver, speaker_driver, current_input_id, current_output_id
+    global configured_input_id, configured_output_id
 
     devices = scan_alsa_devices()
     for d in devices:
@@ -313,6 +348,7 @@ def init(cfg):
             chunk_duration_s=int(cfg.get("mic_chunk_ms") or os.environ.get("AUDIO_MIC_CHUNK_MS", "100")) / 1000.0,
         )
         current_input_id = mic_dev_id
+        configured_input_id = mic_dev_id
 
     if spk_dev_id is not None:
         speaker_driver = SpeakerDriver(
@@ -322,6 +358,7 @@ def init(cfg):
             bits_per_sample=int(cfg.get("speaker_bits") or os.environ.get("AUDIO_SPEAKER_BITS", "16")),
         )
         current_output_id = spk_dev_id
+        configured_output_id = spk_dev_id
     return Ok()
 
 

--- a/examples/webots/primitives/audio_driver/audio_driver/speaker_driver.py
+++ b/examples/webots/primitives/audio_driver/audio_driver/speaker_driver.py
@@ -130,22 +130,27 @@ class SpeakerDriver:
     def stop(self) -> None:
         """Stop the aplay subprocess gracefully.
 
-        Closes stdin (signals aplay to finish), then sends SIGTERM.
-        Waits up to 5 seconds, then SIGKILL if necessary.
+        Closing stdin lets aplay drain its device buffer and exit normally.
+        Only send SIGTERM/SIGKILL if it does not exit within the deadline.
         Safe to call multiple times.
         """
         with self._lock:
-            if self._process:
+            process = self._process
+            self._process = None
+            if process:
                 try:
-                    self._process.stdin.close()
+                    process.stdin.close()
                 except Exception:
                     pass
-                self._process.terminate()
                 try:
-                    self._process.wait(timeout=5)
+                    process.wait(timeout=5)
                 except subprocess.TimeoutExpired:
-                    self._process.kill()
-                self._process = None
+                    process.terminate()
+                    try:
+                        process.wait(timeout=1)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        process.wait(timeout=1)
                 log.info("Speaker playback stopped")
 
     @property

--- a/examples/webots/primitives/audio_driver/test_speaker_driver.py
+++ b/examples/webots/primitives/audio_driver/test_speaker_driver.py
@@ -1,0 +1,42 @@
+import subprocess
+import unittest
+from unittest import mock
+
+from audio_driver.speaker_driver import SpeakerDriver
+
+
+class SpeakerDriverStopTest(unittest.TestCase):
+    def test_stop_closes_stdin_and_allows_normal_drain(self):
+        driver = SpeakerDriver("null")
+        process = mock.Mock()
+        process.wait.return_value = 0
+        driver._process = process
+
+        driver.stop()
+
+        process.stdin.close.assert_called_once_with()
+        process.wait.assert_called_once_with(timeout=5)
+        process.terminate.assert_not_called()
+        process.kill.assert_not_called()
+        self.assertFalse(driver.is_running)
+
+    def test_stop_terminates_then_kills_a_stuck_player(self):
+        driver = SpeakerDriver("null")
+        process = mock.Mock()
+        process.wait.side_effect = [
+            subprocess.TimeoutExpired("aplay", 5),
+            subprocess.TimeoutExpired("aplay", 1),
+            0,
+        ]
+        driver._process = process
+
+        driver.stop()
+
+        process.terminate.assert_called_once_with()
+        process.kill.assert_called_once_with()
+        self.assertEqual(process.wait.call_count, 3)
+        self.assertFalse(driver.is_running)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/webots/robonix_manifest.yaml
+++ b/examples/webots/robonix_manifest.yaml
@@ -33,6 +33,10 @@ system:
   liaison:
     listen: 0.0.0.0:50081
     log: info
+    # Disabled until the operator enables it from robonix-client. The client
+    # then supplies its persisted input/output provider selection; no client
+    # address is stored in this deployment.
+    handsfree_enabled: false
 
 # after booted all the system components, start the devices (primitives)
 # the robonix boot "device tree"
@@ -72,21 +76,18 @@ primitive:
       update_rate: 10
       frame_id: lidar
   # ── audio mic/speaker source ─────────────────────────────────────────────
-  # Default: local ALSA via audio_driver. liaison/speech resolve
-  # robonix/primitive/audio/{mic,speaker} from whichever single provider is
-  # active here.
+  # Local ALSA provider. It remains available for robot-local audio.
   - name: audio_driver
     path: ./primitives/audio_driver
     config: {}
-  # audio client bridge variant (opt-in): relays mic/speaker over a WebSocket from a
-  # client machine across the LAN. To use it, comment out the audio_driver block
-  # above and uncomment this one, then point host at the client machine's address
-  # and run client_audio_server/server.py (or server_web.py) on it.
-  # - name: audio_client_bridge
-  #   path: ./primitives/audio_client_bridge
-  #   config:
-  #     host: 127.0.0.1           # client machine address reachable by robonix
-  #     port: 60000
+  # Reverse bridge for a robonix-client audio route. It advertises its
+  # endpoint through Atlas and waits for the client to connect, so neither
+  # this manifest nor Liaison stores a client IP.
+  - name: audio_client_bridge
+    path: ./primitives/audio_client_bridge
+    config:
+      transport: reverse
+      listen_port: 60002
 
 # after booted all the primitives, start the services
 service:
@@ -94,18 +95,16 @@ service:
   # agent. Lives at services/memsearch in the robonix tree; pilot
   # queries it for relevant past context when planning.
   - name: memory
-    path: ../../services/memsearch
+    path: ${ROBONIX_SOURCE_PATH}/services/memsearch
     config:
       backend: sqlite
 
   # speech — ASR + TTS. Provides robonix/service/speech/asr_stream + tts that
-  # liaison's voice loop connects to. Captures mic through the
-  # robonix/primitive/audio/mic primitive, which `audio_driver` (primitive
-  # section above) provides — so voice runs fully local on this host's ALSA
-  # mic. The audio client bridge variant can be enabled in this primitive section when the mic/speaker live on a client machine.
+  # liaison's voice loop connects to. The selected audio provider is supplied
+  # by the client for F2, voice steer, and hands-free turns.
   # disable_whisper => FunASR-only (Paraformer) streaming ASR path.
   - name: speech
-    path: ../../services/speech
+    path: ${ROBONIX_SOURCE_PATH}/services/speech
     config:
       disable_whisper: true
       funasr_device: cuda
@@ -117,7 +116,7 @@ service:
   # modal enrolls/lists speakers. Config is env-driven (port 50092,
   # threshold 0.25, device auto) so the manifest block stays empty.
   - name: voiceprint
-    path: ../../services/voiceprint
+    path: ${ROBONIX_SOURCE_PATH}/services/voiceprint
     config: {}
 
   # mapping_rbnx — SLAM service. Listed FIRST because simple_nav

--- a/examples/webots/robonix_manifest.yaml
+++ b/examples/webots/robonix_manifest.yaml
@@ -1,17 +1,11 @@
 manifestVersion: 1
 name: robonix-webots-example-deploy
 
-env:
-  # FALLBACK binding of scene's semantic store to the named SLAM map of
-  # `mapping` below (the join key between geometric + semantic maps).
-  # Scene now learns the map identity from mapping's latched
-  # robonix/service/map/lifecycle broadcast (authoritative, wins over
-  # this env) — but in this boot order scene starts BEFORE mapping, so
-  # the first boot binds from this env; keep it == mapping's `map_id`.
-  # A scene restart while mapping runs binds from the broadcast alone.
-  # Propagated by `rbnx boot` into the process env, which scene's
-  # start.sh forwards as `-e SCENE_MAP_ID` into the container.
-  SCENE_MAP_ID: webots_lab
+# Default Webots boot starts a fresh live SLAM session. The map/room UI
+# names and persists that session when the operator clicks Save; clicking
+# Load later switches mapping to localization mode and binds scene objects +
+# room annotations to the selected saved map. Do not set SCENE_MAP_ID here: a
+# static default would make a first run look like a loaded map.
 
 # boot in sequence: system -> soma+scene -> execution -> interaction
 system:
@@ -136,8 +130,6 @@ service:
     config:
       algo: rtabmap
       platform: x86_desktop
-      map_id: webots_lab
-      map_mode: mapping
       sensors:
         lidar2d: true # webots do not have 3d pointcloud, so we use 2d lidar
         lidar3d: false

--- a/examples/webots/robonix_manifest.yaml
+++ b/examples/webots/robonix_manifest.yaml
@@ -2,10 +2,15 @@ manifestVersion: 1
 name: robonix-webots-example-deploy
 
 env:
-  # Bind scene's semantic store to the same named SLAM map as `mapping`
-  # below (the join key between geometric + semantic maps). Propagated by
-  # `rbnx boot` into the process env, which scene's start.sh forwards as
-  # `-e SCENE_MAP_ID` into the container. Keep this id == mapping's `map_id`.
+  # FALLBACK binding of scene's semantic store to the named SLAM map of
+  # `mapping` below (the join key between geometric + semantic maps).
+  # Scene now learns the map identity from mapping's latched
+  # robonix/service/map/lifecycle broadcast (authoritative, wins over
+  # this env) — but in this boot order scene starts BEFORE mapping, so
+  # the first boot binds from this env; keep it == mapping's `map_id`.
+  # A scene restart while mapping runs binds from the broadcast alone.
+  # Propagated by `rbnx boot` into the process env, which scene's
+  # start.sh forwards as `-e SCENE_MAP_ID` into the container.
   SCENE_MAP_ID: webots_lab
 
 # boot in sequence: system -> soma+scene -> execution -> interaction

--- a/examples/webots/sim/ros_ws/src/eaios_webots/worlds/complete_apartment.wbt
+++ b/examples/webots/sim/ros_ws/src/eaios_webots/worlds/complete_apartment.wbt
@@ -1319,53 +1319,17 @@ Wall {
   name "wall 7(3)"
   size 0.3 3.2 2.4
 }
-Door {
-  translation -6.24 -8.43 0
-  rotation 0 0 1 -1.5707953071795862
-  size 0.3 1 2.4
-  jointAtLeft FALSE
-  frameSize 0.001 0.05 0.05
-  frameAppearance BrushedAluminium {
-  }
-  doorHandle DoorLever {
-    jointAtLeft FALSE
-  }
-}
-Door {
-  translation -3.89 -3.95 0
-  name "door(6)"
-  size 0.3 1 2.4
-  frameSize 0.001 0.05 0.05
-  frameAppearance BrushedAluminium {
-  }
-}
-Door {
-  translation -4.94 -8.43 0
-  rotation 0 0 1 -1.5707953071795862
-  name "door(5)"
-  size 0.3 1 2.4
-  frameSize 0.001 0.05 0.05
-  frameAppearance BrushedAluminium {
-  }
-}
-Door {
-  translation -6.97 -7.24 0
-  rotation 0 0 1 3.14159
-  name "door(3)"
-  size 0.3 1 2.4
-  frameSize 0.001 0.05 0.05
-  frameAppearance BrushedAluminium {
-  }
-}
-Door {
-  translation -0.91 -6.6 0
-  rotation 0 0 1 1.5708
-  name "door(4)"
-  size 0.3 1 2.4
-  frameSize 0.001 0.05 0.05
-  frameAppearance BrushedAluminium {
-  }
-}
+
+# Interior door door removed for open-room apartment navigation.
+
+# Interior door door(6) removed for open-room apartment navigation.
+
+# Interior door door(5) removed for open-room apartment navigation.
+
+# Interior door door(3) removed for open-room apartment navigation.
+
+# Interior door door(4) removed for open-room apartment navigation.
+
 Door {
   translation 0 -7.49 0
   name "door(1)"
@@ -1374,15 +1338,8 @@ Door {
   frameAppearance BrushedAluminium {
   }
 }
-Door {
-  translation -2.14977 -8.43 0
-  rotation 0 0 1 -1.5707953071795862
-  name "door(2)"
-  size 0.3 1 2.4
-  frameSize 0.001 0.05 0.05
-  frameAppearance BrushedAluminium {
-  }
-}
+# Interior door door(2) removed for open-room apartment navigation.
+
 Wall {
   translation -2.93 -6.6 0
   rotation 0 0 1 1.5708

--- a/examples/webots/sim/stop.sh
+++ b/examples/webots/sim/stop.sh
@@ -29,8 +29,9 @@ echo "[sim/stop] killing host-side python service zombies (speech / memsearch / 
 pkill -9 -f "speech_service\\.service" 2>/dev/null || true
 pkill -9 -f "memsearch_service\\.service" 2>/dev/null || true
 pkill -9 -f "scene_service\\.service" 2>/dev/null || true
-pkill -9 -f "audio_driver\\.node" 2>/dev/null || true
-pkill -9 -f "audio_client_bridge\\.node" 2>/dev/null || true
+pkill -9 -f "audio_driver\\.main|audio_driver\\.node" 2>/dev/null || true
+pkill -9 -f "audio_client_bridge\\.main|audio_client_bridge\\.node" 2>/dev/null || true
+pkill -9 -f "voiceprint_service\\.service" 2>/dev/null || true
 pkill -9 -f "simple_nav\\.atlas_bridge" 2>/dev/null || true
 pkill -9 -f "mapping_service\\.service" 2>/dev/null || true
 

--- a/scripts/test_executor_cancel_isolation.sh
+++ b/scripts/test_executor_cancel_isolation.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MulanPSL-2.0
+# Real Executor integration test: concurrent long-running RTDL plans,
+# boundary stop, targeted cancel, and isolation of unrelated work.
+set -euo pipefail
+
+ROOT="${ROBONIX_SOURCE_PATH:-$(cd "$(dirname "$0")/.." && pwd)}"
+ATLAS_ADDR="${RBNX_TEST_ATLAS_ADDR:-127.0.0.1:51051}"
+EXECUTOR_ADDR="${RBNX_TEST_EXECUTOR_ADDR:-127.0.0.1:51061}"
+WORK="$(mktemp -d /tmp/robonix-rtdl-isolation.XXXXXX)"
+TRACE="$WORK/timeline.log"
+ATLAS_LOG="$WORK/atlas.log"
+EXECUTOR_LOG="$WORK/executor.log"
+
+cleanup() {
+  local rc=$?
+  if [[ -n "${EXECUTOR_PID:-}" ]]; then kill "$EXECUTOR_PID" 2>/dev/null || true; fi
+  if [[ -n "${ATLAS_PID:-}" ]]; then kill "$ATLAS_PID" 2>/dev/null || true; fi
+  wait "${EXECUTOR_PID:-}" 2>/dev/null || true
+  wait "${ATLAS_PID:-}" 2>/dev/null || true
+  if [[ $rc -ne 0 ]]; then
+    echo "FAIL: artifacts retained at $WORK" >&2
+    echo "--- executor log tail ---" >&2
+    tail -80 "$EXECUTOR_LOG" >&2 || true
+  else
+    rm -rf "$WORK"
+  fi
+  exit "$rc"
+}
+trap cleanup EXIT INT TERM
+
+export ROBONIX_SOURCE_PATH="$ROOT"
+export SCRIBE_STDOUT_LEVEL=warn
+export SCRIBE_FILE_LEVEL=debug
+
+"$HOME/.cargo/bin/robonix-atlas" \
+  --listen "$ATLAS_ADDR" \
+  --capabilities "$ROOT/capabilities" \
+  >"$ATLAS_LOG" 2>&1 &
+ATLAS_PID=$!
+
+python3 - "$ATLAS_ADDR" <<'PY'
+import socket, sys, time
+host, port = sys.argv[1].rsplit(":", 1)
+deadline = time.time() + 10
+while time.time() < deadline:
+    try:
+        with socket.create_connection((host, int(port)), timeout=0.25):
+            raise SystemExit(0)
+    except OSError:
+        time.sleep(0.1)
+raise SystemExit("atlas did not listen within 10s")
+PY
+
+"$HOME/.cargo/bin/robonix-executor" \
+  --atlas "$ATLAS_ADDR" \
+  --listen "$EXECUTOR_ADDR" \
+  --id executor \
+  >"$EXECUTOR_LOG" 2>&1 &
+EXECUTOR_PID=$!
+
+python3 - "$EXECUTOR_ADDR" <<'PY'
+import socket, sys, time
+host, port = sys.argv[1].rsplit(":", 1)
+deadline = time.time() + 10
+while time.time() < deadline:
+    try:
+        with socket.create_connection((host, int(port)), timeout=0.25):
+            raise SystemExit(0)
+    except OSError:
+        time.sleep(0.1)
+raise SystemExit("executor did not listen within 10s")
+PY
+
+PROTO_GEN="$(find "$ROOT" -path '*/rbnx-build/codegen/proto_gen/robonix_contracts_pb2_grpc.py' -print -quit | xargs dirname)"
+if [[ -z "$PROTO_GEN" || ! -d "$PROTO_GEN" ]]; then
+  echo "generated Python gRPC stubs not found; build one Robonix package first" >&2
+  exit 2
+fi
+
+PYTHONPATH="$PROTO_GEN${PYTHONPATH:+:$PYTHONPATH}" python3 - "$EXECUTOR_ADDR" "$TRACE" <<'PY'
+import asyncio
+import json
+import pathlib
+import shlex
+import sys
+import time
+
+import grpc
+import pilot_pb2
+import robonix_contracts_pb2_grpc as contracts
+
+endpoint, trace_arg = sys.argv[1:3]
+trace = pathlib.Path(trace_arg)
+started = time.monotonic()
+session_id = "bash-cancel-isolation"
+
+
+def rel() -> float:
+    return time.monotonic() - started
+
+
+def shell_mark(label: str, sleep_s: int, end: str | None = None) -> str:
+    target = shlex.quote(str(trace))
+    command = f'printf "%.3f {label}\\n" "$(date +%s.%N)" >> {target}; sleep {sleep_s}'
+    if end:
+        command += f'; printf "%.3f {end}\\n" "$(date +%s.%N)" >> {target}'
+    return command
+
+
+def bash_call(plan_id: str, call_id: str, op_id: str, description: str, command: str):
+    return pilot_pb2.RtdlNode(
+        node_kind=2,
+        op_id=op_id,
+        description=description,
+        call=pilot_pb2.CapabilityCall(
+            call_id=f"{plan_id}:{call_id}",
+            provider_id="executor",
+            contract_id="robonix/system/executor/builtin/run_command",
+            args_json=json.dumps({"command": command}),
+        ),
+    )
+
+
+def control_plan(plan_id: str, op: str, args: dict):
+    return pilot_pb2.Plan(
+        plan_id=plan_id,
+        session_id=session_id,
+        nodes=[pilot_pb2.RtdlNode(
+            node_kind=2,
+            op_id=f"{plan_id}-op",
+            description=f"{op} target plan",
+            call=pilot_pb2.CapabilityCall(
+                call_id=f"{plan_id}:0",
+                provider_id="executor",
+                contract_id=f"robonix/system/executor/builtin/{op}",
+                args_json=json.dumps(args),
+            ),
+        )],
+        root_index=0,
+    )
+
+
+plan_a = pilot_pb2.Plan(
+    plan_id="A-route",
+    session_id=session_id,
+    nodes=[
+        pilot_pb2.RtdlNode(
+            node_kind=0,
+            children=[1, 2],
+            op_id="A-sequence",
+            description="restaurant then meeting room",
+        ),
+        bash_call("A-route", "1", "A-restaurant", "move to restaurant",
+                  shell_mark("A_RESTAURANT_START", 8, "A_RESTAURANT_END")),
+        bash_call("A-route", "2", "A-meeting", "move to meeting room",
+                  shell_mark("A_MEETING_START", 20, "A_MEETING_END")),
+    ],
+    root_index=0,
+)
+
+greet_target = shlex.quote(str(trace))
+greet_cmd = (
+    f'printf "%.3f B_GREET_START\\n" "$(date +%s.%N)" >> {greet_target}; '
+    f'for i in $(seq 1 60); do printf "%.3f B_GREET_TICK_%02d\\n" '
+    f'"$(date +%s.%N)" "$i" >> {greet_target}; sleep 1; done; '
+    f'printf "%.3f B_GREET_END\\n" "$(date +%s.%N)" >> {greet_target}'
+)
+plan_b = pilot_pb2.Plan(
+    plan_id="B-greet",
+    session_id=session_id,
+    nodes=[bash_call("B-greet", "0", "B-watch", "continuous greet watch", greet_cmd)],
+    root_index=0,
+)
+plan_c = pilot_pb2.Plan(
+    plan_id="C-open-area",
+    session_id=session_id,
+    nodes=[bash_call("C-open-area", "0", "C-drive", "move to open area",
+                     shell_mark("C_OPEN_START", 30, "C_OPEN_END"))],
+    root_index=0,
+)
+plan_d = pilot_pb2.Plan(
+    plan_id="D-return-315",
+    session_id=session_id,
+    nodes=[bash_call("D-return-315", "0", "D-return", "return to office 315",
+                     shell_mark("D_315_START", 10, "D_315_END"))],
+    root_index=0,
+)
+
+events: dict[str, list] = {}
+
+
+async def drive(stub, plan):
+    rows = []
+    print(f"[{rel():6.2f}s] SUBMIT {plan.plan_id}", flush=True)
+    async for event in stub.Execute(plan):
+        if event.HasField("node_state"):
+            ns = event.node_state
+            leaf = ns.leaf_result
+            rows.append((ns.op_id, ns.state, bool(leaf.success), leaf.error))
+            print(
+                f"[{rel():6.2f}s] {plan.plan_id:<15} op={ns.op_id:<18} "
+                f"state={ns.state} success={bool(leaf.success) if ns.HasField('leaf_result') else '-'} "
+                f"error={leaf.error!r}",
+                flush=True,
+            )
+        elif event.HasField("plan_complete"):
+            print(
+                f"[{rel():6.2f}s] COMPLETE {plan.plan_id} any_failed={event.plan_complete.any_failed}",
+                flush=True,
+            )
+    events[plan.plan_id] = rows
+    return rows
+
+
+async def main():
+    async with grpc.aio.insecure_channel(endpoint) as channel:
+        stub = contracts.RobonixSystemExecutorExecuteStub(channel)
+        a = asyncio.create_task(drive(stub, plan_a))
+        b = asyncio.create_task(drive(stub, plan_b))
+
+        await asyncio.sleep(5)
+        stop_a = control_plan(
+            "ctl-stop-A",
+            "stop_plan_at",
+            {"plan_id": "A-route", "op_id": "A-meeting", "when": "on_enter"},
+        )
+        await drive(stub, stop_a)
+
+        await asyncio.sleep(max(0, 12 - rel()))
+        c = asyncio.create_task(drive(stub, plan_c))
+
+        await asyncio.sleep(5)
+        cancel_c = control_plan(
+            "ctl-cancel-C", "cancel_plan", {"plan_id": "C-open-area", "wait_ms": 5000}
+        )
+        await drive(stub, cancel_c)
+        d = asyncio.create_task(drive(stub, plan_d))
+
+        await asyncio.gather(a, c, d)
+        await b
+
+
+asyncio.run(main())
+
+lines = trace.read_text().splitlines() if trace.exists() else []
+labels = [line.split(maxsplit=1)[1] for line in lines]
+ticks = [label for label in labels if label.startswith("B_GREET_TICK_")]
+
+checks = {
+    "A restaurant completed": "A_RESTAURANT_END" in labels,
+    "A meeting never started": "A_MEETING_START" not in labels,
+    "B greet completed 60 heartbeats": len(ticks) == 60 and "B_GREET_END" in labels,
+    "C open-area started": "C_OPEN_START" in labels,
+    "C open-area was canceled before end": "C_OPEN_END" not in labels,
+    "D return 315 completed": "D_315_END" in labels,
+}
+
+def terminal_state(plan_id: str, op_id: str) -> int | None:
+    matches = [state for op, state, _ok, _err in events.get(plan_id, []) if op == op_id]
+    return matches[-1] if matches else None
+
+checks.update({
+    "A boundary node canceled": terminal_state("A-route", "A-meeting") == 4,
+    "C targeted node canceled": terminal_state("C-open-area", "C-drive") == 4,
+    "D succeeded": terminal_state("D-return-315", "D-return") == 2,
+    "B unaffected and succeeded": terminal_state("B-greet", "B-watch") == 2,
+})
+
+print("\n=== ASSERTIONS ===")
+for name, passed in checks.items():
+    print(f"{'PASS' if passed else 'FAIL'}  {name}")
+if not all(checks.values()):
+    print("\n=== TRACE ===")
+    print("\n".join(lines))
+    raise SystemExit(1)
+print(f"\nPASS: targeted cancellation isolation verified in {rel():.2f}s")
+PY

--- a/scripts/test_pilot_natural_language_rtdl.sh
+++ b/scripts/test_pilot_natural_language_rtdl.sh
@@ -1,0 +1,355 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MulanPSL-2.0
+# Black-box Pilot test: natural-language steers must produce correctly scoped
+# RTDL plans. The driver never constructs an RTDL Plan itself.
+set -euo pipefail
+
+ROOT="${ROBONIX_SOURCE_PATH:-$(cd "$(dirname "$0")/.." && pwd)}"
+DEPLOY_DIR="${ROBONIX_TEST_DEPLOY_DIR:-$HOME/robot-agilex-ranger_mini_v3}"
+ATLAS_ADDR="${RBNX_TEST_ATLAS_ADDR:-127.0.0.1:52051}"
+EXECUTOR_ADDR="${RBNX_TEST_EXECUTOR_ADDR:-127.0.0.1:52061}"
+PILOT_ADDR="${RBNX_TEST_PILOT_ADDR:-127.0.0.1:52071}"
+WORK="$(mktemp -d /tmp/robonix-pilot-language.XXXXXX)"
+TRACE="$WORK/timeline.log"
+ATLAS_LOG="$WORK/atlas.log"
+EXECUTOR_LOG="$WORK/executor.log"
+PILOT_LOG="$WORK/pilot.log"
+
+cleanup() {
+  local rc=$?
+  for pid in "${PILOT_PID:-}" "${EXECUTOR_PID:-}" "${ATLAS_PID:-}"; do
+    [[ -n "$pid" ]] && kill "$pid" 2>/dev/null || true
+  done
+  for pid in "${PILOT_PID:-}" "${EXECUTOR_PID:-}" "${ATLAS_PID:-}"; do
+    [[ -n "$pid" ]] && wait "$pid" 2>/dev/null || true
+  done
+  if [[ $rc -ne 0 ]]; then
+    echo "FAIL: artifacts retained at $WORK" >&2
+    echo "--- pilot log tail ---" >&2
+    tail -120 "$PILOT_LOG" >&2 || true
+    echo "--- executor log tail ---" >&2
+    tail -80 "$EXECUTOR_LOG" >&2 || true
+  else
+    rm -rf "$WORK"
+  fi
+  exit "$rc"
+}
+trap cleanup EXIT INT TERM
+
+if [[ ! -f "$DEPLOY_DIR/.env" ]]; then
+  echo "missing $DEPLOY_DIR/.env" >&2
+  exit 2
+fi
+set -a
+# shellcheck disable=SC1090
+source "$DEPLOY_DIR/.env"
+set +a
+: "${VLM_BASE_URL:?VLM_BASE_URL missing}"
+: "${VLM_API_KEY:?VLM_API_KEY missing}"
+: "${VLM_MODEL:?VLM_MODEL missing}"
+export ROBONIX_VLM_UPSTREAM="$VLM_BASE_URL"
+export ROBONIX_VLM_API_KEY="$VLM_API_KEY"
+export ROBONIX_VLM_MODEL="$VLM_MODEL"
+export ROBONIX_VLM_FORMAT=openai
+export ROBONIX_SOURCE_PATH="$ROOT"
+export ROBONIX_PILOT_MAX_TOOL_ROUNDS=64
+export SCRIBE_STDOUT_LEVEL=warn
+export SCRIBE_FILE_LEVEL=debug
+
+wait_port() {
+  python3 - "$1" <<'PY'
+import socket, sys, time
+host, port = sys.argv[1].rsplit(":", 1)
+deadline = time.time() + 15
+while time.time() < deadline:
+    try:
+        with socket.create_connection((host, int(port)), timeout=0.25):
+            raise SystemExit(0)
+    except OSError:
+        time.sleep(0.1)
+raise SystemExit(f"{sys.argv[1]} did not listen within 15s")
+PY
+}
+
+"$HOME/.cargo/bin/robonix-atlas" \
+  --listen "$ATLAS_ADDR" --capabilities "$ROOT/capabilities" \
+  >"$ATLAS_LOG" 2>&1 &
+ATLAS_PID=$!
+wait_port "$ATLAS_ADDR"
+
+"$HOME/.cargo/bin/robonix-executor" \
+  --atlas "$ATLAS_ADDR" --listen "$EXECUTOR_ADDR" --id executor \
+  >"$EXECUTOR_LOG" 2>&1 &
+EXECUTOR_PID=$!
+wait_port "$EXECUTOR_ADDR"
+
+"$HOME/.cargo/bin/robonix-pilot" \
+  --atlas "$ATLAS_ADDR" --listen "$PILOT_ADDR" --id pilot \
+  >"$PILOT_LOG" 2>&1 &
+PILOT_PID=$!
+wait_port "$PILOT_ADDR"
+
+PROTO_GEN="$(find "$ROOT" -path '*/rbnx-build/codegen/proto_gen/robonix_contracts_pb2_grpc.py' -print -quit | xargs dirname)"
+if [[ -z "$PROTO_GEN" || ! -d "$PROTO_GEN" ]]; then
+  echo "generated Python gRPC stubs not found; build one Robonix package first" >&2
+  exit 2
+fi
+
+PYTHONPATH="$PROTO_GEN${PYTHONPATH:+:$PYTHONPATH}" python3 - "$PILOT_ADDR" "$TRACE" <<'PY'
+import asyncio
+import json
+import pathlib
+import shlex
+import sys
+import time
+import uuid
+
+import grpc
+import pilot_pb2
+import robonix_contracts_pb2_grpc as contracts
+
+endpoint, trace_arg = sys.argv[1:3]
+trace = pathlib.Path(trace_arg)
+trace_q = shlex.quote(str(trace))
+session_id = f"pilot-language-{uuid.uuid4()}"
+turn_id = f"turn-{uuid.uuid4()}"
+started = time.monotonic()
+plans = []
+node_events = []
+task_states = []
+final_texts = []
+
+
+def rel() -> float:
+    return time.monotonic() - started
+
+
+def mark_command(start_label: str, duration: int, end_label: str) -> str:
+    return (
+        f'printf "%.3f {start_label}\\n" "$(date +%s.%N)" >> {trace_q}; '
+        f'sleep {duration}; '
+        f'printf "%.3f {end_label}\\n" "$(date +%s.%N)" >> {trace_q}'
+    )
+
+
+a1 = mark_command("A_RESTAURANT_START", 20, "A_RESTAURANT_END")
+a2 = mark_command("A_MEETING_START", 20, "A_MEETING_END")
+c_cmd = mark_command("C_OPEN_START", 30, "C_OPEN_END")
+d_cmd = mark_command("D_315_START", 10, "D_315_END")
+greet_cmd = (
+    f'printf "%.3f B_GREET_START\\n" "$(date +%s.%N)" >> {trace_q}; '
+    f'for i in $(seq 1 60); do printf "%.3f B_GREET_TICK_%02d\\n" '
+    f'"$(date +%s.%N)" "$i" >> {trace_q}; sleep 1; done; '
+    f'printf "%.3f B_GREET_END\\n" "$(date +%s.%N)" >> {trace_q}'
+)
+
+messages = {
+    "initial": (
+        "这是纯 Bash 编码代理任务，不涉及机器人硬件。请先执行任务 A1，再执行任务 A2。"
+        "A1 和 A2 是两个有先后关系、可分别停止的步骤，不要合并成一个 shell command。"
+        f"任务 A1 的命令是：{a1}。任务 A2 的命令是：{a2}。"
+    ),
+    "greet": (
+        "请同时运行一个独立的长期 greet 问候任务，持续运行，不要停止或等待前面的 A 任务。"
+        f"greet 命令是：{greet_cmd}。"
+    ),
+    "stop_after_a1": (
+        "我改变主意了：让当前 A1 步骤正常完成，但不要开始 A2。"
+        "持续 greet 任务必须继续运行，不要取消它。"
+    ),
+    "open_area": (
+        "请前往开阔区域；在这个 Bash 测试中对应启动一个新的独立任务 C。"
+        f"任务 C 的命令是：{c_cmd}。持续 greet 仍然保持运行。"
+    ),
+    "cancel_and_return": (
+        "取消前往开阔区域对应的任务 C，但不要取消持续 greet。"
+        "然后返回 315 办公室；在这个 Bash 测试中对应执行任务 D。"
+        f"任务 D 的命令是：{d_cmd}。"
+    ),
+}
+
+
+def trace_labels():
+    if not trace.exists():
+        return []
+    return [line.split(maxsplit=1)[1] for line in trace.read_text().splitlines()]
+
+
+async def wait_label(label: str, timeout: float):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if label in trace_labels():
+            return
+        await asyncio.sleep(0.2)
+    raise RuntimeError(f"timeout waiting for {label}; labels={trace_labels()}")
+
+
+async def collect_original(stream):
+    async for event in stream:
+        if event.HasField("plan"):
+            plan = event.plan
+            calls = []
+            for node in plan.nodes:
+                if node.HasField("call"):
+                    calls.append({
+                        "op_id": node.op_id,
+                        "description": node.description,
+                        "contract_id": node.call.contract_id,
+                        "args_json": node.call.args_json,
+                    })
+            plans.append({
+                "t": rel(),
+                "plan_id": plan.plan_id,
+                "round": plan.round,
+                "calls": calls,
+            })
+            print(f"[{rel():6.2f}s] PLAN {plan.plan_id} calls={len(calls)}", flush=True)
+            for call in calls:
+                print(
+                    f"           {call['contract_id'].rsplit('/', 1)[-1]} "
+                    f"op={call['op_id']} args={call['args_json'][:220]}",
+                    flush=True,
+                )
+        elif event.HasField("node_state"):
+            ns = event.node_state
+            node_events.append((rel(), ns.plan_id, ns.op_id, ns.state))
+            print(
+                f"[{rel():6.2f}s] NODE plan={ns.plan_id} op={ns.op_id} state={ns.state}",
+                flush=True,
+            )
+        elif event.HasField("task_state"):
+            task_states.append(event.task_state.status)
+            print(f"[{rel():6.2f}s] TASK_STATE {event.task_state.status}", flush=True)
+        elif event.final_text:
+            final_texts.append(event.final_text)
+            print(f"[{rel():6.2f}s] FINAL {event.final_text[:180]!r}", flush=True)
+
+
+async def submit_steer(stub, name: str):
+    print(f"[{rel():6.2f}s] STEER {name}: {messages[name]}", flush=True)
+    task = pilot_pb2.Task(
+        task_id=f"steer-{name}-{uuid.uuid4()}",
+        session_id=session_id,
+        text=messages[name],
+        context_json=json.dumps({
+            "client": "pilot-natural-language-test",
+            "interaction_mode": "steer",
+            "steer": True,
+            "expected_turn_id": turn_id,
+        }),
+    )
+    async for _ in stub.SubmitTask(task):
+        pass
+
+
+async def main():
+    async with grpc.aio.insecure_channel(endpoint) as channel:
+        stub = contracts.RobonixSystemPilotStub(channel)
+        initial = pilot_pb2.Task(
+            task_id=turn_id,
+            session_id=session_id,
+            text=messages["initial"],
+            context_json=json.dumps({
+                "client": "pilot-natural-language-test",
+                "interaction_mode": "task",
+            }),
+        )
+        original_stream = stub.SubmitTask(initial)
+        collector = asyncio.create_task(collect_original(original_stream))
+
+        await wait_label("A_RESTAURANT_START", 45)
+        await submit_steer(stub, "greet")
+        await wait_label("B_GREET_START", 45)
+
+        await asyncio.sleep(2)
+        await submit_steer(stub, "stop_after_a1")
+        await wait_label("A_RESTAURANT_END", 20)
+        await asyncio.sleep(1)
+
+        await submit_steer(stub, "open_area")
+        await wait_label("C_OPEN_START", 45)
+        await asyncio.sleep(5)
+        await submit_steer(stub, "cancel_and_return")
+        await wait_label("D_315_END", 60)
+        await wait_label("B_GREET_END", 90)
+        await asyncio.sleep(3)
+
+        collector.cancel()
+        try:
+            await collector
+        except asyncio.CancelledError:
+            pass
+
+
+asyncio.run(asyncio.wait_for(main(), timeout=210))
+
+labels = trace_labels()
+ticks = [label for label in labels if label.startswith("B_GREET_TICK_")]
+
+
+def plan_with_marker(marker: str):
+    return next(
+        (plan for plan in plans if any(marker in call["args_json"] for call in plan["calls"])),
+        None,
+    )
+
+
+plan_a1 = plan_with_marker("A_RESTAURANT_START")
+plan_a2 = plan_with_marker("A_MEETING_START")
+plan_b = plan_with_marker("B_GREET_START")
+plan_c = plan_with_marker("C_OPEN_START")
+plan_d = plan_with_marker("D_315_START")
+control_calls = [
+    (plan, call)
+    for plan in plans
+    for call in plan["calls"]
+    if call["contract_id"].rsplit("/", 1)[-1]
+    in {"cancel_plan", "cancel_all_plans", "stop_plan_at", "stop_after_current"}
+]
+cancel_targets = []
+stop_targets = []
+cancel_all_seen = False
+for _plan, call in control_calls:
+    leaf = call["contract_id"].rsplit("/", 1)[-1]
+    args = json.loads(call["args_json"] or "{}")
+    if leaf == "cancel_plan":
+        cancel_targets.append(args.get("plan_id"))
+    elif leaf in {"stop_plan_at", "stop_after_current"}:
+        stop_targets.append(args.get("plan_id"))
+    elif leaf == "cancel_all_plans":
+        cancel_all_seen = True
+
+checks = {
+    "Pilot planned A1": plan_a1 is not None,
+    "A1 completed": "A_RESTAURANT_END" in labels,
+    "A2 never started": "A_MEETING_START" not in labels,
+    "Pilot planned independent greet": plan_b is not None,
+    "greet produced all 60 heartbeats": len(ticks) == 60 and "B_GREET_END" in labels,
+    "Pilot planned open-area task C": plan_c is not None,
+    "C started but did not finish": "C_OPEN_START" in labels and "C_OPEN_END" not in labels,
+    "Pilot planned return task D": plan_d is not None,
+    "D completed": "D_315_END" in labels,
+    "cancel targeted C": plan_c is not None and plan_c["plan_id"] in cancel_targets,
+    "cancel did not target greet": plan_b is not None and plan_b["plan_id"] not in cancel_targets,
+    "cancel_all was never used": not cancel_all_seen,
+}
+
+# If A2 was already placed in the same in-flight tree as A1, Pilot must arm a
+# boundary stop. If A2 was not yet dispatched, latest-steer suppression is the
+# correct behavior and no stop call is required.
+if plan_a2 is not None and plan_a1 is not None and plan_a2["plan_id"] == plan_a1["plan_id"]:
+    checks["A sequence had a targeted boundary stop"] = plan_a1["plan_id"] in stop_targets
+else:
+    checks["latest steer suppressed undispatched A2"] = "A_MEETING_START" not in labels
+
+print("\n=== PILOT BLACK-BOX ASSERTIONS ===")
+for name, passed in checks.items():
+    print(f"{'PASS' if passed else 'FAIL'}  {name}")
+if not all(checks.values()):
+    print("\n=== PLAN RECORDS ===")
+    print(json.dumps(plans, ensure_ascii=False, indent=2))
+    print("\n=== TRACE ===")
+    print(trace.read_text() if trace.exists() else "<empty>")
+    raise SystemExit(1)
+print(f"\nPASS: natural-language Pilot RTDL management verified in {rel():.2f}s")
+PY

--- a/scripts/test_pilot_natural_language_rtdl.sh
+++ b/scripts/test_pilot_natural_language_rtdl.sh
@@ -118,6 +118,8 @@ plans = []
 node_events = []
 task_states = []
 final_texts = []
+text_chunks = []
+milestones = {}
 
 
 def rel() -> float:
@@ -132,9 +134,9 @@ def mark_command(start_label: str, duration: int, end_label: str) -> str:
     )
 
 
-a1 = mark_command("A_RESTAURANT_START", 20, "A_RESTAURANT_END")
+a1 = mark_command("A_RESTAURANT_START", 60, "A_RESTAURANT_END")
 a2 = mark_command("A_MEETING_START", 20, "A_MEETING_END")
-c_cmd = mark_command("C_OPEN_START", 30, "C_OPEN_END")
+c_cmd = mark_command("C_OPEN_START", 60, "C_OPEN_END")
 d_cmd = mark_command("D_315_START", 10, "D_315_END")
 greet_cmd = (
     f'printf "%.3f B_GREET_START\\n" "$(date +%s.%N)" >> {trace_q}; '
@@ -184,9 +186,21 @@ async def wait_label(label: str, timeout: float):
     raise RuntimeError(f"timeout waiting for {label}; labels={trace_labels()}")
 
 
-async def collect_original(stream):
+async def wait_final_after(after: float, timeout: float):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if any(event_time >= after for event_time, _ in final_texts):
+            return
+        await asyncio.sleep(0.2)
+    raise RuntimeError(f"timeout waiting for final reply after t={after:.2f}")
+
+
+async def collect_stream(stream):
     async for event in stream:
-        if event.HasField("plan"):
+        if event.text_chunk:
+            text_chunks.append((rel(), event.text_chunk))
+            print(f"[{rel():6.2f}s] TEXT {event.text_chunk[:180]!r}", flush=True)
+        elif event.HasField("plan"):
             plan = event.plan
             calls = []
             for node in plan.nodes:
@@ -221,7 +235,7 @@ async def collect_original(stream):
             task_states.append(event.task_state.status)
             print(f"[{rel():6.2f}s] TASK_STATE {event.task_state.status}", flush=True)
         elif event.final_text:
-            final_texts.append(event.final_text)
+            final_texts.append((rel(), event.final_text))
             print(f"[{rel():6.2f}s] FINAL {event.final_text[:180]!r}", flush=True)
 
 
@@ -238,8 +252,9 @@ async def submit_steer(stub, name: str):
             "expected_turn_id": turn_id,
         }),
     )
-    async for _ in stub.SubmitTask(task):
-        pass
+    collector = asyncio.create_task(collect_stream(stub.SubmitTask(task)))
+    await asyncio.sleep(0)
+    return collector
 
 
 async def main():
@@ -255,30 +270,36 @@ async def main():
             }),
         )
         original_stream = stub.SubmitTask(initial)
-        collector = asyncio.create_task(collect_original(original_stream))
+        collectors = [asyncio.create_task(collect_stream(original_stream))]
 
         await wait_label("A_RESTAURANT_START", 45)
-        await submit_steer(stub, "greet")
+        collectors.append(await submit_steer(stub, "greet"))
         await wait_label("B_GREET_START", 45)
 
         await asyncio.sleep(2)
-        await submit_steer(stub, "stop_after_a1")
-        await wait_label("A_RESTAURANT_END", 20)
+        collectors.append(await submit_steer(stub, "stop_after_a1"))
+        await wait_label("A_RESTAURANT_END", 65)
+        milestones["a_stopped"] = rel()
+        await wait_final_after(milestones["a_stopped"], 45)
         await asyncio.sleep(1)
 
-        await submit_steer(stub, "open_area")
+        collectors.append(await submit_steer(stub, "open_area"))
         await wait_label("C_OPEN_START", 45)
         await asyncio.sleep(5)
-        await submit_steer(stub, "cancel_and_return")
+        collectors.append(await submit_steer(stub, "cancel_and_return"))
         await wait_label("D_315_END", 60)
+        milestones["d_completed"] = rel()
+        await wait_final_after(milestones["d_completed"], 45)
         await wait_label("B_GREET_END", 90)
         await asyncio.sleep(3)
 
-        collector.cancel()
-        try:
-            await collector
-        except asyncio.CancelledError:
-            pass
+        for collector in collectors:
+            collector.cancel()
+        for collector in collectors:
+            try:
+                await collector
+            except asyncio.CancelledError:
+                pass
 
 
 asyncio.run(asyncio.wait_for(main(), timeout=210))
@@ -334,6 +355,16 @@ checks = {
     "cancel targeted C": plan_c is not None and plan_c["plan_id"] in cancel_targets,
     "cancel did not target greet": plan_b is not None and plan_b["plan_id"] not in cancel_targets,
     "cancel_all was never used": not cancel_all_seen,
+    "each RTDL plan had live natural-language feedback": len(text_chunks) >= len(plans),
+    "no final reply was broadcast more than once": len({text for _, text in final_texts}) == len(final_texts),
+    "return completion reply followed D completion": any(
+        event_time >= milestones.get("d_completed", float("inf"))
+        for event_time, _ in final_texts
+    ),
+    "boundary-stop completion reply followed A1 completion": any(
+        event_time >= milestones.get("a_stopped", float("inf"))
+        for event_time, _ in final_texts
+    ),
 }
 
 # If A2 was already placed in the same in-flight tree as A1, Pilot must arm a

--- a/scripts/test_pilot_natural_language_rtdl.sh
+++ b/scripts/test_pilot_natural_language_rtdl.sh
@@ -154,7 +154,7 @@ messages = {
         f"greet 命令是：{greet_cmd}。"
     ),
     "stop_after_a1": (
-        "我改变主意了：让当前 A1 步骤正常完成，但不要开始 A2。"
+        "我改变主意了：请在 A1 任务完成之后停止整个 A 计划。"
         "持续 greet 任务必须继续运行，不要取消它。"
     ),
     "open_area": (
@@ -304,18 +304,20 @@ control_calls = [
     for plan in plans
     for call in plan["calls"]
     if call["contract_id"].rsplit("/", 1)[-1]
-    in {"cancel_plan", "cancel_all_plans", "stop_plan_at", "stop_after_current"}
+    in {"cancel_plan", "cancel_all_plans", "stop_plan_at"}
 ]
 cancel_targets = []
 stop_targets = []
+stop_records = []
 cancel_all_seen = False
 for _plan, call in control_calls:
     leaf = call["contract_id"].rsplit("/", 1)[-1]
     args = json.loads(call["args_json"] or "{}")
     if leaf == "cancel_plan":
         cancel_targets.append(args.get("plan_id"))
-    elif leaf in {"stop_plan_at", "stop_after_current"}:
+    elif leaf == "stop_plan_at":
         stop_targets.append(args.get("plan_id"))
+        stop_records.append(args)
     elif leaf == "cancel_all_plans":
         cancel_all_seen = True
 
@@ -338,7 +340,17 @@ checks = {
 # boundary stop. If A2 was not yet dispatched, latest-steer suppression is the
 # correct behavior and no stop call is required.
 if plan_a2 is not None and plan_a1 is not None and plan_a2["plan_id"] == plan_a1["plan_id"]:
-    checks["A sequence had a targeted boundary stop"] = plan_a1["plan_id"] in stop_targets
+    a1_op = next(
+        call["op_id"]
+        for call in plan_a1["calls"]
+        if "A_RESTAURANT_START" in call["args_json"]
+    )
+    checks["A sequence stopped at the explicit A1 boundary"] = any(
+        record.get("plan_id") == plan_a1["plan_id"]
+        and record.get("op_id") == a1_op
+        and record.get("when", "on_complete") == "on_complete"
+        for record in stop_records
+    )
 else:
     checks["latest steer suppressed undispatched A2"] = "A_MEETING_START" not in labels
 

--- a/services/speech/speech_service/service.py
+++ b/services/speech/speech_service/service.py
@@ -895,10 +895,11 @@ class SpeechWakeWordServicer(SpeechWakeWordBase):
             context.set_details("wake-word backend is unavailable; run the speech package build")
             return speech_pb2.DetectWakeWord_Response(error="wake-word backend unavailable")
         try:
+            # Robonix codegen unwraps the sole request field for a client-stream
+            # RPC. gRPC therefore yields bare audio.AudioChunk messages here,
+            # not DetectWakeWord_Request wrappers.
             keyword = self.backend.detect(
-                bytes(request.chunk.data)
-                for request in request_iterator
-                if request.chunk and request.chunk.data
+                bytes(chunk.data) for chunk in request_iterator if chunk.data
             )
             return speech_pb2.DetectWakeWord_Response(
                 detected=bool(keyword),

--- a/services/speech/speech_service/service.py
+++ b/services/speech/speech_service/service.py
@@ -895,7 +895,11 @@ class SpeechWakeWordServicer(SpeechWakeWordBase):
             context.set_details("wake-word backend is unavailable; run the speech package build")
             return speech_pb2.DetectWakeWord_Response(error="wake-word backend unavailable")
         try:
-            keyword = self.backend.detect(bytes(chunk.data) for chunk in request_iterator if chunk.data)
+            keyword = self.backend.detect(
+                bytes(request.chunk.data)
+                for request in request_iterator
+                if request.chunk and request.chunk.data
+            )
             return speech_pb2.DetectWakeWord_Response(
                 detected=bool(keyword),
                 keyword=keyword,

--- a/services/speech/speech_service/tencent_cloud.py
+++ b/services/speech/speech_service/tencent_cloud.py
@@ -234,19 +234,23 @@ class TencentRealtimeASRBackend:
 
     @staticmethod
     def _to_incremental_event(event: dict, last_text: str) -> tuple[dict | None, str]:
-        """Convert Tencent cumulative hypotheses into Liaison's incremental ASR text."""
+        """Hold Tencent's revisable hypothesis until it becomes final.
+
+        Tencent sends cumulative snapshots and may rewrite earlier characters
+        between snapshots.  Liaison's stream contract is append-only, so a
+        revised snapshot cannot be represented as a safe delta (for example
+        ``I may`` may become ``I have already...``). Emitting partials would
+        concatenate every revision.  Keep only the newest snapshot and emit it
+        once when Tencent marks it final.
+        """
         text = event.get("text", "")
         if not text:
             return None, last_text
-        if text.startswith(last_text):
-            delta = text[len(last_text) :]
-        else:
-            delta = text
         last_text = text
-        if not delta and not event.get("is_final", False):
+        if not event.get("is_final", False):
             return None, last_text
         out = dict(event)
-        out["text"] = delta
+        out["text"] = last_text
         return out, last_text
 
 

--- a/services/speech/speech_service/tencent_cloud.py
+++ b/services/speech/speech_service/tencent_cloud.py
@@ -78,7 +78,12 @@ class TencentRealtimeASRBackend:
         self.filter_punc = int(os.environ.get("TENCENT_ASR_FILTER_PUNC", "0"))
         self.chunk_bytes = int(os.environ.get("TENCENT_ASR_CHUNK_BYTES", "6400"))
         self.recv_timeout_s = float(os.environ.get("TENCENT_ASR_RECV_TIMEOUT", "0.05"))
-        log.info("Tencent ASR initialized (engine=%s)", self.engine)
+        log.info(
+            "Tencent ASR initialized (appid=%s engine=%s credential=%s)",
+            self.creds.appid,
+            self.engine,
+            self._credential_fingerprint(self.creds),
+        )
 
     def recognize(
         self,
@@ -101,7 +106,17 @@ class TencentRealtimeASRBackend:
     def recognize_stream(self, pcm_chunks: Iterator[bytes]) -> Iterator[dict]:
         url = self._signed_url()
         last_text = ""
-        with connect(url, max_size=None, open_timeout=5, close_timeout=2) as ws:
+        # Robot deployments may export a proxy for GitHub/model downloads.
+        # Tencent's signed ASR WebSocket must connect directly: inheriting
+        # HTTP_PROXY/ALL_PROXY can route the handshake through a local proxy
+        # and Tencent then reports a misleading resource-package error (4004).
+        with connect(
+            url,
+            max_size=None,
+            open_timeout=5,
+            close_timeout=2,
+            proxy=None,
+        ) as ws:
             first = self._recv_json(ws, timeout_s=5.0)
             if first and first.get("code", 0) != 0:
                 raise RuntimeError(f"Tencent ASR handshake failed: {first}")
@@ -141,6 +156,12 @@ class TencentRealtimeASRBackend:
                     break
 
     def _signed_url(self) -> str:
+        # Driver(INIT) is allowed to update the manifest-backed Tencent
+        # settings after the service process has started. Refresh the session
+        # snapshot here so a long-lived backend never signs with stale AppID
+        # or credentials captured by an earlier initialization attempt.
+        self.creds = TencentCredentials.from_env()
+        self.engine = os.environ.get("TENCENT_ASR_ENGINE", "16k_zh_en")
         now = int(time.time())
         params = {
             "engine_model_type": self.engine,
@@ -167,6 +188,11 @@ class TencentRealtimeASRBackend:
             f"wss://{self.host}/asr/v2/{self.creds.appid}?"
             f"{query}&signature={quote(signature, safe='')}"
         )
+
+    @staticmethod
+    def _credential_fingerprint(creds: TencentCredentials) -> str:
+        material = f"{creds.appid}\0{creds.secret_id}".encode("utf-8")
+        return hashlib.sha256(material).hexdigest()[:12]
 
     def _chunk_pcm(self, audio_data: bytes) -> Iterator[bytes]:
         for i in range(0, len(audio_data), self.chunk_bytes):

--- a/services/speech/tests/test_tencent_cloud.py
+++ b/services/speech/tests/test_tencent_cloud.py
@@ -1,0 +1,32 @@
+import unittest
+
+from speech_service.tencent_cloud import TencentRealtimeASRBackend
+
+
+class TencentStreamingTranscriptTest(unittest.TestCase):
+    def test_revisable_hypotheses_emit_only_final_snapshot(self):
+        last = ""
+        emitted = []
+        for text, final in [
+            ("okay, I may", False),
+            ("okay, I have seen him", False),
+            ("okay, I have seen it start", True),
+        ]:
+            event, last = TencentRealtimeASRBackend._to_incremental_event(
+                {"text": text, "is_final": final, "event_type": int(final)}, last
+            )
+            if event is not None:
+                emitted.append(event["text"])
+
+        self.assertEqual(emitted, ["okay, I have seen it start"])
+
+    def test_nonfinal_duplicate_snapshot_is_suppressed(self):
+        event, last = TencentRealtimeASRBackend._to_incremental_event(
+            {"text": "still there", "is_final": False}, "still there"
+        )
+        self.assertIsNone(event)
+        self.assertEqual(last, "still there")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/services/voiceprint/voiceprint_service/engine.py
+++ b/services/voiceprint/voiceprint_service/engine.py
@@ -27,6 +27,7 @@ from typing import Optional
 _MODELSCOPE_ID = "speechbrain/spkrec-ecapa-voxceleb"
 
 import numpy as np
+import soundfile as sf
 import torch
 import torchaudio
 
@@ -58,14 +59,16 @@ class EcapaTdnnEngine:
         self.savedir = Path(savedir) if savedir else _DEFAULT_SAVEDIR
         self.savedir.mkdir(parents=True, exist_ok=True)
         # Resolve the model from ModelScope (returns a local snapshot dir with
-        # the full repo). Passing that dir as `source` makes speechbrain read
-        # every weight locally — it never touches HuggingFace. The snapshot is
-        # cached after the first pull (build.sh pre-warms it).
+        # the full repo). The upstream hyperparams file still names its
+        # Hugging Face repository in `pretrained_path`, so pass an explicit
+        # override as well as the local source. Without it SpeechBrain fetches
+        # checkpoint metadata from Hugging Face despite the local snapshot.
         source = self._resolve_source()
         log.info("Loading ECAPA-TDNN on %s (source=%s, savedir=%s)", self.device, source, self.savedir)
         self.model = SpeakerRecognition.from_hparams(
             source=source,
             savedir=str(self.savedir),
+            overrides={"pretrained_path": str(source)},
             run_opts={"device": self.device},
         )
         log.info("ECAPA-TDNN loaded (embedding_dim=192)")
@@ -82,7 +85,14 @@ class EcapaTdnnEngine:
     # -- public extraction -------------------------------------------------
 
     def extract_from_file(self, path: str) -> np.ndarray:
-        signal, _ = torchaudio.load(path)
+        # Do not use torchaudio.load here: current torchaudio releases route
+        # it through optional torchcodec, which is not needed for the WAV/FLAC
+        # files supported by this service. soundfile is already a declared
+        # runtime dependency and keeps build-time model verification sealed.
+        samples, _ = sf.read(path, dtype="float32", always_2d=True)
+        signal = torch.from_numpy(samples.T)
+        if signal.shape[0] > 1:
+            signal = signal.mean(dim=0, keepdim=True)
         emb = self.model.encode_batch(signal.to(self.device))
         return emb.cpu().numpy().flatten()
 

--- a/system/executor/Cargo.toml
+++ b/system/executor/Cargo.toml
@@ -25,6 +25,9 @@ uuid.workspace = true
 rmcp = { workspace = true, features = ["client", "transport-child-process", "transport-streamable-http-client-reqwest"] }
 robonix-atlas = { path = "../atlas" }
 
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.31", features = ["signal", "process"] }
+
 [build-dependencies]
 robonix-codegen.workspace = true
 tonic-build.workspace = true

--- a/system/executor/src/dispatch/async_poll.rs
+++ b/system/executor/src/dispatch/async_poll.rs
@@ -27,7 +27,7 @@ pub async fn run_until_terminal(
     node: &NodeEventContext,
     runtime: &PlanRuntime,
 ) -> CapabilityCallResult {
-    let initial = dispatch::dispatch(call, self_provider_id, atlas, runtime).await;
+    let initial = dispatch::dispatch(call, self_provider_id, atlas, runtime, &node.plan_id).await;
     if !initial.success {
         let _ = tx
             .send(Ok(rtdl_wire::node_state_from_result(

--- a/system/executor/src/dispatch/builtin.rs
+++ b/system/executor/src/dispatch/builtin.rs
@@ -84,9 +84,6 @@ pub async fn execute(
     if op == "stop_plan_at" {
         return runtime.stop_plan_at_builtin(call).await;
     }
-    if op == "stop_after_current" {
-        return runtime.stop_after_current_builtin(call).await;
-    }
     if op == "get_plan_status" {
         return runtime.get_plan_status_builtin(call).await;
     }
@@ -186,11 +183,6 @@ pub const BUILTINS: &[BuiltinSpec] = &[
         op: "stop_plan_at",
         description: "Set a stop point on an in-flight RTDL plan: when execution reaches the op with the given op_id, cancel the whole plan. Use 'on_complete' (default) to stop right after that op finishes, or 'on_enter' to stop the moment it is reached, before it runs. op_ids are the per-node identifiers shown in RTDL node_state events.",
         input_schema_json: r#"{"type":"object","properties":{"plan_id":{"type":"string","description":"RTDL Plan.plan_id to set the stop point on"},"op_id":{"type":"string","description":"Node op_id at which to stop (cancel) the plan"},"when":{"type":"string","enum":["on_enter","on_complete"],"description":"on_enter = before the op runs; on_complete = after it finishes. Default on_complete."}},"required":["plan_id","op_id"]}"#,
-    },
-    BuiltinSpec {
-        op: "stop_after_current",
-        description: "Atomically stop one in-flight sequential RTDL plan after its currently running step completes. Use this directly when the user says 'finish the current step, then stop' or 'do not start the next step'. It takes only plan_id and avoids a get_plan_status round trip. If execution is between steps it stops before the next pending step. It rejects ambiguous parallel plans with multiple running leaves; only then inspect and use stop_plan_at.",
-        input_schema_json: r#"{"type":"object","properties":{"plan_id":{"type":"string","description":"RTDL Plan.plan_id whose current sequential step may finish, after which the plan stops"}},"required":["plan_id"]}"#,
     },
     BuiltinSpec {
         op: "read_capability_doc",

--- a/system/executor/src/dispatch/builtin.rs
+++ b/system/executor/src/dispatch/builtin.rs
@@ -69,6 +69,7 @@ pub async fn execute(
     runtime: &PlanRuntime,
     self_provider_id: &str,
     atlas: &mut AtlasClient,
+    plan_id: &str,
 ) -> CapabilityCallResult {
     let op = call
         .contract_id
@@ -93,7 +94,7 @@ pub async fn execute(
         return read_capability_doc(call, atlas).await;
     }
 
-    let result = run(op, &call.args_json).await;
+    let result = run(op, &call.args_json, runtime, plan_id).await;
     let mut out = CapabilityCallResult {
         call_id: call.call_id.clone(),
         provider_id: call.provider_id.clone(),
@@ -113,13 +114,18 @@ pub async fn execute(
     out
 }
 
-async fn run(op: &str, args_json: &str) -> anyhow::Result<String> {
+async fn run(
+    op: &str,
+    args_json: &str,
+    runtime: &PlanRuntime,
+    plan_id: &str,
+) -> anyhow::Result<String> {
     match op {
         "read_file" => read_file(args_json),
         "write_file" => write_file(args_json),
         "patch_file" => patch_file(args_json),
         "list_dir" => list_dir(args_json),
-        "run_command" => run_command(args_json).await,
+        "run_command" => run_command(args_json, runtime, plan_id).await,
         other => anyhow::bail!("unknown builtin: {}", other),
     }
 }
@@ -336,7 +342,7 @@ const MAX_COMMAND_LEN: usize = 8192;
 /// Command execution timeout.
 const COMMAND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
 
-async fn run_command(args: &str) -> anyhow::Result<String> {
+async fn run_command(args: &str, runtime: &PlanRuntime, plan_id: &str) -> anyhow::Result<String> {
     let a: CmdArgs = serde_json::from_str(args)?;
     if a.command.len() > MAX_COMMAND_LEN {
         anyhow::bail!(
@@ -345,14 +351,85 @@ async fn run_command(args: &str) -> anyhow::Result<String> {
             MAX_COMMAND_LEN
         );
     }
-    let child = tokio::process::Command::new("bash")
+    if runtime.is_cancelled(plan_id).await {
+        anyhow::bail!("command canceled before spawn");
+    }
+
+    use std::process::Stdio;
+    let mut command = tokio::process::Command::new("bash");
+    command
         .arg("-c")
         .arg(&a.command)
-        .output();
-    let out = tokio::time::timeout(COMMAND_TIMEOUT, child)
-        .await
-        .map_err(|_| anyhow::anyhow!("command timed out after {}s", COMMAND_TIMEOUT.as_secs()))?
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .process_group(0);
+    let child = command
+        .spawn()
         .map_err(|e| anyhow::anyhow!("failed to execute command: {e}"))?;
+    let pgid = child
+        .id()
+        .ok_or_else(|| anyhow::anyhow!("spawned command has no pid"))?;
+    let output = child.wait_with_output();
+    tokio::pin!(output);
+
+    enum StopReason {
+        Canceled,
+        Timeout,
+    }
+    let canceled = async {
+        loop {
+            if runtime.is_cancelled(plan_id).await {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    };
+    tokio::pin!(canceled);
+    let deadline = tokio::time::sleep(COMMAND_TIMEOUT);
+    tokio::pin!(deadline);
+
+    let stop_reason = tokio::select! {
+        result = &mut output => {
+            let out = result.map_err(|e| anyhow::anyhow!("failed to execute command: {e}"))?;
+            return format_command_output(out);
+        }
+        _ = &mut canceled => StopReason::Canceled,
+        _ = &mut deadline => StopReason::Timeout,
+    };
+
+    terminate_command_group(pgid, nix::sys::signal::Signal::SIGTERM);
+    if tokio::time::timeout(std::time::Duration::from_secs(2), &mut output)
+        .await
+        .is_err()
+    {
+        terminate_command_group(pgid, nix::sys::signal::Signal::SIGKILL);
+        let _ = output.await;
+    }
+    match stop_reason {
+        StopReason::Canceled => anyhow::bail!("command canceled"),
+        StopReason::Timeout => {
+            anyhow::bail!("command timed out after {}s", COMMAND_TIMEOUT.as_secs())
+        }
+    }
+}
+
+fn terminate_command_group(pgid: u32, signal: nix::sys::signal::Signal) {
+    use nix::sys::signal::killpg;
+    use nix::unistd::Pid;
+    match killpg(Pid::from_raw(pgid as i32), signal) {
+        Ok(()) | Err(nix::errno::Errno::ESRCH) => {}
+        Err(error) => robonix_scribe::warn!(
+            "[executor] signal {:?} command pgid {} failed: {}",
+            signal,
+            pgid,
+            error
+        ),
+    }
+}
+
+fn format_command_output(out: std::process::Output) -> anyhow::Result<String> {
     let mut result = String::new();
     let stdout = String::from_utf8_lossy(&out.stdout);
     let stderr = String::from_utf8_lossy(&out.stderr);

--- a/system/executor/src/dispatch/builtin.rs
+++ b/system/executor/src/dispatch/builtin.rs
@@ -84,6 +84,9 @@ pub async fn execute(
     if op == "stop_plan_at" {
         return runtime.stop_plan_at_builtin(call).await;
     }
+    if op == "stop_after_current" {
+        return runtime.stop_after_current_builtin(call).await;
+    }
     if op == "get_plan_status" {
         return runtime.get_plan_status_builtin(call).await;
     }
@@ -183,6 +186,11 @@ pub const BUILTINS: &[BuiltinSpec] = &[
         op: "stop_plan_at",
         description: "Set a stop point on an in-flight RTDL plan: when execution reaches the op with the given op_id, cancel the whole plan. Use 'on_complete' (default) to stop right after that op finishes, or 'on_enter' to stop the moment it is reached, before it runs. op_ids are the per-node identifiers shown in RTDL node_state events.",
         input_schema_json: r#"{"type":"object","properties":{"plan_id":{"type":"string","description":"RTDL Plan.plan_id to set the stop point on"},"op_id":{"type":"string","description":"Node op_id at which to stop (cancel) the plan"},"when":{"type":"string","enum":["on_enter","on_complete"],"description":"on_enter = before the op runs; on_complete = after it finishes. Default on_complete."}},"required":["plan_id","op_id"]}"#,
+    },
+    BuiltinSpec {
+        op: "stop_after_current",
+        description: "Atomically stop one in-flight sequential RTDL plan after its currently running step completes. Use this directly when the user says 'finish the current step, then stop' or 'do not start the next step'. It takes only plan_id and avoids a get_plan_status round trip. If execution is between steps it stops before the next pending step. It rejects ambiguous parallel plans with multiple running leaves; only then inspect and use stop_plan_at.",
+        input_schema_json: r#"{"type":"object","properties":{"plan_id":{"type":"string","description":"RTDL Plan.plan_id whose current sequential step may finish, after which the plan stops"}},"required":["plan_id"]}"#,
     },
     BuiltinSpec {
         op: "read_capability_doc",

--- a/system/executor/src/dispatch/mod.rs
+++ b/system/executor/src/dispatch/mod.rs
@@ -141,6 +141,16 @@ async fn ensure_skill_active(atlas: &mut AtlasClient, provider_id: &str) -> Resu
         mark_activated(provider_id);
         return Ok(());
     }
+    if provider.state != atlas_pb::LifecycleState::StateInactive as i32 {
+        let state = lifecycle_state_label(provider.state);
+        anyhow::bail!(
+            "skill {} is {}; automatic activation is only valid from INACTIVE. The executor \
+             will not repeat CMD_ACTIVATE after an activation error; recover or restart the \
+             provider lifecycle first",
+            provider_id,
+            state
+        );
+    }
     info!(
         "[skill-activate] {provider_id} (ns={}, state={}): sending Driver(CMD_ACTIVATE)",
         provider.namespace, provider.state
@@ -211,6 +221,22 @@ async fn ensure_skill_active(atlas: &mut AtlasClient, provider_id: &str) -> Resu
     Ok(())
 }
 
+fn lifecycle_state_label(state: i32) -> &'static str {
+    if state == atlas_pb::LifecycleState::StateRegistered as i32 {
+        "REGISTERED"
+    } else if state == atlas_pb::LifecycleState::StateInactive as i32 {
+        "INACTIVE"
+    } else if state == atlas_pb::LifecycleState::StateActive as i32 {
+        "ACTIVE"
+    } else if state == atlas_pb::LifecycleState::StateError as i32 {
+        "ERROR"
+    } else if state == atlas_pb::LifecycleState::StateTerminated as i32 {
+        "TERMINATED"
+    } else {
+        "UNSPECIFIED"
+    }
+}
+
 /// Mirrors robonix_codegen::contract_gen::contract_id_to_service_name.
 /// `robonix/skill/explore/driver` → `RobonixSkillExploreDriver`. Uniform
 /// PascalCase per `/`-segment, no prefix stripping.
@@ -243,5 +269,27 @@ pub(crate) fn error_result(call: &CapabilityCall, msg: String) -> CapabilityCall
         success: false,
         output: String::new(),
         error: msg,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::lifecycle_state_label;
+    use robonix_atlas::pb::LifecycleState;
+
+    #[test]
+    fn lifecycle_state_labels_are_actionable() {
+        assert_eq!(
+            lifecycle_state_label(LifecycleState::StateInactive as i32),
+            "INACTIVE"
+        );
+        assert_eq!(
+            lifecycle_state_label(LifecycleState::StateError as i32),
+            "ERROR"
+        );
+        assert_eq!(
+            lifecycle_state_label(LifecycleState::StateTerminated as i32),
+            "TERMINATED"
+        );
     }
 }

--- a/system/executor/src/dispatch/mod.rs
+++ b/system/executor/src/dispatch/mod.rs
@@ -78,9 +78,10 @@ pub async fn dispatch(
     self_provider_id: &str,
     atlas: &mut AtlasClient,
     runtime: &PlanRuntime,
+    plan_id: &str,
 ) -> CapabilityCallResult {
     if call.provider_id == self_provider_id {
-        return builtin::execute(call, runtime, self_provider_id, atlas).await;
+        return builtin::execute(call, runtime, self_provider_id, atlas, plan_id).await;
     }
 
     if let Err(e) = ensure_skill_active(atlas, &call.provider_id).await {

--- a/system/executor/src/plan_runtime.rs
+++ b/system/executor/src/plan_runtime.rs
@@ -102,6 +102,11 @@ struct StopPlanAtArgs {
     when: Option<String>,
 }
 
+#[derive(Deserialize)]
+struct StopAfterCurrentArgs {
+    plan_id: String,
+}
+
 impl PlanRuntime {
     /// Register a plan before execution starts.
     ///
@@ -446,6 +451,81 @@ impl PlanRuntime {
         ok_result(call, output)
     }
 
+    /// Atomically stop a sequential plan after its currently running leaf.
+    ///
+    /// This avoids the two-round `get_plan_status` -> `stop_plan_at` race. If
+    /// execution is between leaves, arm `on_enter` on the first pending leaf.
+    /// Multiple running leaves are rejected because "current" is ambiguous.
+    pub async fn stop_after_current_builtin(&self, call: &CapabilityCall) -> CapabilityCallResult {
+        let args: StopAfterCurrentArgs = match serde_json::from_str(&call.args_json) {
+            Ok(args) => args,
+            Err(e) => {
+                return error_result(call, format!("invalid stop_after_current args: {e}"));
+            }
+        };
+        let output = {
+            let mut plans = self.inner.lock().await;
+            let Some(run) = plans.get_mut(&args.plan_id) else {
+                return ok_result(
+                    call,
+                    format!(
+                        "RTDL plan '{}' is not running (already finished or cancelled); no stop point needed.",
+                        args.plan_id
+                    ),
+                );
+            };
+
+            let running: Vec<&OpMeta> = run
+                .ops
+                .iter()
+                .filter(|op| {
+                    op.node_kind == 2
+                        && run
+                            .op_state
+                            .get(&op.op_id)
+                            .is_some_and(|state| *state == RtdlNodeStateEnum::Running as u32)
+                })
+                .collect();
+            if running.len() > 1 {
+                return error_result(
+                    call,
+                    format!(
+                        "stop_after_current: RTDL plan '{}' has {} running leaf ops; current step is ambiguous in a parallel plan. Use get_plan_status and stop_plan_at with an explicit op_id.",
+                        args.plan_id,
+                        running.len()
+                    ),
+                );
+            }
+            if let Some(op) = running.first() {
+                let op_id = op.op_id.clone();
+                let description = op.description.clone();
+                run.stop_points.insert(op_id.clone(), StopWhen::OnComplete);
+                format!(
+                    "Atomic boundary stop armed: RTDL plan '{}' will stop after current op_id={} ({}).",
+                    args.plan_id, op_id, description
+                )
+            } else if let Some(op) = run
+                .ops
+                .iter()
+                .find(|op| op.node_kind == 2 && !run.op_state.contains_key(&op.op_id))
+            {
+                let op_id = op.op_id.clone();
+                let description = op.description.clone();
+                run.stop_points.insert(op_id.clone(), StopWhen::OnEnter);
+                format!(
+                    "Atomic boundary stop armed between steps: RTDL plan '{}' will stop before pending op_id={} ({}).",
+                    args.plan_id, op_id, description
+                )
+            } else {
+                format!(
+                    "RTDL plan '{}' has no running or pending leaf; no stop point needed.",
+                    args.plan_id
+                )
+            }
+        };
+        ok_result(call, output)
+    }
+
     /// Whether the plan has a stop point on `op_id` for the given phase.
     /// Read by the execution loop at each `do` node entry and completion.
     pub async fn should_stop_at(&self, plan_id: &str, op_id: &str, when: StopWhen) -> bool {
@@ -695,6 +775,78 @@ mod tests {
             contract_id: "robonix/system/executor/builtin/stop_plan_at".into(),
             args_json: args_json.into(),
         }
+    }
+
+    fn stop_after_current_call(args_json: &str) -> CapabilityCall {
+        CapabilityCall {
+            call_id: "c".into(),
+            provider_id: "executor".into(),
+            contract_id: "robonix/system/executor/builtin/stop_after_current".into(),
+            args_json: args_json.into(),
+        }
+    }
+
+    async fn record_two_leaf_plan(runtime: &PlanRuntime) {
+        use crate::pb::pilot::{Plan, RtdlNode};
+        runtime.register_plan("p").await;
+        runtime
+            .record_plan_ops(&Plan {
+                plan_id: "p".into(),
+                session_id: "s".into(),
+                round: 0,
+                root_index: 0,
+                nodes: vec![
+                    RtdlNode {
+                        node_kind: 0,
+                        children: vec![1, 2],
+                        op_id: "seq".into(),
+                        description: "sequence".into(),
+                        ..Default::default()
+                    },
+                    RtdlNode {
+                        node_kind: 2,
+                        op_id: "a".into(),
+                        description: "step A".into(),
+                        ..Default::default()
+                    },
+                    RtdlNode {
+                        node_kind: 2,
+                        op_id: "b".into(),
+                        description: "step B".into(),
+                        ..Default::default()
+                    },
+                ],
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn stop_after_current_arms_running_leaf_on_complete() {
+        let runtime = PlanRuntime::default();
+        record_two_leaf_plan(&runtime).await;
+        runtime
+            .record_op_state("p", "a", RtdlNodeStateEnum::Running as u32)
+            .await;
+        let result = runtime
+            .stop_after_current_builtin(&stop_after_current_call(r#"{"plan_id":"p"}"#))
+            .await;
+        assert!(result.success, "{}", result.error);
+        assert!(runtime.should_stop_at("p", "a", StopWhen::OnComplete).await);
+        assert!(!runtime.should_stop_at("p", "b", StopWhen::OnEnter).await);
+    }
+
+    #[tokio::test]
+    async fn stop_after_current_between_steps_arms_next_leaf_on_enter() {
+        let runtime = PlanRuntime::default();
+        record_two_leaf_plan(&runtime).await;
+        runtime
+            .record_op_state("p", "a", RtdlNodeStateEnum::Succeeded as u32)
+            .await;
+        let result = runtime
+            .stop_after_current_builtin(&stop_after_current_call(r#"{"plan_id":"p"}"#))
+            .await;
+        assert!(result.success, "{}", result.error);
+        assert!(runtime.should_stop_at("p", "b", StopWhen::OnEnter).await);
     }
 
     #[tokio::test]

--- a/system/executor/src/plan_runtime.rs
+++ b/system/executor/src/plan_runtime.rs
@@ -102,11 +102,6 @@ struct StopPlanAtArgs {
     when: Option<String>,
 }
 
-#[derive(Deserialize)]
-struct StopAfterCurrentArgs {
-    plan_id: String,
-}
-
 impl PlanRuntime {
     /// Register a plan before execution starts.
     ///
@@ -451,81 +446,6 @@ impl PlanRuntime {
         ok_result(call, output)
     }
 
-    /// Atomically stop a sequential plan after its currently running leaf.
-    ///
-    /// This avoids the two-round `get_plan_status` -> `stop_plan_at` race. If
-    /// execution is between leaves, arm `on_enter` on the first pending leaf.
-    /// Multiple running leaves are rejected because "current" is ambiguous.
-    pub async fn stop_after_current_builtin(&self, call: &CapabilityCall) -> CapabilityCallResult {
-        let args: StopAfterCurrentArgs = match serde_json::from_str(&call.args_json) {
-            Ok(args) => args,
-            Err(e) => {
-                return error_result(call, format!("invalid stop_after_current args: {e}"));
-            }
-        };
-        let output = {
-            let mut plans = self.inner.lock().await;
-            let Some(run) = plans.get_mut(&args.plan_id) else {
-                return ok_result(
-                    call,
-                    format!(
-                        "RTDL plan '{}' is not running (already finished or cancelled); no stop point needed.",
-                        args.plan_id
-                    ),
-                );
-            };
-
-            let running: Vec<&OpMeta> = run
-                .ops
-                .iter()
-                .filter(|op| {
-                    op.node_kind == 2
-                        && run
-                            .op_state
-                            .get(&op.op_id)
-                            .is_some_and(|state| *state == RtdlNodeStateEnum::Running as u32)
-                })
-                .collect();
-            if running.len() > 1 {
-                return error_result(
-                    call,
-                    format!(
-                        "stop_after_current: RTDL plan '{}' has {} running leaf ops; current step is ambiguous in a parallel plan. Use get_plan_status and stop_plan_at with an explicit op_id.",
-                        args.plan_id,
-                        running.len()
-                    ),
-                );
-            }
-            if let Some(op) = running.first() {
-                let op_id = op.op_id.clone();
-                let description = op.description.clone();
-                run.stop_points.insert(op_id.clone(), StopWhen::OnComplete);
-                format!(
-                    "Atomic boundary stop armed: RTDL plan '{}' will stop after current op_id={} ({}).",
-                    args.plan_id, op_id, description
-                )
-            } else if let Some(op) = run
-                .ops
-                .iter()
-                .find(|op| op.node_kind == 2 && !run.op_state.contains_key(&op.op_id))
-            {
-                let op_id = op.op_id.clone();
-                let description = op.description.clone();
-                run.stop_points.insert(op_id.clone(), StopWhen::OnEnter);
-                format!(
-                    "Atomic boundary stop armed between steps: RTDL plan '{}' will stop before pending op_id={} ({}).",
-                    args.plan_id, op_id, description
-                )
-            } else {
-                format!(
-                    "RTDL plan '{}' has no running or pending leaf; no stop point needed.",
-                    args.plan_id
-                )
-            }
-        };
-        ok_result(call, output)
-    }
-
     /// Whether the plan has a stop point on `op_id` for the given phase.
     /// Read by the execution loop at each `do` node entry and completion.
     pub async fn should_stop_at(&self, plan_id: &str, op_id: &str, when: StopWhen) -> bool {
@@ -775,78 +695,6 @@ mod tests {
             contract_id: "robonix/system/executor/builtin/stop_plan_at".into(),
             args_json: args_json.into(),
         }
-    }
-
-    fn stop_after_current_call(args_json: &str) -> CapabilityCall {
-        CapabilityCall {
-            call_id: "c".into(),
-            provider_id: "executor".into(),
-            contract_id: "robonix/system/executor/builtin/stop_after_current".into(),
-            args_json: args_json.into(),
-        }
-    }
-
-    async fn record_two_leaf_plan(runtime: &PlanRuntime) {
-        use crate::pb::pilot::{Plan, RtdlNode};
-        runtime.register_plan("p").await;
-        runtime
-            .record_plan_ops(&Plan {
-                plan_id: "p".into(),
-                session_id: "s".into(),
-                round: 0,
-                root_index: 0,
-                nodes: vec![
-                    RtdlNode {
-                        node_kind: 0,
-                        children: vec![1, 2],
-                        op_id: "seq".into(),
-                        description: "sequence".into(),
-                        ..Default::default()
-                    },
-                    RtdlNode {
-                        node_kind: 2,
-                        op_id: "a".into(),
-                        description: "step A".into(),
-                        ..Default::default()
-                    },
-                    RtdlNode {
-                        node_kind: 2,
-                        op_id: "b".into(),
-                        description: "step B".into(),
-                        ..Default::default()
-                    },
-                ],
-            })
-            .await;
-    }
-
-    #[tokio::test]
-    async fn stop_after_current_arms_running_leaf_on_complete() {
-        let runtime = PlanRuntime::default();
-        record_two_leaf_plan(&runtime).await;
-        runtime
-            .record_op_state("p", "a", RtdlNodeStateEnum::Running as u32)
-            .await;
-        let result = runtime
-            .stop_after_current_builtin(&stop_after_current_call(r#"{"plan_id":"p"}"#))
-            .await;
-        assert!(result.success, "{}", result.error);
-        assert!(runtime.should_stop_at("p", "a", StopWhen::OnComplete).await);
-        assert!(!runtime.should_stop_at("p", "b", StopWhen::OnEnter).await);
-    }
-
-    #[tokio::test]
-    async fn stop_after_current_between_steps_arms_next_leaf_on_enter() {
-        let runtime = PlanRuntime::default();
-        record_two_leaf_plan(&runtime).await;
-        runtime
-            .record_op_state("p", "a", RtdlNodeStateEnum::Succeeded as u32)
-            .await;
-        let result = runtime
-            .stop_after_current_builtin(&stop_after_current_call(r#"{"plan_id":"p"}"#))
-            .await;
-        assert!(result.success, "{}", result.error);
-        assert!(runtime.should_stop_at("p", "b", StopWhen::OnEnter).await);
     }
 
     #[tokio::test]

--- a/system/executor/src/service.rs
+++ b/system/executor/src/service.rs
@@ -276,6 +276,19 @@ fn is_operator_node(node_kind: u32) -> bool {
     matches!(node_kind, RTDL_SEQUENCE | RTDL_PARALLEL)
 }
 
+/// Map a completed leaf call to its RTDL state. Cancellation wins over the
+/// provider result: a command terminated by cancel_plan normally returns
+/// success=false, but that is an expected CANCELED outcome, not a FAILED tool.
+fn leaf_terminal_state(success: bool, cancelled: bool) -> u32 {
+    if cancelled {
+        RtdlNodeStateEnum::Canceled as u32
+    } else if success {
+        RtdlNodeStateEnum::Succeeded as u32
+    } else {
+        RtdlNodeStateEnum::Failed as u32
+    }
+}
+
 /// Emit the terminal event for an `on_enter` stop point on any RTDL node.
 async fn send_stop_on_enter(
     tx: &Sender<Result<RtdlEvent, Status>>,
@@ -414,11 +427,8 @@ async fn execute_call(
             let r =
                 crate::dispatch::dispatch(call, &provider_id, &mut atlas, &runtime, &node.plan_id)
                     .await;
-            let state = if r.success {
-                RtdlNodeStateEnum::Succeeded as u32
-            } else {
-                RtdlNodeStateEnum::Failed as u32
-            };
+            let cancelled = runtime.is_cancelled(&node.plan_id).await;
+            let state = leaf_terminal_state(r.success, cancelled);
             runtime
                 .record_op_state(&node.plan_id, &node.op_id, state)
                 .await;
@@ -563,7 +573,7 @@ fn visit_for_cycles(index: usize, plan: &Plan, colors: &mut [VisitColor]) -> Res
 #[cfg(test)]
 mod tests {
     use super::{
-        PlanRuntime, RTDL_DO, RTDL_PARALLEL, RTDL_SEQUENCE, RtdlNodeStateEnum,
+        PlanRuntime, RTDL_DO, RTDL_PARALLEL, RTDL_SEQUENCE, RtdlNodeStateEnum, leaf_terminal_state,
         send_operator_terminal, send_stop_on_enter, validate_plan,
     };
     use crate::pb::executor::rtdl_event::RtdlEventEnum;
@@ -577,6 +587,22 @@ mod tests {
             contract_id: "robonix/test/cap".to_string(),
             args_json: "{}".to_string(),
         }
+    }
+
+    #[test]
+    fn canceled_leaf_is_not_reported_as_failed_provider_work() {
+        assert_eq!(
+            leaf_terminal_state(false, true),
+            RtdlNodeStateEnum::Canceled as u32
+        );
+        assert_eq!(
+            leaf_terminal_state(false, false),
+            RtdlNodeStateEnum::Failed as u32
+        );
+        assert_eq!(
+            leaf_terminal_state(true, false),
+            RtdlNodeStateEnum::Succeeded as u32
+        );
     }
 
     fn node(kind: u32, children: Vec<u32>, call: Option<CapabilityCall>) -> RtdlNode {

--- a/system/executor/src/service.rs
+++ b/system/executor/src/service.rs
@@ -411,7 +411,9 @@ async fn execute_call(
             .await
         }
         Ok(None) => {
-            let r = crate::dispatch::dispatch(call, &provider_id, &mut atlas, &runtime).await;
+            let r =
+                crate::dispatch::dispatch(call, &provider_id, &mut atlas, &runtime, &node.plan_id)
+                    .await;
             let state = if r.success {
                 RtdlNodeStateEnum::Succeeded as u32
             } else {

--- a/system/liaison/src/handsfree.rs
+++ b/system/liaison/src/handsfree.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use tokio::sync::{Mutex, Notify, mpsc};
+use tokio::sync::{Mutex, Notify, broadcast, mpsc};
 use tokio_stream::{StreamExt, wrappers::ReceiverStream};
 use tonic::Request;
 
@@ -19,8 +19,11 @@ use crate::pb::contracts::{
     robonix_primitive_audio_mic_client::RobonixPrimitiveAudioMicClient,
     robonix_service_speech_wake_word_client::RobonixServiceSpeechWakeWordClient,
 };
-use crate::pb::liaison::{GetHandsfreeStatusResponse, StartVoiceSessionRequest};
-use crate::{voice, voice::KIND_ASR_FINAL};
+use crate::pb::liaison::{GetHandsfreeStatusResponse, StartVoiceSessionRequest, VoiceEvent};
+use crate::{
+    voice,
+    voice::{KIND_ASR_FINAL, KIND_ERROR},
+};
 
 const MIC_CONTRACT: &str = "robonix/primitive/audio/mic";
 const WAKE_WORD_CONTRACT: &str = "robonix/service/speech/wake_word";
@@ -70,6 +73,7 @@ pub struct HandsfreeController {
     atlas: Arc<Mutex<AtlasClient>>,
     pilot_endpoint_default: String,
     access: Arc<AccessControlConfig>,
+    events: broadcast::Sender<VoiceEvent>,
 }
 
 impl HandsfreeController {
@@ -82,6 +86,7 @@ impl HandsfreeController {
         let enabled = config.handsfree_enabled
             && !config.handsfree_mic_provider_id.is_empty()
             && !config.handsfree_speaker_provider_id.is_empty();
+        let (events, _) = broadcast::channel(256);
         Arc::new(Self {
             enabled: AtomicBool::new(enabled),
             config: Mutex::new(config),
@@ -93,6 +98,7 @@ impl HandsfreeController {
             atlas,
             pilot_endpoint_default,
             access,
+            events,
         })
     }
 
@@ -146,6 +152,35 @@ impl HandsfreeController {
         }
     }
 
+    /// Subscribe to the existing VoiceEvent model rather than inventing a
+    /// hands-free-specific client protocol. This stream is observational and
+    /// never drives microphone ownership or task execution.
+    pub fn subscribe_events(&self) -> ReceiverStream<Result<VoiceEvent, tonic::Status>> {
+        let mut source = self.events.subscribe();
+        let (tx, rx) = mpsc::channel(64);
+        tokio::spawn(async move {
+            loop {
+                match source.recv().await {
+                    Ok(event) => {
+                        if tx.send(Ok(event)).await.is_err() {
+                            break;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                        warn!("[liaison/handsfree] event observer lagged by {skipped} event(s)");
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        });
+        ReceiverStream::new(rx)
+    }
+
+    fn publish(&self, event: VoiceEvent) {
+        // A disconnected UI must never block the robot-local interaction.
+        let _ = self.events.send(event);
+    }
+
     async fn set_state(&self, value: &str, error: Option<String>) {
         let mut state = self.state.lock().await;
         state.state = value.to_string();
@@ -190,6 +225,18 @@ impl HandsfreeController {
                     if let Err(error) = self.run_voice_turn().await {
                         let message = format!("{error:#}");
                         warn!("[liaison/handsfree] voice turn failed: {message}");
+                        let session_id = self.config.lock().await.handsfree_session_id.clone();
+                        self.publish(VoiceEvent {
+                            event_kind: KIND_ERROR,
+                            session_id,
+                            text: String::new(),
+                            user_id: String::new(),
+                            confidence: 0.0,
+                            pilot: None,
+                            error: message.clone(),
+                            status_message: String::new(),
+                            timestamp_ms: now_ms(),
+                        });
                         self.set_state("error", Some(message)).await;
                         tokio::time::sleep(Duration::from_secs(1)).await;
                     }
@@ -300,8 +347,9 @@ impl HandsfreeController {
         while let Some(event) = stream.next().await {
             let event = event.map_err(|status| anyhow!(status.to_string()))?;
             if event.event_kind == KIND_ASR_FINAL {
-                self.state.lock().await.last_transcript = event.text;
+                self.state.lock().await.last_transcript = event.text.clone();
             }
+            self.publish(event.clone());
             if !event.error.is_empty() {
                 return Err(anyhow!(event.error));
             }

--- a/system/liaison/src/handsfree.rs
+++ b/system/liaison/src/handsfree.rs
@@ -8,9 +8,10 @@ use robonix_atlas::client::AtlasClient;
 use robonix_scribe::{info, warn};
 use serde::Deserialize;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::{Mutex, Notify, broadcast, mpsc};
+use tokio::task::JoinHandle;
 use tokio_stream::{StreamExt, wrappers::ReceiverStream};
 use tonic::Request;
 
@@ -67,6 +68,7 @@ struct RuntimeState {
 
 pub struct HandsfreeController {
     enabled: AtomicBool,
+    suspended: AtomicUsize,
     config: Mutex<HandsfreeConfig>,
     state: Mutex<RuntimeState>,
     changed: Notify,
@@ -74,6 +76,7 @@ pub struct HandsfreeController {
     pilot_endpoint_default: String,
     access: Arc<AccessControlConfig>,
     events: broadcast::Sender<VoiceEvent>,
+    active_turns: Mutex<Vec<JoinHandle<()>>>,
 }
 
 impl HandsfreeController {
@@ -89,6 +92,7 @@ impl HandsfreeController {
         let (events, _) = broadcast::channel(256);
         Arc::new(Self {
             enabled: AtomicBool::new(enabled),
+            suspended: AtomicUsize::new(0),
             config: Mutex::new(config),
             state: Mutex::new(RuntimeState {
                 state: if enabled { "starting" } else { "disabled" }.to_string(),
@@ -99,6 +103,7 @@ impl HandsfreeController {
             pilot_endpoint_default,
             access,
             events,
+            active_turns: Mutex::new(Vec::new()),
         })
     }
 
@@ -131,6 +136,12 @@ impl HandsfreeController {
             }
         }
         self.enabled.store(enabled, Ordering::Release);
+        if !enabled {
+            let mut turns = self.active_turns.lock().await;
+            for turn in turns.drain(..) {
+                turn.abort();
+            }
+        }
         self.set_state(if enabled { "starting" } else { "disabled" }, None)
             .await;
         self.changed.notify_waiters();
@@ -149,6 +160,33 @@ impl HandsfreeController {
             last_wake_ms: state.last_wake_ms,
             last_transcript: state.last_transcript.clone(),
             last_error: state.last_error.clone(),
+        }
+    }
+
+    /// Pause only wake-word microphone ownership while an explicit voice
+    /// capture is active.  Enabled state is preserved and listening resumes
+    /// automatically at ASR final (or on any failed/disconnected capture).
+    pub async fn suspend_capture(&self) {
+        self.suspended.fetch_add(1, Ordering::AcqRel);
+        self.set_state("suspended", None).await;
+        self.changed.notify_waiters();
+    }
+
+    pub async fn resume_capture(&self) {
+        let mut current = self.suspended.load(Ordering::Acquire);
+        while current > 0 {
+            match self.suspended.compare_exchange_weak(
+                current,
+                current - 1,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => break,
+                Err(actual) => current = actual,
+            }
+        }
+        if self.suspended.load(Ordering::Acquire) == 0 {
+            self.changed.notify_waiters();
         }
     }
 
@@ -197,6 +235,11 @@ impl HandsfreeController {
         loop {
             if !self.enabled.load(Ordering::Acquire) {
                 self.set_state("disabled", None).await;
+                self.changed.notified().await;
+                continue;
+            }
+            if self.suspended.load(Ordering::Acquire) > 0 {
+                self.set_state("suspended", None).await;
                 self.changed.notified().await;
                 continue;
             }
@@ -300,10 +343,14 @@ impl HandsfreeController {
         Ok(response.detected.then_some(response.keyword))
     }
 
-    async fn run_voice_turn(&self) -> Result<()> {
+    async fn run_voice_turn(self: &Arc<Self>) -> Result<()> {
         let config = self.config.lock().await.clone();
+        let is_steer = self.has_active_turn().await;
         let ack = config.handsfree_ack_text.trim();
-        if !ack.is_empty() {
+        // A mid-task wake phrase is itself the acknowledgement.  Starting a
+        // second prompt here would queue behind the reply the user is trying
+        // to interrupt and delay capture by several seconds.
+        if !is_steer && !ack.is_empty() {
             self.set_state("acknowledging", None).await;
             if let Err(error) = voice::play_prompt(
                 &self.atlas,
@@ -332,9 +379,11 @@ impl HandsfreeController {
             voiceprint_node_id: config.handsfree_voiceprint_provider_id.clone(),
             tts_node_id: config.handsfree_speech_provider_id.clone(),
             speaker_node_id: config.handsfree_speaker_provider_id.clone(),
-            context_json:
-                r#"{"client":"robot-handsfree","interaction_mode":"auto","handsfree":true}"#
-                    .to_string(),
+            context_json: if is_steer {
+                r#"{"client":"robot-handsfree","interaction_mode":"steer","steer":true,"barge_in":true,"handsfree":true}"#.to_string()
+            } else {
+                r#"{"client":"robot-handsfree","interaction_mode":"auto","barge_in":false,"handsfree":true}"#.to_string()
+            },
         };
         let mut stream = voice::start_voice_session(
             request,
@@ -353,11 +402,49 @@ impl HandsfreeController {
             if !event.error.is_empty() {
                 return Err(anyhow!(event.error));
             }
+            if event.event_kind == KIND_ASR_FINAL {
+                // Recording ownership ends at ASR final, not when Pilot and
+                // TTS eventually finish.  Continue relaying that turn in the
+                // background and immediately restore wake-word listening so
+                // the user can steer a long-running action.
+                let controller = Arc::clone(self);
+                let handle = tokio::spawn(async move {
+                    while let Some(item) = stream.next().await {
+                        match item {
+                            Ok(event) => {
+                                let failed = !event.error.is_empty();
+                                controller.publish(event.clone());
+                                if failed {
+                                    warn!(
+                                        "[liaison/handsfree] background voice turn failed: {}",
+                                        event.error
+                                    );
+                                    break;
+                                }
+                            }
+                            Err(status) => {
+                                warn!(
+                                    "[liaison/handsfree] background voice stream failed: {status}"
+                                );
+                                break;
+                            }
+                        }
+                    }
+                });
+                self.active_turns.lock().await.push(handle);
+                if self.enabled.load(Ordering::Acquire) {
+                    self.set_state("listening", None).await;
+                }
+                return Ok(());
+            }
         }
-        if self.enabled.load(Ordering::Acquire) {
-            self.set_state("listening", None).await;
-        }
-        Ok(())
+        Err(anyhow!("voice session ended before ASR final"))
+    }
+
+    async fn has_active_turn(&self) -> bool {
+        let mut turns = self.active_turns.lock().await;
+        turns.retain(|turn| !turn.is_finished());
+        !turns.is_empty()
     }
 }
 

--- a/system/liaison/src/main.rs
+++ b/system/liaison/src/main.rs
@@ -288,14 +288,44 @@ impl RobonixSystemLiaisonVoice for LiaisonServiceImpl {
         request: Request<StartVoiceSessionRequest>,
     ) -> Result<Response<Self::StartVoiceSessionStream>, Status> {
         let req = request.into_inner();
-        let stream = voice::start_voice_session(
+        self.handsfree.suspend_capture().await;
+        let stream = match voice::start_voice_session(
             req,
             Arc::clone(&self.atlas),
             self.pilot_endpoint_default.clone(),
             Arc::clone(&self.access),
         )
-        .await?;
-        let boxed: Self::StartVoiceSessionStream = Box::pin(stream);
+        .await
+        {
+            Ok(stream) => stream,
+            Err(status) => {
+                self.handsfree.resume_capture().await;
+                return Err(status);
+            }
+        };
+        let (tx, rx) = mpsc::channel(64);
+        let handsfree = Arc::clone(&self.handsfree);
+        tokio::spawn(async move {
+            let mut stream = Box::pin(stream);
+            let mut capture_suspended = true;
+            while let Some(item) = stream.next().await {
+                if capture_suspended
+                    && item
+                        .as_ref()
+                        .is_ok_and(|event| event.event_kind == voice::KIND_ASR_FINAL)
+                {
+                    handsfree.resume_capture().await;
+                    capture_suspended = false;
+                }
+                if tx.send(item).await.is_err() {
+                    break;
+                }
+            }
+            if capture_suspended {
+                handsfree.resume_capture().await;
+            }
+        });
+        let boxed: Self::StartVoiceSessionStream = Box::pin(ReceiverStream::new(rx));
         Ok(Response::new(boxed))
     }
 }

--- a/system/liaison/src/main.rs
+++ b/system/liaison/src/main.rs
@@ -30,6 +30,9 @@ use access::{AccessControlConfig, AccessDecision};
 use anyhow::{Context, Result, anyhow};
 use clap::Parser;
 use pb::contracts::{
+    robonix_system_liaison_handsfree_events_server::{
+        RobonixSystemLiaisonHandsfreeEvents, RobonixSystemLiaisonHandsfreeEventsServer,
+    },
     robonix_system_liaison_handsfree_set_enabled_server::{
         RobonixSystemLiaisonHandsfreeSetEnabled, RobonixSystemLiaisonHandsfreeSetEnabledServer,
     },
@@ -46,7 +49,7 @@ use pb::contracts::{
 };
 use pb::liaison::{
     GetHandsfreeStatusRequest, GetHandsfreeStatusResponse, SetHandsfreeRequest,
-    SetHandsfreeResponse, StartVoiceSessionRequest, VoiceEvent,
+    SetHandsfreeResponse, StartVoiceSessionRequest, VoiceEvent, WatchHandsfreeEventsRequest,
 };
 use pb::pilot::rtdl_node_state::RtdlNodeStateEnum;
 use pb::pilot::{CapabilityCall, PilotEvent, Plan, Task};
@@ -67,11 +70,13 @@ const LIAISON_SUBMIT_CONTRACT: &str = "robonix/system/liaison/submit";
 const LIAISON_VOICE_CONTRACT: &str = "robonix/system/liaison/voice";
 const LIAISON_HANDSFREE_SET_CONTRACT: &str = "robonix/system/liaison/handsfree/set_enabled";
 const LIAISON_HANDSFREE_STATUS_CONTRACT: &str = "robonix/system/liaison/handsfree/status";
+const LIAISON_HANDSFREE_EVENTS_CONTRACT: &str = "robonix/system/liaison/handsfree/events";
 const LIAISON_SUBMIT_TOML: &str = "capabilities/system/liaison/submit.v1.toml";
 const LIAISON_VOICE_TOML: &str = "capabilities/system/liaison/voice.v1.toml";
 const LIAISON_HANDSFREE_SET_TOML: &str =
     "capabilities/system/liaison/handsfree/set_enabled.v1.toml";
 const LIAISON_HANDSFREE_STATUS_TOML: &str = "capabilities/system/liaison/handsfree/status.v1.toml";
+const LIAISON_HANDSFREE_EVENTS_TOML: &str = "capabilities/system/liaison/handsfree/events.v1.toml";
 
 /// `lib/system/pilot/msg/Task.msg` source: TEXT=0 AUDIO=1
 const INTENT_SOURCE_TEXT: u32 = 0;
@@ -327,6 +332,18 @@ impl RobonixSystemLiaisonHandsfreeStatus for LiaisonServiceImpl {
         _request: Request<GetHandsfreeStatusRequest>,
     ) -> Result<Response<GetHandsfreeStatusResponse>, Status> {
         Ok(Response::new(self.handsfree.snapshot().await))
+    }
+}
+
+#[tonic::async_trait]
+impl RobonixSystemLiaisonHandsfreeEvents for LiaisonServiceImpl {
+    type WatchHandsfreeEventsStream = ReceiverStream<Result<VoiceEvent, Status>>;
+
+    async fn watch_handsfree_events(
+        &self,
+        _request: Request<WatchHandsfreeEventsRequest>,
+    ) -> Result<Response<Self::WatchHandsfreeEventsStream>, Status> {
+        Ok(Response::new(self.handsfree.subscribe_events()))
     }
 }
 
@@ -610,6 +627,20 @@ async fn main() -> Result<()> {
         )
         .await
         .context("declare liaison hands-free status gRPC capability")?;
+    atlas
+        .declare_capability(
+            LIAISON_PROVIDER_ID,
+            LIAISON_HANDSFREE_EVENTS_CONTRACT,
+            atlas_pb::Transport::Grpc,
+            &advertised,
+            atlas_client::grpc_params(
+                LIAISON_HANDSFREE_EVENTS_TOML,
+                "robonix.contracts.RobonixSystemLiaisonHandsfreeEvents",
+                "/robonix.contracts.RobonixSystemLiaisonHandsfreeEvents/WatchHandsfreeEvents",
+            ),
+        )
+        .await
+        .context("declare liaison hands-free events gRPC capability")?;
     // Liaison has no Driver(CMD_INIT/CMD_ACTIVATE) handshake — it's a Rust binary
     // that's fully ready as soon as the gRPC server is listening. Push the
     // state explicitly so `rbnx caps` shows ACTIVE instead of stopping at
@@ -690,7 +721,10 @@ async fn main() -> Result<()> {
         .add_service(RobonixSystemLiaisonHandsfreeSetEnabledServer::from_arc(
             Arc::clone(&svc),
         ))
-        .add_service(RobonixSystemLiaisonHandsfreeStatusServer::from_arc(svc))
+        .add_service(RobonixSystemLiaisonHandsfreeStatusServer::from_arc(
+            Arc::clone(&svc),
+        ))
+        .add_service(RobonixSystemLiaisonHandsfreeEventsServer::from_arc(svc))
         .serve(listen_addr);
 
     if let Some(handle) = text_handle {

--- a/system/liaison/src/voice.rs
+++ b/system/liaison/src/voice.rs
@@ -33,8 +33,10 @@ use robonix_atlas::client::AtlasClient;
 use robonix_atlas::pb as atlas_pb;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
+use std::task::{Context, Poll};
 use std::time::Duration;
 use tokio::sync::{Mutex, mpsc};
 use tokio_stream::{StreamExt, wrappers::ReceiverStream};
@@ -85,9 +87,37 @@ const DEFAULT_RECORD_SECONDS: u32 = 10;
 /// background noise sits around 50–300, so 500 is a comfortable gap.
 const VAD_SPEECH_RMS: f32 = 500.0;
 const VAD_END_SILENCE_SECS: f32 = 1.2;
+const VAD_NO_SPEECH_TIMEOUT_SECS: u64 = 5;
 const DEFAULT_ASR_LANGUAGE: &str = "";
 const DEFAULT_AUDIO_ENCODING: &str = "pcm_s16le";
 const DEFAULT_AUDIO_SAMPLE_RATE: u32 = 16_000;
+
+struct AbortOnDrop(tokio::task::AbortHandle);
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+struct VoiceSessionStream {
+    inner: ReceiverStream<Result<VoiceEvent, Status>>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl Stream for VoiceSessionStream {
+    type Item = Result<VoiceEvent, Status>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.inner).poll_next(cx)
+    }
+}
+
+impl Drop for VoiceSessionStream {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
 
 // ── Discovery helpers ────────────────────────────────────────────────────────
 //
@@ -199,7 +229,7 @@ pub async fn start_voice_session(
             KIND_SESSION_STARTED,
             &session_id,
             &format!(
-                "voice session started (vad, record≤{record_seconds}s, tts={}, lang={})",
+                "voice session started (vad, record≤{record_seconds}s, no-speech≤{VAD_NO_SPEECH_TIMEOUT_SECS}s, tts={}, lang={})",
                 req.tts_enabled,
                 if language.is_empty() {
                     "auto"
@@ -211,7 +241,7 @@ pub async fn start_voice_session(
         .await;
 
     let session_id_for_task = session_id.clone();
-    tokio::spawn(async move {
+    let task = tokio::spawn(async move {
         let outcome = run_session(
             req,
             session_id_for_task.clone(),
@@ -242,7 +272,10 @@ pub async fn start_voice_session(
         }
     });
 
-    Ok(ReceiverStream::new(rx))
+    Ok(VoiceSessionStream {
+        inner: ReceiverStream::new(rx),
+        task,
+    })
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -627,6 +660,7 @@ async fn stream_capture_and_recognize(
         // the audio-source startup (e.g. audio client bridge over the network); the
         // chunk count + total audio vs wall time shows transfer throughput.
         let t_pump = tokio::time::Instant::now();
+        let no_speech_deadline = t_pump + Duration::from_secs(VAD_NO_SPEECH_TIMEOUT_SECS);
         let mut n_chunks: u32 = 0u32;
         let mut audio_s: f32 = 0.0;
         let mut logged_first = false;
@@ -634,10 +668,15 @@ async fn stream_capture_and_recognize(
         let mut silence_secs: f32 = 0.0;
         let mut first_chunk = true;
         loop {
-            if tokio::time::Instant::now() >= deadline {
+            let active_deadline = if has_spoken {
+                deadline
+            } else {
+                deadline.min(no_speech_deadline)
+            };
+            if tokio::time::Instant::now() >= active_deadline {
                 break;
             }
-            let remaining = deadline - tokio::time::Instant::now();
+            let remaining = active_deadline - tokio::time::Instant::now();
             match tokio::time::timeout(remaining, mic_stream.message()).await {
                 Ok(Ok(Some(chunk))) => {
                     if !logged_first {
@@ -691,6 +730,7 @@ async fn stream_capture_and_recognize(
             (wall as f32 / 1000.0) / audio_s.max(0.001)
         );
     });
+    let _pump_abort_guard = AbortOnDrop(pump_handle.abort_handle());
 
     // FunASR docs: AsrAudioChunk + ASR backend reads its own audio_config
     // defaults (16 kHz mono pcm_s16le); language hint is on the bidi
@@ -1311,5 +1351,29 @@ mod tests {
             tts_boundary_text(4, String::new(), "final answer"),
             Some("final answer".to_string())
         );
+    }
+
+    #[tokio::test]
+    async fn dropping_voice_stream_aborts_session_task() {
+        let (_tx, rx) = mpsc::channel(1);
+        let task = tokio::spawn(std::future::pending::<()>());
+        let abort = task.abort_handle();
+        let stream = VoiceSessionStream {
+            inner: ReceiverStream::new(rx),
+            task,
+        };
+        drop(stream);
+        tokio::task::yield_now().await;
+        assert!(abort.is_finished());
+    }
+
+    #[tokio::test]
+    async fn dropping_abort_guard_aborts_nested_mic_pump() {
+        let task = tokio::spawn(std::future::pending::<()>());
+        let abort = task.abort_handle();
+        drop(AbortOnDrop(abort.clone()));
+        tokio::task::yield_now().await;
+        assert!(abort.is_finished());
+        let _ = task.await;
     }
 }

--- a/system/liaison/src/voice.rs
+++ b/system/liaison/src/voice.rs
@@ -471,7 +471,11 @@ async fn run_session(
                         if kind == 0 {
                             seg.push_str(&ev.text_chunk);
                         }
-                        let is_boundary = matches!(kind, 1 | 2 | 4);
+                        // Status (3) is also a narration boundary. Pilot uses
+                        // it after an in-progress no-call round so TTS can play
+                        // the complete progress update without mislabelling it
+                        // as FinalText and closing the interaction stream.
+                        let is_boundary = is_narration_boundary(kind);
                         let say = if is_boundary {
                             let streamed = std::mem::take(&mut seg);
                             if req.tts_enabled {
@@ -1139,6 +1143,10 @@ fn tts_boundary_text(kind: u32, streamed: String, final_text: &str) -> Option<St
     (!streamed.trim().is_empty()).then_some(streamed)
 }
 
+fn is_narration_boundary(kind: u32) -> bool {
+    matches!(kind, 1 | 2 | 3 | 4)
+}
+
 fn event_status(kind: u32, session_id: &str, message: &str) -> VoiceEvent {
     VoiceEvent {
         event_kind: kind,
@@ -1366,6 +1374,15 @@ mod tests {
         assert_eq!(
             tts_boundary_text(4, String::new(), "final answer"),
             Some("final answer".to_string())
+        );
+    }
+
+    #[test]
+    fn status_flushes_progress_without_requiring_final_text() {
+        assert!(is_narration_boundary(3));
+        assert_eq!(
+            tts_boundary_text(3, "still navigating".to_string(), ""),
+            Some("still navigating".to_string())
         );
     }
 

--- a/system/liaison/src/voice.rs
+++ b/system/liaison/src/voice.rs
@@ -336,6 +336,7 @@ async fn run_session(
             max_seconds,
             &session_id,
             &tx,
+            context_flag(&req.context_json, "barge_in"),
         )
         .await?
     };
@@ -597,6 +598,7 @@ async fn stream_capture_and_recognize(
     max_seconds: u32,
     session_id: &str,
     tx: &mpsc::Sender<Result<VoiceEvent, Status>>,
+    barge_in: bool,
 ) -> Result<(Vec<u8>, String)> {
     let mic_endpoint = resolve_endpoint(atlas, "robonix/primitive/audio/mic", mic_pin)
         .await
@@ -624,8 +626,15 @@ async fn stream_capture_and_recognize(
         )))
         .await;
 
+    let mut mic_request = Request::new(());
+    if barge_in {
+        mic_request.metadata_mut().insert(
+            "x-robonix-barge-in",
+            "true".parse().expect("static metadata value"),
+        );
+    }
     let mut mic_stream = mic_client
-        .mic(Request::new(()))
+        .mic(mic_request)
         .await
         .map_err(|e| anyhow::anyhow!("mic rpc failed: {e}"))?
         .into_inner();
@@ -1098,6 +1107,13 @@ fn build_task(
     }
 }
 
+fn context_flag(raw: &str, key: &str) -> bool {
+    serde_json::from_str::<serde_json::Value>(raw)
+        .ok()
+        .and_then(|value| value.get(key).and_then(serde_json::Value::as_bool))
+        .unwrap_or(false)
+}
+
 fn accumulate_text(ev: &PilotEvent, into: &mut String) {
     const EVT_TEXT_CHUNK: u32 = 0;
     const EVT_FINAL_TEXT: u32 = 4;
@@ -1351,6 +1367,13 @@ mod tests {
             tts_boundary_text(4, String::new(), "final answer"),
             Some("final answer".to_string())
         );
+    }
+
+    #[test]
+    fn barge_in_metadata_is_explicit_not_inferred_from_voice_mode() {
+        assert!(context_flag(r#"{"barge_in":true}"#, "barge_in"));
+        assert!(!context_flag(r#"{"interaction_mode":"voice"}"#, "barge_in"));
+        assert!(!context_flag("not json", "barge_in"));
     }
 
     #[tokio::test]

--- a/system/pilot/README.md
+++ b/system/pilot/README.md
@@ -42,6 +42,8 @@ Common configuration:
 
 The VLM-facing RTDL envelope rules (grammar, example, constraints) live in `rtdl_protocol.md` at the crate root and are embedded at compile time via `include_str!` into the per-turn capability list prompt. Edit that file to change RTDL instructions without touching `planner.rs`.
 
+Pilot's standing system prompt is built in `src/planner.rs`; it includes the runtime operating principles, including the rule that failed required capability calls stop autonomous physical task progress until the user confirms the next step.
+
 ## RTDL Planning Flow
 
 Pilot no longer sends OpenAI `tools` / function schemas as the primary planning path. Instead, it writes the RTDL grammar and available capability list into the prompt. The model must return a single JSON object:

--- a/system/pilot/rtdl_protocol.md
+++ b/system/pilot/rtdl_protocol.md
@@ -80,6 +80,12 @@ new request conflicts with what a tree is doing; leave it running when the new
 request is additive. Cancel a given `plan_id` at most once. If the harness says
 an identical call is already in flight, wait for it; never issue a duplicate.
 
+Executor feedback is scoped to the `plan_id` and independent tree named directly
+before the result. A failure blocks only dependent steps in that tree; it does
+not invalidate unrelated in-flight trees. Never cancel navigation or another
+physical tree merely because an independent greet, monitoring, observation, or
+query tree failed.
+
 When the user explicitly asks to stop or cancel all running work, call the
 executor `cancel_all_plans` capability directly in one `do` node. Do not call
 `get_all_plans` first, and never cancel the query/control tree itself.
@@ -138,6 +144,15 @@ Rules:
    into `/explore/CAPABILITY.md`) — those paths live in the provider's own
    container and are unreadable here. A provider not listed in "Capability docs"
    has no manual; call it directly from its `args_schema`.
+9. For a named room or region, current Scene data is authoritative. Call Scene
+   `list_objects`, use the returned stable ID with `goal_room`, and only then
+   call navigation with the reachable pose returned by Scene. A Memory
+   coordinate, grasp pose, observation pose, room label, or guessed ID is not a
+   substitute. Because the navigation arguments depend on the `goal_room`
+   result, these are separate planning rounds.
+10. Treat navigation completion in relation to the resolved requested
+    destination. `SUCCEEDED` for a pose equal to the current pose is a
+    zero-distance no-op; do not describe it as movement to a different place.
 
 Example — dispatch one tree, keep the existing goal (`task_update` null):
 
@@ -155,34 +170,24 @@ Example — dispatch one tree, keep the existing goal (`task_update` null):
   "task_update": null
 }
 
-Example — accept a new goal and dispatch a MULTI-STEP tree for it in one round
-(the steps are known up front, so do not split them across rounds). The two
-independent goals run in `parallel`; the water errand is an ordered `sequence`:
+Example — accept a new goal and dispatch independent work in one `parallel`
+tree (the steps are known up front, so do not split them across rounds):
 
 {
-  "content": "On it — fetching water and starting music at the same time.",
-  "rtdl_description": "fetch water + play music",
+  "content": "I will capture the scene and check battery status together.",
+  "rtdl_description": "snapshot + battery check",
   "rtdl": {
     "op": "parallel",
     "op_id": 0,
-    "description": "fetch water and play music at the same time",
+    "description": "capture the scene and check battery status",
     "children": [
-      {
-        "op": "sequence",
-        "op_id": 0,
-        "description": "fetch water from the kitchen",
-        "children": [
-          { "op": "do", "op_id": 0, "description": "drive to the kitchen", "cap": "nav.navigation_navigate", "args": { "target": "kitchen" } },
-          { "op": "do", "op_id": 0, "description": "grasp the water cup", "cap": "arm.manipulation_grasp", "args": { "object": "water cup" } },
-          { "op": "do", "op_id": 0, "description": "bring the cup back to the user", "cap": "nav.navigation_navigate", "args": { "target": "user" } }
-        ]
-      },
-      { "op": "do", "op_id": 0, "description": "start playing music", "cap": "audio.audio_play", "args": { "track": "music" } }
+      { "op": "do", "op_id": 0, "description": "capture the current scene", "cap": "camera.camera_snapshot", "args": {} },
+      { "op": "do", "op_id": 0, "description": "read current battery status", "cap": "battery.battery_status", "args": {} }
     ]
   },
   "task_update": {
-    "goal": "bring the user water and play music at the same time",
-    "success_criterion": "a water cup is next to the user AND music is playing",
+    "goal": "capture the current scene and report battery status",
+    "success_criterion": "a current image and battery status have both been returned",
     "status": "in_progress"
   }
 }
@@ -205,18 +210,19 @@ just the observation:
   "task_update": null
 }
 
-Example — cancel an in-flight tree the user no longer wants, then re-plan:
+Example — cancel an in-flight tree the user no longer wants. Resolve any new
+semantic destination through Scene in later rounds rather than inventing a
+navigation target:
 
 {
-  "content": "Stopping the patrol and coming back to you.",
-  "rtdl_description": "return to user",
+  "content": "Stopping the patrol first.",
+  "rtdl_description": "stop patrol",
   "rtdl": {
     "op": "sequence",
     "op_id": 0,
-    "description": "stop the patrol and return to the user",
+    "description": "stop the running patrol",
     "children": [
-      { "op": "do", "op_id": 0, "description": "cancel the running patrol tree", "cap": "executor.builtin_cancel_plan", "args": { "plan_id": "PASTE_THE_INFLIGHT_PLAN_ID" } },
-      { "op": "do", "op_id": 0, "description": "drive back to the user", "cap": "nav.navigation_navigate", "args": { "target": "user" } }
+      { "op": "do", "op_id": 0, "description": "cancel the running patrol tree", "cap": "executor.builtin_cancel_plan", "args": { "plan_id": "PASTE_THE_INFLIGHT_PLAN_ID" } }
     ]
   },
   "task_update": null
@@ -225,12 +231,12 @@ Example — cancel an in-flight tree the user no longer wants, then re-plan:
 Example — overall task finished (no new tree, mark done):
 
 {
-  "content": "Done — the water is by you and music is playing.",
+  "content": "Done — the current image and battery status are available.",
   "rtdl_description": "",
   "rtdl": { "op": "sequence", "op_id": 0, "description": "no new work this round", "children": [] },
   "task_update": {
-    "goal": "bring the user water and play music at the same time",
-    "success_criterion": "a water cup is next to the user AND music is playing",
+    "goal": "capture the current scene and report battery status",
+    "success_criterion": "a current image and battery status have both been returned",
     "status": "done"
   }
 }

--- a/system/pilot/rtdl_protocol.md
+++ b/system/pilot/rtdl_protocol.md
@@ -15,16 +15,18 @@ Do not output markdown fences, headings, explanations, or any text outside the J
 
 ### Task state (`task_update`)
 
-The harness owns one persistent overall task per conversation. It creates the
-goal from user input and appends every steer/follow-up verbatim, so unfinished
-work cannot disappear. `task_update` reports progress; it is not a
-set-current-goal command:
+The harness owns one persistent overall task per conversation. It creates a
+chronological instruction history from user input and appends every
+steer/follow-up verbatim. Interpret it oldest to newest: the latest instruction
+overrides any conflicting older instruction, while unrelated unfinished work
+remains active. `task_update` reports progress; it is not a set-current-goal
+command:
 
 - `null` — keep the current criterion and status exactly as they are.
 - object with these keys (all required when the value is an object):
-  - `goal`: copy this EXACTLY from the "Current overall task" block. Never
-    summarize, shorten, replace, or drop an unfinished part. The harness ignores
-    attempted replacements.
+  - `goal`: copy the instruction history EXACTLY from the "Current overall
+    task" block. Never summarize, shorten, or rewrite it. The harness ignores
+    attempted replacements; precedence is determined by instruction order.
   - `success_criterion`: how to know the goal is done — concrete and checkable,
     e.g. `"the water cup is next to the user AND music is audibly playing"`.
     You may refine the harness default once; do not later weaken or erase it.
@@ -79,6 +81,11 @@ an in-flight tree when the user steers you is your call: cancel only when the
 new request conflicts with what a tree is doing; leave it running when the new
 request is additive. Cancel a given `plan_id` at most once. If the harness says
 an identical call is already in flight, wait for it; never issue a duplicate.
+
+When a steer asks to finish the current step and then stop, do not immediately
+cancel the tree. Inspect it with `get_plan_status`, then arm `stop_plan_at` on
+the current op with `on_complete`, or on the next op with `on_enter`. Immediate
+`cancel_plan` is only for stopping now.
 
 Executor feedback is scoped to the `plan_id` and independent tree named directly
 before the result. A failure blocks only dependent steps in that tree; it does

--- a/system/pilot/rtdl_protocol.md
+++ b/system/pilot/rtdl_protocol.md
@@ -1,28 +1,33 @@
 ## RTDL output protocol
 
 Return a valid JSON object with exactly these top-level keys:
-- `content`: a string visible to the user.
+- `content`: user-facing text. It is surfaced only when the task completes or
+  when you genuinely need more user input; it is not a planning scratchpad.
 - `rtdl_description`: a short string naming what THIS `rtdl` tree is doing
   (the current sub-task, e.g. `"fetch water"`). Used to label the tree while it
   runs. Empty string is allowed only when `rtdl` is an empty sequence.
 - `rtdl`: a Robot Task Description Language JSON AST (the tree to dispatch now).
-- `task_update`: either `null` (keep the current overall task/goal unchanged)
-  or an object updating the overall task. See "Task state" below.
+- `task_update`: either `null` (keep current progress) or a progress object.
+  The harness owns the overall goal. See "Task state" below.
 
 The whole assistant message MUST begin with `{` and end with `}`.
 Do not output markdown fences, headings, explanations, or any text outside the JSON object.
 
 ### Task state (`task_update`)
 
-You own one persistent overall task per conversation. Each turn you may revise
-it through `task_update`:
+The harness owns one persistent overall task per conversation. It creates the
+goal from user input and appends every steer/follow-up verbatim, so unfinished
+work cannot disappear. `task_update` reports progress; it is not a
+set-current-goal command:
 
-- `null` — keep the current goal, criterion, and status exactly as they are.
+- `null` — keep the current criterion and status exactly as they are.
 - object with these keys (all required when the value is an object):
-  - `goal`: the overall objective in one sentence, e.g.
-    `"bring me water and play music at the same time"`. Replaces the prior goal.
+  - `goal`: copy this EXACTLY from the "Current overall task" block. Never
+    summarize, shorten, replace, or drop an unfinished part. The harness ignores
+    attempted replacements.
   - `success_criterion`: how to know the goal is done — concrete and checkable,
     e.g. `"the water cup is next to the user AND music is audibly playing"`.
+    You may refine the harness default once; do not later weaken or erase it.
   - `status`: `"in_progress"` or `"done"`.
 
 `status: "done"` is the ONE authoritative completion signal. The turn ends only
@@ -38,10 +43,14 @@ make the task done; wait for that tree to actually leave the In-flight list (you
 will see its result) before declaring done. Keep emitting empty-`rtdl` rounds
 (which just wait) until the forest is clear, then mark `done`.
 
-Set `task_update` to a fresh object when:
-- the user gives a new goal or steers you mid-task (incorporate their change);
-- you refine the goal as you learn more;
-- the goal is complete (`status: "done"`).
+Set `task_update` to a fresh object only when you refine the default success
+criterion or report a status change. User goal and steer incorporation is done
+by the harness.
+
+During planning or execution, keep `content` empty or concise. Do not emit
+"waiting", "still working", repeated cancel explanations, or other heartbeat
+replies. The harness exposes plans and node states separately and surfaces
+`content` only at completion or a genuine user-input boundary.
 
 ### RTDL tree
 
@@ -66,9 +75,10 @@ do not block each other. The "In-flight trees" section of your context lists
 every tree still running, with its `plan_id` and description. To stop one, emit
 a `do` node whose `cap` is the cancel-plan capability_name from the list (e.g.
 `executor.builtin_cancel_plan`), passing that tree's `plan_id`. Whether to cancel
-an in-flight tree when the user steers you is your
-call: cancel when the new request conflicts with what a tree is doing; leave it
-running when the new request is additive.
+an in-flight tree when the user steers you is your call: cancel only when the
+new request conflicts with what a tree is doing; leave it running when the new
+request is additive. Cancel a given `plan_id` at most once. If the harness says
+an identical call is already in flight, wait for it; never issue a duplicate.
 
 ### Plan IDs (read this — you do NOT choose them)
 

--- a/system/pilot/rtdl_protocol.md
+++ b/system/pilot/rtdl_protocol.md
@@ -80,6 +80,10 @@ new request conflicts with what a tree is doing; leave it running when the new
 request is additive. Cancel a given `plan_id` at most once. If the harness says
 an identical call is already in flight, wait for it; never issue a duplicate.
 
+When the user explicitly asks to stop or cancel all running work, call the
+executor `cancel_all_plans` capability directly in one `do` node. Do not call
+`get_all_plans` first, and never cancel the query/control tree itself.
+
 ### Plan IDs (read this — you do NOT choose them)
 
 Every tree you dispatch is assigned a `plan_id` by the system — a string holding

--- a/system/pilot/src/main.rs
+++ b/system/pilot/src/main.rs
@@ -27,6 +27,7 @@ mod pb;
 mod planner;
 mod service;
 mod soma_context;
+mod state_context;
 mod vlm;
 
 use anyhow::{Context, Result};

--- a/system/pilot/src/planner.rs
+++ b/system/pilot/src/planner.rs
@@ -18,7 +18,7 @@ use futures_util::StreamExt;
 use robonix_atlas::client::AtlasClient;
 use robonix_atlas::pb as atlas_pb;
 use robonix_scribe::{debug, info, warn};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -61,11 +61,14 @@ const MAX_HISTORY: usize = 200;
 /// "keep the current task unchanged" and is represented as `None` at the
 /// call site, not as a `TaskState`.
 #[derive(Clone, Debug, PartialEq, Eq)]
-struct TaskState {
+pub(crate) struct TaskState {
     goal: String,
     success_criterion: String,
     status: String,
 }
+
+const DEFAULT_SUCCESS_CRITERION: &str =
+    "The user's request is completed and the result has been verified.";
 
 impl TaskState {
     /// Whether the LLM has declared the overall task complete. This is the
@@ -135,6 +138,11 @@ struct TreeMeta {
     /// cancellable in-flight work — a cancel is not itself a task tree, and
     /// listing it makes the model cancel its own cancels in a loop.
     control_only: bool,
+    /// Canonical provider/contract/args signatures for calls in this tree.
+    /// The harness rejects a second tree containing an identical call while
+    /// the first is still in flight; execution latency must not duplicate a
+    /// physical or external command.
+    call_signatures: HashSet<String>,
 }
 
 /// Events fed from per-tree driver tasks back to the supervisor loop. One
@@ -172,12 +180,14 @@ async fn drive_plan(
     plan: Plan,
     mut client: RobonixSystemExecutorExecuteClient<Channel>,
     events_tx: mpsc::Sender<ForestEvent>,
+    forest_revision: Arc<AtomicU64>,
 ) {
     let plan_id = plan.plan_id.clone();
     let mut stream = match client.execute(Request::new(plan)).await {
         Ok(resp) => resp.into_inner(),
         Err(e) => {
             warn!("[pilot/forest] plan_id={plan_id} Execute RPC failed: {e}");
+            forest_revision.fetch_add(1, Ordering::Release);
             let _ = events_tx
                 .send(ForestEvent::PlanDone {
                     plan_id,
@@ -216,6 +226,7 @@ async fn drive_plan(
                     // a terminal state (leaf and non-leaf). A non-success
                     // terminal state marks the round as failed.
                     if is_terminal_executor_state(ns.state) {
+                        forest_revision.fetch_add(1, Ordering::Release);
                         if ns.state == RtdlNodeStateEnum::Canceled as u32 {
                             // Cancellation is not a failure to recover from — it
                             // is the model's own stop request taking effect. Flag
@@ -238,6 +249,7 @@ async fn drive_plan(
         }
     }
 
+    forest_revision.fetch_add(1, Ordering::Release);
     let _ = events_tx
         .send(ForestEvent::PlanDone {
             plan_id,
@@ -333,11 +345,16 @@ fn is_control_only(plan: &Plan) -> bool {
     has_do
 }
 
-fn build_forest_block(forest: &HashMap<String, TreeMeta>) -> String {
+fn build_forest_block(
+    forest: &HashMap<String, TreeMeta>,
+    cancel_requested: &HashSet<String>,
+) -> String {
     // Only real task trees are cancellable in-flight work; hide pure control
     // (cancel-only) trees so the model never tries to cancel its own cancels.
-    let mut entries: Vec<(&String, &TreeMeta)> =
-        forest.iter().filter(|(_, m)| !m.control_only).collect();
+    let mut entries: Vec<(&String, &TreeMeta)> = forest
+        .iter()
+        .filter(|(plan_id, meta)| !meta.control_only && !cancel_requested.contains(*plan_id))
+        .collect();
     if entries.is_empty() {
         return String::new();
     }
@@ -374,21 +391,92 @@ fn build_forest_block(forest: &HashMap<String, TreeMeta>) -> String {
 /// running. Draining is non-blocking; returns whether anything was pulled so
 /// the caller knows to re-plan. The model decides for itself whether the steer
 /// requires cancelling an in-flight tree (via `builtin_cancel_plan`).
-fn drain_steers(steer_rx: &mut mpsc::Receiver<Task>, history: &mut Vec<Message>) -> bool {
+fn append_steer(
+    task: Task,
+    history: &mut Vec<Message>,
+    current_task: &mut Option<TaskState>,
+) -> bool {
+    let text = task.text.trim();
+    if text.is_empty() {
+        return false;
+    }
+    info!("[pilot/steer] mid-task input: {text}");
+    history.push(Message::user(text));
+    if let Some(state) = current_task.as_mut() {
+        state.goal.push_str("\nUser steer/follow-up: ");
+        state.goal.push_str(text);
+        state.status = "in_progress".to_string();
+    }
+    true
+}
+
+fn drain_steers(
+    steer_rx: &mut mpsc::Receiver<Task>,
+    history: &mut Vec<Message>,
+    current_task: &mut Option<TaskState>,
+) -> bool {
     let mut pulled = false;
     while let Ok(task) = steer_rx.try_recv() {
-        let text = task.text.trim();
-        if text.is_empty() {
-            continue;
-        }
-        info!("[pilot/steer] mid-task input: {text}");
-        history.push(Message::user(text));
-        pulled = true;
+        pulled |= append_steer(task, history, current_task);
     }
     if pulled {
         history::trim(history, MAX_HISTORY);
     }
     pulled
+}
+
+fn start_or_resume_task(current_task: &mut Option<TaskState>, user_text: &str) {
+    let text = user_text.trim();
+    if text.is_empty() {
+        return;
+    }
+    match current_task {
+        Some(state) if !state.is_done() => {
+            state.goal.push_str("\nUser follow-up: ");
+            state.goal.push_str(text);
+            state.status = "in_progress".to_string();
+        }
+        slot => {
+            *slot = Some(TaskState {
+                goal: text.to_string(),
+                success_criterion: DEFAULT_SUCCESS_CRITERION.to_string(),
+                status: "in_progress".to_string(),
+            });
+        }
+    }
+}
+
+/// Apply only progress fields from the model. The user-owned goal is immutable
+/// within the standing task; steering is appended by the harness above. The
+/// model may refine the default success criterion once, but cannot erase or
+/// replace an established criterion. Completion is accepted only at a harness
+/// safe point with no new or in-flight execution.
+fn apply_task_update(
+    current_task: &mut Option<TaskState>,
+    update: TaskState,
+    can_finish: bool,
+) -> bool {
+    let Some(state) = current_task.as_mut() else {
+        return false;
+    };
+    let before = state.clone();
+    if update.goal != state.goal {
+        warn!(
+            "[pilot/rtdl] ignoring model goal replacement {:?}; harness goal remains {:?}",
+            update.goal, state.goal
+        );
+    }
+    if state.success_criterion == DEFAULT_SUCCESS_CRITERION
+        && !update.success_criterion.trim().is_empty()
+    {
+        state.success_criterion = update.success_criterion;
+    }
+    state.status = if update.status == "done" && can_finish {
+        "done".to_string()
+    } else {
+        "in_progress".to_string()
+    };
+    *state != before
 }
 
 /// Approx history size (in chars; ~4 chars/token) past which we compact. Tuned
@@ -476,6 +564,7 @@ fn feed_results_into_history(history: &mut Vec<Message>, results: &[CapabilityCa
 pub async fn run_turn(
     task: &Task,
     history: &mut Vec<Message>,
+    standing_task: &mut Option<TaskState>,
     vlm: &VlmClient,
     executor: &mut ExecutorConn,
     atlas: &mut AtlasClient,
@@ -615,14 +704,22 @@ pub async fn run_turn(
     // 2. Add user message to history
     history.push(Message::user(&task.text));
     history::trim(history, MAX_HISTORY);
+    start_or_resume_task(standing_task, &task.text);
+    if let Some(state) = standing_task.as_ref() {
+        let _ = tx
+            .send(Ok(service::pack(
+                &session_id,
+                PilotStreamBody::TaskState(TaskStateEvent {
+                    goal: state.goal.clone(),
+                    success_criterion: state.success_criterion.clone(),
+                    status: state.status.clone(),
+                }),
+            )))
+            .await;
+    }
 
     let max_rounds = max_tool_rounds();
     let mut round: u32 = 0;
-
-    // The LLM's standing overall task. `None` until the model first emits a
-    // `task_update`; thereafter it persists across rounds and is replaced only
-    // when the model sends a fresh `task_update`.
-    let mut current_task: Option<TaskState> = None;
 
     // Pilot-assigned plan ids: monotonic from 1, never reused — and shared
     // across every turn of this session (the counter lives in the service's
@@ -640,11 +737,13 @@ pub async fn run_turn(
     // `done` (or was never set, i.e. chit-chat) AND no tree is still running.
     let (forest_tx, mut forest_rx) = mpsc::channel::<ForestEvent>(256);
     let mut forest: HashMap<String, TreeMeta> = HashMap::new();
+    let mut cancel_requested: HashSet<String> = HashSet::new();
+    let forest_revision = Arc::new(AtomicU64::new(0));
     let mut should_plan = true;
     // Last user-facing narration; surfaced as FinalText when the turn ends.
     let mut last_content = String::new();
 
-    loop {
+    'supervisor: loop {
         // Check for hard interrupt at the top of every iteration.
         if *cancel_rx.borrow() {
             return_interrupted!(&forest);
@@ -652,12 +751,12 @@ pub async fn run_turn(
 
         if !should_plan {
             // No planning due. Either wait for a running tree, or end the turn.
-            let task_done = current_task
+            let task_done = standing_task
                 .as_ref()
                 .map(TaskState::is_done)
                 .unwrap_or(false);
             if forest.is_empty() {
-                if task_done || current_task.is_none() {
+                if task_done || standing_task.is_none() {
                     let _ = tx
                         .send(Ok(service::pack(
                             &session_id,
@@ -678,10 +777,7 @@ pub async fn run_turn(
                     steer = steer_rx.recv() => {
                         match steer {
                             Some(task) => {
-                                let text = task.text.trim();
-                                if !text.is_empty() {
-                                    info!("[pilot/steer] resuming waiting task: {text}");
-                                    history.push(Message::user(text));
+                                if append_steer(task, history, standing_task) {
                                     history::trim(history, MAX_HISTORY);
                                     should_plan = true;
                                 }
@@ -701,10 +797,7 @@ pub async fn run_turn(
                 }
                 steer = steer_rx.recv() => {
                     if let Some(task) = steer {
-                        let text = task.text.trim();
-                        if !text.is_empty() {
-                            info!("[pilot/steer] mid-task input: {text}");
-                            history.push(Message::user(text));
+                        if append_steer(task, history, standing_task) {
                             history::trim(history, MAX_HISTORY);
                             // Re-plan now so the model can react (and decide
                             // whether to cancel any in-flight tree).
@@ -759,6 +852,7 @@ pub async fn run_turn(
                         }
                         Some(ForestEvent::PlanDone { plan_id, results, any_failed, canceled }) => {
                             forest.remove(&plan_id);
+                            cancel_requested.remove(&plan_id);
                             // Leaf results were already fed per-node (see above);
                             // only surface the batch to the chat UI here.
                             log_plan_complete(&plan_id, &results, any_failed);
@@ -801,7 +895,7 @@ pub async fn run_turn(
 
         // Pull any steers that landed while we were busy (e.g. during the
         // previous VLM stream) so this round plans with the latest user input.
-        drain_steers(&mut steer_rx, history);
+        drain_steers(&mut steer_rx, history, standing_task);
 
         // Roll up old history into a summary once it gets large, so the rest of
         // the turn plans against a compact window instead of the full transcript.
@@ -817,11 +911,11 @@ pub async fn run_turn(
         let target_map = build_capability_target_map(&display_caps);
         let rtdl_prompt = build_rtdl_prompt(&display_caps, round == 0)?;
 
-        let task_block = current_task
+        let task_block = standing_task
             .as_ref()
             .map(TaskState::prompt_block)
             .unwrap_or_default();
-        let forest_block = build_forest_block(&forest);
+        let forest_block = build_forest_block(&forest, &cancel_requested);
         // Plan with a single corrective retry (merged from dev #88): if the
         // VLM's RTDL fails to parse or expand, feed the error back and let it
         // fix the reply once; a second failure ends the turn gracefully (empty
@@ -837,6 +931,7 @@ pub async fn run_turn(
                 messages.push(Message::user(correction));
             }
 
+            let planning_revision = forest_revision.load(Ordering::Acquire);
             let (content, raw_tool_calls) = {
                 let mut stream = vlm
                     .chat_stream(&messages, &[])
@@ -853,6 +948,19 @@ pub async fn run_turn(
                         _ = cancel_rx.changed() => {
                             drop(stream);
                             return_interrupted!(&forest);
+                        }
+                        steer = steer_rx.recv() => {
+                            if let Some(task) = steer {
+                                append_steer(task, history, standing_task);
+                                drain_steers(&mut steer_rx, history, standing_task);
+                                history::trim(history, MAX_HISTORY);
+                            }
+                            // The response being sampled was built without this
+                            // input. Drop it before parsing or dispatching any
+                            // call, then sample again from the updated history.
+                            drop(stream);
+                            should_plan = true;
+                            continue 'supervisor;
                         }
                         item = stream.next() => {
                             let item = match item {
@@ -876,6 +984,14 @@ pub async fn run_turn(
                 };
                 (content, tool_calls)
             };
+
+            if forest_revision.load(Ordering::Acquire) != planning_revision {
+                // Executor state changed while the model was thinking. Never
+                // dispatch a plan based on the stale in-flight snapshot. Return
+                // to the event arm, consume the queued state, then re-plan.
+                should_plan = false;
+                continue 'supervisor;
+            }
 
             if !raw_tool_calls.is_empty() {
                 anyhow::bail!("VLM returned tool_calls in RTDL mode");
@@ -988,31 +1104,57 @@ pub async fn run_turn(
             break;
         }
 
-        // Apply the task update now that we have a real expanded tree (recovery
-        // breaks carry `None`). `None` keeps the standing task unchanged.
+        let calls = plan_call_count(&graph);
+        let call_signatures = plan_call_signatures(&graph);
+        let cancel_targets = plan_cancel_targets(&graph);
+        if let Some(target) = invalid_cancel_target(&cancel_targets, &forest, &cancel_requested) {
+            warn!("[pilot/harness] suppressed stale or duplicate cancel for plan {target}");
+            history.push(Message::user(
+                "Pilot harness feedback: that plan is not cancellable now (it already finished or cancellation was already requested). Do not issue another cancel; wait for current executor events or answer the user.",
+            ));
+            history::trim(history, MAX_HISTORY);
+            should_plan = false;
+            continue 'supervisor;
+        }
+        if let Some(duplicate) = duplicate_in_flight_signature(&call_signatures, &forest) {
+            warn!("[pilot/harness] suppressed duplicate in-flight call: {duplicate}");
+            history.push(Message::user(
+                "Pilot harness feedback: that exact capability call is already in flight. Do not dispatch or cancel it again; wait for its result.",
+            ));
+            history::trim(history, MAX_HISTORY);
+            should_plan = false;
+            continue 'supervisor;
+        }
+
+        // Apply progress only after the harness knows whether this response can
+        // safely finish. A model cannot mark a task done while it is also
+        // dispatching work or while an older tree remains in flight.
         if let Some(updated) = task_update {
             info!(
                 "[pilot/rtdl] task_update goal='{}' status='{}'",
                 updated.goal, updated.status
             );
-            let _ = tx
-                .send(Ok(service::pack(
-                    &session_id,
-                    PilotStreamBody::TaskState(TaskStateEvent {
-                        goal: updated.goal.clone(),
-                        success_criterion: updated.success_criterion.clone(),
-                        status: updated.status.clone(),
-                    }),
-                )))
-                .await;
-            current_task = Some(updated);
+            let changed =
+                apply_task_update(standing_task, updated, calls == 0 && forest.is_empty());
+            if changed && let Some(state) = standing_task.as_ref() {
+                let _ = tx
+                    .send(Ok(service::pack(
+                        &session_id,
+                        PilotStreamBody::TaskState(TaskStateEvent {
+                            goal: state.goal.clone(),
+                            success_criterion: state.success_criterion.clone(),
+                            status: state.status.clone(),
+                        }),
+                    )))
+                    .await;
+            }
         }
 
-        let calls = plan_call_count(&graph);
         log_plan_start(&graph, &rtdl_description, round, calls);
 
-        // Narration enters history once; it streams to the client as a
-        // TextChunk while the turn continues, or as FinalText when it ends.
+        // Planning narration is model scratch context, not a user reply. It is
+        // retained for the next planning round but only surfaced when the turn
+        // actually completes or deliberately pauses for more user input.
         if !assistant_content.is_empty() {
             history.push(Message::assistant(&assistant_content));
             last_content = assistant_content.clone();
@@ -1020,35 +1162,32 @@ pub async fn run_turn(
 
         round += 1;
         let hit_cap = round as usize >= max_rounds;
-        let task_done = current_task
+        let task_done = standing_task
             .as_ref()
             .map(TaskState::is_done)
             .unwrap_or(false);
 
         if calls == 0 {
-            // No new tree this round. End only when nothing is running and the
-            // task is done (or was never set — chit-chat). Otherwise the model
-            // is waiting on the forest: keep its narration flowing and loop back
-            // to the wait arm.
-            if forest.is_empty() && (task_done || current_task.is_none() || hit_cap) {
-                if hit_cap && !(task_done || current_task.is_none()) {
+            // With no tree left, this is either a final answer or a deliberate
+            // request for more user input. End this transport turn exactly once;
+            // an in-progress standing task remains persisted by the service and
+            // resumes on the next user message.
+            if forest.is_empty() {
+                if hit_cap && !(task_done || standing_task.is_none()) {
                     warn!("[pilot] hit max tool rounds ({max_rounds}), stopping turn");
                 }
+                let reply = if assistant_content.trim().is_empty() && !task_done {
+                    "I need more information before I can continue.".to_string()
+                } else {
+                    assistant_content
+                };
                 let _ = tx
                     .send(Ok(service::pack(
                         &session_id,
-                        PilotStreamBody::FinalText(assistant_content),
+                        PilotStreamBody::FinalText(reply),
                     )))
                     .await;
                 break;
-            }
-            if !assistant_content.is_empty() {
-                let _ = tx
-                    .send(Ok(service::pack(
-                        &session_id,
-                        PilotStreamBody::TextChunk(assistant_content),
-                    )))
-                    .await;
             }
             if hit_cap {
                 warn!("[pilot] hit max tool rounds ({max_rounds}), stopping turn");
@@ -1059,17 +1198,8 @@ pub async fn run_turn(
             continue;
         }
 
-        // Non-empty tree: narrate, hand the structure to the client, and dispatch
-        // it to the forest without blocking. Trees added across rounds (e.g. by a
-        // mid-task steer) run side by side.
-        if !assistant_content.is_empty() {
-            let _ = tx
-                .send(Ok(service::pack(
-                    &session_id,
-                    PilotStreamBody::TextChunk(assistant_content),
-                )))
-                .await;
-        }
+        // Non-empty tree: hand the structure to the client and dispatch it to
+        // the forest without leaking planning narration as a premature reply.
         let _ = tx
             .send(Ok(service::pack(
                 &session_id,
@@ -1078,14 +1208,21 @@ pub async fn run_turn(
             .await;
         // Commit the plan id now that a real tree is being dispatched.
         plan_seq.fetch_add(1, Ordering::Relaxed);
+        cancel_requested.extend(cancel_targets);
         forest.insert(
             plan_id.clone(),
             TreeMeta {
                 description: rtdl_description,
                 control_only: is_control_only(&graph),
+                call_signatures,
             },
         );
-        tokio::spawn(drive_plan(graph, executor.graph.clone(), forest_tx.clone()));
+        tokio::spawn(drive_plan(
+            graph,
+            executor.graph.clone(),
+            forest_tx.clone(),
+            Arc::clone(&forest_revision),
+        ));
         info!(
             "[pilot/forest] plan_id={plan_id} dispatched forest_size={}",
             forest.len()
@@ -1156,8 +1293,9 @@ A capability name goes ONLY in a do node's `cap` — NEVER as an `op`. \
 Beyond `op_id` and `description`, do NOT add other node fields (no `plan_id`, no `out`, no `id`). \
 Copy each `cap` EXACTLY from a capability_name in the list below (it is provider-qualified, \
 e.g. `tiago_camera.camera_snapshot`); never invent or shorten names.\n\
-`task_update`: null keeps the current goal (use null when you are not changing the task this round — \
-NOT an object with null fields), or {\"goal\",\"success_criterion\",\"status\"} where status is the \
+`task_update`: null keeps current progress, or {\"goal\",\"success_criterion\",\"status\"}. \
+The harness owns the goal: copy `goal` EXACTLY from \"Current overall task\" and never rewrite, \
+shorten, replace, or drop unfinished parts. You may refine the default success criterion once. status is the \
 string \"in_progress\" or \"done\" (never null), set to \
 \"done\" only when the success_criterion verifiably holds AND no tree in the \
 \"In-flight trees\" list is still running (cancelling a tree does not make the task done — wait \
@@ -1618,6 +1756,58 @@ fn plan_call_count(plan: &Plan) -> usize {
         .count()
 }
 
+fn plan_call_signatures(plan: &Plan) -> HashSet<String> {
+    plan.nodes
+        .iter()
+        .filter_map(|node| node.call.as_ref())
+        .map(|call| {
+            let args = serde_json::from_str::<serde_json::Value>(&call.args_json)
+                .ok()
+                .and_then(|value| serde_json::to_string(&value).ok())
+                .unwrap_or_else(|| call.args_json.clone());
+            format!("{}|{}|{args}", call.provider_id, call.contract_id)
+        })
+        .collect()
+}
+
+fn duplicate_in_flight_signature(
+    signatures: &HashSet<String>,
+    forest: &HashMap<String, TreeMeta>,
+) -> Option<String> {
+    signatures.iter().find_map(|signature| {
+        forest
+            .values()
+            .any(|meta| meta.call_signatures.contains(signature))
+            .then(|| signature.clone())
+    })
+}
+
+fn plan_cancel_targets(plan: &Plan) -> Vec<String> {
+    plan.nodes
+        .iter()
+        .filter_map(|node| node.call.as_ref())
+        .filter(|call| call.contract_id.rsplit('/').next() == Some("cancel_plan"))
+        .filter_map(|call| serde_json::from_str::<serde_json::Value>(&call.args_json).ok())
+        .filter_map(|args| {
+            args.get("plan_id")
+                .and_then(|value| value.as_str())
+                .map(str::to_string)
+        })
+        .collect()
+}
+
+fn invalid_cancel_target(
+    targets: &[String],
+    forest: &HashMap<String, TreeMeta>,
+    cancel_requested: &HashSet<String>,
+) -> Option<String> {
+    targets.iter().find_map(|target| {
+        let invalid = cancel_requested.contains(target)
+            || forest.get(target).is_none_or(|meta| meta.control_only);
+        invalid.then(|| target.clone())
+    })
+}
+
 /// Render an RTDL node state as a stable human-readable name for logs.
 fn rtdl_state_name(state: u32) -> String {
     match RtdlNodeStateEnum::try_from(state as i32) {
@@ -1907,6 +2097,12 @@ by planning capability calls available to you.
   just to confirm unchanged data.
 
 ## Persistence (READ THIS — most common failure mode)
+The harness owns the overall goal. It is created from the user's message and
+appends later steer/follow-up messages verbatim. Never replace it with your own
+summary, a current sub-step, or only the newest request. When emitting a
+non-null `task_update`, copy its `goal` exactly from \"Current overall task\".
+`task_update` is a progress report, not a set-current-goal command.
+
 The turn ends only when your overall task is `done` (you set
 `task_update.status: \"done\"`), every tree you dispatched has finished, and
 there is no pending user input. An empty RTDL sequence alone does NOT end the
@@ -1933,6 +2129,9 @@ while you wait for an in-flight tree). Do NOT mark the task `done` until it is
   verification is wrong — verify first.
 - On the very rare case where the user explicitly cancels, you may stop
   early; otherwise keep going.
+- `content` is user-facing only when the task is complete or when you genuinely
+  need more user input. During planning/execution, keep it empty or concise;
+  the harness will not surface planning narration as a reply.
 ",
     );
     p
@@ -1941,13 +2140,107 @@ while you wait for an in-flight tree). Do NOT mark the task `done` until it is
 #[cfg(test)]
 mod tests {
     use super::{
-        CapabilityTargetMap, RTDL_DO, RTDL_PARALLEL, RTDL_SEQUENCE, TaskState, expand_rtdl_to_plan,
-        extract_json_object, format_plan_summary, is_control_only, parse_rtdl_assistant_response,
-        parse_task_update, rtdl_node_kind_name, rtdl_recovery_final_text, rtdl_state_name,
-        skip_memory_prefetch, task_is_session_end,
+        CapabilityTargetMap, DEFAULT_SUCCESS_CRITERION, RTDL_DO, RTDL_PARALLEL, RTDL_SEQUENCE,
+        TaskState, TreeMeta, apply_task_update, duplicate_in_flight_signature, expand_rtdl_to_plan,
+        extract_json_object, format_plan_summary, invalid_cancel_target, is_control_only,
+        parse_rtdl_assistant_response, parse_task_update, plan_call_signatures,
+        rtdl_node_kind_name, rtdl_recovery_final_text, rtdl_state_name, skip_memory_prefetch,
+        start_or_resume_task, task_is_session_end,
     };
     use crate::pb::pilot::{CapabilityCall, Plan, RtdlNode, Task};
     use serde_json::json;
+    use std::collections::{HashMap, HashSet};
+
+    #[test]
+    fn harness_goal_cannot_be_replaced_by_task_update() {
+        let mut standing = None;
+        start_or_resume_task(&mut standing, "inspect room and report");
+        let original_goal = standing.as_ref().unwrap().goal.clone();
+        assert_eq!(
+            standing.as_ref().unwrap().success_criterion,
+            DEFAULT_SUCCESS_CRITERION
+        );
+
+        assert!(apply_task_update(
+            &mut standing,
+            TaskState {
+                goal: "drop the inspection and say done".into(),
+                success_criterion: "room was actually inspected".into(),
+                status: "done".into(),
+            },
+            false,
+        ));
+        let state = standing.as_ref().unwrap();
+        assert_eq!(state.goal, original_goal);
+        assert_eq!(state.success_criterion, "room was actually inspected");
+        assert_eq!(state.status, "in_progress");
+
+        assert!(apply_task_update(
+            &mut standing,
+            TaskState {
+                goal: original_goal.clone(),
+                success_criterion: "weaker replacement".into(),
+                status: "done".into(),
+            },
+            true,
+        ));
+        let state = standing.as_ref().unwrap();
+        assert_eq!(state.goal, original_goal);
+        assert_eq!(state.success_criterion, "room was actually inspected");
+        assert_eq!(state.status, "done");
+    }
+
+    #[test]
+    fn duplicate_in_flight_calls_are_detected_by_canonical_signature() {
+        let plan = Plan {
+            plan_id: "2".into(),
+            nodes: vec![RtdlNode {
+                node_kind: RTDL_DO,
+                call: Some(CapabilityCall {
+                    provider_id: "executor".into(),
+                    contract_id: "test/run".into(),
+                    args_json: r#"{"b":2,"a":1}"#.into(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let signatures = plan_call_signatures(&plan);
+        let mut forest = HashMap::new();
+        forest.insert(
+            "1".to_string(),
+            TreeMeta {
+                description: "same call".into(),
+                control_only: false,
+                call_signatures: signatures.clone(),
+            },
+        );
+        assert!(duplicate_in_flight_signature(&signatures, &forest).is_some());
+    }
+
+    #[test]
+    fn cancel_target_must_be_live_and_not_already_requested() {
+        let mut forest = HashMap::new();
+        forest.insert(
+            "7".to_string(),
+            TreeMeta {
+                description: "drive".into(),
+                control_only: false,
+                call_signatures: HashSet::new(),
+            },
+        );
+        let targets = vec!["7".to_string()];
+        assert!(invalid_cancel_target(&targets, &forest, &HashSet::new()).is_none());
+        assert_eq!(
+            invalid_cancel_target(&targets, &forest, &HashSet::from(["7".to_string()])),
+            Some("7".to_string())
+        );
+        assert_eq!(
+            invalid_cancel_target(&["8".to_string()], &forest, &HashSet::new()),
+            Some("8".to_string())
+        );
+    }
 
     #[test]
     fn rtdl_recovery_final_text_hides_internal_error() {

--- a/system/pilot/src/planner.rs
+++ b/system/pilot/src/planner.rs
@@ -1269,6 +1269,18 @@ pub async fn run_turn(
                     .await;
                 break;
             }
+            // A long-running tree (monitoring, greeting, navigation, etc.) is
+            // session work, not a reason to swallow a conversational reply.
+            // FinalText closes only the current SubmitTask subscriber; the
+            // supervisor and forest stay alive and accept later steer/tasks.
+            if !assistant_content.trim().is_empty() {
+                let _ = tx
+                    .send(Ok(service::pack(
+                        &session_id,
+                        PilotStreamBody::FinalText(assistant_content.clone()),
+                    )))
+                    .await;
+            }
             if hit_cap {
                 warn!("[pilot] hit max tool rounds ({max_rounds}), stopping turn");
                 break;

--- a/system/pilot/src/planner.rs
+++ b/system/pilot/src/planner.rs
@@ -341,6 +341,7 @@ fn is_control_only(plan: &Plan) -> bool {
                 | "get_all_plans"
                 | "get_plan_status"
                 | "stop_plan_at"
+                | "stop_after_current"
         ) {
             return false;
         }
@@ -367,13 +368,16 @@ fn build_forest_block(
          These RTDL trees you dispatched earlier are still running concurrently. \
          To stop one immediately, call `builtin_cancel_plan` with its exact \
          `plan_id` below (or `executor_cancel_all_plans` to stop everything at \
-         once). To stop a plan at a specific step instead of now, first call \
+         once). When the user says to finish the current step but not start the \
+         next one, call `builtin_stop_after_current` directly with the exact \
+         `plan_id`; it atomically arms the boundary and must NOT be preceded by \
+         a status query. To stop at some other explicitly named step, first call \
          `builtin_get_plan_status` with its `plan_id` to read its ops (each op's \
          `op_id`, description, and live state), then call `builtin_stop_plan_at` \
          with that `plan_id`, the chosen `op_id`, and `when` (`on_enter` to stop \
          before that op runs, `on_complete` to stop after it finishes) — this \
-         is the correct mechanism when the user asks to finish the current step \
-         and then stop; do not use immediate cancel for a boundary stop. It \
+         and then call `builtin_stop_plan_at`; do not use immediate cancel for \
+         a boundary stop. It \
          cancels the whole plan when execution reaches that op. Cancel/stop each \
          plan_id at most once — a cancel that returned is already stopping; do NOT \
          re-issue it. Only the plan_ids listed here are running; never cancel an id \
@@ -1136,6 +1140,15 @@ pub async fn run_turn(
         let calls = plan_call_count(&graph);
         let call_signatures = plan_call_signatures(&graph);
         let cancel_targets = plan_cancel_targets(&graph);
+        if mixes_control_inspection_with_action(&graph) {
+            warn!("[pilot/harness] suppressed mixed control inspection and action tree");
+            history.push(Message::user(
+                "Pilot harness feedback: get_plan_status/get_all_plans is an inspection whose result is required before deciding how to stop work. Dispatch only that inspection now. Do not put a new action, navigation, shell command, cancel, or stop_plan_at in the same RTDL tree. After its result arrives, first complete the targeted stop/cancel decision; only then dispatch unrelated successor work.",
+            ));
+            history::trim(history, MAX_HISTORY);
+            should_plan = true;
+            continue 'supervisor;
+        }
         if let Some(target) = invalid_cancel_target(&cancel_targets, &forest, &cancel_requested) {
             warn!("[pilot/harness] suppressed stale or duplicate cancel for plan {target}");
             history.push(Message::user(
@@ -1796,6 +1809,22 @@ fn plan_call_count(plan: &Plan) -> usize {
         .count()
 }
 
+fn mixes_control_inspection_with_action(plan: &Plan) -> bool {
+    let leaves: Vec<&str> = plan
+        .nodes
+        .iter()
+        .filter_map(|node| node.call.as_ref())
+        .filter_map(|call| call.contract_id.rsplit('/').next())
+        .collect();
+    let has_inspection = leaves
+        .iter()
+        .any(|leaf| matches!(*leaf, "get_plan_status" | "get_all_plans"));
+    has_inspection
+        && leaves
+            .iter()
+            .any(|leaf| !matches!(*leaf, "get_plan_status" | "get_all_plans"))
+}
+
 fn plan_call_signatures(plan: &Plan) -> HashSet<String> {
     plan.nodes
         .iter()
@@ -2123,6 +2152,11 @@ by planning capability calls available to you.
   work covered by that tree, or when continuing that same tree is unsafe. A
   failure in an independent monitoring, greeting, observation, or query branch
   is not permission to cancel navigation or another physical task.
+- When the latest steer says to let the current step finish but not start its
+  successor, call `builtin_stop_after_current` immediately for that in-flight
+  plan. Do not call get_plan_status first: the extra model round creates a race
+  in which the successor can start. Use get_plan_status + stop_plan_at only for
+  a different explicitly named boundary or an ambiguous parallel plan.
 - Do not execute a later physical step unless its required earlier steps have succeeded.
 - For semantic navigation, resolve names through Scene before calling navigation:
   - call Scene `list_objects` first to discover the stable ID for a named room or
@@ -2200,9 +2234,9 @@ mod tests {
         TaskState, TreeMeta, append_steer, apply_task_update, build_forest_block,
         duplicate_in_flight_signature, expand_rtdl_to_plan, extract_json_object,
         feed_results_into_history, format_plan_summary, invalid_cancel_target, is_control_only,
-        parse_rtdl_assistant_response, parse_task_update, plan_call_signatures,
-        rtdl_node_kind_name, rtdl_recovery_final_text, rtdl_state_name, skip_memory_prefetch,
-        start_or_resume_task, task_is_session_end,
+        mixes_control_inspection_with_action, parse_rtdl_assistant_response, parse_task_update,
+        plan_call_signatures, rtdl_node_kind_name, rtdl_recovery_final_text, rtdl_state_name,
+        skip_memory_prefetch, start_or_resume_task, task_is_session_end,
     };
     use crate::pb::pilot::{CapabilityCall, CapabilityCallResult, Plan, RtdlNode, Task};
     use serde_json::json;
@@ -2283,6 +2317,8 @@ mod tests {
         );
         let prompt = build_forest_block(&forest, &HashSet::new());
         assert!(prompt.contains("finish the current step"));
+        assert!(prompt.contains("builtin_stop_after_current"));
+        assert!(prompt.contains("must NOT be preceded by"));
         assert!(prompt.contains("do not use immediate cancel for a boundary stop"));
         assert!(prompt.contains("on_complete"));
         assert!(prompt.contains("on_enter"));
@@ -2336,6 +2372,38 @@ mod tests {
             },
         );
         assert!(duplicate_in_flight_signature(&signatures, &forest).is_some());
+    }
+
+    #[test]
+    fn inspection_result_must_arrive_before_new_action_is_admitted() {
+        let plan = Plan {
+            nodes: vec![
+                RtdlNode {
+                    node_kind: RTDL_DO,
+                    call: Some(CapabilityCall {
+                        contract_id: "robonix/system/executor/builtin/get_plan_status".into(),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+                RtdlNode {
+                    node_kind: RTDL_DO,
+                    call: Some(CapabilityCall {
+                        contract_id: "robonix/system/executor/builtin/run_command".into(),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+        assert!(mixes_control_inspection_with_action(&plan));
+
+        let inspection_only = Plan {
+            nodes: vec![plan.nodes[0].clone()],
+            ..Default::default()
+        };
+        assert!(!mixes_control_inspection_with_action(&inspection_only));
     }
 
     #[test]
@@ -2442,6 +2510,7 @@ mod tests {
             "get_all_plans",
             "get_plan_status",
             "stop_plan_at",
+            "stop_after_current",
         ] {
             assert!(is_control_only(&single_do_plan(leaf)), "{leaf}");
         }

--- a/system/pilot/src/planner.rs
+++ b/system/pilot/src/planner.rs
@@ -1110,10 +1110,10 @@ pub async fn run_turn(
         if let Some(target) = invalid_cancel_target(&cancel_targets, &forest, &cancel_requested) {
             warn!("[pilot/harness] suppressed stale or duplicate cancel for plan {target}");
             history.push(Message::user(
-                "Pilot harness feedback: that plan is not cancellable now (it already finished or cancellation was already requested). Do not issue another cancel; wait for current executor events or answer the user.",
+                "Pilot harness feedback: that cancel target is not cancellable now (it finished, is a control-only plan, or cancellation was already requested). Continue planning now; re-read In-flight trees and never cancel the query/control plan itself. If the user's unresolved intent is to stop everything, call executor_cancel_all_plans directly instead of listing plans or retrying this target.",
             ));
             history::trim(history, MAX_HISTORY);
-            should_plan = false;
+            should_plan = true;
             continue 'supervisor;
         }
         if let Some(duplicate) = duplicate_in_flight_signature(&call_signatures, &forest) {
@@ -1304,6 +1304,8 @@ Compose multi-step trees; don't drip one node per round. No new capability call 
 {\"op\":\"sequence\",\"op_id\":0,\"description\":\"wait\",\"children\":[]}.\n\
 To stop a running tree, add a do node whose `cap` is the list's cancel-plan capability_name \
 (e.g. `executor.builtin_cancel_plan`), passing the exact plan_id string from the In-flight trees list.\n\
+For an explicit user request to stop/cancel ALL work, call executor_cancel_all_plans directly \
+in one do node. Do NOT call get_all_plans first and do NOT cancel the control/query tree itself.\n\
 Example: {\"content\":\"listing\",\"rtdl_description\":\"list tmp\",\"rtdl\":{\"op\":\"sequence\",\
 \"op_id\":0,\"description\":\"list /tmp\",\"children\":[{\"op\":\"do\",\"op_id\":0,\
 \"description\":\"list the /tmp directory\",\"cap\":\"executor.builtin_list_dir\",\"args\":{\"path\":\"/tmp\"}}]},\

--- a/system/pilot/src/planner.rs
+++ b/system/pilot/src/planner.rs
@@ -22,6 +22,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 use tokio::sync::{mpsc, watch};
 use tonic::Request;
 use tonic::transport::Channel;
@@ -54,12 +55,27 @@ fn max_tool_rounds() -> usize {
         .unwrap_or(64)
 }
 
+fn vlm_idle_timeout() -> Duration {
+    configured_vlm_idle_timeout(
+        std::env::var("ROBONIX_PILOT_VLM_IDLE_TIMEOUT_SECS")
+            .ok()
+            .as_deref(),
+    )
+}
+
+fn configured_vlm_idle_timeout(value: Option<&str>) -> Duration {
+    let seconds = value
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(30)
+        .clamp(5, 300);
+    Duration::from_secs(seconds)
+}
+
 const MAX_HISTORY: usize = 200;
 
-/// The LLM's persistent overall task for the turn, parsed from the
-/// `task_update` field of the RTDL envelope. `null` in the envelope means
-/// "keep the current task unchanged" and is represented as `None` at the
-/// call site, not as a `TaskState`.
+/// Harness-owned state for the latest user interaction. Long-running work is
+/// represented independently by the RTDL forest; it must not keep older user
+/// text welded into the current goal forever.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct TaskState {
     goal: String,
@@ -78,13 +94,10 @@ impl TaskState {
         self.status == "done"
     }
 
-    /// Render the current task as a system-prompt block so the LLM always sees
-    /// its own standing goal and success criterion.
+    /// Render the latest interaction separately from the in-flight forest.
     fn prompt_block(&self) -> String {
         format!(
-            "\n\n## Current overall task\n- user_instruction_history (oldest to newest): {}\n\
-             - precedence: the newest user instruction overrides any conflicting older \
-             instruction; preserve older work only when it does not conflict\n\
+            "\n\n## Current user interaction\n- instruction: {}\n\
              - success_criterion: {}\n- status: {}\n",
             self.goal, self.success_criterion, self.status
         )
@@ -449,11 +462,11 @@ fn append_steer(
     }
     info!("[pilot/steer] mid-task input: {text}");
     history.push(Message::user(text));
-    if let Some(state) = current_task.as_mut() {
-        state.goal.push_str("\nUser steer/follow-up: ");
-        state.goal.push_str(text);
-        state.status = "in_progress".to_string();
-    }
+    *current_task = Some(TaskState {
+        goal: text.to_string(),
+        success_criterion: DEFAULT_SUCCESS_CRITERION.to_string(),
+        status: "in_progress".to_string(),
+    });
     true
 }
 
@@ -477,20 +490,11 @@ fn start_or_resume_task(current_task: &mut Option<TaskState>, user_text: &str) {
     if text.is_empty() {
         return;
     }
-    match current_task {
-        Some(state) if !state.is_done() => {
-            state.goal.push_str("\nUser follow-up: ");
-            state.goal.push_str(text);
-            state.status = "in_progress".to_string();
-        }
-        slot => {
-            *slot = Some(TaskState {
-                goal: text.to_string(),
-                success_criterion: DEFAULT_SUCCESS_CRITERION.to_string(),
-                status: "in_progress".to_string(),
-            });
-        }
-    }
+    *current_task = Some(TaskState {
+        goal: text.to_string(),
+        success_criterion: DEFAULT_SUCCESS_CRITERION.to_string(),
+        status: "in_progress".to_string(),
+    });
 }
 
 /// Apply only progress fields from the model. The user-owned goal is immutable
@@ -512,6 +516,10 @@ fn apply_task_update(
             "[pilot/rtdl] ignoring model goal replacement {:?}; harness goal remains {:?}",
             update.goal, state.goal
         );
+        // The response was sampled for an older interaction. Applying even
+        // its status or success criterion can falsely complete and discard a
+        // newer steer, so reject the entire stale update.
+        return false;
     }
     if state.success_criterion == DEFAULT_SUCCESS_CRITERION
         && !update.success_criterion.trim().is_empty()
@@ -907,6 +915,7 @@ pub async fn run_turn(
                             // "re-plan on every node" caused.
                             if is_terminal_executor_state(ns.state)
                                 && ns.state != RtdlNodeStateEnum::Succeeded as u32
+                                && standing_task.as_ref().is_some_and(|state| !state.is_done())
                             {
                                 should_plan = true;
                             }
@@ -923,7 +932,17 @@ pub async fn run_turn(
                         }
                         Some(ForestEvent::PlanDone { plan_id, results, any_failed, canceled }) => {
                             forest.remove(&plan_id);
-                            cancel_requested.remove(&plan_id);
+                            let requested_cancellation = cancel_requested.remove(&plan_id);
+                            if requested_cancellation {
+                                history.push(Message::user(&format!(
+                                    "Pilot harness event: the requested cancellation of RTDL plan \
+                                     {plan_id} is complete. Do not query or cancel that plan again. \
+                                     Unrelated in-flight trees remain independent. If the current \
+                                     interaction requested only this stop and has no successor action, \
+                                     mark it done and report the completed stop now."
+                                )));
+                                history::trim(history, MAX_HISTORY);
+                            }
                             // Leaf results were already fed per-node (see above);
                             // only surface the batch to the chat UI here.
                             log_plan_complete(&plan_id, &results, any_failed);
@@ -940,13 +959,16 @@ pub async fn run_turn(
                                     PilotStreamBody::BatchResult(batch),
                                 )))
                                 .await;
-                            // A canceled tree finishing is the fulfilment of a
-                            // prior stop request, not new task progress: replanning
-                            // here lets the model re-cancel the siblings it just
-                            // chose to keep, which cancels more trees and fires more
-                            // PlanDone — a self-feeding storm that grows plan ids
-                            // without bound. Only natural completion replans.
-                            if !canceled {
+                            // Re-plan after natural completion or exactly once
+                            // when a cancellation explicitly requested by this
+                            // supervisor is fulfilled. Unsolicited canceled
+                            // events stay quiet, preventing the old self-feeding
+                            // cancel storm across unrelated sibling trees.
+                            if should_replan_after_plan_done(
+                                canceled,
+                                requested_cancellation,
+                                standing_task.as_ref().is_some_and(|state| !state.is_done()),
+                            ) {
                                 should_plan = true;
                             }
                         }
@@ -987,6 +1009,16 @@ pub async fn run_turn(
             .map(TaskState::prompt_block)
             .unwrap_or_default();
         let forest_block = build_forest_block(&forest, &cancel_requested);
+        let _ = tx
+            .send(Ok(service::pack(
+                &session_id,
+                PilotStreamBody::Status(SessionStatusEvent {
+                    session_id: session_id.clone(),
+                    state: SessionState::Active as u32,
+                    message: "Planning the next step".to_string(),
+                }),
+            )))
+            .await;
         // Plan with a single corrective retry (merged from dev #88): if the
         // VLM's RTDL fails to parse or expand, feed the error back and let it
         // fix the reply once; a second failure ends the turn gracefully (empty
@@ -1003,16 +1035,32 @@ pub async fn run_turn(
             }
 
             let planning_revision = forest_revision.load(Ordering::Acquire);
-            let (content, raw_tool_calls) = {
-                let mut stream = vlm
-                    .chat_stream(&messages, &[])
-                    .await
-                    .map_err(|e| anyhow::anyhow!("VLM stream error: {e}"))?;
-
+            let mut vlm_attempt = 0_u8;
+            let (content, raw_tool_calls) = loop {
+                let mut stream =
+                    match tokio::time::timeout(vlm_idle_timeout(), vlm.chat_stream(&messages, &[]))
+                        .await
+                    {
+                        Ok(Ok(stream)) => stream,
+                        Ok(Err(error)) if vlm_attempt == 0 => {
+                            warn!("[pilot/vlm] opening stream failed; retrying once: {error:#}");
+                            vlm_attempt += 1;
+                            continue;
+                        }
+                        Ok(Err(error)) => {
+                            return Err(anyhow::anyhow!("VLM stream error: {error:#}"));
+                        }
+                        Err(_) if vlm_attempt == 0 => {
+                            warn!("[pilot/vlm] opening stream timed out; retrying once");
+                            vlm_attempt += 1;
+                            continue;
+                        }
+                        Err(_) => return Err(anyhow::anyhow!("VLM stream open timed out")),
+                    };
                 let mut full_text = String::new();
                 let mut tool_calls: Vec<crate::vlm::ToolCall> = Vec::new();
 
-                loop {
+                let receive_result: anyhow::Result<()> = loop {
                     tokio::select! {
                         biased;
                         // Cancel takes priority — checked before every new VLM token.
@@ -1036,8 +1084,8 @@ pub async fn run_turn(
                         item = stream.next() => {
                             let item = match item {
                                 Some(Ok(it)) => it,
-                                Some(Err(e)) => return Err(anyhow::anyhow!("VLM stream recv: {e:#}")),
-                                None => break,
+                                Some(Err(error)) => break Err(anyhow::anyhow!("VLM stream recv: {error:#}")),
+                                None => break Ok(()),
                             };
                             match item {
                                 VlmStreamItem::TextDelta(delta) => full_text.push_str(&delta),
@@ -1045,7 +1093,29 @@ pub async fn run_turn(
                                 VlmStreamItem::Finish => {}
                             }
                         }
+                        _ = tokio::time::sleep(vlm_idle_timeout()) => {
+                            break Err(anyhow::anyhow!("VLM stream idle timeout"));
+                        }
                     }
+                };
+
+                if let Err(error) = receive_result {
+                    if vlm_attempt == 0 {
+                        warn!("[pilot/vlm] {error:#}; retrying once");
+                        let _ = tx
+                            .send(Ok(service::pack(
+                                &session_id,
+                                PilotStreamBody::Status(SessionStatusEvent {
+                                    session_id: session_id.clone(),
+                                    state: SessionState::Active as u32,
+                                    message: "VLM response delayed; retrying once".to_string(),
+                                }),
+                            )))
+                            .await;
+                        vlm_attempt += 1;
+                        continue;
+                    }
+                    return Err(error);
                 }
 
                 let content = if full_text.is_empty() {
@@ -1053,7 +1123,7 @@ pub async fn run_turn(
                 } else {
                     Some(full_text)
                 };
-                (content, tool_calls)
+                break (content, tool_calls);
             };
 
             if forest_revision.load(Ordering::Acquire) != planning_revision {
@@ -1214,8 +1284,7 @@ pub async fn run_turn(
                 "[pilot/rtdl] task_update goal='{}' status='{}'",
                 updated.goal, updated.status
             );
-            let changed =
-                apply_task_update(standing_task, updated, calls == 0 && forest.is_empty());
+            let changed = apply_task_update(standing_task, updated, calls == 0);
             if changed && let Some(state) = standing_task.as_ref() {
                 let _ = tx
                     .send(Ok(service::pack(
@@ -1269,17 +1338,32 @@ pub async fn run_turn(
                     .await;
                 break;
             }
-            // A long-running tree (monitoring, greeting, navigation, etc.) is
-            // session work, not a reason to swallow a conversational reply.
-            // FinalText closes only the current SubmitTask subscriber; the
-            // supervisor and forest stay alive and accept later steer/tasks.
+            // A completed interaction may close while unrelated long-running
+            // work remains. If this interaction is still in progress, keep its
+            // stream open: surface the model text as progress and wait for the
+            // relevant plan result before producing FinalText.
             if !assistant_content.trim().is_empty() {
-                let _ = tx
-                    .send(Ok(service::pack(
-                        &session_id,
-                        PilotStreamBody::FinalText(assistant_content.clone()),
-                    )))
-                    .await;
+                let body = if task_done {
+                    PilotStreamBody::FinalText(assistant_content.clone())
+                } else {
+                    PilotStreamBody::TextChunk(assistant_content.clone())
+                };
+                let _ = tx.send(Ok(service::pack(&session_id, body))).await;
+                if !task_done {
+                    // Status is the narration boundary consumed by Liaison:
+                    // display/TTS the complete progress text now without
+                    // closing the SubmitTask stream.
+                    let _ = tx
+                        .send(Ok(service::pack(
+                            &session_id,
+                            PilotStreamBody::Status(SessionStatusEvent {
+                                session_id: session_id.clone(),
+                                state: SessionState::Active as u32,
+                                message: "Waiting for in-flight work".to_string(),
+                            }),
+                        )))
+                        .await;
+                }
             }
             if hit_cap {
                 warn!("[pilot] hit max tool rounds ({max_rounds}), stopping turn");
@@ -1937,6 +2021,14 @@ fn invalid_cancel_target(
     })
 }
 
+fn should_replan_after_plan_done(
+    canceled: bool,
+    requested_cancellation: bool,
+    interaction_active: bool,
+) -> bool {
+    interaction_active && (!canceled || requested_cancellation)
+}
+
 /// Render an RTDL node state as a stable human-readable name for logs.
 fn rtdl_state_name(state: u32) -> String {
     match RtdlNodeStateEnum::try_from(state as i32) {
@@ -2243,22 +2335,19 @@ by planning capability calls available to you.
   output an empty RTDL sequence. Do not repeat the same observation capability
   just to confirm unchanged data.
 
-## Persistence (READ THIS — most common failure mode)
-The harness owns the overall goal. It is created from the user's message and
-appends later steer/follow-up messages verbatim as a chronological instruction
-history. The newest user instruction overrides older instructions wherever they
-conflict (for example a change of destination or a request to stop after the
-current step); preserve unrelated ongoing work. Never replace this history with
-your own summary or a current sub-step. When emitting a non-null `task_update`,
-copy its `goal` exactly from \"Current overall task\".
-`task_update` is a progress report, not a set-current-goal command.
+## Interaction and execution lifetime
+The harness owns the latest instruction shown in \"Current user interaction\".
+Copy it exactly into a non-null `task_update.goal`; `task_update` reports
+progress and never replaces user intent. Older conversation remains in message
+history. Independently running work appears only in \"In-flight RTDL trees\"
+and may outlive this interaction. Preserve unrelated trees; if the latest
+instruction conflicts with one, target that specific plan with cancel/stop
+before dispatching its replacement.
 
-The turn ends only when your overall task is `done` (you set
-`task_update.status: \"done\"`), every tree you dispatched has finished, and
-there is no pending user input. An empty RTDL sequence alone does NOT end the
-turn — it just means you are dispatching no new tree this round (for example,
-while you wait for an in-flight tree). Do NOT mark the task `done` until it is
-*verifiably* complete. Concretely:
+Mark the current interaction `done` once its own requested outcome is verified,
+even when an unrelated long-running tree remains active. An empty RTDL sequence
+alone does not prove completion; it may also mean waiting for an in-flight tree.
+Concretely:
 
 - Set a concrete `task_update.success_criterion` as soon as you understand the
   goal (e.g. for 'turn around': yaw delta ≈ 180° from the starting pose; for
@@ -2293,15 +2382,42 @@ mod tests {
     use super::{
         CapabilityTargetMap, DEFAULT_SUCCESS_CRITERION, RTDL_DO, RTDL_PARALLEL, RTDL_SEQUENCE,
         TaskState, TreeMeta, TreeStep, append_steer, apply_task_update, build_forest_block,
-        duplicate_in_flight_signature, expand_rtdl_to_plan, extract_json_object,
-        feed_results_into_history, format_plan_summary, invalid_cancel_target, is_control_only,
-        mixes_control_inspection_with_action, parse_rtdl_assistant_response, parse_task_update,
-        plan_call_signatures, rtdl_node_kind_name, rtdl_recovery_final_text, rtdl_state_name,
-        skip_memory_prefetch, start_or_resume_task, task_is_session_end,
+        configured_vlm_idle_timeout, duplicate_in_flight_signature, expand_rtdl_to_plan,
+        extract_json_object, feed_results_into_history, format_plan_summary, invalid_cancel_target,
+        is_control_only, mixes_control_inspection_with_action, parse_rtdl_assistant_response,
+        parse_task_update, plan_call_signatures, rtdl_node_kind_name, rtdl_recovery_final_text,
+        rtdl_state_name, should_replan_after_plan_done, skip_memory_prefetch, start_or_resume_task,
+        task_is_session_end,
     };
     use crate::pb::pilot::{CapabilityCall, CapabilityCallResult, Plan, RtdlNode, Task};
     use serde_json::json;
     use std::collections::{HashMap, HashSet};
+    use std::time::Duration;
+
+    #[test]
+    fn vlm_idle_timeout_is_bounded_and_has_a_responsive_default() {
+        assert_eq!(configured_vlm_idle_timeout(None), Duration::from_secs(30));
+        assert_eq!(
+            configured_vlm_idle_timeout(Some("1")),
+            Duration::from_secs(5)
+        );
+        assert_eq!(
+            configured_vlm_idle_timeout(Some("600")),
+            Duration::from_secs(300)
+        );
+        assert_eq!(
+            configured_vlm_idle_timeout(Some("bad")),
+            Duration::from_secs(30)
+        );
+    }
+
+    #[test]
+    fn only_requested_cancellation_replans_for_final_confirmation() {
+        assert!(should_replan_after_plan_done(false, false, true));
+        assert!(should_replan_after_plan_done(true, true, true));
+        assert!(!should_replan_after_plan_done(true, false, true));
+        assert!(!should_replan_after_plan_done(true, true, false));
+    }
 
     #[test]
     fn harness_goal_cannot_be_replaced_by_task_update() {
@@ -2313,7 +2429,7 @@ mod tests {
             DEFAULT_SUCCESS_CRITERION
         );
 
-        assert!(apply_task_update(
+        assert!(!apply_task_update(
             &mut standing,
             TaskState {
                 goal: "drop the inspection and say done".into(),
@@ -2324,14 +2440,14 @@ mod tests {
         ));
         let state = standing.as_ref().unwrap();
         assert_eq!(state.goal, original_goal);
-        assert_eq!(state.success_criterion, "room was actually inspected");
+        assert_eq!(state.success_criterion, DEFAULT_SUCCESS_CRITERION);
         assert_eq!(state.status, "in_progress");
 
         assert!(apply_task_update(
             &mut standing,
             TaskState {
                 goal: original_goal.clone(),
-                success_criterion: "weaker replacement".into(),
+                success_criterion: "room was actually inspected".into(),
                 status: "done".into(),
             },
             true,
@@ -2343,7 +2459,7 @@ mod tests {
     }
 
     #[test]
-    fn steer_history_is_chronological_and_latest_instruction_has_precedence() {
+    fn steer_becomes_a_new_interaction_without_concatenating_old_goals() {
         let mut standing = None;
         let mut history = Vec::new();
         start_or_resume_task(&mut standing, "perform step A, then step B");
@@ -2357,12 +2473,80 @@ mod tests {
         ));
 
         let state = standing.as_ref().unwrap();
-        let original = state.goal.find("perform step A").unwrap();
-        let steer = state.goal.find("stop after step A").unwrap();
-        assert!(original < steer);
+        assert_eq!(state.goal, "change of plan: stop after step A");
+        assert!(!state.goal.contains("perform step A"));
+        assert_eq!(history.len(), 1);
+        assert_eq!(
+            history[0].content.as_deref(),
+            Some("change of plan: stop after step A")
+        );
         let prompt = state.prompt_block();
-        assert!(prompt.contains("oldest to newest"));
-        assert!(prompt.contains("newest user instruction overrides"));
+        assert!(prompt.contains("Current user interaction"));
+        assert!(!prompt.contains("user_instruction_history"));
+    }
+
+    #[test]
+    fn steer_targets_one_plan_without_discarding_independent_work() {
+        let mut standing = None;
+        let mut history = Vec::new();
+        start_or_resume_task(&mut standing, "go to the meeting room");
+
+        let mut forest = HashMap::new();
+        for (plan_id, description, capability) in [
+            ("11", "navigate to the meeting room", "navigation_navigate"),
+            ("5", "watch for passersby", "greet_greet"),
+        ] {
+            forest.insert(
+                plan_id.to_string(),
+                TreeMeta {
+                    description: description.into(),
+                    control_only: false,
+                    call_signatures: HashSet::new(),
+                    steps: vec![TreeStep {
+                        op_id: format!("op-{plan_id}"),
+                        description: description.into(),
+                        capability: capability.into(),
+                    }],
+                },
+            );
+        }
+
+        assert!(append_steer(
+            Task {
+                text: "cancel the meeting-room trip and return to room 315".into(),
+                ..Default::default()
+            },
+            &mut history,
+            &mut standing,
+        ));
+        assert_eq!(
+            standing.as_ref().unwrap().goal,
+            "cancel the meeting-room trip and return to room 315"
+        );
+
+        let prompt = build_forest_block(&forest, &HashSet::new());
+        assert!(prompt.contains("plan_id=11"));
+        assert!(prompt.contains("plan_id=5"));
+        assert!(prompt.contains("navigate to the meeting room"));
+        assert!(prompt.contains("watch for passersby"));
+        assert_eq!(
+            invalid_cancel_target(&["11".into()], &forest, &HashSet::new()),
+            None
+        );
+        assert_eq!(
+            invalid_cancel_target(&["5".into()], &forest, &HashSet::new()),
+            None
+        );
+
+        let requested = HashSet::from(["11".to_string()]);
+        assert_eq!(
+            invalid_cancel_target(&["11".into()], &forest, &requested),
+            Some("11".to_string())
+        );
+        assert_eq!(
+            invalid_cancel_target(&["5".into()], &forest, &requested),
+            None
+        );
     }
 
     #[test]

--- a/system/pilot/src/planner.rs
+++ b/system/pilot/src/planner.rs
@@ -82,7 +82,10 @@ impl TaskState {
     /// its own standing goal and success criterion.
     fn prompt_block(&self) -> String {
         format!(
-            "\n\n## Current overall task\n- goal: {}\n- success_criterion: {}\n- status: {}\n",
+            "\n\n## Current overall task\n- user_instruction_history (oldest to newest): {}\n\
+             - precedence: the newest user instruction overrides any conflicting older \
+             instruction; preserve older work only when it does not conflict\n\
+             - success_criterion: {}\n- status: {}\n",
             self.goal, self.success_criterion, self.status
         )
     }
@@ -369,6 +372,8 @@ fn build_forest_block(
          `op_id`, description, and live state), then call `builtin_stop_plan_at` \
          with that `plan_id`, the chosen `op_id`, and `when` (`on_enter` to stop \
          before that op runs, `on_complete` to stop after it finishes) — this \
+         is the correct mechanism when the user asks to finish the current step \
+         and then stop; do not use immediate cancel for a boundary stop. It \
          cancels the whole plan when execution reaches that op. Cancel/stop each \
          plan_id at most once — a cancel that returned is already stopping; do NOT \
          re-issue it. Only the plan_ids listed here are running; never cancel an id \
@@ -1318,8 +1323,10 @@ Beyond `op_id` and `description`, do NOT add other node fields (no `plan_id`, no
 Copy each `cap` EXACTLY from a capability_name in the list below (it is provider-qualified, \
 e.g. `tiago_camera.camera_snapshot`); never invent or shorten names.\n\
 `task_update`: null keeps current progress, or {\"goal\",\"success_criterion\",\"status\"}. \
-The harness owns the goal: copy `goal` EXACTLY from \"Current overall task\" and never rewrite, \
-shorten, replace, or drop unfinished parts. You may refine the default success criterion once. status is the \
+The harness owns the instruction history: copy it EXACTLY from \"Current overall task\" and never \
+rewrite it. Interpret entries chronologically: the newest user instruction overrides conflicting \
+older instructions, while non-conflicting work remains active. You may refine the default success \
+criterion once. status is the \
 string \"in_progress\" or \"done\" (never null), set to \
 \"done\" only when the success_criterion verifiably holds AND no tree in the \
 \"In-flight trees\" list is still running (cancelling a tree does not make the task done — wait \
@@ -2144,9 +2151,12 @@ by planning capability calls available to you.
 
 ## Persistence (READ THIS — most common failure mode)
 The harness owns the overall goal. It is created from the user's message and
-appends later steer/follow-up messages verbatim. Never replace it with your own
-summary, a current sub-step, or only the newest request. When emitting a
-non-null `task_update`, copy its `goal` exactly from \"Current overall task\".
+appends later steer/follow-up messages verbatim as a chronological instruction
+history. The newest user instruction overrides older instructions wherever they
+conflict (for example a change of destination or a request to stop after the
+current step); preserve unrelated ongoing work. Never replace this history with
+your own summary or a current sub-step. When emitting a non-null `task_update`,
+copy its `goal` exactly from \"Current overall task\".
 `task_update` is a progress report, not a set-current-goal command.
 
 The turn ends only when your overall task is `done` (you set
@@ -2187,9 +2197,10 @@ while you wait for an in-flight tree). Do NOT mark the task `done` until it is
 mod tests {
     use super::{
         CapabilityTargetMap, DEFAULT_SUCCESS_CRITERION, RTDL_DO, RTDL_PARALLEL, RTDL_SEQUENCE,
-        TaskState, TreeMeta, apply_task_update, duplicate_in_flight_signature, expand_rtdl_to_plan,
-        extract_json_object, feed_results_into_history, format_plan_summary, invalid_cancel_target,
-        is_control_only, parse_rtdl_assistant_response, parse_task_update, plan_call_signatures,
+        TaskState, TreeMeta, append_steer, apply_task_update, build_forest_block,
+        duplicate_in_flight_signature, expand_rtdl_to_plan, extract_json_object,
+        feed_results_into_history, format_plan_summary, invalid_cancel_target, is_control_only,
+        parse_rtdl_assistant_response, parse_task_update, plan_call_signatures,
         rtdl_node_kind_name, rtdl_recovery_final_text, rtdl_state_name, skip_memory_prefetch,
         start_or_resume_task, task_is_session_end,
     };
@@ -2234,6 +2245,47 @@ mod tests {
         assert_eq!(state.goal, original_goal);
         assert_eq!(state.success_criterion, "room was actually inspected");
         assert_eq!(state.status, "done");
+    }
+
+    #[test]
+    fn steer_history_is_chronological_and_latest_instruction_has_precedence() {
+        let mut standing = None;
+        let mut history = Vec::new();
+        start_or_resume_task(&mut standing, "perform step A, then step B");
+        assert!(append_steer(
+            Task {
+                text: "change of plan: stop after step A".into(),
+                ..Default::default()
+            },
+            &mut history,
+            &mut standing,
+        ));
+
+        let state = standing.as_ref().unwrap();
+        let original = state.goal.find("perform step A").unwrap();
+        let steer = state.goal.find("stop after step A").unwrap();
+        assert!(original < steer);
+        let prompt = state.prompt_block();
+        assert!(prompt.contains("oldest to newest"));
+        assert!(prompt.contains("newest user instruction overrides"));
+    }
+
+    #[test]
+    fn forest_prompt_distinguishes_immediate_cancel_from_boundary_stop() {
+        let mut forest = HashMap::new();
+        forest.insert(
+            "4".to_string(),
+            TreeMeta {
+                description: "ordered multi-step task".into(),
+                control_only: false,
+                call_signatures: HashSet::new(),
+            },
+        );
+        let prompt = build_forest_block(&forest, &HashSet::new());
+        assert!(prompt.contains("finish the current step"));
+        assert!(prompt.contains("do not use immediate cancel for a boundary stop"));
+        assert!(prompt.contains("on_complete"));
+        assert!(prompt.contains("on_enter"));
     }
 
     #[test]

--- a/system/pilot/src/planner.rs
+++ b/system/pilot/src/planner.rs
@@ -25,11 +25,13 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::sync::{mpsc, watch};
 use tonic::Request;
 use tonic::transport::Channel;
+use uuid::Uuid;
 
 /// gRPC client for executor's plan-dispatch contract. Pilot only ever calls
 /// `Execute(Plan)` — discovery happens directly against atlas now.
 pub struct ExecutorConn {
     pub graph: RobonixSystemExecutorExecuteClient<Channel>,
+    pub provider_id: String,
 }
 
 type CapabilityTarget = (String, String);
@@ -246,6 +248,59 @@ async fn drive_plan(
         .await;
 }
 
+/// Cancel every real task tree owned by this turn before reporting the Pilot
+/// session interrupted. Dropping the Execute stream alone only detaches Pilot;
+/// Executor continues the plan (and synchronous tools such as run_command)
+/// unless its PlanRuntime receives an explicit cancel_plan request.
+async fn cancel_forest_plans(
+    executor: &mut ExecutorConn,
+    forest: &HashMap<String, TreeMeta>,
+    session_id: &str,
+) {
+    let targets: Vec<String> = forest
+        .iter()
+        .filter(|(_, meta)| !meta.control_only)
+        .map(|(plan_id, _)| plan_id.clone())
+        .collect();
+    for target in targets {
+        let control_plan_id = format!("abort-{}", Uuid::new_v4());
+        let plan = Plan {
+            plan_id: control_plan_id.clone(),
+            session_id: session_id.to_string(),
+            round: 0,
+            nodes: vec![RtdlNode {
+                node_kind: RTDL_DO,
+                children: Vec::new(),
+                call: Some(CapabilityCall {
+                    call_id: format!("{control_plan_id}:0"),
+                    provider_id: executor.provider_id.clone(),
+                    contract_id: "robonix/system/executor/builtin/cancel_plan".to_string(),
+                    args_json: serde_json::json!({"plan_id": target, "wait_ms": 5000}).to_string(),
+                }),
+                op_id: next_op_id(),
+                description: format!("abort session plan {target}"),
+            }],
+            root_index: 0,
+        };
+        let cancel = async {
+            let mut stream = executor
+                .graph
+                .execute(Request::new(plan))
+                .await?
+                .into_inner();
+            while stream.message().await?.is_some() {}
+            Ok::<(), tonic::Status>(())
+        };
+        match tokio::time::timeout(std::time::Duration::from_secs(7), cancel).await {
+            Ok(Ok(())) => info!("[pilot] canceled executor plan {target} on abort_turn"),
+            Ok(Err(error)) => {
+                warn!("[pilot] cancel executor plan {target} failed: {error}")
+            }
+            Err(_) => warn!("[pilot] cancel executor plan {target} timed out"),
+        }
+    }
+}
+
 /// Render the in-flight forest as a system-prompt block so the LLM can see what
 /// is still running and reference a `plan_id` to cancel it. Empty when no tree
 /// is running. Trees are ordered by numeric plan id for stable output.
@@ -434,7 +489,8 @@ pub async fn run_turn(
     let session_id = task.session_id.clone();
 
     macro_rules! return_interrupted {
-        () => {{
+        ($forest:expr) => {{
+            cancel_forest_plans(executor, $forest, &session_id).await;
             let _ = tx
                 .send(Ok(service::pack(
                     &session_id,
@@ -591,7 +647,7 @@ pub async fn run_turn(
     loop {
         // Check for hard interrupt at the top of every iteration.
         if *cancel_rx.borrow() {
-            return_interrupted!();
+            return_interrupted!(&forest);
         }
 
         if !should_plan {
@@ -610,8 +666,30 @@ pub async fn run_turn(
                         .await;
                     break;
                 }
-                // Not done and nothing running: plan again to make progress.
-                should_plan = true;
+                // An in-progress task with no running tree and no planning event
+                // is deliberately waiting for operator input. Replanning here
+                // turns an empty "wait for instructions" response (or a completed
+                // cancel-only tree) into an unbounded VLM/reply/cancel loop.
+                tokio::select! {
+                    biased;
+                    _ = cancel_rx.changed() => {
+                        return_interrupted!(&forest);
+                    }
+                    steer = steer_rx.recv() => {
+                        match steer {
+                            Some(task) => {
+                                let text = task.text.trim();
+                                if !text.is_empty() {
+                                    info!("[pilot/steer] resuming waiting task: {text}");
+                                    history.push(Message::user(text));
+                                    history::trim(history, MAX_HISTORY);
+                                    should_plan = true;
+                                }
+                            }
+                            None => break,
+                        }
+                    }
+                }
                 continue;
             }
             // A tree is still running: block until it emits an event, a steer
@@ -619,7 +697,7 @@ pub async fn run_turn(
             tokio::select! {
                 biased;
                 _ = cancel_rx.changed() => {
-                    return_interrupted!();
+                    return_interrupted!(&forest);
                 }
                 steer = steer_rx.recv() => {
                     if let Some(task) = steer {
@@ -774,7 +852,7 @@ pub async fn run_turn(
                         // Cancel takes priority — checked before every new VLM token.
                         _ = cancel_rx.changed() => {
                             drop(stream);
-                            return_interrupted!();
+                            return_interrupted!(&forest);
                         }
                         item = stream.next() => {
                             let item = match item {
@@ -976,8 +1054,8 @@ pub async fn run_turn(
                 warn!("[pilot] hit max tool rounds ({max_rounds}), stopping turn");
                 break;
             }
-            // should_plan stays false: wait for forest events (or, when the
-            // forest is empty and the task isn't done, the loop top re-plans).
+            // should_plan stays false: wait for a forest event, or for a steer
+            // when an in-progress task has intentionally produced no new tree.
             continue;
         }
 
@@ -1806,7 +1884,20 @@ by planning capability calls available to you.
   - If `memory_search` / `memory_save` / `memory_compact` capabilities are available,
     treat long-term memory as available via those capabilities.
 - Prefer structured output; report capability results concisely.
-- If a capability returns an error, diagnose and retry, or report to the user.
+- If any required capability call fails, times out, returns success=false, or gives an
+  unsafe/unexpected result, stop autonomous task progress. Report what failed and ask
+  the user what to do next. Do not skip ahead, reinterpret the goal, or try new
+  physical actions unless the user confirms.
+- Do not execute a later physical step unless its required earlier steps have succeeded.
+- For semantic navigation, resolve names through Scene before calling navigation:
+  - call Scene `list_objects` first to discover the stable ID for a named room or
+    physical object; pass that exact full ID to the goal tool, never its label,
+    room number, or a guessed ID; use `get_scene_graph` only when object
+    relationships are needed;
+  - named rooms or regions MUST use Scene `goal_room`; never use `goal_near`,
+    Memory coordinates, or guessed coordinates for a room destination;
+  - physical objects MUST use Scene `goal_near` to obtain an approach pose;
+  - call navigation only when Scene returns `reachable=true`.
 - Some later messages may be labelled `Executor feedback for the current task`.
   Treat those as results of capability calls you already planned, not as new
   user requests.

--- a/system/pilot/src/planner.rs
+++ b/system/pilot/src/planner.rs
@@ -1232,9 +1232,9 @@ pub async fn run_turn(
 
         log_plan_start(&graph, &rtdl_description, round, calls);
 
-        // Planning narration is model scratch context, not a user reply. It is
-        // retained for the next planning round but only surfaced when the turn
-        // actually completes or deliberately pauses for more user input.
+        // Retain model narration for later planning. Action-producing RTDL
+        // rounds are also streamed below so the current user sees and hears
+        // progress instead of receiving only a final burst after a long task.
         if !assistant_content.is_empty() {
             history.push(Message::assistant(&assistant_content));
             last_content = assistant_content.clone();
@@ -1290,8 +1290,17 @@ pub async fn run_turn(
             continue;
         }
 
+        if !assistant_content.trim().is_empty() {
+            let _ = tx
+                .send(Ok(service::pack(
+                    &session_id,
+                    PilotStreamBody::TextChunk(assistant_content.clone()),
+                )))
+                .await;
+        }
+
         // Non-empty tree: hand the structure to the client and dispatch it to
-        // the forest without leaking planning narration as a premature reply.
+        // the forest after its user-facing narration above.
         let _ = tx
             .send(Ok(service::pack(
                 &session_id,
@@ -2270,9 +2279,10 @@ while you wait for an in-flight tree). Do NOT mark the task `done` until it is
   verification is wrong — verify first.
 - On the very rare case where the user explicitly cancels, you may stop
   early; otherwise keep going.
-- `content` is user-facing only when the task is complete or when you genuinely
-  need more user input. During planning/execution, keep it empty or concise;
-  the harness will not surface planning narration as a reply.
+- For every action-producing RTDL response, put one concise user-facing progress
+  update in `content` that says what is happening now. Do not repeat an unchanged
+  update. When the task completes or needs clarification, use `content` for the
+  concise final result or question.
 ",
     );
     p

--- a/system/pilot/src/planner.rs
+++ b/system/pilot/src/planner.rs
@@ -12,6 +12,7 @@ use crate::pb::pilot::{
     SessionStatusEvent, Task, TaskStateEvent,
 };
 use crate::service::{self, PilotStreamBody, SessionState};
+use crate::state_context;
 use crate::vlm::{Message, VlmClient, VlmStreamItem};
 use anyhow::{Context, Result};
 use futures_util::StreamExt;
@@ -866,13 +867,13 @@ pub async fn run_turn(
                     return_interrupted!(&forest);
                 }
                 steer = steer_rx.recv() => {
-                    if let Some(task) = steer {
-                        if append_steer(task, history, standing_task) {
-                            history::trim(history, MAX_HISTORY);
-                            // Re-plan now so the model can react (and decide
-                            // whether to cancel any in-flight tree).
-                            should_plan = true;
-                        }
+                    if let Some(task) = steer
+                        && append_steer(task, history, standing_task)
+                    {
+                        history::trim(history, MAX_HISTORY);
+                        // Re-plan now so the model can react (and decide
+                        // whether to cancel any in-flight tree).
+                        should_plan = true;
                     }
                 }
                 ev = forest_rx.recv() => {
@@ -1000,6 +1001,10 @@ pub async fn run_turn(
             .await
             .map_err(|e| anyhow::anyhow!("atlas capability discovery failed: {e}"))?;
 
+        let embodiment_block =
+            crate::soma_context::fetch_runtime_prompt_block(atlas, consumer_id).await;
+        let environment_block = state_context::collect(executor, atlas, &cap_list).await;
+
         let display_caps = build_display_capabilities(&cap_list);
         let target_map = build_capability_target_map(&display_caps);
         let rtdl_prompt = build_rtdl_prompt(&display_caps, round == 0)?;
@@ -1027,7 +1032,7 @@ pub async fn run_turn(
         let mut correction: Option<String> = None;
         let (assistant_content, rtdl_description, graph, plan_id, task_update, recovered) = loop {
             let mut messages = vec![Message::system(&format!(
-                "{system_prompt}\n\n{rtdl_prompt}{task_block}{forest_block}"
+                "{system_prompt}\n\n{rtdl_prompt}{task_block}{forest_block}{embodiment_block}{environment_block}"
             ))];
             messages.extend(history::sanitize_for_vlm(history));
             if let Some(ref correction) = correction {

--- a/system/pilot/src/planner.rs
+++ b/system/pilot/src/planner.rs
@@ -146,6 +146,16 @@ struct TreeMeta {
     /// the first is still in flight; execution latency must not duplicate a
     /// physical or external command.
     call_signatures: HashSet<String>,
+    /// Ordered executable leaves from the original RTDL graph. Keeping these
+    /// visible lets the model target any semantic boundary in one control call
+    /// instead of querying live state first or guessing what "current" means.
+    steps: Vec<TreeStep>,
+}
+
+struct TreeStep {
+    op_id: String,
+    description: String,
+    capability: String,
 }
 
 /// Events fed from per-tree driver tasks back to the supervisor loop. One
@@ -341,12 +351,31 @@ fn is_control_only(plan: &Plan) -> bool {
                 | "get_all_plans"
                 | "get_plan_status"
                 | "stop_plan_at"
-                | "stop_after_current"
         ) {
             return false;
         }
     }
     has_do
+}
+
+fn plan_steps(plan: &Plan) -> Vec<TreeStep> {
+    plan.nodes
+        .iter()
+        .filter(|node| node.node_kind == RTDL_DO)
+        .filter_map(|node| {
+            let call = node.call.as_ref()?;
+            Some(TreeStep {
+                op_id: node.op_id.clone(),
+                description: node.description.clone(),
+                capability: call
+                    .contract_id
+                    .rsplit('/')
+                    .next()
+                    .unwrap_or(&call.contract_id)
+                    .to_string(),
+            })
+        })
+        .collect()
 }
 
 fn build_forest_block(
@@ -368,16 +397,16 @@ fn build_forest_block(
          These RTDL trees you dispatched earlier are still running concurrently. \
          To stop one immediately, call `builtin_cancel_plan` with its exact \
          `plan_id` below (or `executor_cancel_all_plans` to stop everything at \
-         once). When the user says to finish the current step but not start the \
-         next one, call `builtin_stop_after_current` directly with the exact \
-         `plan_id`; it atomically arms the boundary and must NOT be preceded by \
-         a status query. To stop at some other explicitly named step, first call \
-         `builtin_get_plan_status` with its `plan_id` to read its ops (each op's \
-         `op_id`, description, and live state), then call `builtin_stop_plan_at` \
-         with that `plan_id`, the chosen `op_id`, and `when` (`on_enter` to stop \
-         before that op runs, `on_complete` to stop after it finishes) — this \
-         and then call `builtin_stop_plan_at`; do not use immediate cancel for \
-         a boundary stop. It \
+         once). Every plan's ordered executable steps are listed below. To stop \
+         at any requested semantic boundary (for example after step 8 or after \
+         reaching the restaurant), call `builtin_stop_plan_at` directly with \
+         that `plan_id`, the chosen `op_id`, and `when` (`on_enter` to stop \
+         before that op runs, `on_complete` to stop after it finishes). Do not \
+         assume the target is the currently running step, and do not query status \
+         first when the requested boundary is already present in this list. Bind \
+         the user's named boundary literally: `after X` means X/on_complete and \
+         `before X` means X/on_enter. Never rewrite `after X` as `before` its \
+         successor because those are not equivalent in branching/parallel trees. It \
          cancels the whole plan when execution reaches that op. Cancel/stop each \
          plan_id at most once — a cancel that returned is already stopping; do NOT \
          re-issue it. Only the plan_ids listed here are running; never cancel an id \
@@ -390,6 +419,15 @@ fn build_forest_block(
             "- plan_id={} running: {}\n",
             plan_id, meta.description
         ));
+        for (index, step) in meta.steps.iter().enumerate() {
+            block.push_str(&format!(
+                "  {}. op_id={} [{}] {}\n",
+                index + 1,
+                step.op_id,
+                step.capability,
+                step.description
+            ));
+        }
     }
     block
 }
@@ -1257,6 +1295,7 @@ pub async fn run_turn(
                 description: rtdl_description,
                 control_only: is_control_only(&graph),
                 call_signatures,
+                steps: plan_steps(&graph),
             },
         );
         tokio::spawn(drive_plan(
@@ -2152,11 +2191,11 @@ by planning capability calls available to you.
   work covered by that tree, or when continuing that same tree is unsafe. A
   failure in an independent monitoring, greeting, observation, or query branch
   is not permission to cancel navigation or another physical task.
-- When the latest steer says to let the current step finish but not start its
-  successor, call `builtin_stop_after_current` immediately for that in-flight
-  plan. Do not call get_plan_status first: the extra model round creates a race
-  in which the successor can start. Use get_plan_status + stop_plan_at only for
-  a different explicitly named boundary or an ambiguous parallel plan.
+- For any boundary stop, select the explicitly requested step from the ordered
+  in-flight RTDL step list and call `builtin_stop_plan_at` once. The target may
+  be any step in the plan; never assume it means the currently running step.
+  Use `on_complete` for 'after step X' and `on_enter` for 'before step X'.
+  Bind X itself; never substitute X's predecessor or successor.
 - Do not execute a later physical step unless its required earlier steps have succeeded.
 - For semantic navigation, resolve names through Scene before calling navigation:
   - call Scene `list_objects` first to discover the stable ID for a named room or
@@ -2231,7 +2270,7 @@ while you wait for an in-flight tree). Do NOT mark the task `done` until it is
 mod tests {
     use super::{
         CapabilityTargetMap, DEFAULT_SUCCESS_CRITERION, RTDL_DO, RTDL_PARALLEL, RTDL_SEQUENCE,
-        TaskState, TreeMeta, append_steer, apply_task_update, build_forest_block,
+        TaskState, TreeMeta, TreeStep, append_steer, apply_task_update, build_forest_block,
         duplicate_in_flight_signature, expand_rtdl_to_plan, extract_json_object,
         feed_results_into_history, format_plan_summary, invalid_cancel_target, is_control_only,
         mixes_control_inspection_with_action, parse_rtdl_assistant_response, parse_task_update,
@@ -2313,13 +2352,25 @@ mod tests {
                 description: "ordered multi-step task".into(),
                 control_only: false,
                 call_signatures: HashSet::new(),
+                steps: vec![
+                    TreeStep {
+                        op_id: "op-restaurant".into(),
+                        description: "move to restaurant".into(),
+                        capability: "navigate".into(),
+                    },
+                    TreeStep {
+                        op_id: "op-meeting".into(),
+                        description: "move to meeting room".into(),
+                        capability: "navigate".into(),
+                    },
+                ],
             },
         );
         let prompt = build_forest_block(&forest, &HashSet::new());
-        assert!(prompt.contains("finish the current step"));
-        assert!(prompt.contains("builtin_stop_after_current"));
-        assert!(prompt.contains("must NOT be preceded by"));
-        assert!(prompt.contains("do not use immediate cancel for a boundary stop"));
+        assert!(prompt.contains("op_id=op-restaurant"));
+        assert!(prompt.contains("move to meeting room"));
+        assert!(prompt.contains("target is the currently running step"));
+        assert!(prompt.contains("do not query status"));
         assert!(prompt.contains("on_complete"));
         assert!(prompt.contains("on_enter"));
     }
@@ -2369,6 +2420,7 @@ mod tests {
                 description: "same call".into(),
                 control_only: false,
                 call_signatures: signatures.clone(),
+                steps: Vec::new(),
             },
         );
         assert!(duplicate_in_flight_signature(&signatures, &forest).is_some());
@@ -2415,6 +2467,7 @@ mod tests {
                 description: "drive".into(),
                 control_only: false,
                 call_signatures: HashSet::new(),
+                steps: Vec::new(),
             },
         );
         let targets = vec!["7".to_string()];
@@ -2510,7 +2563,6 @@ mod tests {
             "get_all_plans",
             "get_plan_status",
             "stop_plan_at",
-            "stop_after_current",
         ] {
             assert!(is_control_only(&single_do_plan(leaf)), "{leaf}");
         }

--- a/system/pilot/src/planner.rs
+++ b/system/pilot/src/planner.rs
@@ -549,7 +549,17 @@ async fn collect_vlm_text(vlm: &VlmClient, messages: &[Message]) -> Option<Strin
 
 /// Feed one finished tree's terminal results into the LLM history, mirroring
 /// the per-round feedback the blocking loop used to produce.
-fn feed_results_into_history(history: &mut Vec<Message>, results: &[CapabilityCallResult]) {
+fn feed_results_into_history(
+    history: &mut Vec<Message>,
+    plan_id: &str,
+    plan_description: &str,
+    results: &[CapabilityCallResult],
+) {
+    history.push(Message::user(&format!(
+        "Executor feedback scope: plan_id={plan_id}, independent RTDL tree={plan_description:?}. \
+         Attribute the following results only to this tree. A failure here blocks dependent \
+         steps in this tree, but does not cancel or invalidate other in-flight trees."
+    )));
     let mut deferred_followups: Vec<Message> = Vec::new();
     for r in results {
         let mapped = rtdl_result_to_messages(r);
@@ -639,7 +649,12 @@ pub async fn run_turn(
     } else {
         match memory::prefetch(&task.text, executor, search_memory_target).await {
             Some(mem) => format!(
-                "{base_prompt}\n\n## Relevant past memories (System Context)\n\n{mem}\n\n---\n\n"
+                "{base_prompt}\n\n## Relevant past memories (historical hints only)\n\n\
+                 These entries may be stale or task-specific. They are not current robot state, \
+                 not authorization for a physical action, and not a substitute for resolving a \
+                 named room, region, object, or person through the current capabilities. In \
+                 particular, a remembered grasp or observation pose is not a room navigation \
+                 goal.\n\n{mem}\n\n---\n\n"
             ),
             None => base_prompt,
         }
@@ -824,7 +839,16 @@ pub async fn run_turn(
                             if TERMINAL.contains(&ns.state)
                                 && let Some(r) = ns.leaf_result.as_ref()
                             {
-                                feed_results_into_history(history, std::slice::from_ref(r));
+                                let description = forest
+                                    .get(&plan_id)
+                                    .map(|meta| meta.description.as_str())
+                                    .unwrap_or("unknown tree");
+                                feed_results_into_history(
+                                    history,
+                                    &plan_id,
+                                    description,
+                                    std::slice::from_ref(r),
+                                );
                             }
                             // Any non-success terminal outcome escalates to the VLM
                             // immediately rather than waiting for the whole tree to
@@ -1306,6 +1330,13 @@ To stop a running tree, add a do node whose `cap` is the list's cancel-plan capa
 (e.g. `executor.builtin_cancel_plan`), passing the exact plan_id string from the In-flight trees list.\n\
 For an explicit user request to stop/cancel ALL work, call executor_cancel_all_plans directly \
 in one do node. Do NOT call get_all_plans first and do NOT cancel the control/query tree itself.\n\
+Executor results are scoped to the plan_id/tree named immediately before them. A failed tree \
+blocks only its dependent steps; do not cancel an unrelated in-flight tree because another \
+tree failed. Cancel only for an explicit user steer covering that tree or a safety hazard.\n\
+For a named room or region, current Scene data is authoritative: call Scene list_objects, then \
+goal_room with its stable ID, then navigation with the returned pose. Never substitute a Memory \
+coordinate or an object/grasp pose. A navigation SUCCEEDED result proves completion only for the \
+resolved requested destination; a zero-distance result does not prove that the robot moved.\n\
 Example: {\"content\":\"listing\",\"rtdl_description\":\"list tmp\",\"rtdl\":{\"op\":\"sequence\",\
 \"op_id\":0,\"description\":\"list /tmp\",\"children\":[{\"op\":\"do\",\"op_id\":0,\
 \"description\":\"list the /tmp directory\",\"cap\":\"executor.builtin_list_dir\",\"args\":{\"path\":\"/tmp\"}}]},\
@@ -2076,10 +2107,15 @@ by planning capability calls available to you.
   - If `memory_search` / `memory_save` / `memory_compact` capabilities are available,
     treat long-term memory as available via those capabilities.
 - Prefer structured output; report capability results concisely.
-- If any required capability call fails, times out, returns success=false, or gives an
-  unsafe/unexpected result, stop autonomous task progress. Report what failed and ask
-  the user what to do next. Do not skip ahead, reinterpret the goal, or try new
-  physical actions unless the user confirms.
+- Scope every result to the `plan_id` and independent RTDL tree named in its
+  Executor feedback. If a capability fails, times out, returns success=false,
+  or gives an unsafe/unexpected result, stop only steps that depend on that
+  result. Report that branch failure, but let unrelated in-flight trees continue.
+  Never cancel a different in-flight tree merely because this tree failed.
+- Cancel a running tree only when the latest user steer explicitly asks to stop
+  work covered by that tree, or when continuing that same tree is unsafe. A
+  failure in an independent monitoring, greeting, observation, or query branch
+  is not permission to cancel navigation or another physical task.
 - Do not execute a later physical step unless its required earlier steps have succeeded.
 - For semantic navigation, resolve names through Scene before calling navigation:
   - call Scene `list_objects` first to discover the stable ID for a named room or
@@ -2090,6 +2126,14 @@ by planning capability calls available to you.
     Memory coordinates, or guessed coordinates for a room destination;
   - physical objects MUST use Scene `goal_near` to obtain an approach pose;
   - call navigation only when Scene returns `reachable=true`.
+- Long-term Memory is historical context, not live spatial state. It may help
+  recall what the user called a place, but it never replaces current Scene
+  resolution for a named destination and never turns a task-specific grasp or
+  observation pose into a room goal.
+- After navigation, relate the result to the resolved requested destination.
+  A transport/action status of `SUCCEEDED` does not by itself prove that the
+  requested movement occurred: if the submitted pose was already the current
+  pose, state that the robot was already there instead of claiming it moved.
 - Some later messages may be labelled `Executor feedback for the current task`.
   Treat those as results of capability calls you already planned, not as new
   user requests.
@@ -2144,12 +2188,12 @@ mod tests {
     use super::{
         CapabilityTargetMap, DEFAULT_SUCCESS_CRITERION, RTDL_DO, RTDL_PARALLEL, RTDL_SEQUENCE,
         TaskState, TreeMeta, apply_task_update, duplicate_in_flight_signature, expand_rtdl_to_plan,
-        extract_json_object, format_plan_summary, invalid_cancel_target, is_control_only,
-        parse_rtdl_assistant_response, parse_task_update, plan_call_signatures,
+        extract_json_object, feed_results_into_history, format_plan_summary, invalid_cancel_target,
+        is_control_only, parse_rtdl_assistant_response, parse_task_update, plan_call_signatures,
         rtdl_node_kind_name, rtdl_recovery_final_text, rtdl_state_name, skip_memory_prefetch,
         start_or_resume_task, task_is_session_end,
     };
-    use crate::pb::pilot::{CapabilityCall, Plan, RtdlNode, Task};
+    use crate::pb::pilot::{CapabilityCall, CapabilityCallResult, Plan, RtdlNode, Task};
     use serde_json::json;
     use std::collections::{HashMap, HashSet};
 
@@ -2190,6 +2234,27 @@ mod tests {
         assert_eq!(state.goal, original_goal);
         assert_eq!(state.success_criterion, "room was actually inspected");
         assert_eq!(state.status, "done");
+    }
+
+    #[test]
+    fn executor_feedback_is_scoped_to_its_independent_tree() {
+        let mut history = Vec::new();
+        feed_results_into_history(
+            &mut history,
+            "9",
+            "start greet watch",
+            &[CapabilityCallResult {
+                call_id: "9:0".into(),
+                contract_id: "robonix/skill/greet/greet".into(),
+                success: false,
+                error: "activation failed".into(),
+                ..Default::default()
+            }],
+        );
+        let scope = history[0].content.as_deref().unwrap_or_default();
+        assert!(scope.contains("plan_id=9"));
+        assert!(scope.contains("start greet watch"));
+        assert!(scope.contains("does not cancel or invalidate other in-flight trees"));
     }
 
     #[test]

--- a/system/pilot/src/service.rs
+++ b/system/pilot/src/service.rs
@@ -20,7 +20,7 @@ use robonix_scribe::{debug, error};
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
-use tokio::sync::{Mutex, mpsc, watch};
+use tokio::sync::{Mutex, broadcast, mpsc, watch};
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status};
 use uuid::Uuid;
@@ -103,6 +103,43 @@ type TaskStates = Arc<Mutex<HashMap<String, Arc<Mutex<Option<TaskState>>>>>>;
 struct ActiveTurnInput {
     turn_id: String,
     tx: mpsc::Sender<Task>,
+    events: broadcast::Sender<Result<PilotEvent, String>>,
+}
+
+/// Give each SubmitTask caller its own view of the active supervisor stream.
+/// A caller is complete after one user-facing FinalText, while the underlying
+/// supervisor and its long-running RTDL trees may remain alive for later input.
+fn subscribe_turn_events(
+    events: &broadcast::Sender<Result<PilotEvent, String>>,
+) -> ReceiverStream<Result<PilotEvent, Status>> {
+    let mut subscriber = events.subscribe();
+    let (tx, rx) = mpsc::channel(64);
+    tokio::spawn(async move {
+        loop {
+            match subscriber.recv().await {
+                Ok(Ok(event)) => {
+                    let complete = event.event_kind == EVT_FINAL_TEXT;
+                    if tx.send(Ok(event)).await.is_err() || complete {
+                        break;
+                    }
+                }
+                Ok(Err(error)) => {
+                    let _ = tx.send(Err(Status::internal(error))).await;
+                    break;
+                }
+                Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                    let _ = tx
+                        .send(Err(Status::resource_exhausted(format!(
+                            "Pilot event subscriber lagged by {skipped} event(s)"
+                        ))))
+                        .await;
+                    break;
+                }
+                Err(broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    });
+    ReceiverStream::new(rx)
 }
 
 const SEEN_TASK_IDS_PER_SESSION: usize = 256;
@@ -308,6 +345,7 @@ impl RobonixSystemPilot for PilotServiceImpl {
         // check and the registration atomically prevents a check-then-insert race
         // where two near-simultaneous submits for one session both start a turn.
         let (steer_tx, steer_rx) = mpsc::channel::<Task>(32);
+        let (candidate_events, _) = broadcast::channel(128);
         let explicit_steer = task_is_steer(&task);
         let expected_turn = expected_turn_id(&task);
         let existing_turn = {
@@ -326,6 +364,7 @@ impl RobonixSystemPilot for PilotServiceImpl {
                         ActiveTurnInput {
                             turn_id: task.task_id.clone(),
                             tx: steer_tx.clone(),
+                            events: candidate_events.clone(),
                         },
                     );
                     None
@@ -333,12 +372,6 @@ impl RobonixSystemPilot for PilotServiceImpl {
             }
         };
         if let Some(existing) = existing_turn {
-            if !explicit_steer {
-                return Err(Status::already_exists(format!(
-                    "session already has active turn {}; submit explicit steer input instead",
-                    existing.turn_id
-                )));
-            }
             if let Some(expected) = expected_turn
                 && expected != existing.turn_id
             {
@@ -347,13 +380,20 @@ impl RobonixSystemPilot for PilotServiceImpl {
                     existing.turn_id
                 )));
             }
-            // A turn is already live: hand this to its steer queue and return an
-            // empty stream; events keep flowing on that turn's original stream.
+            // A turn is already live: every new same-session task is a steer of
+            // that supervisor. Subscribe before queueing it so this caller sees
+            // the response produced for its input instead of receiving an empty
+            // stream and being forced to stop the background plan.
             let id = task.session_id.clone();
+            let rx = subscribe_turn_events(&existing.events);
             let ok = existing.tx.send(task).await.is_ok();
             debug!("[pilot] steer task for session {id} (queued={ok})");
-            let (_tx, rx) = tokio::sync::mpsc::channel::<Result<PilotEvent, Status>>(1);
-            return Ok(Response::new(ReceiverStream::new(rx)));
+            if !ok {
+                return Err(Status::unavailable(
+                    "active Pilot turn stopped before steer was queued",
+                ));
+            }
+            return Ok(Response::new(rx));
         }
 
         let history_arc = self.get_or_create_history(&task.session_id).await;
@@ -363,7 +403,15 @@ impl RobonixSystemPilot for PilotServiceImpl {
         // https://docs.rs/tokio/latest/tokio/sync/mpsc/struct.Sender.html
         // https://tokio.rs/tokio/tutorial/channels
         // MPSC: Multiple Producer Single Consumer
-        let (tx, rx) = tokio::sync::mpsc::channel::<Result<PilotEvent, Status>>(64);
+        let (tx, mut internal_rx) = tokio::sync::mpsc::channel::<Result<PilotEvent, Status>>(64);
+        let rx = subscribe_turn_events(&candidate_events);
+        let relay_events = candidate_events.clone();
+        tokio::spawn(async move {
+            while let Some(item) = internal_rx.recv().await {
+                let shared = item.map_err(|status| status.message().to_string());
+                let _ = relay_events.send(shared);
+            }
+        });
         let atlas = self.atlas.clone();
         let provider_id = self.provider_id.clone();
         let vlm = self.vlm.clone();
@@ -431,7 +479,7 @@ impl RobonixSystemPilot for PilotServiceImpl {
             steers.lock().await.remove(&session_id);
         });
 
-        Ok(Response::new(ReceiverStream::new(rx)))
+        Ok(Response::new(rx))
     }
 }
 
@@ -475,8 +523,12 @@ async fn build_executor_conn(
 
 #[cfg(test)]
 mod tests {
-    use super::{expected_turn_id, task_is_abort_turn, task_is_steer};
-    use crate::pb::pilot::Task;
+    use super::{
+        EVT_FINAL_TEXT, EVT_STATUS, expected_turn_id, subscribe_turn_events, task_is_abort_turn,
+        task_is_steer,
+    };
+    use crate::pb::pilot::{PilotEvent, Task};
+    use tokio_stream::StreamExt;
 
     fn task(ctx: &str) -> Task {
         Task {
@@ -506,5 +558,36 @@ mod tests {
         assert_eq!(expected_turn_id(&value).as_deref(), Some("turn-7"));
         assert!(task_is_steer(&task(r#"{"steer":true}"#)));
         assert!(!task_is_steer(&task(r#"{"interaction_mode":"task"}"#)));
+    }
+
+    #[tokio::test]
+    async fn submit_subscriber_closes_at_its_final_text_boundary() {
+        let (events, _) = tokio::sync::broadcast::channel(8);
+        let mut stream = subscribe_turn_events(&events);
+        events
+            .send(Ok(PilotEvent {
+                event_kind: EVT_STATUS,
+                ..Default::default()
+            }))
+            .unwrap();
+        events
+            .send(Ok(PilotEvent {
+                event_kind: EVT_FINAL_TEXT,
+                final_text: "still running".into(),
+                ..Default::default()
+            }))
+            .unwrap();
+        events
+            .send(Ok(PilotEvent {
+                event_kind: EVT_STATUS,
+                ..Default::default()
+            }))
+            .unwrap();
+
+        assert_eq!(stream.next().await.unwrap().unwrap().event_kind, EVT_STATUS);
+        let final_event = stream.next().await.unwrap().unwrap();
+        assert_eq!(final_event.event_kind, EVT_FINAL_TEXT);
+        assert_eq!(final_event.final_text, "still running");
+        assert!(stream.next().await.is_none());
     }
 }

--- a/system/pilot/src/service.rs
+++ b/system/pilot/src/service.rs
@@ -279,6 +279,16 @@ fn expected_turn_id(task: &Task) -> Option<String> {
     })
 }
 
+fn strict_expected_turn(task: &Task) -> bool {
+    task_context(task)
+        .and_then(|value| {
+            value
+                .get("strict_expected_turn")
+                .and_then(|field| field.as_bool())
+        })
+        .unwrap_or(false)
+}
+
 #[tonic::async_trait]
 impl RobonixSystemPilot for PilotServiceImpl {
     type SubmitTaskStream = ReceiverStream<Result<PilotEvent, Status>>;
@@ -388,10 +398,16 @@ impl RobonixSystemPilot for PilotServiceImpl {
             if let Some(expected) = expected_turn
                 && expected != existing.turn_id
             {
-                return Err(Status::failed_precondition(format!(
-                    "steer expected turn {expected}, but active turn is {}",
-                    existing.turn_id
-                )));
+                if strict_expected_turn(&task) {
+                    return Err(Status::failed_precondition(format!(
+                        "steer expected turn {expected}, but active turn is {}",
+                        existing.turn_id
+                    )));
+                }
+                debug!(
+                    "[pilot] accepting same-session steer with stale expected turn {} (active={})",
+                    expected, existing.turn_id
+                );
             }
             // A turn is already live: every new same-session task is a steer of
             // that supervisor. Subscribe before queueing it so this caller sees
@@ -537,8 +553,8 @@ async fn build_executor_conn(
 #[cfg(test)]
 mod tests {
     use super::{
-        EVT_FINAL_TEXT, EVT_STATUS, expected_turn_id, subscribe_turn_events, task_is_abort_turn,
-        task_is_steer,
+        EVT_FINAL_TEXT, EVT_STATUS, expected_turn_id, strict_expected_turn, subscribe_turn_events,
+        task_is_abort_turn, task_is_steer,
     };
     use crate::pb::pilot::{PilotEvent, Task};
     use tokio_stream::StreamExt;
@@ -569,6 +585,10 @@ mod tests {
         let value = task(r#"{"interaction_mode":"steer","expected_turn_id":"turn-7"}"#);
         assert!(task_is_steer(&value));
         assert_eq!(expected_turn_id(&value).as_deref(), Some("turn-7"));
+        assert!(!strict_expected_turn(&value));
+        assert!(strict_expected_turn(&task(
+            r#"{"expected_turn_id":"turn-7","strict_expected_turn":true}"#
+        )));
         assert!(task_is_steer(&task(r#"{"steer":true}"#)));
         assert!(!task_is_steer(&task(r#"{"interaction_mode":"task"}"#)));
     }

--- a/system/pilot/src/service.rs
+++ b/system/pilot/src/service.rs
@@ -4,9 +4,11 @@
 // `RobonixSystemPilot` gRPC handler (contract `robonix/system/pilot`).
 
 use crate::pb::contracts::{
+    robonix_system_executor_cancel_all_plans_client::RobonixSystemExecutorCancelAllPlansClient,
     robonix_system_executor_execute_client::RobonixSystemExecutorExecuteClient,
     robonix_system_pilot_server::RobonixSystemPilot,
 };
+use crate::pb::executor::CancelAllRequest;
 use crate::pb::pilot::{
     BatchResult, PilotEvent, Plan, RtdlNodeState, SessionStatusEvent, Task, TaskStateEvent,
 };
@@ -260,7 +262,7 @@ impl RobonixSystemPilot for PilotServiceImpl {
 
         if task_is_abort_turn(&task) {
             let id = task.session_id.clone();
-            let ok = if let Some(tx) = self.cancels.lock().await.get(&id) {
+            let turn_signaled = if let Some(tx) = self.cancels.lock().await.get(&id) {
                 tx.send_if_modified(|interrupted| {
                     if *interrupted {
                         false
@@ -272,8 +274,32 @@ impl RobonixSystemPilot for PilotServiceImpl {
             } else {
                 false
             };
-            debug!("[pilot] abort_turn task for session {id} (signaled={ok})");
-            let (_tx, rx) = tokio::sync::mpsc::channel::<Result<PilotEvent, Status>>(1);
+            let executor_cancelled =
+                cancel_all_executor_plans(self.atlas.clone(), &self.provider_id).await;
+            debug!(
+                "[pilot] abort_turn session {id} (turn_signaled={turn_signaled}, executor={executor_cancelled:?})"
+            );
+            let (tx, rx) = tokio::sync::mpsc::channel::<Result<PilotEvent, Status>>(1);
+            let message = match executor_cancelled {
+                Ok(true) => "stop completed",
+                Ok(false) => "stop reached Executor but cancellation was not accepted",
+                Err(ref error) => error.as_str(),
+            };
+            let state = if executor_cancelled == Ok(true) {
+                SessionState::Completed
+            } else {
+                SessionState::Failed
+            };
+            let _ = tx
+                .send(Ok(pack(
+                    &id,
+                    PilotStreamBody::Status(SessionStatusEvent {
+                        session_id: id.clone(),
+                        state: state as u32,
+                        message: message.to_string(),
+                    }),
+                )))
+                .await;
             return Ok(Response::new(ReceiverStream::new(rx)));
         }
 
@@ -406,6 +432,25 @@ impl RobonixSystemPilot for PilotServiceImpl {
 
         Ok(Response::new(ReceiverStream::new(rx)))
     }
+}
+
+async fn cancel_all_executor_plans(
+    mut atlas: AtlasClient,
+    consumer_id: &str,
+) -> Result<bool, String> {
+    let (_, _, channel) = atlas_client::connect_to_capability(
+        &mut atlas,
+        consumer_id,
+        "robonix/system/executor/cancel_all_plans",
+    )
+    .await
+    .map_err(|error| format!("stop could not reach Executor: {error:#}"))?;
+    let mut client = RobonixSystemExecutorCancelAllPlansClient::new(channel);
+    client
+        .cancel_all(CancelAllRequest::default())
+        .await
+        .map(|response| response.into_inner().success)
+        .map_err(|error| format!("Executor cancellation failed: {error}"))
 }
 
 /// Connect to executor's Execute RPC. Capability discovery (what's available

--- a/system/pilot/src/service.rs
+++ b/system/pilot/src/service.rs
@@ -19,7 +19,7 @@ use robonix_atlas::client::{self as atlas_client, AtlasClient};
 use robonix_scribe::{debug, error};
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::sync::{Mutex, broadcast, mpsc, watch};
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status};
@@ -104,6 +104,7 @@ struct ActiveTurnInput {
     turn_id: String,
     tx: mpsc::Sender<Task>,
     events: broadcast::Sender<Result<PilotEvent, String>>,
+    reply_generation: Arc<AtomicU64>,
 }
 
 /// Give each SubmitTask caller its own view of the active supervisor stream.
@@ -111,13 +112,23 @@ struct ActiveTurnInput {
 /// supervisor and its long-running RTDL trees may remain alive for later input.
 fn subscribe_turn_events(
     events: &broadcast::Sender<Result<PilotEvent, String>>,
+    reply_generation: &Arc<AtomicU64>,
 ) -> ReceiverStream<Result<PilotEvent, Status>> {
+    let generation = reply_generation.fetch_add(1, Ordering::AcqRel) + 1;
+    let reply_generation = Arc::clone(reply_generation);
     let mut subscriber = events.subscribe();
     let (tx, rx) = mpsc::channel(64);
     tokio::spawn(async move {
         loop {
             match subscriber.recv().await {
                 Ok(Ok(event)) => {
+                    // A newer same-session SubmitTask owns all subsequent
+                    // user-facing events. Closing this stale view prevents one
+                    // supervisor reply from being rendered by every historical
+                    // request stream while leaving its RTDL trees untouched.
+                    if reply_generation.load(Ordering::Acquire) != generation {
+                        break;
+                    }
                     let complete = event.event_kind == EVT_FINAL_TEXT;
                     if tx.send(Ok(event)).await.is_err() || complete {
                         break;
@@ -346,6 +357,7 @@ impl RobonixSystemPilot for PilotServiceImpl {
         // where two near-simultaneous submits for one session both start a turn.
         let (steer_tx, steer_rx) = mpsc::channel::<Task>(32);
         let (candidate_events, _) = broadcast::channel(128);
+        let candidate_reply_generation = Arc::new(AtomicU64::new(0));
         let explicit_steer = task_is_steer(&task);
         let expected_turn = expected_turn_id(&task);
         let existing_turn = {
@@ -365,6 +377,7 @@ impl RobonixSystemPilot for PilotServiceImpl {
                             turn_id: task.task_id.clone(),
                             tx: steer_tx.clone(),
                             events: candidate_events.clone(),
+                            reply_generation: Arc::clone(&candidate_reply_generation),
                         },
                     );
                     None
@@ -385,7 +398,7 @@ impl RobonixSystemPilot for PilotServiceImpl {
             // the response produced for its input instead of receiving an empty
             // stream and being forced to stop the background plan.
             let id = task.session_id.clone();
-            let rx = subscribe_turn_events(&existing.events);
+            let rx = subscribe_turn_events(&existing.events, &existing.reply_generation);
             let ok = existing.tx.send(task).await.is_ok();
             debug!("[pilot] steer task for session {id} (queued={ok})");
             if !ok {
@@ -404,7 +417,7 @@ impl RobonixSystemPilot for PilotServiceImpl {
         // https://tokio.rs/tokio/tutorial/channels
         // MPSC: Multiple Producer Single Consumer
         let (tx, mut internal_rx) = tokio::sync::mpsc::channel::<Result<PilotEvent, Status>>(64);
-        let rx = subscribe_turn_events(&candidate_events);
+        let rx = subscribe_turn_events(&candidate_events, &candidate_reply_generation);
         let relay_events = candidate_events.clone();
         tokio::spawn(async move {
             while let Some(item) = internal_rx.recv().await {
@@ -563,7 +576,8 @@ mod tests {
     #[tokio::test]
     async fn submit_subscriber_closes_at_its_final_text_boundary() {
         let (events, _) = tokio::sync::broadcast::channel(8);
-        let mut stream = subscribe_turn_events(&events);
+        let generation = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let mut stream = subscribe_turn_events(&events, &generation);
         events
             .send(Ok(PilotEvent {
                 event_kind: EVT_STATUS,
@@ -589,5 +603,27 @@ mod tests {
         assert_eq!(final_event.event_kind, EVT_FINAL_TEXT);
         assert_eq!(final_event.final_text, "still running");
         assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn newest_submit_subscriber_exclusively_owns_future_replies() {
+        let (events, _) = tokio::sync::broadcast::channel(8);
+        let generation = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let mut stale = subscribe_turn_events(&events, &generation);
+        let mut current = subscribe_turn_events(&events, &generation);
+
+        events
+            .send(Ok(PilotEvent {
+                event_kind: EVT_FINAL_TEXT,
+                final_text: "one reply".into(),
+                ..Default::default()
+            }))
+            .unwrap();
+
+        assert!(stale.next().await.is_none());
+        let final_event = current.next().await.unwrap().unwrap();
+        assert_eq!(final_event.event_kind, EVT_FINAL_TEXT);
+        assert_eq!(final_event.final_text, "one reply");
+        assert!(current.next().await.is_none());
     }
 }

--- a/system/pilot/src/service.rs
+++ b/system/pilot/src/service.rs
@@ -301,7 +301,7 @@ async fn build_executor_conn(
     mut atlas: AtlasClient,
     consumer_id: &str,
 ) -> anyhow::Result<ExecutorConn> {
-    let (_, _, exec_ch) = atlas_client::connect_to_capability(
+    let (_, executor_provider_id, exec_ch) = atlas_client::connect_to_capability(
         &mut atlas,
         consumer_id,
         "robonix/system/executor/execute",
@@ -310,6 +310,7 @@ async fn build_executor_conn(
     .context("connect_to_capability robonix/system/executor/execute")?;
     Ok(ExecutorConn {
         graph: RobonixSystemExecutorExecuteClient::new(exec_ch),
+        provider_id: executor_provider_id,
     })
 }
 

--- a/system/pilot/src/service.rs
+++ b/system/pilot/src/service.rs
@@ -277,7 +277,7 @@ impl RobonixSystemPilot for PilotServiceImpl {
             let executor_cancelled =
                 cancel_all_executor_plans(self.atlas.clone(), &self.provider_id).await;
             debug!(
-                "[pilot] abort_turn session {id} (turn_signaled={turn_signaled}, executor={executor_cancelled:?})"
+                "[pilot] deterministic stop session {id} (turn_signaled={turn_signaled}, executor={executor_cancelled:?})"
             );
             let (tx, rx) = tokio::sync::mpsc::channel::<Result<PilotEvent, Status>>(1);
             let message = match executor_cancelled {
@@ -316,9 +316,10 @@ impl RobonixSystemPilot for PilotServiceImpl {
                 Some(existing) => Some(existing.clone()),
                 None => {
                     if explicit_steer {
-                        return Err(Status::failed_precondition(
-                            "no active turn to steer for this session",
-                        ));
+                        debug!(
+                            "[pilot] steer for session {} has no active turn; starting a new turn",
+                            task.session_id
+                        );
                     }
                     steers.insert(
                         task.session_id.clone(),

--- a/system/pilot/src/service.rs
+++ b/system/pilot/src/service.rs
@@ -10,12 +10,12 @@ use crate::pb::contracts::{
 use crate::pb::pilot::{
     BatchResult, PilotEvent, Plan, RtdlNodeState, SessionStatusEvent, Task, TaskStateEvent,
 };
-use crate::planner::{self, ExecutorConn};
+use crate::planner::{self, ExecutorConn, TaskState};
 use crate::vlm::{Message, VlmClient};
 use anyhow::Context;
 use robonix_atlas::client::{self as atlas_client, AtlasClient};
 use robonix_scribe::{debug, error};
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
 use tokio::sync::{Mutex, mpsc, watch};
@@ -43,6 +43,7 @@ pub const EVT_FINAL_TEXT: u32 = 4;
 pub const EVT_NODE_STATE: u32 = 5;
 pub const EVT_TASK_STATE: u32 = 6;
 
+#[allow(dead_code)]
 pub enum PilotStreamBody {
     TextChunk(String),
     FinalText(String),
@@ -94,6 +95,15 @@ pub fn pack(session_id: &str, body: PilotStreamBody) -> PilotEvent {
 /// LLM conversation history per `session_id`. Grows across turns; never
 /// expired (turns trim themselves at MAX_HISTORY in planner).
 type Histories = Arc<Mutex<HashMap<String, Arc<Mutex<Vec<Message>>>>>>;
+type TaskStates = Arc<Mutex<HashMap<String, Arc<Mutex<Option<TaskState>>>>>>;
+
+#[derive(Clone)]
+struct ActiveTurnInput {
+    turn_id: String,
+    tx: mpsc::Sender<Task>,
+}
+
+const SEEN_TASK_IDS_PER_SESSION: usize = 256;
 
 pub struct PilotServiceImpl {
     /// `AtlasClient` is cheap to clone (its inner channel is just a handle);
@@ -107,13 +117,21 @@ pub struct PilotServiceImpl {
     vlm: VlmClient,
     soma_prompt_block: Arc<String>,
     histories: Histories,
+    /// Harness-owned standing goal per session. It survives a transport turn
+    /// that pauses for user input, so the next message cannot silently replace
+    /// unfinished work with a model-authored summary.
+    task_states: TaskStates,
     /// Per-session cancellation senders. `abort_turn` Task signals this
     /// without holding the history lock.
     cancels: Arc<Mutex<HashMap<String, watch::Sender<bool>>>>,
     /// Per-session steer queues. A Task submitted while a turn is already
     /// running for that session is pushed here as a mid-task steer instead of
     /// starting a second turn; the running `run_turn` drains it.
-    steers: Arc<Mutex<HashMap<String, mpsc::Sender<Task>>>>,
+    steers: Arc<Mutex<HashMap<String, ActiveTurnInput>>>,
+    /// Recently accepted task ids, scoped by session. A client retry with the
+    /// same id is acknowledged exactly once and never starts or steers a turn
+    /// twice. The bounded queue prevents an unbounded session-lifetime set.
+    seen_task_ids: Arc<Mutex<HashMap<String, VecDeque<String>>>>,
     /// Per-session RTDL plan-id counter. Monotonic, never reused, and shared
     /// across every turn of the session so plan ids never reset to 1 on a new
     /// message.
@@ -133,8 +151,10 @@ impl PilotServiceImpl {
             vlm,
             soma_prompt_block: Arc::new(soma_prompt_block),
             histories: Arc::new(Mutex::new(HashMap::new())),
+            task_states: Arc::new(Mutex::new(HashMap::new())),
             cancels: Arc::new(Mutex::new(HashMap::new())),
             steers: Arc::new(Mutex::new(HashMap::new())),
+            seen_task_ids: Arc::new(Mutex::new(HashMap::new())),
             plan_seqs: Arc::new(Mutex::new(HashMap::new())),
         }
     }
@@ -146,6 +166,13 @@ impl PilotServiceImpl {
             .clone()
     }
 
+    async fn get_or_create_task_state(&self, session_id: &str) -> Arc<Mutex<Option<TaskState>>> {
+        let mut map = self.task_states.lock().await;
+        map.entry(session_id.to_string())
+            .or_insert_with(|| Arc::new(Mutex::new(None)))
+            .clone()
+    }
+
     /// The session's shared, monotonic RTDL plan-id counter, created on first
     /// use and persisted for the process lifetime so ids never reset per turn.
     async fn get_or_create_plan_seq(&self, session_id: &str) -> Arc<AtomicU64> {
@@ -154,17 +181,52 @@ impl PilotServiceImpl {
             .or_insert_with(|| Arc::new(AtomicU64::new(0)))
             .clone()
     }
+
+    async fn accept_task_id_once(&self, session_id: &str, task_id: &str) -> bool {
+        if task_id.is_empty() {
+            return true;
+        }
+        let mut sessions = self.seen_task_ids.lock().await;
+        let ids = sessions.entry(session_id.to_string()).or_default();
+        if ids.iter().any(|seen| seen == task_id) {
+            return false;
+        }
+        ids.push_back(task_id.to_string());
+        while ids.len() > SEEN_TASK_IDS_PER_SESSION {
+            ids.pop_front();
+        }
+        true
+    }
+}
+
+fn task_context(task: &Task) -> Option<serde_json::Value> {
+    let raw = task.context_json.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    serde_json::from_str(raw).ok()
 }
 
 fn task_is_abort_turn(task: &Task) -> bool {
-    let j = task.context_json.trim();
-    if j.is_empty() {
-        return false;
-    }
-    serde_json::from_str::<serde_json::Value>(j)
-        .ok()
+    task_context(task)
         .and_then(|v| v.get("abort_turn").and_then(|x| x.as_bool()))
         .unwrap_or(false)
+}
+
+fn task_is_steer(task: &Task) -> bool {
+    task_context(task).is_some_and(|v| {
+        v.get("steer").and_then(|x| x.as_bool()).unwrap_or(false)
+            || v.get("interaction_mode").and_then(|x| x.as_str()) == Some("steer")
+    })
+}
+
+fn expected_turn_id(task: &Task) -> Option<String> {
+    task_context(task).and_then(|v| {
+        v.get("expected_turn_id")
+            .and_then(|x| x.as_str())
+            .filter(|id| !id.is_empty())
+            .map(str::to_string)
+    })
 }
 
 #[tonic::async_trait]
@@ -177,11 +239,36 @@ impl RobonixSystemPilot for PilotServiceImpl {
     ) -> Result<Response<Self::SubmitTaskStream>, Status> {
         let mut task = request.into_inner();
 
+        if task.session_id.is_empty() {
+            task.session_id = Uuid::new_v4().to_string();
+        }
+        if task.task_id.is_empty() {
+            task.task_id = Uuid::new_v4().to_string();
+        }
+
+        if !self
+            .accept_task_id_once(&task.session_id, &task.task_id)
+            .await
+        {
+            debug!(
+                "[pilot] duplicate task ignored session={} task_id={}",
+                task.session_id, task.task_id
+            );
+            let (_tx, rx) = tokio::sync::mpsc::channel::<Result<PilotEvent, Status>>(1);
+            return Ok(Response::new(ReceiverStream::new(rx)));
+        }
+
         if task_is_abort_turn(&task) {
             let id = task.session_id.clone();
             let ok = if let Some(tx) = self.cancels.lock().await.get(&id) {
-                let _ = tx.send(true);
-                true
+                tx.send_if_modified(|interrupted| {
+                    if *interrupted {
+                        false
+                    } else {
+                        *interrupted = true;
+                        true
+                    }
+                })
             } else {
                 false
             };
@@ -190,36 +277,60 @@ impl RobonixSystemPilot for PilotServiceImpl {
             return Ok(Response::new(ReceiverStream::new(rx)));
         }
 
-        if task.session_id.is_empty() {
-            task.session_id = Uuid::new_v4().to_string();
-        }
-
         // Decide — under a single `steers` lock — whether this task is a mid-task
         // steer for an already-live turn or the start of a new turn. Doing the
         // check and the registration atomically prevents a check-then-insert race
         // where two near-simultaneous submits for one session both start a turn.
         let (steer_tx, steer_rx) = mpsc::channel::<Task>(32);
-        let existing_steer = {
+        let explicit_steer = task_is_steer(&task);
+        let expected_turn = expected_turn_id(&task);
+        let existing_turn = {
             let mut steers = self.steers.lock().await;
             match steers.get(&task.session_id) {
                 Some(existing) => Some(existing.clone()),
                 None => {
-                    steers.insert(task.session_id.clone(), steer_tx.clone());
+                    if explicit_steer {
+                        return Err(Status::failed_precondition(
+                            "no active turn to steer for this session",
+                        ));
+                    }
+                    steers.insert(
+                        task.session_id.clone(),
+                        ActiveTurnInput {
+                            turn_id: task.task_id.clone(),
+                            tx: steer_tx.clone(),
+                        },
+                    );
                     None
                 }
             }
         };
-        if let Some(existing) = existing_steer {
+        if let Some(existing) = existing_turn {
+            if !explicit_steer {
+                return Err(Status::already_exists(format!(
+                    "session already has active turn {}; submit explicit steer input instead",
+                    existing.turn_id
+                )));
+            }
+            if let Some(expected) = expected_turn
+                && expected != existing.turn_id
+            {
+                return Err(Status::failed_precondition(format!(
+                    "steer expected turn {expected}, but active turn is {}",
+                    existing.turn_id
+                )));
+            }
             // A turn is already live: hand this to its steer queue and return an
             // empty stream; events keep flowing on that turn's original stream.
             let id = task.session_id.clone();
-            let ok = existing.send(task).await.is_ok();
+            let ok = existing.tx.send(task).await.is_ok();
             debug!("[pilot] steer task for session {id} (queued={ok})");
             let (_tx, rx) = tokio::sync::mpsc::channel::<Result<PilotEvent, Status>>(1);
             return Ok(Response::new(ReceiverStream::new(rx)));
         }
 
         let history_arc = self.get_or_create_history(&task.session_id).await;
+        let task_state_arc = self.get_or_create_task_state(&task.session_id).await;
         let plan_seq = self.get_or_create_plan_seq(&task.session_id).await;
         // what is tokio's tx and rx:
         // https://docs.rs/tokio/latest/tokio/sync/mpsc/struct.Sender.html
@@ -247,7 +358,7 @@ impl RobonixSystemPilot for PilotServiceImpl {
                     PilotStreamBody::Status(SessionStatusEvent {
                         session_id: session_id.clone(),
                         state: SessionState::Active as u32,
-                        message: String::new(),
+                        message: format!("turn_id={}", task.task_id),
                     }),
                 )))
                 .await;
@@ -268,9 +379,11 @@ impl RobonixSystemPilot for PilotServiceImpl {
             };
 
             let mut history = history_arc.lock().await;
+            let mut standing_task = task_state_arc.lock().await;
             if let Err(e) = planner::run_turn(
                 &task,
                 &mut history,
+                &mut standing_task,
                 &vlm,
                 &mut executor,
                 &mut atlas_for_turn,
@@ -316,7 +429,7 @@ async fn build_executor_conn(
 
 #[cfg(test)]
 mod tests {
-    use super::task_is_abort_turn;
+    use super::{expected_turn_id, task_is_abort_turn, task_is_steer};
     use crate::pb::pilot::Task;
 
     fn task(ctx: &str) -> Task {
@@ -338,5 +451,14 @@ mod tests {
         assert!(!task_is_abort_turn(&task(r#"{"foo":1}"#)));
         assert!(!task_is_abort_turn(&task("")));
         assert!(!task_is_abort_turn(&task("not json")));
+    }
+
+    #[test]
+    fn explicit_steer_and_expected_turn_are_parsed() {
+        let value = task(r#"{"interaction_mode":"steer","expected_turn_id":"turn-7"}"#);
+        assert!(task_is_steer(&value));
+        assert_eq!(expected_turn_id(&value).as_deref(), Some("turn-7"));
+        assert!(task_is_steer(&task(r#"{"steer":true}"#)));
+        assert!(!task_is_steer(&task(r#"{"interaction_mode":"task"}"#)));
     }
 }

--- a/system/pilot/src/soma_context.rs
+++ b/system/pilot/src/soma_context.rs
@@ -8,16 +8,114 @@
 // without the user first calling a bridge tool.
 
 use crate::pb::contracts::{
+    robonix_system_soma_get_health_client::RobonixSystemSomaGetHealthClient,
     robonix_system_soma_get_urdf_client::RobonixSystemSomaGetUrdfClient,
     robonix_system_soma_get_yaml_client::RobonixSystemSomaGetYamlClient,
 };
-use crate::pb::soma::{GetUrdfRequest, GetYamlRequest};
+use crate::pb::soma::{GetHealthRequest, GetUrdfRequest, GetYamlRequest};
 use anyhow::{Context, Result};
 use robonix_atlas::client::{self as atlas_client, AtlasClient};
 use robonix_scribe::warn;
 
 const GET_YAML_CONTRACT: &str = "robonix/system/soma/get_yaml";
 const GET_URDF_CONTRACT: &str = "robonix/system/soma/get_urdf";
+const GET_HEALTH_CONTRACT: &str = "robonix/system/soma/get_health";
+
+pub async fn fetch_runtime_prompt_block(atlas: &mut AtlasClient, consumer_id: &str) -> String {
+    match fetch_health(atlas, consumer_id).await {
+        Ok(value) => format!(
+            "\n\n## Current embodiment state (from Soma)\n\
+             This snapshot was refreshed immediately before planning. Fresh fields are \
+             authoritative. Stale or missing fields mean unknown; never reconstruct them \
+             from conversation history. `likely_holding` means the calibrated gripper is \
+             not fully open; it does not identify the object.\n\n{}\n",
+            serde_json::to_string_pretty(&value).unwrap_or_else(|_| "{}".into())
+        ),
+        Err(error) => format!(
+            "\n\n## Current embodiment state (from Soma)\n\
+             {{\"available\":false,\"error\":{}}}\n",
+            serde_json::to_string(&error.to_string()).unwrap_or_else(|_| "\"unknown\"".into())
+        ),
+    }
+}
+
+async fn fetch_health(atlas: &mut AtlasClient, consumer_id: &str) -> Result<serde_json::Value> {
+    let (channel_id, _provider_id, channel) =
+        atlas_client::connect_to_capability(atlas, consumer_id, GET_HEALTH_CONTRACT)
+            .await
+            .context("connect to Soma get_health")?;
+    let result = async {
+        let response = RobonixSystemSomaGetHealthClient::new(channel)
+            .get_health(GetHealthRequest {})
+            .await
+            .context("call Soma get_health")?
+            .into_inner();
+        let snapshot = response
+            .snapshot
+            .context("Soma has not published a health snapshot yet")?;
+        let components: Vec<_> = snapshot
+            .components
+            .into_iter()
+            .map(|component| {
+                serde_json::json!({
+                    "id": component.id,
+                    "parent_id": component.parent_id,
+                    "kind": component.kind,
+                    "health": component.health,
+                    "operational_state": component.operational_state,
+                    "online": component.online,
+                    "detail": component.detail,
+                })
+            })
+            .collect();
+        let actuators: Vec<_> = snapshot
+            .actuators
+            .into_iter()
+            .map(|actuator| {
+                serde_json::json!({
+                    "component_id": actuator.component_id,
+                    "joint_name": actuator.joint_name,
+                    "position": actuator.position.map(|value| serde_json::json!({
+                        "value": value.value, "unit": value.unit, "quality": value.quality,
+                    })),
+                    "communication_ok": actuator.communication_ok,
+                })
+            })
+            .collect();
+        let metrics: Vec<_> = snapshot
+            .metrics
+            .into_iter()
+            .map(|metric| {
+                serde_json::json!({
+                    "component_id": metric.component_id,
+                    "name": metric.name,
+                    "value": metric.value.map(|value| serde_json::json!({
+                        "value": value.value, "unit": value.unit, "quality": value.quality,
+                    })),
+                })
+            })
+            .collect();
+        Ok::<_, anyhow::Error>(serde_json::json!({
+            "available": true,
+            "body_id": snapshot.body_id,
+            "seq": snapshot.seq,
+            "source_ts_ns": snapshot.source_ts_ns,
+            "ttl_ms": snapshot.ttl_ms,
+            "components": components,
+            "actuators": actuators,
+            "metrics": metrics,
+            "safety": snapshot.safety.map(|safety| serde_json::json!({
+                "motion_allowed": safety.motion_allowed,
+                "motor_power_allowed": safety.motor_power_allowed,
+                "aggregate_state": safety.aggregate_state,
+                "detail": safety.detail,
+            })),
+        }))
+    }
+    .await;
+    let _ = atlas.disconnect_capability(&channel_id).await;
+    result
+}
 
 pub async fn fetch_system_prompt_block(
     atlas: &mut AtlasClient,

--- a/system/pilot/src/state_context.rs
+++ b/system/pilot/src/state_context.rs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MulanPSL-2.0
+
+use crate::pb::contracts::robonix_system_executor_execute_client::RobonixSystemExecutorExecuteClient;
+use crate::pb::executor::rtdl_event::RtdlEventEnum;
+use crate::pb::pilot::rtdl_node_state::RtdlNodeStateEnum;
+use crate::pb::pilot::{CapabilityCall, Plan, RtdlNode};
+use crate::planner::ExecutorConn;
+use robonix_atlas::client::AtlasClient;
+use robonix_atlas::pb as atlas_pb;
+use serde_json::{Value, json};
+use std::time::Duration;
+use tonic::Request;
+use tonic::transport::Channel;
+use uuid::Uuid;
+
+const RTDL_DO: u32 = 2;
+const SCENE_CONTEXT: &str = "robonix/system/scene/get_robot_context";
+
+pub async fn collect(
+    executor: &ExecutorConn,
+    atlas: &mut AtlasClient,
+    caps: &[(String, atlas_pb::Capability)],
+) -> String {
+    let scene_target = caps
+        .iter()
+        .find(|(_, capability)| capability.contract_id == SCENE_CONTEXT)
+        .map(|(provider_id, _)| provider_id.clone());
+    let scene = match scene_target {
+        Some(provider_id) => query_scene(executor.graph.clone(), provider_id).await,
+        None => json!({"available": false, "error": "Scene context contract is not registered"}),
+    };
+    let providers = match atlas
+        .query_capabilities("", "", atlas_pb::Transport::Unspecified)
+        .await
+    {
+        Ok(rows) => rows
+            .into_iter()
+            .filter(|provider| {
+                provider.capabilities.iter().any(|capability| {
+                    let id = capability.contract_id.as_str();
+                    id.contains("/navigation/")
+                        || id.contains("/scene/")
+                        || id.contains("/arm/")
+                        || id.contains("/chassis/")
+                        || id.contains("/skill/")
+                })
+            })
+            .map(|provider| {
+                json!({
+                    "provider_id": provider.id,
+                    "state": lifecycle_name(provider.state),
+                    "detail": provider.state_detail,
+                })
+            })
+            .collect::<Vec<_>>(),
+        Err(error) => vec![json!({"available": false, "error": error.to_string()})],
+    };
+    format!(
+        "\n\n## Current environment and provider state\n\
+         Refreshed immediately before this planning round. Scene owns map pose, \
+         room membership, areas, and nearby objects. Atlas state only indicates \
+         provider availability; current task progress remains in the in-flight RTDL \
+         tree block. Missing or stale state means unknown.\n\n{}\n",
+        serde_json::to_string_pretty(&json!({
+            "scene": scene,
+            "provider_availability": providers,
+        }))
+        .unwrap_or_else(|_| "{}".into())
+    )
+}
+
+async fn query_scene(
+    mut graph: RobonixSystemExecutorExecuteClient<Channel>,
+    provider_id: String,
+) -> Value {
+    let plan_id = format!("state-prefetch-{}", Uuid::new_v4());
+    let plan = Plan {
+        plan_id: plan_id.clone(),
+        session_id: "pilot-state-prefetch".into(),
+        round: 0,
+        nodes: vec![RtdlNode {
+            node_kind: RTDL_DO,
+            children: Vec::new(),
+            call: Some(CapabilityCall {
+                call_id: format!("{plan_id}:0"),
+                provider_id,
+                contract_id: SCENE_CONTEXT.into(),
+                args_json: "{}".into(),
+            }),
+            op_id: "scene_snapshot".into(),
+            description: "Read Scene spatial context before planning".into(),
+        }],
+        root_index: 0,
+    };
+    let query = async {
+        let mut stream = graph
+            .execute(Request::new(plan))
+            .await
+            .map_err(|error| error.to_string())?
+            .into_inner();
+        while let Some(event) = stream.message().await.map_err(|error| error.to_string())? {
+            if event.event_kind != RtdlEventEnum::NodeState as u32 {
+                continue;
+            }
+            let Some(state) = event.node_state else {
+                continue;
+            };
+            if state.state == RtdlNodeStateEnum::Succeeded as u32 {
+                let output = state
+                    .leaf_result
+                    .map(|result| result.output)
+                    .unwrap_or(state.operator_detail);
+                return Ok(serde_json::from_str(&output).unwrap_or_else(|_| json!({"raw": output})));
+            }
+            if matches!(
+                RtdlNodeStateEnum::try_from(state.state as i32),
+                Ok(RtdlNodeStateEnum::Failed
+                    | RtdlNodeStateEnum::Canceled
+                    | RtdlNodeStateEnum::Timeout)
+            ) {
+                return Err(state.operator_detail);
+            }
+        }
+        Err("Scene query ended without a terminal result".into())
+    };
+    match tokio::time::timeout(Duration::from_secs(3), query).await {
+        Ok(Ok(value)) => json!({"available": true, "state": value}),
+        Ok(Err(error)) => json!({"available": false, "error": error}),
+        Err(_) => json!({"available": false, "error": "Scene query timed out after 3 seconds"}),
+    }
+}
+
+fn lifecycle_name(state: i32) -> &'static str {
+    match atlas_pb::LifecycleState::try_from(state) {
+        Ok(atlas_pb::LifecycleState::StateRegistered) => "registered",
+        Ok(atlas_pb::LifecycleState::StateInactive) => "inactive",
+        Ok(atlas_pb::LifecycleState::StateActive) => "active",
+        Ok(atlas_pb::LifecycleState::StateError) => "error",
+        Ok(atlas_pb::LifecycleState::StateTerminated) => "terminated",
+        _ => "unknown",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::lifecycle_name;
+    use robonix_atlas::pb::LifecycleState;
+
+    #[test]
+    fn lifecycle_labels_are_stable() {
+        assert_eq!(lifecycle_name(LifecycleState::StateActive as i32), "active");
+        assert_eq!(lifecycle_name(LifecycleState::StateError as i32), "error");
+    }
+}

--- a/system/pilot/src/vlm.rs
+++ b/system/pilot/src/vlm.rs
@@ -20,6 +20,26 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::BTreeMap;
 use std::pin::Pin;
+use std::time::Duration;
+
+const MAX_OPEN_RETRIES: usize = 3;
+
+fn open_retry_delay(
+    status: reqwest::StatusCode,
+    retry_after: Option<&str>,
+    retry_index: usize,
+) -> Option<Duration> {
+    if retry_index >= MAX_OPEN_RETRIES
+        || !(status == reqwest::StatusCode::TOO_MANY_REQUESTS || status.is_server_error())
+    {
+        return None;
+    }
+    let server_seconds = retry_after
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .map(|seconds| seconds.clamp(1, 10));
+    let seconds = server_seconds.unwrap_or_else(|| 1_u64 << retry_index.min(3));
+    Some(Duration::from_secs(seconds))
+}
 
 /// One message in an OpenAI Chat Completions conversation.
 /// Spec: https://platform.openai.com/docs/api-reference/chat/create#chat/create-messages
@@ -221,21 +241,41 @@ impl VlmClient {
             .context("build chat completion request")?;
 
         let url = format!("{}/chat/completions", self.api_base);
-        let response = self
-            .inner
-            .post(url)
-            .bearer_auth(&self.api_key)
-            .header(reqwest::header::ACCEPT, "text/event-stream")
-            .header(reqwest::header::CONTENT_TYPE, "application/json")
-            .json(&request)
-            .send()
-            .await
-            .context("open VLM chat stream")?;
-        let status = response.status();
-        if !status.is_success() {
+        let mut retry_index = 0;
+        let response = loop {
+            let response = self
+                .inner
+                .post(&url)
+                .bearer_auth(&self.api_key)
+                .header(reqwest::header::ACCEPT, "text/event-stream")
+                .header(reqwest::header::CONTENT_TYPE, "application/json")
+                .json(&request)
+                .send()
+                .await
+                .context("open VLM chat stream")?;
+            let status = response.status();
+            if status.is_success() {
+                break response;
+            }
+            let retry_after = response
+                .headers()
+                .get(reqwest::header::RETRY_AFTER)
+                .and_then(|value| value.to_str().ok())
+                .map(str::to_string);
             let text = response.text().await.unwrap_or_default();
+            if let Some(delay) = open_retry_delay(status, retry_after.as_deref(), retry_index) {
+                robonix_scribe::warn!(
+                    "[pilot/vlm] open stream HTTP {status}; retry {}/{} in {:.1}s",
+                    retry_index + 1,
+                    MAX_OPEN_RETRIES,
+                    delay.as_secs_f64()
+                );
+                tokio::time::sleep(delay).await;
+                retry_index += 1;
+                continue;
+            }
             bail!("open VLM chat stream: HTTP {status}: {text}");
-        }
+        };
         let mut upstream = response.bytes_stream();
 
         // Walk the upstream chunk-by-chunk, accumulating tool-call deltas by
@@ -314,6 +354,36 @@ impl VlmClient {
         });
 
         Ok(Box::pin(tokio_stream::wrappers::ReceiverStream::new(rx)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MAX_OPEN_RETRIES, open_retry_delay};
+    use std::time::Duration;
+
+    #[test]
+    fn transient_open_errors_use_bounded_backoff() {
+        assert_eq!(
+            open_retry_delay(reqwest::StatusCode::TOO_MANY_REQUESTS, None, 0),
+            Some(Duration::from_secs(1))
+        );
+        assert_eq!(
+            open_retry_delay(reqwest::StatusCode::SERVICE_UNAVAILABLE, Some("7"), 1),
+            Some(Duration::from_secs(7))
+        );
+        assert_eq!(
+            open_retry_delay(reqwest::StatusCode::BAD_REQUEST, None, 0),
+            None
+        );
+        assert_eq!(
+            open_retry_delay(
+                reqwest::StatusCode::TOO_MANY_REQUESTS,
+                None,
+                MAX_OPEN_RETRIES
+            ),
+            None
+        );
     }
 }
 

--- a/system/scene/README.md
+++ b/system/scene/README.md
@@ -257,6 +257,7 @@ plain `humble`.
 | `SCENE_OBJECT_MEMORY_DB` | `/data/robonix/scene_memory/objects.db` | milvus-lite DB path (inside container; host-mounted via `rbnx-build/data/robonix`) |
 | `SCENE_MAP_ID` | `default` | FALLBACK map binding: mapping's latched `robonix/service/map/lifecycle` broadcast wins when present at startup; this env (below manifest `map_id`) applies when mapping isn't up yet (normal full-boot order) or doesn't broadcast |
 | `SCENE_MAP_BINDING_WAIT_S` | `3.0` | how long the startup probe waits for the lifecycle contract to appear on atlas before falling back to static binding; `0` disables the probe |
+| `SCENE_ANNOTATIONS_DIR` | `/data/robonix/scene_annotations` | per-map JSON files holding user annotations (rooms / POIs); host-mounted like the object DB |
 | `VLM_REASONING_EFFORT` | `` (unset) | opt-in, forwarded to all scene VLM/LLM calls (relation inference + VLM perception): `minimal`\|`low`\|`medium`\|`high`. **Unset → the field is omitted**, so non-reasoning models and strict endpoints are unaffected. Set `minimal` (= no thinking) to keep a reasoning `VLM_MODEL` (e.g. `doubao-seed-2-1-pro`) answering in ~2 s instead of timing out |
 
 ## Object memory (warm restore)
@@ -292,6 +293,43 @@ mapping-mode session start) drifts from the startup binding, scene logs a
 warning and keeps its binding — reacting (flush + re-anchor) is the planned
 lifecycle linkage (P3).
 
+## User annotations (rooms / POIs)
+
+Scene also stores **user-authored** semantics: annotations the user draws on
+the map canvas — a `room` (named polygon) or a `poi` (named point, optional
+heading; model-ready, no UI yet). They live on the same foundation as
+perceived objects: coordinates are map-frame meters, storage partitions by
+the map binding's `map_id`, and validity follows mapping's `generation`
+epoch. Unlike perceived objects they are user assets: a map rebuild (reset /
+re-mapping) never deletes them — they are flagged `stale` (with a reason)
+for the user to confirm ("still valid" clears the flag) or redraw (new
+geometry is authored against the current frame, so redrawing also clears it).
+
+Storage is one JSON file per map under `SCENE_ANNOTATIONS_DIR`
+(`<map_id>.json`, atomic writes, no vectors — deliberately not in the milvus
+object DB). CRUD goes through the web server's REST API (same trust domain
+as the rest of this LAN debug/UI server — no auth):
+
+| Route | Body | Returns |
+|---|---|---|
+| `GET /api/annotations` | — | `{ok, annotations: [...]}` |
+| `POST /api/annotations` | `{kind, name, points, theta?}` | `{ok, annotation}` (with generated id) |
+| `PUT /api/annotations/{id}` | any of `{name, points, theta, stale: false}` | `{ok, annotation}` |
+| `DELETE /api/annotations/{id}` | — | `{ok}` |
+
+Errors: `400` invalid fields (unknown kind, room polygon < 3 points, poi ≠ 1
+point, non-finite numbers, `theta` on a room — headings are poi-only), `404`
+unknown id, `503` store unavailable — those carry `{ok: false, detail}`; a
+store write failure (e.g. disk full) surfaces as a plain `500` because the
+edit was not saved. On `PUT`, `theta: null` (or absent) means "keep the
+current heading" — a set heading can be changed but not cleared (deliberate
+until the poi UI lands). `points` are `[[x, y], ...]` map-frame
+meters. **This shape is the contract any frontend builds on; treat changes
+as breaking.** The full annotation list also rides along in `GET /api/state`
+(field `annotations`, next to `map_binding`) so map pages get everything in
+one poll. There is deliberately no atlas/MCP surface yet — exposing rooms to
+Pilot (scene-graph `in_room` edges) is a planned follow-up.
+
 ## Capabilities exposed
 
 | Contract                                       | Tool name        | What it does                                                        |
@@ -314,12 +352,14 @@ curl -s http://127.0.0.1:50106/mcp/ -H "Content-Type: application/json" \
 ## Web UI quick tour
 
 * `/` — combined 3-column layout (default): 2D map · 3D scene · cam stack
+* `/user` — **end-user map page**: SLAM map + room annotations (draw a polygon, name it, rename / delete / confirm-stale) with a lightweight object overlay; the debug pages above are untouched by it
 * `/2d` — only the 2D top-down map
 * `/3d` — only the 3D point clouds + bboxes
 * `/cam` — only the camera stack: live RGB on top, live depth below
-* `/api/state` — JSON: registry + relations + occupancy PNG + robot pose
+* `/api/state` — JSON: registry + relations + occupancy PNG + robot pose + user annotations + map binding
 * `/api/objects3d` — JSON: per-object pcd + 8 bbox corners + CLIP class
 * `/api/camera` — JSON: latest RGB + depth as base64 PNGs (5 Hz polling)
+* `/api/annotations` — user annotation CRUD (see "User annotations" above)
 
 The 3D viz draws the OccupancyGrid as a translucent floor plane at z = -0.01 (so you can read room geometry under the point clouds), each detected object as a coloured pcd + yaw-rotated wireframe bbox + class label sprite, and the robot as a composite Tiago-shaped proxy (mobile base + torso + shoulder + head + arm), all parented to a `THREE.Group` that updates from `/api/state`'s `robot` field at 4 Hz.
 
@@ -347,7 +387,7 @@ The cam panel shows the same RGB + depth frames the perception pipeline consumes
 
 ## Scope (what's NOT here)
 
-- **No write API.** No `IngestObservation`, no `UpdateTaskContext`. Per the spec, scene is a sink.
+- **No write contract.** No `IngestObservation`, no `UpdateTaskContext` on atlas/MCP — perception-wise, scene is a sink. (The web server's annotation REST is an internal UI API, not a capability contract.)
 - **No subscribe-stream.** `SubscribeUpdates` doesn't fit MCP semantics. Pilot polls.
 - **No episodic memory.** Long-term memory belongs to memory services, not scene.
 - **No direct motion control.** `goal_near` returns an approach pose; navigation is performed by `robonix/service/navigation/navigate`.

--- a/system/scene/README.md
+++ b/system/scene/README.md
@@ -255,7 +255,8 @@ plain `humble`.
 | `SCENE_PORT` / `SCENE_WEB_PORT` | `50106` / `50107` | gRPC + web UI ports |
 | `SCENE_OBJECT_MEMORY_ENABLED` | `true` | persist stable objects + warm-restore the registry on boot |
 | `SCENE_OBJECT_MEMORY_DB` | `/data/robonix/scene_memory/objects.db` | milvus-lite DB path (inside container; host-mounted via `rbnx-build/data/robonix`) |
-| `SCENE_MAP_ID` | `default` | SLAM map the persisted objects belong to; restore loads only this map's objects (manifest `map_id` overrides) |
+| `SCENE_MAP_ID` | `default` | FALLBACK map binding: mapping's latched `robonix/service/map/lifecycle` broadcast wins when present at startup; this env (below manifest `map_id`) applies when mapping isn't up yet (normal full-boot order) or doesn't broadcast |
+| `SCENE_MAP_BINDING_WAIT_S` | `3.0` | how long the startup probe waits for the lifecycle contract to appear on atlas before falling back to static binding; `0` disables the probe |
 | `VLM_REASONING_EFFORT` | `` (unset) | opt-in, forwarded to all scene VLM/LLM calls (relation inference + VLM perception): `minimal`\|`low`\|`medium`\|`high`. **Unset → the field is omitted**, so non-reasoning models and strict endpoints are unaffected. Set `minimal` (= no thinking) to keep a reasoning `VLM_MODEL` (e.g. `doubao-seed-2-1-pro`) answering in ~2 s instead of timing out |
 
 ## Object memory (warm restore)
@@ -273,13 +274,23 @@ DB — and lives under the host-mounted `/data/robonix`, which also makes the
 scene-graph JSON caches survive boots. Writes are driven by the scene-graph
 builder, so disabling `SCENE_GRAPH_ENABLED` stops new writes (restore still runs).
 
-Persistence is partitioned by `SCENE_MAP_ID` (or the manifest `map_id`): an
-object's pose is only meaningful in the `map` frame of the SLAM map it was
-observed on, so restore loads exactly the current map's objects and never mixes
-two maps. The same `object_id` may exist on different maps without colliding.
-`map_id` is a deploy-controlled string today (default `"default"`) and stays
-internal to scene — no atlas/MCP contract changes — until mapping emits a real
-map identity to wire in here.
+Persistence is partitioned by the map binding: an object's pose is only
+meaningful in the `map` frame of the SLAM map it was observed on, so restore
+loads exactly the current map's objects and never mixes two maps. The same
+`object_id` may exist on different maps without colliding.
+
+The binding itself (`scene_service/map_binding.py`) is learned at startup with
+this precedence: mapping's latched `robonix/service/map/lifecycle` broadcast
+(`{map_id, mode, generation}` — the authoritative map identity, probed for
+`SCENE_MAP_BINDING_WAIT_S`) → manifest `config.map_id` → `SCENE_MAP_ID` env →
+`"default"`. The broadcast needs the generated `map` interface package
+(`rbnx codegen --ros2` → colcon overlay, built by `scripts/build.sh`, sourced
+by the container entrypoint); without it scene falls back to static binding
+with a warning. At runtime scene only WATCHES the broadcast: if mapping's
+identity or `generation` (bumped when the map origin may have changed: reset /
+mapping-mode session start) drifts from the startup binding, scene logs a
+warning and keeps its binding — reacting (flush + re-anchor) is the planned
+lifecycle linkage (P3).
 
 ## Capabilities exposed
 

--- a/system/scene/docker/entrypoint.sh
+++ b/system/scene/docker/entrypoint.sh
@@ -16,6 +16,16 @@ set -eo pipefail
 # shellcheck disable=SC1091
 source "/opt/ros/${ROS_DISTRO:-humble}/setup.bash"
 
+# Robonix ros2_idl overlay (generated `map` interface package — mapping's
+# latched lifecycle broadcast that scene's map binding subscribes to).
+# Built by scripts/build.sh onto the bind-mounted rbnx-build/; when absent
+# scene logs a warning and falls back to static map binding.
+ROS2_IDL_SETUP=/scene/rbnx-build/codegen/ros2_idl/install/setup.bash
+if [ -f "$ROS2_IDL_SETUP" ]; then
+    # shellcheck disable=SC1090
+    source "$ROS2_IDL_SETUP"
+fi
+
 configure_zenoh_session() {
     if [ "${RMW_IMPLEMENTATION:-}" != "rmw_zenoh_cpp" ] || [ -z "${ROBONIX_ZENOH_ROUTER:-}" ]; then
         return 0

--- a/system/scene/package_manifest.jetson-docker.yaml
+++ b/system/scene/package_manifest.jetson-docker.yaml
@@ -23,6 +23,7 @@ start: ROBONIX_SCENE_FORCE=docker bash scripts/start.sh
 capabilities:
   - name: robonix/system/scene/list_objects
   - name: robonix/system/scene/goal_near
+  - name: robonix/system/scene/goal_room
   - name: robonix/system/scene/get_scene_graph
   - name: robonix/system/scene/get_object_context
   - name: robonix/system/scene/list_relations

--- a/system/scene/package_manifest.jetson-docker.yaml
+++ b/system/scene/package_manifest.jetson-docker.yaml
@@ -22,6 +22,7 @@ start: ROBONIX_SCENE_FORCE=docker bash scripts/start.sh
 
 capabilities:
   - name: robonix/system/scene/list_objects
+  - name: robonix/system/scene/get_robot_context
   - name: robonix/system/scene/goal_near
   - name: robonix/system/scene/goal_room
   - name: robonix/system/scene/get_scene_graph

--- a/system/scene/package_manifest.jetson-native.yaml
+++ b/system/scene/package_manifest.jetson-native.yaml
@@ -26,6 +26,7 @@ start: ROBONIX_SCENE_FORCE=native bash scripts/start.sh
 
 capabilities:
   - name: robonix/system/scene/list_objects
+  - name: robonix/system/scene/get_robot_context
   - name: robonix/system/scene/goal_near
   - name: robonix/system/scene/goal_room
   - name: robonix/system/scene/get_scene_graph

--- a/system/scene/package_manifest.jetson-native.yaml
+++ b/system/scene/package_manifest.jetson-native.yaml
@@ -27,6 +27,7 @@ start: ROBONIX_SCENE_FORCE=native bash scripts/start.sh
 capabilities:
   - name: robonix/system/scene/list_objects
   - name: robonix/system/scene/goal_near
+  - name: robonix/system/scene/goal_room
   - name: robonix/system/scene/get_scene_graph
   - name: robonix/system/scene/get_object_context
   - name: robonix/system/scene/list_relations

--- a/system/scene/package_manifest.yaml
+++ b/system/scene/package_manifest.yaml
@@ -32,6 +32,7 @@ stop: docker rm -f "${ROBONIX_SCENE_CONTAINER:-robonix_scene}"
 
 capabilities:
   - name: robonix/system/scene/list_objects
+  - name: robonix/system/scene/get_robot_context
   - name: robonix/system/scene/goal_near
   - name: robonix/system/scene/goal_room
   - name: robonix/system/scene/get_scene_graph

--- a/system/scene/package_manifest.yaml
+++ b/system/scene/package_manifest.yaml
@@ -1,5 +1,5 @@
 # Scene MCP server — current-state semantic + geometric map of the
-# robot's environment. Exposes 5 read-only MCP tools for Pilot.
+# robot's environment. Exposes 6 read-only MCP tools for Pilot.
 #
 # Deployment shape: scene runs in its OWN docker container (image
 # `robonix-scene`, built by scripts/build.sh). Joins host network so:
@@ -33,6 +33,7 @@ stop: docker rm -f "${ROBONIX_SCENE_CONTAINER:-robonix_scene}"
 capabilities:
   - name: robonix/system/scene/list_objects
   - name: robonix/system/scene/goal_near
+  - name: robonix/system/scene/goal_room
   - name: robonix/system/scene/get_scene_graph
   - name: robonix/system/scene/get_object_context
   - name: robonix/system/scene/list_relations

--- a/system/scene/scene_service/annotations.py
+++ b/system/scene/scene_service/annotations.py
@@ -1,0 +1,354 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+"""User annotations — user-authored semantics anchored to the SLAM map.
+
+An annotation is a named geometric mark the user draws on the map canvas:
+a `room` (polygon + name) or a `poi` (single point, optional heading).
+Annotations share the same foundation as perceived objects: coordinates
+are map-frame meters, storage is partitioned by `map_id`, and validity is
+judged by mapping's `generation` epoch (see map_binding.py). Unlike
+perceived objects they are USER ASSETS: a map rebuild never deletes them —
+they are kept and flagged `stale` for the user to confirm or redraw.
+
+Storage is one JSON file per map (`<base_dir>/<map_id>.json`, atomic
+tmp+rename writes). Annotations carry no vectors, so they stay out of the
+milvus object store on purpose; the per-map JSON mirrors SceneGraphStore's
+partitioning pattern.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+import threading
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+from .map_binding import sanitize_map_id
+
+log = logging.getLogger(__name__)
+
+# The kind whitelist lives here (single source); every consumer checks it
+# through validate_annotation_fields below. `poi` is model-reserved: the
+# store handles it, the first UI iteration only draws rooms.
+VALID_KINDS = ("room", "poi")
+MAX_NAME_LEN = 128
+
+
+def validate_annotation_fields(
+    kind: str,
+    name: Any,
+    points: Any,
+    theta: Any,
+) -> Optional[str]:
+    """Validate user-supplied annotation fields; return an error string on
+    the first violation, None when everything is acceptable.
+
+    Rules: `kind` must be whitelisted; `name` a string ≤ MAX_NAME_LEN;
+    `points` a list of finite [x, y] number pairs — exactly 1 for a poi,
+    ≥3 for a room (a polygon needs three vertices); `theta` (a heading)
+    only applies to a poi and must be None or a finite number — a region
+    has no heading, so a room carrying theta is rejected rather than
+    silently stored. NaN/inf anywhere is rejected so bad JSON can never
+    poison the stored file."""
+    if kind not in VALID_KINDS:
+        return f"kind must be one of {list(VALID_KINDS)}, got {kind!r}"
+    if not isinstance(name, str):
+        return "name must be a string"
+    if len(name) > MAX_NAME_LEN:
+        return f"name too long (max {MAX_NAME_LEN} chars)"
+    if not isinstance(points, list):
+        return "points must be a list of [x, y] pairs"
+    for p in points:
+        if (
+            not isinstance(p, (list, tuple))
+            or len(p) != 2
+            or not all(isinstance(v, (int, float)) and not isinstance(v, bool) for v in p)
+            or not all(math.isfinite(float(v)) for v in p)
+        ):
+            return "each point must be a finite [x, y] number pair"
+    if kind == "poi" and len(points) != 1:
+        return "a poi takes exactly one point"
+    if kind == "room" and len(points) < 3:
+        return "a room polygon needs at least 3 points"
+    if theta is not None:
+        if kind != "poi":
+            return "theta (heading) only applies to a poi"
+        if not isinstance(theta, (int, float)) or isinstance(theta, bool) or not math.isfinite(float(theta)):
+            return "theta must be a finite number or null"
+    return None
+
+
+@dataclass
+class Annotation:
+    """One user annotation. `points` are map-frame meters; `stale` means
+    the map's generation changed after this was drawn — geometry may no
+    longer line up, and the user must confirm or redraw (never auto-deleted)."""
+    annotation_id: str
+    kind: str                       # "room" | "poi" (see VALID_KINDS)
+    name: str
+    points: list[list[float]] = field(default_factory=list)   # [[x, y], ...]
+    # Optional poi heading, radians (rooms never carry one — validated).
+    # API semantics: theta=None on update means "keep"; a set heading
+    # cannot be cleared, only changed. Revisit if/when the poi UI lands.
+    theta: Optional[float] = None
+    created_at: float = 0.0
+    updated_at: float = 0.0
+    stale: bool = False
+    stale_reason: str = ""
+
+    def to_json(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_json(cls, d: dict) -> "Annotation":
+        """Rebuild from a stored dict, dropping unknown keys so a file
+        written by a newer scene still loads (forward-tolerant)."""
+        known = set(cls.__dataclass_fields__)
+        return cls(**{k: v for k, v in d.items() if k in known})
+
+
+class AnnotationStore:
+    """Per-map JSON persistence for user annotations.
+
+    One file per map: `<base_dir>/<map_id>.json` (map_id sanitized with the
+    same rule as the object store so the two partitions always agree). The
+    file records `{map_id, generation, annotations}`; on load, a stored
+    generation that differs from the current binding's means the map frame
+    was rebuilt since the annotations were drawn — every annotation is
+    marked stale (kept, never dropped: user assets, unlike perceived
+    objects, are never cleaned up automatically). When either side
+    has no generation (static binding, pre-P2 file) staleness cannot be
+    judged and the stored value is preserved for the next boot that can.
+
+    All methods are synchronous and guarded by an internal lock; writes are
+    atomic (tmp + os.replace) and happen on every mutation — annotation
+    traffic is human-speed, so write-through is cheap and never loses an
+    accepted edit."""
+
+    def __init__(self, base_dir: str, *, map_id: str, generation: Optional[int] = None) -> None:
+        """Open (creating dirs as needed) the store for `map_id` and load
+        its file, applying the generation staleness check described on the
+        class. A corrupt file is set aside (renamed `*.corrupt-<ts>`) and
+        the store starts empty — loudly, and without destroying the bytes."""
+        self._lock = threading.Lock()
+        self._map_id = sanitize_map_id(map_id)
+        self._base = Path(base_dir).expanduser()
+        self._base.mkdir(parents=True, exist_ok=True)
+        self._path = self._base / f"{self._map_id}.json"
+        self._generation = generation
+        self._annotations: dict[str, Annotation] = {}
+        self._load(current_generation=generation)
+
+    @property
+    def map_id(self) -> str:
+        return self._map_id
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    # ── load / save ──────────────────────────────────────────────────────
+    def _load(self, current_generation: Optional[int]) -> None:
+        """Read the per-map file into memory. Missing file → empty store.
+        A file that fails to parse, has an unexpected shape, or contains a
+        record that would not pass `validate_annotation_fields` (the file
+        is a user-visible JSON asset, so hand edits happen) is treated as
+        corrupt as a whole: renamed aside + empty store — the user's bytes
+        are never dropped or overwritten by a failed load. A stored
+        generation differing from `current_generation` marks everything
+        stale and persists the flag."""
+        if not self._path.exists():
+            return
+        try:
+            data = json.loads(self._path.read_text(encoding="utf-8"))
+            if not isinstance(data, dict):
+                raise ValueError(f"top-level JSON is {type(data).__name__}, not an object")
+            stored_gen = data.get("generation")
+            if stored_gen is not None:
+                stored_gen = int(stored_gen)
+            anns = []
+            for d in data.get("annotations", []):
+                if not isinstance(d, dict):
+                    raise ValueError(f"annotation entry is {type(d).__name__}, not an object")
+                a = Annotation.from_json(d)
+                err = validate_annotation_fields(a.kind, a.name, a.points, a.theta)
+                if err:
+                    raise ValueError(f"annotation {a.annotation_id!r}: {err}")
+                if not isinstance(a.annotation_id, str) or not a.annotation_id:
+                    raise ValueError("annotation with missing/empty id")
+                anns.append(a)
+        except (ValueError, TypeError, KeyError, AttributeError) as e:
+            aside = self._path.with_suffix(f".json.corrupt-{int(time.time())}")
+            # Rename failures re-raise: continuing with an empty store
+            # would let the next accepted edit os.replace() the corrupt
+            # file — destroying exactly the bytes this path promises to
+            # keep. Failing __init__ disables the API loudly instead.
+            self._path.rename(aside)
+            log.error(
+                "[scene-anno] %s failed to load (%s) — moved to %s, "
+                "starting empty", self._path, e, aside,
+            )
+            return
+        self._annotations = {a.annotation_id: a for a in anns}
+        if current_generation is None:
+            # Cannot judge staleness this session; keep the recorded epoch
+            # so a later broadcast-bound boot still can.
+            self._generation = stored_gen
+            return
+        if stored_gen is not None and stored_gen != int(current_generation):
+            reason = f"map generation {stored_gen}→{current_generation}"
+            n = self._flag_all_stale_locked(reason, new_generation=None)
+            if n:
+                log.warning(
+                    "[scene-anno] map frame epoch changed (%s) — %d "
+                    "annotation(s) marked stale for user confirmation", reason, n,
+                )
+
+    def _save_locked(self) -> None:
+        """Atomically write the current state (caller holds the lock or is
+        __init__). tmp file lands in the same directory so os.replace stays
+        on one filesystem. Raises on I/O failure — callers accepted a user
+        edit, losing it silently is worse than a 500. Synchronous file I/O
+        on the event loop is deliberate: annotation traffic is human-speed
+        and the files are a few KB."""
+        payload = {
+            "map_id": self._map_id,
+            "generation": self._generation,
+            "annotations": [a.to_json() for a in self._annotations.values()],
+        }
+        tmp = self._path.with_suffix(".json.tmp")
+        tmp.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=1), encoding="utf-8"
+        )
+        os.replace(tmp, self._path)
+
+    # ── read ─────────────────────────────────────────────────────────────
+    # list()/get() hand out the LIVE Annotation objects — treat them as
+    # read-only. Mutating them directly bypasses both the lock and
+    # persistence; go through update() instead.
+    def list(self) -> list[Annotation]:
+        with self._lock:
+            return list(self._annotations.values())
+
+    def get(self, annotation_id: str) -> Optional[Annotation]:
+        with self._lock:
+            return self._annotations.get(annotation_id)
+
+    def list_json(self) -> list[dict]:
+        """JSON-ready dump of every annotation (the `/api/state` field and
+        `GET /api/annotations` share this shape)."""
+        with self._lock:
+            return [a.to_json() for a in self._annotations.values()]
+
+    # ── mutate (each call persists before returning) ─────────────────────
+    def create(self, *, kind: str, name: str, points: list,
+               theta: Optional[float] = None) -> Annotation:
+        """Create + persist a new annotation and return it. Fields must
+        already be validated (validate_annotation_fields) — the store
+        trusts its callers and only owns id/timestamp assignment."""
+        now = time.time()
+        ann = Annotation(
+            annotation_id=f"anno.{uuid.uuid4().hex[:8]}",
+            kind=kind,
+            name=name,
+            points=[[float(x), float(y)] for x, y in points],
+            theta=None if theta is None else float(theta),
+            created_at=now,
+            updated_at=now,
+        )
+        with self._lock:
+            self._annotations[ann.annotation_id] = ann
+            self._save_locked()
+        return ann
+
+    def update(self, annotation_id: str, *, name: Optional[str] = None,
+               points: Optional[list] = None, theta: Optional[float] = None,
+               clear_stale: bool = False) -> Optional[Annotation]:
+        """Apply the provided fields to an existing annotation (None = keep),
+        bump `updated_at`, persist, and return it; None when the id is
+        unknown. `clear_stale` is the user's "confirm still valid" action —
+        it resets both the flag and the recorded reason. Redrawing the
+        points also clears staleness: new geometry is authored against the
+        CURRENT map frame, so the old epoch's doubt no longer applies."""
+        with self._lock:
+            ann = self._annotations.get(annotation_id)
+            if ann is None:
+                return None
+            if name is not None:
+                ann.name = name
+            if points is not None:
+                ann.points = [[float(x), float(y)] for x, y in points]
+                ann.stale, ann.stale_reason = False, ""
+            if theta is not None:
+                ann.theta = float(theta)
+            if clear_stale:
+                ann.stale, ann.stale_reason = False, ""
+            ann.updated_at = time.time()
+            self._save_locked()
+            return ann
+
+    def delete(self, annotation_id: str) -> bool:
+        """Remove an annotation; True when it existed. Persists on change."""
+        with self._lock:
+            if annotation_id not in self._annotations:
+                return False
+            del self._annotations[annotation_id]
+            self._save_locked()
+            return True
+
+    def _flag_all_stale_locked(self, reason: str,
+                               new_generation: Optional[int]) -> int:
+        """Shared body of the two stale-sweep entry points (caller holds
+        the lock, or is __init__/_load): flag every non-stale annotation
+        with `reason`, optionally adopt `new_generation`, persist when
+        anything changed. Returns how many annotations flipped."""
+        n = 0
+        for a in self._annotations.values():
+            if not a.stale:
+                a.stale, a.stale_reason = True, reason
+                n += 1
+        gen_changed = new_generation is not None and new_generation != self._generation
+        if gen_changed:
+            self._generation = new_generation
+        if n or gen_changed:
+            self._save_locked()
+        return n
+
+    def reconcile_generation(self, live_generation: int) -> int:
+        """Called when the map's true generation becomes known at runtime
+        (the lifecycle watcher's confirmation) — a store built under a
+        static binding (generation None) cannot judge staleness at load
+        time, so the judgement happens here instead. Adopts the epoch when
+        the store had none; when the recorded epoch differs, flags
+        everything stale (user assets are never auto-deleted, only
+        flagged). Runs decision + sweep under one lock acquisition, so a
+        concurrent create() can never be flagged by a sweep it postdates.
+        Returns how many flipped."""
+        with self._lock:
+            if self._generation is None or int(self._generation) == int(live_generation):
+                if self._generation != live_generation:
+                    self._generation = int(live_generation)
+                    self._save_locked()
+                return 0
+            reason = f"map generation {self._generation}→{live_generation}"
+            n = self._flag_all_stale_locked(reason, int(live_generation))
+        if n:
+            log.warning(
+                "[scene-anno] recorded map epoch differs from mapping's (%s) "
+                "— %d annotation(s) marked stale for user confirmation",
+                reason, n,
+            )
+        return n
+
+    def mark_all_stale(self, reason: str, *, new_generation: Optional[int] = None) -> int:
+        """Flag every non-stale annotation stale with `reason` (map frame
+        epoch changed at runtime — the _lifecycle_watch hook). Optionally
+        records the new generation so the file reflects the epoch the
+        staleness was judged against. Returns how many flipped; persists
+        when anything changed (flag or generation)."""
+        with self._lock:
+            return self._flag_all_stale_locked(reason, new_generation)

--- a/system/scene/scene_service/annotations.py
+++ b/system/scene/scene_service/annotations.py
@@ -38,6 +38,18 @@ VALID_KINDS = ("room", "poi")
 MAX_NAME_LEN = 128
 
 
+def _annotation_identity(kind: str, name: str) -> tuple[str, str]:
+    """Stable user-facing identity for idempotent room creation.
+
+    The UI may submit the same completed polygon twice when double-click or
+    Enter events race. Rooms are named user assets, so a repeated create with
+    the same normalized name updates that room instead of minting a second UUID.
+    POIs keep append semantics.
+    """
+    normalized = " ".join(str(name).strip().split()).casefold()
+    return str(kind).strip().casefold(), normalized
+
+
 def validate_annotation_fields(
     kind: str,
     name: Any,
@@ -151,6 +163,32 @@ class AnnotationStore:
     def path(self) -> Path:
         return self._path
 
+    def rebind(self, map_id: str, *, generation: Optional[int] = None,
+               carry_current: bool = False) -> None:
+        """Switch this store to another map partition.
+
+        `carry_current=True` is used by scene's Save Map UI path: the user
+        just named the live spatial map, so the rooms they drew in the live
+        session must be written under the same map_id before future loads.
+        `carry_current=False` is used by Load Map: discard the in-memory
+        partition and load the target map's annotation JSON.
+        """
+        next_id = sanitize_map_id(map_id)
+        with self._lock:
+            if next_id == self._map_id:
+                self._generation = generation
+                if carry_current:
+                    self._save_locked()
+                return
+            self._map_id = next_id
+            self._path = self._base / f"{self._map_id}.json"
+            self._generation = generation
+            if carry_current:
+                self._save_locked()
+            else:
+                self._annotations = {}
+                self._load(current_generation=generation)
+
     # ── load / save ──────────────────────────────────────────────────────
     def _load(self, current_generation: Optional[int]) -> None:
         """Read the per-map file into memory. Missing file → empty store.
@@ -247,20 +285,40 @@ class AnnotationStore:
     # ── mutate (each call persists before returning) ─────────────────────
     def create(self, *, kind: str, name: str, points: list,
                theta: Optional[float] = None) -> Annotation:
-        """Create + persist a new annotation and return it. Fields must
-        already be validated (validate_annotation_fields) — the store
-        trusts its callers and only owns id/timestamp assignment."""
+        """Create + persist an annotation and return it.
+
+        Room creation is idempotent by normalized room name: the user page can
+        legitimately re-enter this endpoint once when double-click or Enter
+        browser events race around the async name dialog. In that case we keep
+        the existing annotation id and update its polygon instead of creating
+        two visually identical rooms. POIs remain append-style assets. Fields
+        must already be validated (validate_annotation_fields).
+        """
         now = time.time()
-        ann = Annotation(
-            annotation_id=f"anno.{uuid.uuid4().hex[:8]}",
-            kind=kind,
-            name=name,
-            points=[[float(x), float(y)] for x, y in points],
-            theta=None if theta is None else float(theta),
-            created_at=now,
-            updated_at=now,
-        )
+        norm_points = [[float(x), float(y)] for x, y in points]
+        norm_theta = None if theta is None else float(theta)
         with self._lock:
+            if kind == "room":
+                target = _annotation_identity(kind, name)
+                for existing in self._annotations.values():
+                    if _annotation_identity(existing.kind, existing.name) == target:
+                        existing.name = name
+                        existing.points = norm_points
+                        existing.theta = norm_theta
+                        existing.stale = False
+                        existing.stale_reason = ""
+                        existing.updated_at = now
+                        self._save_locked()
+                        return existing
+            ann = Annotation(
+                annotation_id=f"anno.{uuid.uuid4().hex[:8]}",
+                kind=kind,
+                name=name,
+                points=norm_points,
+                theta=norm_theta,
+                created_at=now,
+                updated_at=now,
+            )
             self._annotations[ann.annotation_id] = ann
             self._save_locked()
         return ann

--- a/system/scene/scene_service/annotations.py
+++ b/system/scene/scene_service/annotations.py
@@ -189,6 +189,25 @@ class AnnotationStore:
                 self._annotations = {}
                 self._load(current_generation=generation)
 
+    def delete_map(self, map_id: str) -> bool:
+        """Delete exactly one persisted annotation partition.
+
+        Map deletion is an explicit user action. Unlike a map-generation
+        change, it intentionally removes the matching room/POI JSON asset;
+        unrelated map partitions remain untouched. Clearing the current
+        in-memory partition keeps the user page consistent when the deleted
+        map is presently selected.
+        """
+        target = sanitize_map_id(map_id)
+        target_path = self._base / f"{target}.json"
+        with self._lock:
+            existed = target_path.exists()
+            if existed:
+                target_path.unlink()
+            if target == self._map_id:
+                self._annotations = {}
+            return existed
+
     # ── load / save ──────────────────────────────────────────────────────
     def _load(self, current_generation: Optional[int]) -> None:
         """Read the per-map file into memory. Missing file → empty store.

--- a/system/scene/scene_service/geometry.py
+++ b/system/scene/scene_service/geometry.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+"""Geometry helpers shared by Scene room rendering and navigation."""
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+Point = tuple[float, float]
+
+
+def polygon_centroid(points: Sequence[Point]) -> Point:
+    """Return the area-weighted centroid of a non-self-intersecting polygon."""
+    pts = [(float(x), float(y)) for x, y in points]
+    if not pts:
+        return 0.0, 0.0
+    if len(pts) > 1 and pts[0] == pts[-1]:
+        pts.pop()
+    if len(pts) < 3:
+        return (
+            sum(x for x, _ in pts) / len(pts),
+            sum(y for _, y in pts) / len(pts),
+        )
+
+    twice_area = 0.0
+    cx = 0.0
+    cy = 0.0
+    for (x1, y1), (x2, y2) in zip(pts, pts[1:] + pts[:1]):
+        cross = x1 * y2 - x2 * y1
+        twice_area += cross
+        cx += (x1 + x2) * cross
+        cy += (y1 + y2) * cross
+    if abs(twice_area) < 1e-9:
+        return (
+            sum(x for x, _ in pts) / len(pts),
+            sum(y for _, y in pts) / len(pts),
+        )
+    return cx / (3.0 * twice_area), cy / (3.0 * twice_area)
+
+
+def point_in_polygon(x: float, y: float, points: Sequence[Point]) -> bool:
+    """Return whether a point lies inside a polygon using even-odd crossings."""
+    pts = [(float(px), float(py)) for px, py in points]
+    if len(pts) > 1 and pts[0] == pts[-1]:
+        pts.pop()
+    if len(pts) < 3:
+        return False
+    inside = False
+    for (x1, y1), (x2, y2) in zip(pts, pts[1:] + pts[:1]):
+        if (y1 > y) != (y2 > y):
+            crossing_x = (x2 - x1) * (y - y1) / (y2 - y1) + x1
+            if x < crossing_x:
+                inside = not inside
+    return inside
+
+
+def disc_inside_polygon(
+    x: float,
+    y: float,
+    radius: float,
+    points: Sequence[Point],
+    samples: int = 16,
+) -> bool:
+    """Require a circular robot footprint, not just its centre, inside a room."""
+    if not point_in_polygon(x, y, points):
+        return False
+    return all(
+        point_in_polygon(
+            x + radius * math.cos(2.0 * math.pi * i / samples),
+            y + radius * math.sin(2.0 * math.pi * i / samples),
+            points,
+        )
+        for i in range(samples)
+    )

--- a/system/scene/scene_service/ingest/ros_subscribers.py
+++ b/system/scene/scene_service/ingest/ros_subscribers.py
@@ -44,6 +44,14 @@ def _import_ros():
     # transform is non-identity, and the web UI shows the robot offset
     # from where rviz (which goes through tf) shows it.
     from tf2_ros import Buffer, TransformListener  # type: ignore
+    # map/msg/MapLifecycle comes from the generated ros2_idl overlay
+    # (rbnx codegen --ros2 + colcon build), NOT the ROS distro. Import it
+    # defensively: a deploy without the overlay must lose only the
+    # lifecycle subscription, not every scene subscription.
+    try:
+        from map.msg import MapLifecycle  # type: ignore
+    except ImportError:
+        MapLifecycle = None
     return {
         "rclpy": rclpy,
         "Node": Node,
@@ -65,6 +73,9 @@ def _import_ros():
         "TransformStamped": TransformStamped,
         "Odometry": Odometry,
         "OccupancyGrid": OccupancyGrid,
+        # None when the ros2_idl overlay is missing — _subscribe skips the
+        # spec with a warning instead of crashing the hub.
+        "MapLifecycle": MapLifecycle,
         "Buffer": Buffer,
         "TransformListener": TransformListener,
     }
@@ -166,14 +177,19 @@ class SubscribersHub:
         """Add a new (kind, topic) subscription to a hub already up.
         Used by the background reconciler to absorb topics that come
         online after start(). Returns True if added, False if the
-        kind was already known."""
+        kind was already known — or if the subscription could not be
+        created (missing msg class): committing the slot anyway would
+        make has_kinds() claim a subscription that doesn't exist and
+        pair a success log with the skip warning."""
         if self._ros is None:
             return False
         if spec.kind in self._slots:
             return False
         self._slots[spec.kind] = _LatestSlot()
+        if not self._subscribe(spec):
+            del self._slots[spec.kind]
+            return False
         self.specs.append(spec)
-        self._subscribe(spec)
         log.info("[scene-ros] dynamic add: %s on %s", spec.kind, spec.topic)
         return True
 
@@ -208,9 +224,22 @@ class SubscribersHub:
                 log.debug("[scene-ros] spin tick: %s", e)
 
     # ── subscription wiring ────────────────────────────────────────────────
-    def _subscribe(self, spec: TopicSpec) -> None:
+    def _subscribe(self, spec: TopicSpec) -> bool:
+        """Create the rclpy subscription for one spec. Returns False (with
+        a warning) when the msg class is unavailable — the hub and every
+        other subscription keep running."""
         assert self._ros is not None
-        msg_cls = self._ros[spec.msg_type]
+        msg_cls = self._ros.get(spec.msg_type)
+        if msg_cls is None:
+            # Unknown or unavailable msg class (e.g. MapLifecycle without
+            # the ros2_idl overlay). One subscription degrades, the hub —
+            # and every other subscription — keeps running.
+            log.warning(
+                "[scene-ros] msg type %r unavailable — skipping %s on %s "
+                "(generated interface overlay missing?)",
+                spec.msg_type, spec.kind, spec.topic,
+            )
+            return False
         QoSProfile = self._ros["QoSProfile"]
         ReliabilityPolicy = self._ros["ReliabilityPolicy"]
         DurabilityPolicy = self._ros["DurabilityPolicy"]
@@ -266,6 +295,16 @@ class SubscribersHub:
                 history=HistoryPolicy.KEEP_LAST,
                 depth=5,
             )
+        elif spec.kind == "map_lifecycle":
+            # mapping's identity broadcast is latched (published once per
+            # lifecycle transition); TRANSIENT_LOCAL picks up the cached
+            # sample on a late start.
+            qos = QoSProfile(
+                reliability=ReliabilityPolicy.RELIABLE,
+                durability=DurabilityPolicy.TRANSIENT_LOCAL,
+                history=HistoryPolicy.KEEP_LAST,
+                depth=1,
+            )
         elif spec.kind == "camera_extrinsics":
             # Static camera mount transform (primitive/camera/extrinsics):
             # genuinely latched (published once), so TRANSIENT_LOCAL is
@@ -300,6 +339,7 @@ class SubscribersHub:
         self._node.create_subscription(msg_cls, spec.topic, _cb, qos)
         log.info("[scene-ros] subscribed: %s on %s (%s, qos=%s)",
                  spec.kind, spec.topic, spec.msg_type, spec.kind)
+        return True
 
     # ── consumer-side accessors ────────────────────────────────────────────
     def latest(self, kind: str) -> tuple[Any, float, int]:

--- a/system/scene/scene_service/map_binding.py
+++ b/system/scene/scene_service/map_binding.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+"""Map identity binding — how scene learns WHICH map it is scoped to.
+
+The mapping service broadcasts its current identity {map_id, mode,
+generation} latched on the `robonix/service/map/lifecycle` topic (see
+capabilities/service/map/lifecycle.v1.toml). At startup scene probes that
+broadcast once and, when present, binds to it — the broadcast is
+authoritative, so the deploy no longer needs to hand-copy the same map_id
+into two config blocks. Static fallbacks (manifest config / SCENE_MAP_ID
+env / "default") remain for deployments where mapping is not up yet when
+scene starts (the normal full-boot order) or does not broadcast at all.
+
+`generation` is mapping's map-frame epoch: it bumps whenever the map
+origin may have changed (mapping-mode session start, reset_map) and stays
+put across localization round-trips. P2 records it and warns on runtime
+change; acting on it (flush + re-anchor) is the P3 lifecycle linkage.
+
+Split from service.py so the pure precedence rule and the one-shot ROS
+read are unit-testable without atlas.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+log = logging.getLogger("scene.map_binding")
+
+
+@dataclass(frozen=True)
+class MapBinding:
+    """The resolved binding plus where it came from (for the startup log
+    and for the runtime mismatch watcher)."""
+    map_id: str
+    source: str                      # "lifecycle" | "config" | "env" | "default"
+    mode: str = ""                   # only set when source == "lifecycle"
+    generation: Optional[int] = None  # only set when source == "lifecycle"
+
+
+def choose_map_binding(
+    broadcast: Optional[dict],
+    config_map_id: object,
+    env_map_id: Optional[str],
+) -> MapBinding:
+    """Precedence: mapping's lifecycle broadcast (authoritative source of
+    map identity) > manifest config.map_id > SCENE_MAP_ID env > "default".
+    A broadcast with an empty map_id means mapping runs ephemeral (no named
+    map) — treated as "no broadcast", scene falls back to static binding."""
+    if broadcast and str(broadcast.get("map_id") or ""):
+        return MapBinding(
+            map_id=str(broadcast["map_id"]),
+            source="lifecycle",
+            mode=str(broadcast.get("mode") or ""),
+            generation=int(broadcast.get("generation") or 0),
+        )
+    if config_map_id:
+        return MapBinding(map_id=str(config_map_id), source="config")
+    if env_map_id:
+        return MapBinding(map_id=str(env_map_id), source="env")
+    return MapBinding(map_id="default", source="default")
+
+
+def read_latched_lifecycle(topic: str, timeout_s: float) -> Optional[dict]:
+    """One-shot read of the latched MapLifecycle sample on `topic`.
+
+    Runs on a PRIVATE rclpy context + executor so it neither initialises
+    nor disturbs the default context the ingest hub owns (the hub calls
+    rclpy.init() later and would raise on a double init). Returns
+    {map_id, mode, generation} or None on timeout. Degrades to None with
+    one warning when rclpy or the generated `map` interface package is
+    missing (ros2_idl overlay not built) — binding then falls back to
+    config/env, scene itself keeps working.
+    """
+    try:
+        import rclpy  # type: ignore
+        from rclpy.executors import SingleThreadedExecutor  # type: ignore
+        from rclpy.qos import (  # type: ignore
+            DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy,
+        )
+        from map.msg import MapLifecycle  # type: ignore  # ros2_idl overlay
+    except ImportError as e:
+        log.warning(
+            "[scene] lifecycle probe unavailable (%s) — falling back to "
+            "static map binding (is the ros2_idl overlay built + sourced?)", e,
+        )
+        return None
+
+    ctx = None
+    try:
+        # Context/init INSIDE the guard: a broken RMW env must degrade to
+        # None per the docstring promise, not escape and kill scene startup.
+        ctx = rclpy.Context()
+        rclpy.init(context=ctx, args=None)
+        node = rclpy.create_node("scene_map_binding_probe", context=ctx)
+        executor = SingleThreadedExecutor(context=ctx)
+        executor.add_node(node)
+        got: list = []
+        qos = QoSProfile(
+            reliability=ReliabilityPolicy.RELIABLE,
+            # TRANSIENT_LOCAL: the broadcast is latched; a late-joining
+            # probe must receive the cached sample.
+            durability=DurabilityPolicy.TRANSIENT_LOCAL,
+            history=HistoryPolicy.KEEP_LAST,
+            depth=1,
+        )
+        node.create_subscription(MapLifecycle, topic, got.append, qos)
+        deadline = time.monotonic() + timeout_s
+        while not got and time.monotonic() < deadline:
+            executor.spin_once(timeout_sec=0.2)
+        if not got:
+            return None
+        msg = got[0]
+        return {
+            "map_id": str(msg.map_id),
+            "mode": str(msg.mode),
+            "generation": int(msg.generation),
+        }
+    except Exception as e:  # noqa: BLE001
+        log.warning("[scene] lifecycle probe failed: %s", e)
+        return None
+    finally:
+        if ctx is not None:
+            try:
+                rclpy.shutdown(context=ctx)
+            except Exception:  # noqa: BLE001
+                pass

--- a/system/scene/scene_service/map_binding.py
+++ b/system/scene/scene_service/map_binding.py
@@ -21,11 +21,25 @@ read are unit-testable without atlas.
 from __future__ import annotations
 
 import logging
+import re
 import time
 from dataclasses import dataclass
 from typing import Optional
 
 log = logging.getLogger("scene.map_binding")
+
+# map_id is used as a milvus filter literal and as a filename, so restrict
+# it to a safe identifier charset (no quotes / spaces / separators) — keeps
+# the predicate injection-free and the path escape-free. Anything else is
+# squashed to "_"; empty falls back to "default". Every map_id-partitioned
+# store (objects, scene-graph cache, annotations) MUST key on this one rule
+# so the partitions always agree.
+_MAP_ID_UNSAFE = re.compile(r"[^A-Za-z0-9._\-]")
+
+
+def sanitize_map_id(raw: Optional[str]) -> str:
+    cleaned = _MAP_ID_UNSAFE.sub("_", (raw or "").strip())
+    return cleaned or "default"
 
 
 @dataclass(frozen=True)

--- a/system/scene/scene_service/mcp_tools.py
+++ b/system/scene/scene_service/mcp_tools.py
@@ -36,6 +36,8 @@ from semantic_map_mcp import (  # type: ignore
     GoalRoom_Response,
     GetObjectContext_Request,
     GetObjectContext_Response,
+    GetRobotContext_Request,
+    GetRobotContext_Response,
     GetSceneGraph_Request,
     GetSceneGraph_Response,
     ListObjects_Request,
@@ -211,6 +213,81 @@ async def list_objects(_req: ListObjects_Request) -> ListObjects_Response:
     return ListObjects_Response(
         objects=objects,
         stamp_unix=time.time(),
+    )
+
+
+def _polygon_area(points) -> float:
+    polygon = [(float(x), float(y)) for x, y in (points or [])]
+    if len(polygon) < 3:
+        return 0.0
+    return abs(sum(
+        x0 * y1 - x1 * y0
+        for (x0, y0), (x1, y1) in zip(polygon, polygon[1:] + polygon[:1])
+    )) * 0.5
+
+
+@mcp_contract(mcp, contract_id="robonix/system/scene/get_robot_context")
+async def get_robot_context(_req: GetRobotContext_Request) -> GetRobotContext_Response:
+    """Return one coherent map-frame spatial snapshot for Pilot."""
+    snapshot_at = time.time()
+    if _REGISTRY is None:
+        raise RuntimeError("scene mcp_tools.attach_state was never called")
+    objects, _surfaces = await _REGISTRY.snapshot()
+    robot = next((
+        item for item in objects.values()
+        if not item.missing
+        and (getattr(item, "is_robot", False) or str(item.cls).lower() == "robot")
+    ), None)
+    map_id = _ANNO_STORE.map_id if _ANNO_STORE is not None else ""
+    if robot is None:
+        return GetRobotContext_Response(
+            pose_known=False, map_id=map_id, x=0.0, y=0.0, z=0.0, yaw=0.0,
+            room_id="", room_name="", containing_area_ids=[],
+            containing_area_names=[], nearby_objects=[], observed_at_unix=0.0,
+            snapshot_at_unix=snapshot_at, stale=True,
+            reason="robot pose is not available from Scene",
+        )
+
+    x, y = float(robot.pose.x), float(robot.pose.y)
+    containing = []
+    if _ANNO_STORE is not None:
+        containing = [
+            annotation for annotation in _ANNO_STORE.list()
+            if len(annotation.points or []) >= 3
+            and point_in_polygon(x, y, annotation.points)
+        ]
+    rooms = sorted(
+        (annotation for annotation in containing if annotation.kind == "room"),
+        key=lambda annotation: (_polygon_area(annotation.points), annotation.name),
+    )
+    room = rooms[0] if rooms else None
+    containing.sort(key=lambda annotation: (annotation.kind, annotation.name))
+    nearby = []
+    for item in objects.values():
+        if item is robot or item.missing:
+            continue
+        distance = math.hypot(float(item.pose.x) - x, float(item.pose.y) - y)
+        if distance <= 3.0:
+            nearby.append((distance, item))
+    nearby.sort(key=lambda entry: (entry[0], entry[1].object_id))
+
+    observed_at = float(robot.last_seen or 0.0)
+    stale = observed_at <= 0.0 or snapshot_at - observed_at > 2.0
+    reason = "current Scene spatial snapshot"
+    if stale:
+        reason = "Scene robot pose is older than 2 seconds"
+    elif room is None:
+        reason = "robot pose is current but outside every registered room"
+    return GetRobotContext_Response(
+        pose_known=True, map_id=map_id, x=x, y=y, z=float(robot.pose.z),
+        yaw=float(robot.pose.yaw),
+        room_id=_annotation_object_id(room) if room is not None else "",
+        room_name=str(room.name) if room is not None else "",
+        containing_area_ids=[_annotation_object_id(item) for item in containing],
+        containing_area_names=[str(item.name) for item in containing],
+        nearby_objects=[_to_idl(item) for _, item in nearby[:12]],
+        observed_at_unix=observed_at, snapshot_at_unix=snapshot_at,
+        stale=stale, reason=reason,
     )
 
 
@@ -618,6 +695,7 @@ __all__ = [
     "attach_state",
     "attach_scene_graph_store",
     "attach_annotation_store",
+    "get_robot_context",
     "list_objects",
     "goal_near",
     "goal_room",

--- a/system/scene/scene_service/mcp_tools.py
+++ b/system/scene/scene_service/mcp_tools.py
@@ -2,7 +2,8 @@
 """FastMCP tool definitions — two read-only handlers, that's it.
 
   list_objects()           → flat list of every object in the registry
-  goal_near(object_id)     → reachable approach pose for that object
+  goal_near(object_id)     → reachable approach pose for a physical object
+  goal_room(room_id)       → reachable pose inside a room polygon
 
 Writes happen on the ingest path (perception → registry); these
 handlers only read. Inputs are codegen-derived ROS dataclasses
@@ -14,12 +15,13 @@ from __future__ import annotations
 import logging
 import math
 import time
-from types import SimpleNamespace
+from difflib import SequenceMatcher
 from typing import TYPE_CHECKING
 
 from .state import ObjectRegistry, SceneObject
 from .scene_graph.store import SceneGraphStore
 from .scene_graph.types import SceneGraphSnapshot
+from .geometry import disc_inside_polygon, point_in_polygon, polygon_centroid
 
 if TYPE_CHECKING:
     from .annotations import Annotation, AnnotationStore
@@ -30,6 +32,8 @@ import semantic_map_mcp  # type: ignore
 from semantic_map_mcp import (  # type: ignore
     GoalNear_Request,
     GoalNear_Response,
+    GoalRoom_Request,
+    GoalRoom_Response,
     GetObjectContext_Request,
     GetObjectContext_Response,
     GetSceneGraph_Request,
@@ -88,13 +92,7 @@ def _to_idl(o: SceneObject) -> Object:
 
 
 def _annotation_centroid(a: "Annotation") -> tuple[float, float]:
-    pts = getattr(a, "points", []) or []
-    if not pts:
-        return 0.0, 0.0
-    sx = sum(float(p[0]) for p in pts)
-    sy = sum(float(p[1]) for p in pts)
-    n = max(1, len(pts))
-    return sx / n, sy / n
+    return polygon_centroid(getattr(a, "points", []) or [])
 
 
 def _annotation_object_id(a: "Annotation") -> str:
@@ -117,10 +115,44 @@ def _annotation_to_object(a: "Annotation") -> Object:
 def _find_annotation_target(object_id: str) -> "Annotation | None":
     if _ANNO_STORE is None:
         return None
-    for a in _ANNO_STORE.list():
-        if object_id in (a.annotation_id, _annotation_object_id(a)):
-            return a
+    for annotation in _ANNO_STORE.list():
+        if object_id == _annotation_object_id(annotation):
+            return annotation
     return None
+
+
+def _room_id_hint() -> str:
+    if _ANNO_STORE is None:
+        return "no rooms are currently registered"
+    rooms = [a for a in _ANNO_STORE.list() if a.kind == "room"]
+    if not rooms:
+        return "no rooms are currently registered"
+    candidates = ", ".join(
+        f"{room.name!r} (id={_annotation_object_id(room)})"
+        for room in rooms[:20]
+    )
+    suffix = "" if len(rooms) <= 20 else f", ... {len(rooms) - 20} more"
+    return f"available rooms: {candidates}{suffix}"
+
+
+def _object_id_hint(reference: str, objects: list[SceneObject]) -> str:
+    if not objects:
+        return "no physical objects are currently registered"
+    wanted = str(reference).strip().casefold()
+
+    def score(obj: SceneObject) -> float:
+        object_id = str(obj.object_id).casefold()
+        label = str(obj.cls).casefold()
+        return max(
+            SequenceMatcher(None, wanted, object_id).ratio(),
+            SequenceMatcher(None, wanted, label).ratio(),
+        )
+
+    nearest = sorted(objects, key=score, reverse=True)[:3]
+    candidates = ", ".join(
+        f"{obj.cls!r} (id={obj.object_id})" for obj in nearest
+    )
+    return f"did you mean one of: {candidates}"
 
 
 # ── @mcp_contract handlers ─────────────────────────────────────────────────
@@ -131,8 +163,9 @@ mcp = FastMCP("scene_provider")
 @mcp_contract(mcp, contract_id="robonix/system/scene/list_objects")
 async def list_objects(_req: ListObjects_Request) -> ListObjects_Response:
     """Return every object the scene registry currently believes
-    exists, as a flat list. The LLM filters client-side by label /
-    distance / etc. — no scoping or filter knobs in the schema.
+    exists, plus room annotations, as a flat list. Use this tool to discover
+    stable object/room IDs before goal_near or goal_room. Use get_scene_graph
+    only when object relationships are needed.
     Contract: robonix/system/scene/list_objects."""
     if _REGISTRY is None:
         raise RuntimeError("scene mcp_tools.attach_state was never called")
@@ -205,8 +238,11 @@ def _occupancy_bfs(
 
 @mcp_contract(mcp, contract_id="robonix/system/scene/goal_near")
 async def goal_near(req: GoalNear_Request) -> GoalNear_Response:
-    """Find a navigation-safe approach pose near the named object.
+    """Find a navigation-safe approach pose near a physical scene object.
     Returns map-frame (x, y, yaw); pass to navigation/navigate.
+
+    Room annotations are deliberately not accepted. Resolve those through
+    goal_room so the returned pose is constrained to the room polygon.
 
     `reachable=false` when:
       - the object_id isn't in the registry, or
@@ -217,24 +253,15 @@ async def goal_near(req: GoalNear_Request) -> GoalNear_Response:
         raise RuntimeError("scene mcp_tools.attach_state was never called")
     objs, _surfs = await _REGISTRY.snapshot()
     target = objs.get(req.object_id)
-    ann_target = None
     if target is None:
-        ann_target = _find_annotation_target(req.object_id)
-        if ann_target is None:
-            return GoalNear_Response(
-                reachable=False, x=0.0, y=0.0, yaw=0.0,
-                reason=f"unknown object_id '{req.object_id}'",
-            )
-        tx, ty = _annotation_centroid(ann_target)
-        target = SimpleNamespace(
-            pose=SimpleNamespace(
-                x=float(tx),
-                y=float(ty),
-                z=0.0,
-                yaw=float(ann_target.theta or 0.0),
+        visible = [obj for obj in objs.values() if not obj.missing]
+        return GoalNear_Response(
+            reachable=False, x=0.0, y=0.0, yaw=0.0,
+            reason=(
+                f"unknown physical object_id '{req.object_id}'; "
+                f"{_object_id_hint(req.object_id, visible)}; "
+                "use goal_room for room annotations"
             ),
-            cls=str(ann_target.name or ann_target.kind),
-            object_id=_annotation_object_id(ann_target),
         )
 
     robot = next(
@@ -288,6 +315,110 @@ async def goal_near(req: GoalNear_Request) -> GoalNear_Response:
     return GoalNear_Response(
         reachable=True, x=float(gx), y=float(gy), yaw=float(yaw),
         reason=f"approach pose for '{target.cls}' ({req.object_id})",
+    )
+
+
+def _occupancy_room_goal(grid_msg, points) -> tuple[float, float] | None:
+    """Choose the safest free grid cell nearest a room's polygon centroid."""
+    import numpy as np
+
+    polygon = [(float(x), float(y)) for x, y in points]
+    if len(polygon) < 3:
+        return None
+    info = grid_msg.info
+    width, height = int(info.width), int(info.height)
+    resolution = float(info.resolution)
+    origin_x = float(info.origin.position.x)
+    origin_y = float(info.origin.position.y)
+    grid = np.frombuffer(bytes(grid_msg.data), dtype=np.int8).reshape(height, width)
+    # A room destination must be known free space. Unknown cells are not goals.
+    blocked = (grid < 0) | (grid > 50)
+    footprint_radius = _GOAL_NEAR_ROBOT_RADIUS_M + _GOAL_NEAR_CLEARANCE_M
+    inflation_cells = max(1, int(math.ceil(footprint_radius / resolution)))
+    centroid_x, centroid_y = polygon_centroid(polygon)
+
+    min_x = max(0, int((min(x for x, _ in polygon) - origin_x) / resolution))
+    max_x = min(width - 1, int((max(x for x, _ in polygon) - origin_x) / resolution))
+    min_y = max(0, int((min(y for _, y in polygon) - origin_y) / resolution))
+    max_y = min(height - 1, int((max(y for _, y in polygon) - origin_y) / resolution))
+    candidates = []
+    for gy in range(min_y, max_y + 1):
+        wy = origin_y + (gy + 0.5) * resolution
+        for gx in range(min_x, max_x + 1):
+            wx = origin_x + (gx + 0.5) * resolution
+            if not disc_inside_polygon(wx, wy, footprint_radius, polygon):
+                continue
+            if (
+                gx - inflation_cells < 0
+                or gy - inflation_cells < 0
+                or gx + inflation_cells >= width
+                or gy + inflation_cells >= height
+            ):
+                continue
+            local = blocked[
+                gy - inflation_cells: gy + inflation_cells + 1,
+                gx - inflation_cells: gx + inflation_cells + 1,
+            ]
+            if not bool(local.any()):
+                candidates.append(((wx - centroid_x) ** 2 + (wy - centroid_y) ** 2, wx, wy))
+    if not candidates:
+        return None
+    _, x, y = min(candidates)
+    return x, y
+
+
+@mcp_contract(mcp, contract_id="robonix/system/scene/goal_room")
+async def goal_room(req: GoalRoom_Request) -> GoalRoom_Response:
+    """Resolve a room annotation to a safe map-frame pose inside its polygon.
+
+    Use this for named rooms and user-defined regions before navigation/navigate.
+    The result never falls outside the room polygon.
+    Contract: robonix/system/scene/goal_room.
+    """
+    room = _find_annotation_target(req.room_id)
+    if room is None or room.kind != "room":
+        return GoalRoom_Response(
+            reachable=False, x=0.0, y=0.0, yaw=0.0,
+            reason=(
+                f"unknown room_id '{req.room_id}'; room_id must be the exact "
+                f"stable ID returned by list_objects; {_room_id_hint()}"
+            ),
+        )
+    if _HUB is None or not _HUB.has("occupancy_grid"):
+        return GoalRoom_Response(
+            reachable=False, x=0.0, y=0.0, yaw=0.0,
+            reason="no occupancy_grid available - mapping not running",
+        )
+    try:
+        msg, _stamp, count = _HUB.latest("occupancy_grid")
+    except Exception as exc:  # noqa: BLE001
+        return GoalRoom_Response(
+            reachable=False, x=0.0, y=0.0, yaw=0.0,
+            reason=f"occupancy_grid hub error: {exc}",
+        )
+    if msg is None or count == 0 or not msg.info.width or not msg.info.height:
+        return GoalRoom_Response(
+            reachable=False, x=0.0, y=0.0, yaw=0.0,
+            reason="occupancy_grid empty - wait for mapping to publish",
+        )
+    found = _occupancy_room_goal(msg, room.points)
+    if found is None:
+        return GoalRoom_Response(
+            reachable=False, x=0.0, y=0.0, yaw=0.0,
+            reason=f"no known free pose inside room '{room.name}' ({req.room_id})",
+        )
+    x, y = found
+    if not point_in_polygon(x, y, room.points):
+        return GoalRoom_Response(
+            reachable=False, x=0.0, y=0.0, yaw=0.0,
+            reason="internal validation rejected a pose outside the room polygon",
+        )
+    return GoalRoom_Response(
+        reachable=True,
+        x=float(x),
+        y=float(y),
+        yaw=float(room.theta or 0.0),
+        reason=f"safe pose inside room '{room.name}' ({req.room_id})",
     )
 
 
@@ -442,6 +573,7 @@ __all__ = [
     "attach_annotation_store",
     "list_objects",
     "goal_near",
+    "goal_room",
     "get_scene_graph",
     "get_object_context",
     "list_relations",

--- a/system/scene/scene_service/mcp_tools.py
+++ b/system/scene/scene_service/mcp_tools.py
@@ -14,10 +14,15 @@ from __future__ import annotations
 import logging
 import math
 import time
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
 
 from .state import ObjectRegistry, SceneObject
 from .scene_graph.store import SceneGraphStore
 from .scene_graph.types import SceneGraphSnapshot
+
+if TYPE_CHECKING:
+    from .annotations import Annotation, AnnotationStore
 
 # Resolved at import time. PYTHONPATH is set by package_manifest.yaml's
 # `start:` block to include rbnx-build/codegen/{proto_gen,robonix_mcp_types}.
@@ -34,6 +39,7 @@ from semantic_map_mcp import (  # type: ignore
     ListRelations_Request,
     ListRelations_Response,
     Object,
+    SceneAnnotation as SceneAnnotationIDL,
     SceneGraphEdge as SceneGraphEdgeIDL,
     SceneGraphNode as SceneGraphNodeIDL,
 )
@@ -48,6 +54,7 @@ log = logging.getLogger(__name__)
 _REGISTRY: ObjectRegistry | None = None
 _HUB = None  # SubscribersHub, exposes .latest("occupancy_grid") for goal_near BFS
 _SG_STORE: SceneGraphStore | None = None
+_ANNO_STORE: "AnnotationStore | None" = None
 
 
 def attach_state(*, registry: ObjectRegistry, hub=None) -> None:
@@ -59,6 +66,11 @@ def attach_state(*, registry: ObjectRegistry, hub=None) -> None:
 def attach_scene_graph_store(store: SceneGraphStore) -> None:
     global _SG_STORE
     _SG_STORE = store
+
+
+def attach_annotation_store(store: "AnnotationStore | None") -> None:
+    global _ANNO_STORE
+    _ANNO_STORE = store
 
 
 # ── conversions: SceneObject → IDL Object ──────────────────────────────────
@@ -73,6 +85,42 @@ def _to_idl(o: SceneObject) -> Object:
         yaw=float(o.pose.yaw),
         last_seen_unix=float(o.last_seen),
     )
+
+
+def _annotation_centroid(a: "Annotation") -> tuple[float, float]:
+    pts = getattr(a, "points", []) or []
+    if not pts:
+        return 0.0, 0.0
+    sx = sum(float(p[0]) for p in pts)
+    sy = sum(float(p[1]) for p in pts)
+    n = max(1, len(pts))
+    return sx / n, sy / n
+
+
+def _annotation_object_id(a: "Annotation") -> str:
+    return f"scene.{a.kind}.{a.annotation_id}"
+
+
+def _annotation_to_object(a: "Annotation") -> Object:
+    x, y = _annotation_centroid(a)
+    return Object(
+        id=_annotation_object_id(a),
+        label=str(a.name or a.kind),
+        x=float(x),
+        y=float(y),
+        z=0.0,
+        yaw=float(a.theta or 0.0),
+        last_seen_unix=float(a.updated_at or 0.0),
+    )
+
+
+def _find_annotation_target(object_id: str) -> "Annotation | None":
+    if _ANNO_STORE is None:
+        return None
+    for a in _ANNO_STORE.list():
+        if object_id in (a.annotation_id, _annotation_object_id(a)):
+            return a
+    return None
 
 
 # ── @mcp_contract handlers ─────────────────────────────────────────────────
@@ -90,8 +138,11 @@ async def list_objects(_req: ListObjects_Request) -> ListObjects_Response:
         raise RuntimeError("scene mcp_tools.attach_state was never called")
     objs, _surfs = await _REGISTRY.snapshot()
     visible = [o for o in objs.values() if not o.missing]
+    objects = [_to_idl(o) for o in visible]
+    if _ANNO_STORE is not None:
+        objects.extend(_annotation_to_object(a) for a in _ANNO_STORE.list() if a.kind == "room")
     return ListObjects_Response(
-        objects=[_to_idl(o) for o in visible],
+        objects=objects,
         stamp_unix=time.time(),
     )
 
@@ -166,10 +217,24 @@ async def goal_near(req: GoalNear_Request) -> GoalNear_Response:
         raise RuntimeError("scene mcp_tools.attach_state was never called")
     objs, _surfs = await _REGISTRY.snapshot()
     target = objs.get(req.object_id)
+    ann_target = None
     if target is None:
-        return GoalNear_Response(
-            reachable=False, x=0.0, y=0.0, yaw=0.0,
-            reason=f"unknown object_id '{req.object_id}'",
+        ann_target = _find_annotation_target(req.object_id)
+        if ann_target is None:
+            return GoalNear_Response(
+                reachable=False, x=0.0, y=0.0, yaw=0.0,
+                reason=f"unknown object_id '{req.object_id}'",
+            )
+        tx, ty = _annotation_centroid(ann_target)
+        target = SimpleNamespace(
+            pose=SimpleNamespace(
+                x=float(tx),
+                y=float(ty),
+                z=0.0,
+                yaw=float(ann_target.theta or 0.0),
+            ),
+            cls=str(ann_target.name or ann_target.kind),
+            object_id=_annotation_object_id(ann_target),
         )
 
     robot = next(
@@ -258,6 +323,29 @@ def _edge_to_idl(e) -> SceneGraphEdgeIDL:
     )
 
 
+def _annotation_to_idl(a: "Annotation") -> SceneAnnotationIDL:
+    points_xy: list[float] = []
+    for point in a.points or []:
+        if len(point) >= 2:
+            points_xy.extend([float(point[0]), float(point[1])])
+    return SceneAnnotationIDL(
+        annotation_id=a.annotation_id,
+        kind=a.kind,
+        name=a.name,
+        points_xy=points_xy,
+        theta=float(a.theta) if a.theta is not None else 0.0,
+        stale=bool(a.stale),
+        stale_reason=a.stale_reason or "",
+        updated_at_unix=float(a.updated_at or 0.0),
+    )
+
+
+def _annotation_list() -> list[SceneAnnotationIDL]:
+    if _ANNO_STORE is None:
+        return []
+    return [_annotation_to_idl(a) for a in _ANNO_STORE.list()]
+
+
 @mcp_contract(mcp, contract_id="robonix/system/scene/get_scene_graph")
 async def get_scene_graph(_req: GetSceneGraph_Request) -> GetSceneGraph_Response:
     """Return the current scene graph snapshot — all stable nodes
@@ -266,11 +354,12 @@ async def get_scene_graph(_req: GetSceneGraph_Request) -> GetSceneGraph_Response
     snap = _sg_snapshot()
     if snap is None:
         return GetSceneGraph_Response(
-            nodes=[], edges=[], updated_at=0.0,
+            nodes=[], edges=[], annotations=_annotation_list(), updated_at=0.0,
         )
     return GetSceneGraph_Response(
         nodes=[_node_to_idl(n) for n in snap.nodes.values()],
         edges=[_edge_to_idl(e) for e in snap.edges],
+        annotations=_annotation_list(),
         updated_at=snap.updated_at,
     )
 
@@ -350,6 +439,7 @@ __all__ = [
     "mcp",
     "attach_state",
     "attach_scene_graph_store",
+    "attach_annotation_store",
     "list_objects",
     "goal_near",
     "get_scene_graph",

--- a/system/scene/scene_service/mcp_tools.py
+++ b/system/scene/scene_service/mcp_tools.py
@@ -121,6 +121,40 @@ def _find_annotation_target(object_id: str) -> "Annotation | None":
     return None
 
 
+def _normalize_room_reference(value: str) -> str:
+    return " ".join(str(value or "").strip().casefold().split())
+
+
+def _room_aliases(room: "Annotation") -> set[str]:
+    name = _normalize_room_reference(room.name)
+    aliases = {name}
+    for prefix in ("room ", "room-", "房间 ", "房间"):
+        if name.startswith(prefix) and name[len(prefix):].strip():
+            aliases.add(name[len(prefix):].strip())
+    return aliases
+
+
+def _resolve_room_target(reference: str) -> tuple["Annotation | None", list["Annotation"]]:
+    """Resolve stable ID first, then an exact unique room name/short alias.
+
+    The second return value contains ambiguous candidates. Fuzzy matching is
+    deliberately excluded: navigation must not guess between similar rooms.
+    """
+    exact = _find_annotation_target(reference)
+    if exact is not None and exact.kind == "room":
+        return exact, []
+    if _ANNO_STORE is None:
+        return None, []
+    needle = _normalize_room_reference(reference)
+    matches = [
+        room for room in _ANNO_STORE.list()
+        if room.kind == "room" and needle in _room_aliases(room)
+    ]
+    if len(matches) == 1:
+        return matches[0], []
+    return None, matches
+
+
 def _room_id_hint() -> str:
     if _ANNO_STORE is None:
         return "no rooms are currently registered"
@@ -375,15 +409,28 @@ async def goal_room(req: GoalRoom_Request) -> GoalRoom_Response:
     The result never falls outside the room polygon.
     Contract: robonix/system/scene/goal_room.
     """
-    room = _find_annotation_target(req.room_id)
-    if room is None or room.kind != "room":
+    room, ambiguous = _resolve_room_target(req.room_id)
+    if ambiguous:
+        candidates = ", ".join(
+            f"{item.name!r} (id={_annotation_object_id(item)})"
+            for item in ambiguous
+        )
         return GoalRoom_Response(
             reachable=False, x=0.0, y=0.0, yaw=0.0,
             reason=(
-                f"unknown room_id '{req.room_id}'; room_id must be the exact "
-                f"stable ID returned by list_objects; {_room_id_hint()}"
+                f"ambiguous room reference '{req.room_id}'; candidates: "
+                f"{candidates}; pass one exact stable ID"
             ),
         )
+    if room is None:
+        return GoalRoom_Response(
+            reachable=False, x=0.0, y=0.0, yaw=0.0,
+            reason=(
+                f"unknown room reference '{req.room_id}'; pass a stable ID or "
+                f"unique room name returned by list_objects; {_room_id_hint()}"
+            ),
+        )
+    stable_room_id = _annotation_object_id(room)
     if _HUB is None or not _HUB.has("occupancy_grid"):
         return GoalRoom_Response(
             reachable=False, x=0.0, y=0.0, yaw=0.0,
@@ -405,7 +452,7 @@ async def goal_room(req: GoalRoom_Request) -> GoalRoom_Response:
     if found is None:
         return GoalRoom_Response(
             reachable=False, x=0.0, y=0.0, yaw=0.0,
-            reason=f"no known free pose inside room '{room.name}' ({req.room_id})",
+            reason=f"no known free pose inside room '{room.name}' ({stable_room_id})",
         )
     x, y = found
     if not point_in_polygon(x, y, room.points):
@@ -418,7 +465,7 @@ async def goal_room(req: GoalRoom_Request) -> GoalRoom_Response:
         x=float(x),
         y=float(y),
         yaw=float(room.theta or 0.0),
-        reason=f"safe pose inside room '{room.name}' ({req.room_id})",
+        reason=f"safe pose inside room '{room.name}' ({stable_room_id})",
     )
 
 

--- a/system/scene/scene_service/mcp_tools.py
+++ b/system/scene/scene_service/mcp_tools.py
@@ -128,7 +128,7 @@ def _normalize_room_reference(value: str) -> str:
 def _room_aliases(room: "Annotation") -> set[str]:
     name = _normalize_room_reference(room.name)
     aliases = {name}
-    for prefix in ("room ", "room-", "房间 ", "房间"):
+    for prefix in ("room ", "room-", "房间 ", "房间"):  # i18n-ok: user room aliases
         if name.startswith(prefix) and name[len(prefix):].strip():
             aliases.add(name[len(prefix):].strip())
     return aliases

--- a/system/scene/scene_service/persistence.py
+++ b/system/scene/scene_service/persistence.py
@@ -316,6 +316,27 @@ class ObjectStore:
             )
         return objs
 
+    def delete_map(self, map_id: str) -> int:
+        """Delete persisted scene objects belonging to one map partition.
+
+        The collection is shared, so the filter is mandatory: deleting a map
+        must never affect objects captured for another spatial map.
+        """
+        target = _sanitize_map_id(map_id)
+        predicate = f'map_id == "{target}"'
+        try:
+            rows = self._client.query(
+                collection_name=_COLLECTION,
+                filter=predicate,
+                output_fields=["pk"],
+                limit=16384,
+            )
+            if rows:
+                self._client.delete(collection_name=_COLLECTION, filter=predicate)
+            return len(rows)
+        except Exception as e:  # noqa: BLE001
+            raise RuntimeError(f"delete_map({target}) failed: {e}") from e
+
     # ── lifecycle ────────────────────────────────────────────────────────
     def close(self) -> None:
         """Close the client and release the milvus-lite server so the next

--- a/system/scene/scene_service/persistence.py
+++ b/system/scene/scene_service/persistence.py
@@ -23,25 +23,16 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 from pathlib import Path
 from typing import Callable, Optional
 
+from .map_binding import sanitize_map_id as _sanitize_map_id
 from .state.object_registry import BBox3D, Pose3D, SceneObject
 
 log = logging.getLogger(__name__)
 
 _COLLECTION = "scene_objects"
 
-# map_id is interpolated into a milvus filter expression, so restrict it to a
-# safe identifier charset (no quotes / spaces) to keep the predicate injection
-# -free. Anything else is squashed to "_"; empty falls back to "default".
-_MAP_ID_UNSAFE = re.compile(r"[^A-Za-z0-9._\-]")
-
-
-def _sanitize_map_id(raw: Optional[str]) -> str:
-    cleaned = _MAP_ID_UNSAFE.sub("_", (raw or "").strip())
-    return cleaned or "default"
 # open_clip ViT-B-32 text/image features are 512-d (see
 # ingest/perception_concept_graphs.py). Object image features already live in
 # this space, so caption-text vectors are directly comparable for G3.

--- a/system/scene/scene_service/persistence.py
+++ b/system/scene/scene_service/persistence.py
@@ -77,6 +77,15 @@ class ObjectStore:
         """The sanitized map id this store is scoped to."""
         return self._map_id
 
+    def rebind(self, map_id: str) -> None:
+        """Switch subsequent reads/writes to another map partition.
+
+        The Milvus collection is shared across maps; rows are filtered by the
+        scalar ``map_id`` field and keyed by ``{map_id}::{object_id}``, so a
+        rebind only changes the partition used by ``persist`` / ``load_all``.
+        """
+        self._map_id = _sanitize_map_id(map_id)
+
     # ── schema ───────────────────────────────────────────────────────────
     def _ensure_collection(self) -> None:
         """Create the collection + index on first run; when it already exists

--- a/system/scene/scene_service/scene_graph/store.py
+++ b/system/scene/scene_service/scene_graph/store.py
@@ -45,9 +45,10 @@ class SceneGraphStore:
         (caption/relation answers are only valid within the map frame they were
         computed in — the same per-map isolation the object store gets from its
         ``"{map_id}::{object_id}"`` composite key). The id is run through
-        ``persistence._sanitize_map_id`` so it is a safe path component
-        (imported lazily — that module defers its pymilvus import, so this stays
-        importable on hosts without the milvus backend). With no ``map_id`` the
+        ``map_binding.sanitize_map_id`` (the one sanitize rule shared by every
+        map_id-partitioned store; reached via persistence's alias, imported
+        lazily so this stays importable without the milvus backend) so it is a
+        safe path component. With no ``map_id`` the
         path is unchanged (legacy/"default" behaviour)."""
         self._nodes: dict[str, SceneGraphNode] = {}
         self._geometric_edges: list[SceneGraphEdge] = []

--- a/system/scene/scene_service/service.py
+++ b/system/scene/scene_service/service.py
@@ -37,6 +37,7 @@ scene = Service(id="scene", namespace="robonix/system/scene")
 from . import mcp_tools
 from . import web as web_ui
 from .ingest.capabilities import plan_perception
+from .map_binding import MapBinding, choose_map_binding, read_latched_lifecycle
 from .ingest.perception_concept_graphs import ConceptGraphsDetector
 from .ingest.perception_vlm import VLMObjectDetector, _CamIntrinsics
 from .ingest.ros_subscribers import (
@@ -104,6 +105,12 @@ _SCENE_CONTRACTS: list[tuple[str, str, str]] = [
     ("pose",              "robonix/service/map/pose",            "PoseWithCovarianceStamped"),
     ("odom",              "robonix/service/map/odom",            "Odometry"),
     ("occupancy_grid",    "robonix/service/map/occupancy_grid",  "OccupancyGrid"),
+    # Latched {map_id, mode, generation} broadcast from mapping. Startup
+    # binding is probed separately (_discover_map_binding, before the hub
+    # exists); this hub subscription feeds the runtime mismatch watcher
+    # (_lifecycle_watch). Needs the generated `map` interface package
+    # (ros2_idl overlay) — the hub skips the row gracefully when missing.
+    ("map_lifecycle",     "robonix/service/map/lifecycle",       "MapLifecycle"),
 ]
 
 # Optional manifest opt-out: kinds listed here are dropped even if atlas
@@ -230,6 +237,46 @@ def _resolve_one_contract(
         msg_type=msg_type,
         qos_profile=qos_profile or "default",
     )
+
+
+def _discover_map_binding(wait_s: float) -> Optional[dict]:
+    """Probe mapping's latched lifecycle broadcast for the startup binding.
+
+    Adaptive cost: polls atlas for the `robonix/service/map/lifecycle`
+    contract for at most `wait_s` (the normal full-boot order starts scene
+    BEFORE mapping, so the contract is usually absent and this returns in
+    ~`wait_s`); once the contract resolves — the scene-restart-while-
+    mapping-runs case — the latched sample arrives immediately, with a 5 s
+    ceiling as safety. Returns {map_id, mode, generation} or None; blocking
+    is fine here, it runs before anything else is wired. `wait_s <= 0`
+    disables the probe (unit tests / ROS-less runs)."""
+    if wait_s <= 0:
+        return None
+    deadline = time.monotonic() + wait_s
+    while True:
+        try:
+            spec = _resolve_one_contract(
+                Transport.ROS2, "map_lifecycle",
+                "robonix/service/map/lifecycle", "MapLifecycle",
+            )
+        except Exception as e:  # noqa: BLE001
+            # Probe runs before bootstrap; if atlas isn't reachable yet a
+            # wire error must degrade to static binding, not kill startup.
+            log.warning("[scene] lifecycle probe: atlas query failed (%s) — "
+                        "falling back to static map binding", e)
+            return None
+        if spec is not None:
+            sample = read_latched_lifecycle(spec.topic, timeout_s=5.0)
+            if sample is None:
+                log.warning(
+                    "[scene] lifecycle contract resolved (%s) but no latched "
+                    "sample within 5s — falling back to static map binding",
+                    spec.topic,
+                )
+            return sample
+        if time.monotonic() >= deadline:
+            return None
+        time.sleep(0.5)
 
 
 def _resolve_explicit(
@@ -842,6 +889,71 @@ async def _ingest_detections(registry: ObjectRegistry, detections):
         )
 
 
+def _log_bg_task_exit(task: "asyncio.Task") -> None:
+    """Done-callback for scene's fire-and-forget background tasks: log any
+    exception at ERROR the moment the task dies, instead of letting asyncio
+    sit on it until interpreter shutdown."""
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        log.error("[scene] background task %r died: %r", task.get_name(), exc)
+
+
+async def _lifecycle_watch(hub: SubscribersHub, binding: MapBinding) -> None:
+    """P2 guard: scene binds its map_id ONCE at startup; when mapping's
+    broadcast later disagrees (map loaded/reset/switched at runtime), warn
+    loudly — reacting to it (flush + re-anchor the semantic state) is the
+    P3 lifecycle linkage, not guesswork here. Also confirms a static
+    binding the first time the broadcast appears and agrees."""
+    confirmed = False
+    warned_ephemeral = False
+    last_warned: Optional[tuple] = None
+    while True:
+        await asyncio.sleep(5.0)
+        msg, stamp_unix, _count = hub.latest("map_lifecycle")
+        if msg is None:
+            continue
+        live_id, live_gen = str(msg.map_id), int(msg.generation)
+        if not live_id:
+            # Ephemeral broadcast: no named identity to compare — but if
+            # scene statically bound a NAMED map, that named partition is
+            # being fed coordinates from a frame that resets every boot.
+            # Say so once instead of guarding silently forever.
+            if not warned_ephemeral and binding.source in ("config", "env"):
+                log.warning(
+                    "[scene] mapping broadcasts an EPHEMERAL session (empty "
+                    "map_id) while scene is bound to %r (source=%s) — set "
+                    "mapping's config.map_id to match", binding.map_id,
+                    binding.source,
+                )
+                warned_ephemeral = True
+            continue
+        id_ok = live_id == binding.map_id
+        gen_ok = binding.generation is None or live_gen == binding.generation
+        if id_ok and gen_ok:
+            if not confirmed:
+                log.info(
+                    "[scene] map binding confirmed by mapping lifecycle: "
+                    "id=%s gen=%d mode=%s", live_id, live_gen, str(msg.mode),
+                )
+                confirmed = True
+            last_warned = None
+            continue
+        key = (live_id, live_gen)
+        if key != last_warned:
+            log.warning(
+                "[scene] mapping's live map identity (id=%s gen=%d mode=%s) "
+                "no longer matches scene's startup binding (id=%s gen=%s "
+                "source=%s) — semantic state may be mis-anchored. Scene keeps "
+                "its startup binding until lifecycle linkage (P3) lands; "
+                "restart scene to rebind.",
+                live_id, live_gen, str(msg.mode),
+                binding.map_id, binding.generation, binding.source,
+            )
+            last_warned = key
+
+
 # ── main ───────────────────────────────────────────────────────────────────
 async def _run() -> None:
     config = _load_config()
@@ -865,14 +977,41 @@ async def _run() -> None:
     # arrive; the embedder is wired in later (only needed for writes). The
     # store is independent of SCENE_GRAPH_ENABLED — restore always runs if a
     # prior boot wrote rows — but writes are driven by the scene-graph builder.
-    # Which SLAM map this scene session belongs to. Deploy-controlled until
-    # mapping emits a real map identity — manifest `map_id` wins, else the
-    # SCENE_MAP_ID env, else "default". This is the join key against mapping
-    # and the scope key for ALL of scene's persistent state: object poses are
-    # only valid in their own map's frame, and so are the scene-graph caption/
-    # relation caches. Computed once here so the object store (below) and the
-    # scene-graph cache (further down) partition on the same value.
-    map_id = str(config.get("map_id") or os.environ.get("SCENE_MAP_ID") or "default")
+    # Which SLAM map this scene session belongs to. This is the join key
+    # against mapping and the scope key for ALL of scene's persistent state:
+    # object poses are only valid in their own map's frame, and so are the
+    # scene-graph caption/relation caches. Computed once here so the object
+    # store (below) and the scene-graph cache (further down) partition on
+    # the same value.
+    #
+    # Binding precedence (choose_map_binding): mapping's latched lifecycle
+    # broadcast — the authoritative map identity, probed briefly here —
+    # then manifest `map_id`, then SCENE_MAP_ID env, then "default". The
+    # static levers stay as fallback because the normal full-boot order
+    # starts scene BEFORE mapping (probe cost then ≈ the wait window);
+    # a scene restart while mapping runs binds from the broadcast alone.
+    broadcast = _discover_map_binding(
+        float(os.environ.get("SCENE_MAP_BINDING_WAIT_S", "3.0"))
+    )
+    binding = choose_map_binding(
+        broadcast, config.get("map_id"), os.environ.get("SCENE_MAP_ID")
+    )
+    map_id = binding.map_id
+    log.info(
+        "[scene] map binding: id=%s gen=%s source=%s",
+        binding.map_id, binding.generation, binding.source,
+    )
+    if broadcast is not None and not str(broadcast.get("map_id") or ""):
+        # mapping is provably UP but running ephemeral (no map_id) — its
+        # frame resets every boot, so the named partition scene just bound
+        # statically will never re-anchor. Likely a manifest misconfig
+        # (SCENE_MAP_ID set, mapping's config.map_id forgotten).
+        log.warning(
+            "[scene] mapping broadcasts an EPHEMERAL session (empty map_id) "
+            "while scene binds %r from %s — objects stored under this id "
+            "won't re-anchor across boots; set mapping's config.map_id to "
+            "match", binding.map_id, binding.source,
+        )
 
     obj_store = None
     if os.environ.get("SCENE_OBJECT_MEMORY_ENABLED", "true").lower() in ("true", "1", "yes"):
@@ -960,6 +1099,11 @@ async def _run() -> None:
         obj_store.set_embedder(getattr(perception, "embed_text", None))
     bg_tasks = [
         asyncio.create_task(_stale_tick(registry), name="scene-stale-tick"),
+        # P2 guard: warn when mapping's live map identity drifts from the
+        # binding scene started with (P3 will act on it instead).
+        asyncio.create_task(
+            _lifecycle_watch(hub, binding), name="scene-lifecycle-watch"
+        ),
         # Background reconciler: keeps scene's hub adding subscriptions
         # for new ROS2 topic_outs that appear on atlas after start
         # (mapping comes up after scene; same pattern for any future
@@ -975,6 +1119,11 @@ async def _run() -> None:
         ),
         *ingest_bg,
     ]
+    # These tasks are fire-and-forget: nothing awaits them, so an uncaught
+    # exception would otherwise vanish until shutdown (the failure mode of
+    # the failure-detectors themselves). Surface any death immediately.
+    for _t in bg_tasks:
+        _t.add_done_callback(_log_bg_task_exit)
 
     # ── Relation layer ───────────────────────────────────────────────
     # Fast geometric relations (contact/containment + reachable_by) are

--- a/system/scene/scene_service/service.py
+++ b/system/scene/scene_service/service.py
@@ -1150,6 +1150,7 @@ async def _run() -> None:
     for fn in (
         mcp_tools.list_objects,
         mcp_tools.goal_near,
+        mcp_tools.goal_room,
         mcp_tools.get_scene_graph,
         mcp_tools.get_object_context,
         mcp_tools.list_relations,
@@ -1168,7 +1169,7 @@ async def _run() -> None:
             description=(fn.__doc__ or "").strip(),
             input_schema_json=schema,
         )
-    log.info("scene declared 5 MCP tools at %s", scene.mcp_endpoint)
+    log.info("scene declared 6 MCP tools at %s", scene.mcp_endpoint)
 
     # ROS2 ingest hub + downstream consumers (self-pose, perception).
     # _start_ros_ingest still wants a raw atlas stub for QueryCapabilities;

--- a/system/scene/scene_service/service.py
+++ b/system/scene/scene_service/service.py
@@ -1059,9 +1059,12 @@ async def _run() -> None:
         broadcast, config.get("map_id"), os.environ.get("SCENE_MAP_ID")
     )
     map_id = binding.map_id
+    restore_on_start = os.environ.get("SCENE_RESTORE_ON_START", "false").lower() in ("true", "1", "yes")
+    scene_state_map_id = map_id if restore_on_start else f".live-{os.getpid()}-{int(time.time())}"
     log.info(
-        "[scene] map binding: id=%s gen=%s source=%s",
-        binding.map_id, binding.generation, binding.source,
+        "[scene] map binding: id=%s gen=%s source=%s mode=%s restore_on_start=%s state_partition=%s",
+        binding.map_id, binding.generation, binding.source, binding.mode,
+        restore_on_start, scene_state_map_id,
     )
     if broadcast is not None and not str(broadcast.get("map_id") or ""):
         # mapping is provably UP but running ephemeral (no map_id) — its
@@ -1083,14 +1086,15 @@ async def _run() -> None:
             "SCENE_OBJECT_MEMORY_DB", "/data/robonix/scene_memory/objects.db"
         )
         try:
-            obj_store = ObjectStore(db_path, map_id=map_id)
-            restored = obj_store.load_all()
-            async with registry.lock():
-                for o in restored:
-                    registry.restore_object(o)
+            obj_store = ObjectStore(db_path, map_id=scene_state_map_id)
+            restored = obj_store.load_all() if restore_on_start else []
+            if restored:
+                async with registry.lock():
+                    for o in restored:
+                        registry.restore_object(o)
             log.info(
-                "[scene-persist] restored %d objects (map_id=%s) from %s",
-                len(restored), obj_store.map_id, db_path,
+                "[scene-persist] object store ready: restored %d object(s) (partition=%s, restore_on_start=%s) from %s",
+                len(restored), obj_store.map_id, restore_on_start, db_path,
             )
         except Exception as e:  # noqa: BLE001
             # Object memory is opted in (default on), so a failure here is not
@@ -1115,8 +1119,8 @@ async def _run() -> None:
             os.environ.get(
                 "SCENE_ANNOTATIONS_DIR", "/data/robonix/scene_annotations"
             ),
-            map_id=map_id,
-            generation=binding.generation,
+            map_id=scene_state_map_id,
+            generation=binding.generation if restore_on_start else None,
         )
         anns = anno_store.list()
         log.info(
@@ -1134,6 +1138,7 @@ async def _run() -> None:
     # supplied later in _start_ros_ingest). The geometric relation loop +
     # scene-graph store are wired further down, once the registry is live.
     mcp_tools.attach_state(registry=registry)
+    mcp_tools.attach_annotation_store(anno_store)
 
     # Bring up atlas + lifecycle gRPC + MCP HTTP. Non-blocking; scene
     # keeps running its own asyncio event loop after this returns.
@@ -1227,9 +1232,10 @@ async def _run() -> None:
     sg_cache_dir = os.environ.get(
         "SCENE_GRAPH_CACHE_DIR", "/data/robonix/scene_graph/cache"
     )
-    # Partition the scene-graph caches by the same map_id as the object store,
-    # so caption/relation answers from one map never bleed into another.
-    sg_store = SceneGraphStore(cache_dir=sg_cache_dir, map_id=map_id)
+    # Partition the scene-graph caches by the same runtime state partition as
+    # the object store. Startup defaults to a live session; explicit Load rebinds
+    # persistent room/object state through the web map facade.
+    sg_store = SceneGraphStore(cache_dir=sg_cache_dir, map_id=scene_state_map_id)
     log.info(
         "[scene-graph] cache base=%s partitioned by map_id=%s",
         sg_cache_dir, map_id,
@@ -1291,11 +1297,12 @@ async def _run() -> None:
             detector=perception,
             sg_store=sg_store,
             anno_store=anno_store,
+            object_store=obj_store,
             map_binding={
                 "map_id": binding.map_id,
-                "mode": binding.mode,
-                "generation": binding.generation,
-                "source": binding.source,
+                "mode": binding.mode if restore_on_start else "",
+                "generation": binding.generation if restore_on_start else None,
+                "source": binding.source if restore_on_start else "default",
             },
         )
         web_uv = uvicorn.Config(

--- a/system/scene/scene_service/service.py
+++ b/system/scene/scene_service/service.py
@@ -36,6 +36,7 @@ scene = Service(id="scene", namespace="robonix/system/scene")
 
 from . import mcp_tools
 from . import web as web_ui
+from .annotations import AnnotationStore
 from .ingest.capabilities import plan_perception
 from .map_binding import MapBinding, choose_map_binding, read_latched_lifecycle
 from .ingest.perception_concept_graphs import ConceptGraphsDetector
@@ -900,15 +901,32 @@ def _log_bg_task_exit(task: "asyncio.Task") -> None:
         log.error("[scene] background task %r died: %r", task.get_name(), exc)
 
 
-async def _lifecycle_watch(hub: SubscribersHub, binding: MapBinding) -> None:
+async def _lifecycle_watch(
+    hub: SubscribersHub,
+    binding: MapBinding,
+    anno_store: Optional[AnnotationStore] = None,
+) -> None:
     """P2 guard: scene binds its map_id ONCE at startup; when mapping's
     broadcast later disagrees (map loaded/reset/switched at runtime), warn
     loudly — reacting to it (flush + re-anchor the semantic state) is the
     P3 lifecycle linkage, not guesswork here. Also confirms a static
-    binding the first time the broadcast appears and agrees."""
+    binding the first time the broadcast appears and agrees.
+
+    One reaction IS taken already: a generation bump on the SAME map flags
+    the user's annotations stale (flag-only — user assets are never
+    deleted automatically). That is a marker write, not a flush, so it is
+    safe ahead of P3; and because it is best-effort, a failing marker
+    write must never kill this watcher — the drift WARNING itself is the
+    load-bearing part.
+
+    A static binding (config/env — the normal full-boot order, scene up
+    before mapping) carries no generation, so the epoch reference is
+    learned from the FIRST confirming broadcast: without that, `gen_ok`
+    would stay vacuously true and runtime bumps would be invisible."""
     confirmed = False
     warned_ephemeral = False
     last_warned: Optional[tuple] = None
+    ref_gen = binding.generation
     while True:
         await asyncio.sleep(5.0)
         msg, stamp_unix, _count = hub.latest("map_lifecycle")
@@ -930,7 +948,7 @@ async def _lifecycle_watch(hub: SubscribersHub, binding: MapBinding) -> None:
                 warned_ephemeral = True
             continue
         id_ok = live_id == binding.map_id
-        gen_ok = binding.generation is None or live_gen == binding.generation
+        gen_ok = ref_gen is None or live_gen == ref_gen
         if id_ok and gen_ok:
             if not confirmed:
                 log.info(
@@ -938,6 +956,21 @@ async def _lifecycle_watch(hub: SubscribersHub, binding: MapBinding) -> None:
                     "id=%s gen=%d mode=%s", live_id, live_gen, str(msg.mode),
                 )
                 confirmed = True
+                # Static bindings learn their epoch here; from now on a
+                # bump IS detectable. The annotation store gets to compare
+                # the confirmed epoch against the one its file recorded
+                # (it too may have loaded under an unknown generation).
+                ref_gen = live_gen
+                if anno_store is not None:
+                    try:
+                        anno_store.reconcile_generation(live_gen)
+                    except Exception as e:  # noqa: BLE001
+                        # Best-effort marker write (disk full / read-only
+                        # dir); the watcher itself must survive it.
+                        log.error(
+                            "[scene-anno] generation reconcile failed "
+                            "(annotation staleness may be outdated): %s", e,
+                        )
             last_warned = None
             continue
         key = (live_id, live_gen)
@@ -949,8 +982,37 @@ async def _lifecycle_watch(hub: SubscribersHub, binding: MapBinding) -> None:
                 "its startup binding until lifecycle linkage (P3) lands; "
                 "restart scene to rebind.",
                 live_id, live_gen, str(msg.mode),
-                binding.map_id, binding.generation, binding.source,
+                binding.map_id, ref_gen, binding.source,
             )
+            if anno_store is not None and id_ok and not gen_ok:
+                # Same map, new frame epoch: user-drawn geometry may no
+                # longer line up with the rebuilt map. Flag it for user
+                # confirmation (marker-only; deletion is never automatic).
+                try:
+                    n = anno_store.mark_all_stale(
+                        f"map generation {ref_gen}→{live_gen}",
+                        new_generation=live_gen,
+                    )
+                    if n:
+                        log.warning(
+                            "[scene-anno] %d annotation(s) marked stale — "
+                            "confirm or redraw them in the map UI", n,
+                        )
+                except Exception as e:  # noqa: BLE001
+                    # Losing the stale marker is recoverable (next boot's
+                    # load-time epoch check re-judges); losing this watcher
+                    # would silence ALL drift warnings for the session.
+                    log.error(
+                        "[scene-anno] stale marking failed (annotations "
+                        "may show as fresh until restart): %s", e,
+                    )
+            if id_ok:
+                # Acknowledge the new epoch so a THIRD epoch is reported
+                # against this one (accurate from→to in reason/log), and
+                # each bump warns exactly once. The registry's semantic
+                # state stays anchored to the startup binding until the
+                # lifecycle linkage (P3) actually re-anchors it.
+                ref_gen = live_gen
             last_warned = key
 
 
@@ -1040,6 +1102,34 @@ async def _run() -> None:
                 "writes): %s", e,
             )
             obj_store = None
+
+    # User annotations (rooms / POIs) — user-authored semantics on the same
+    # map_id partition rule as the object store; validity is additionally
+    # tracked against mapping's generation epoch (annotations only — the
+    # object store has no epoch concept). A failure here disables the
+    # annotation API for the session (web answers 503) but never blocks
+    # scene itself.
+    anno_store: Optional[AnnotationStore] = None
+    try:
+        anno_store = AnnotationStore(
+            os.environ.get(
+                "SCENE_ANNOTATIONS_DIR", "/data/robonix/scene_annotations"
+            ),
+            map_id=map_id,
+            generation=binding.generation,
+        )
+        anns = anno_store.list()
+        log.info(
+            "[scene-anno] annotation store ready: %d annotation(s), %d stale "
+            "(map_id=%s) at %s",
+            len(anns), sum(a.stale for a in anns), anno_store.map_id,
+            anno_store.path,
+        )
+    except Exception as e:  # noqa: BLE001
+        log.error(
+            "[scene-anno] annotation store init failed — annotation API "
+            "disabled for this session: %s", e,
+        )
     # mcp_tools v0 only needs the registry + the ROS hub (the latter is
     # supplied later in _start_ros_ingest). The geometric relation loop +
     # scene-graph store are wired further down, once the registry is live.
@@ -1102,7 +1192,8 @@ async def _run() -> None:
         # P2 guard: warn when mapping's live map identity drifts from the
         # binding scene started with (P3 will act on it instead).
         asyncio.create_task(
-            _lifecycle_watch(hub, binding), name="scene-lifecycle-watch"
+            _lifecycle_watch(hub, binding, anno_store),
+            name="scene-lifecycle-watch",
         ),
         # Background reconciler: keeps scene's hub adding subscriptions
         # for new ROS2 topic_outs that appear on atlas after start
@@ -1199,6 +1290,13 @@ async def _run() -> None:
             hub=hub,
             detector=perception,
             sg_store=sg_store,
+            anno_store=anno_store,
+            map_binding={
+                "map_id": binding.map_id,
+                "mode": binding.mode,
+                "generation": binding.generation,
+                "source": binding.source,
+            },
         )
         web_uv = uvicorn.Config(
             app=web_app,

--- a/system/scene/scene_service/web.py
+++ b/system/scene/scene_service/web.py
@@ -27,6 +27,7 @@ from starlette.responses import HTMLResponse, JSONResponse
 from starlette.routing import Mount, Route
 from starlette.staticfiles import StaticFiles
 
+from .annotations import validate_annotation_fields
 from .state import ObjectRegistry
 
 log = logging.getLogger(__name__)
@@ -371,13 +372,18 @@ def _camera_payload(hub: Any) -> dict:
 
 
 def _state_payload(registry: ObjectRegistry,
-                   hub: Any, sg_store: Any = None) -> dict:
+                   hub: Any, sg_store: Any = None,
+                   anno_store: Any = None,
+                   map_binding: Optional[dict] = None) -> dict:
     """Serialise the registry + relations + map into the small JSON
     shape the page consumes. Done in one snapshot so the page never
     sees a half-updated registry. The "relations" field shows the fast
     geometric slice (``reachable_by`` only, under the VLM-primary graph);
     the "scene_graph" field shows the full composed graph (geometric +
-    image-grounded relational/semantic edges)."""
+    image-grounded relational/semantic edges). "annotations" carries the
+    user-drawn rooms/POIs (map-frame meters, same coordinates as objects)
+    and "map_binding" the identity scene is bound to — both consumed by
+    the /user annotation page."""
     objs_dict, _surfaces = _sync_snapshot(registry)
     geo_edges = sg_store.get_geometric_edges() if sg_store is not None else []
     out_objects: list[dict[str, Any]] = []
@@ -427,6 +433,8 @@ def _state_payload(registry: ObjectRegistry,
         "scene_graph": sg_payload,
         "robot": robot_pose,
         "occupancy": _occupancy_payload(hub),
+        "annotations": anno_store.list_json() if anno_store is not None else [],
+        "map_binding": map_binding,
         "stamp_unix": time.time(),
     }
 
@@ -448,21 +456,50 @@ def _sync_snapshot(registry: ObjectRegistry):
 
 def make_app(*, registry: ObjectRegistry,
              hub: Any = None, detector: Any = None,
-             sg_store: Any = None) -> Starlette:
+             sg_store: Any = None, anno_store: Any = None,
+             map_binding: Optional[dict] = None) -> Starlette:
     """Build the Starlette ASGI app the entrypoint mounts on its own
     uvicorn server.
 
     Routes:
-      GET /                — 2D top-down map (occupancy grid + objects)
+      GET /                — combined split layout (2D map · 3D · cam)
+      GET /2d              — 2D top-down map (occupancy grid + objects)
       GET /3d              — 3D scene (point clouds + bbox; three.js)
+      GET /cam             — camera stack (live RGB + depth)
+      GET /user            — end-user map page (rooms: draw / rename /
+                             confirm-stale / delete; light object overlay)
       GET /api/state       — JSON for the 2D map
       GET /api/objects3d   — JSON for the 3D viz (per-object pcd + bbox)
+      GET /api/camera      — JSON: latest RGB + depth frames
+      /api/annotations[..] — user annotation CRUD (see below)
 
     `hub` is the SubscribersHub — passed so the JSON state can include
     the latest OccupancyGrid for the 2D canvas underlay.
     `detector` is the ConceptGraphsDetector — passed so the 3D endpoint
     can serialize its persistent MapObjectList. If None, the 3D page
     just shows an empty world.
+    `anno_store` is the AnnotationStore backing the annotation CRUD; when
+    None (store init failed / disabled) those routes answer 503.
+    `map_binding` is a static {map_id, mode, generation, source} dict shown
+    by the /user page header.
+
+    Annotation API contract (STABLE once shipped — any frontend builds on
+    it; see system/scene/README.md):
+      GET    /api/annotations       → {ok, annotations: [...]}
+      POST   /api/annotations       body {kind, name, points, theta?}
+                                    → {ok, annotation}
+      PUT    /api/annotations/{id}  body: any of {name, points, theta,
+                                    stale:false} → {ok, annotation}
+      DELETE /api/annotations/{id}  → {ok}
+    theta (heading, radians) is poi-only — a room carrying it is a 400.
+    On PUT, theta null/absent means "keep"; a set heading cannot be
+    cleared, only changed (deliberate until the poi UI exists).
+    Errors: 400 invalid body/fields, 404 unknown id, 503 store unavailable;
+    those carry {ok: false, detail}. A store write failure (disk full)
+    deliberately escapes as a plain 500 — the edit was NOT saved and hiding
+    that behind a tidy body would be worse. Coordinates are map-frame
+    meters. Same trust domain as the rest of this LAN debug/UI server —
+    no auth.
     """
 
     async def index(_request) -> HTMLResponse:
@@ -477,7 +514,91 @@ def make_app(*, registry: ObjectRegistry,
         return HTMLResponse(_INDEX_HTML)
 
     async def state(_request) -> JSONResponse:
-        return JSONResponse(_state_payload(registry, hub, sg_store))
+        return JSONResponse(
+            _state_payload(registry, hub, sg_store, anno_store, map_binding)
+        )
+
+    # ── annotation CRUD ──────────────────────────────────────────────
+    def _anno_error(status: int, detail: str) -> JSONResponse:
+        return JSONResponse({"ok": False, "detail": detail}, status_code=status)
+
+    async def _anno_body(request) -> Optional[dict]:
+        """Parse the JSON request body; None (→ caller answers 400) when
+        it is missing, malformed, or not an object."""
+        try:
+            body = await request.json()
+        except Exception:  # noqa: BLE001 — malformed body is a client error
+            return None
+        return body if isinstance(body, dict) else None
+
+    async def annotations_list(_request) -> JSONResponse:
+        if anno_store is None:
+            return _anno_error(503, "annotation store unavailable")
+        return JSONResponse({"ok": True, "annotations": anno_store.list_json()})
+
+    async def annotations_create(request) -> JSONResponse:
+        """POST /api/annotations — validate {kind, name, points, theta?}
+        and persist a new annotation (returned with its generated id)."""
+        if anno_store is None:
+            return _anno_error(503, "annotation store unavailable")
+        body = await _anno_body(request)
+        if body is None:
+            return _anno_error(400, "request body must be a JSON object")
+        kind = body.get("kind")
+        name = body.get("name", "")
+        points = body.get("points")
+        theta = body.get("theta")
+        err = validate_annotation_fields(kind, name, points, theta)
+        if err:
+            return _anno_error(400, err)
+        ann = anno_store.create(kind=kind, name=name, points=points, theta=theta)
+        return JSONResponse({"ok": True, "annotation": ann.to_json()})
+
+    async def annotations_update(request) -> JSONResponse:
+        """PUT /api/annotations/{id} — partial update: any of name /
+        points / theta / stale:false (the user's "confirm still valid").
+        Provided fields are validated against the annotation's kind."""
+        if anno_store is None:
+            return _anno_error(503, "annotation store unavailable")
+        ann_id = request.path_params["annotation_id"]
+        existing = anno_store.get(ann_id)
+        if existing is None:
+            return _anno_error(404, f"unknown annotation id {ann_id!r}")
+        body = await _anno_body(request)
+        if body is None:
+            return _anno_error(400, "request body must be a JSON object")
+        name = body.get("name")
+        points = body.get("points")
+        theta = body.get("theta")
+        # Validate the would-be merged state so a partial update can never
+        # store something a create would have rejected.
+        err = validate_annotation_fields(
+            existing.kind,
+            name if name is not None else existing.name,
+            points if points is not None else existing.points,
+            theta if theta is not None else existing.theta,
+        )
+        if err:
+            return _anno_error(400, err)
+        clear_stale = body.get("stale") is False
+        ann = anno_store.update(
+            ann_id, name=name, points=points, theta=theta,
+            clear_stale=clear_stale,
+        )
+        if ann is None:  # deleted between get and update — still a 404
+            return _anno_error(404, f"unknown annotation id {ann_id!r}")
+        return JSONResponse({"ok": True, "annotation": ann.to_json()})
+
+    async def annotations_delete(request) -> JSONResponse:
+        """DELETE /api/annotations/{id} — remove the annotation; 404 when
+        the id is unknown (delete is the user's explicit action, so unlike
+        staleness it IS allowed to drop a user asset)."""
+        if anno_store is None:
+            return _anno_error(503, "annotation store unavailable")
+        ann_id = request.path_params["annotation_id"]
+        if not anno_store.delete(ann_id):
+            return _anno_error(404, f"unknown annotation id {ann_id!r}")
+        return JSONResponse({"ok": True})
 
     async def index3d(_request) -> HTMLResponse:
         return HTMLResponse(_INDEX_3D_HTML)
@@ -489,6 +610,9 @@ def make_app(*, registry: ObjectRegistry,
 
     async def cam(_request) -> HTMLResponse:
         return HTMLResponse(_INDEX_CAM_HTML)
+
+    async def user_page(_request) -> HTMLResponse:
+        return HTMLResponse(_USER_HTML)
 
     async def camera_state(_request) -> JSONResponse:
         return JSONResponse(_camera_payload(hub))
@@ -504,9 +628,16 @@ def make_app(*, registry: ObjectRegistry,
         Route("/2d", index2d, methods=["GET"]),
         Route("/3d", index3d, methods=["GET"]),
         Route("/cam", cam, methods=["GET"]),
+        Route("/user", user_page, methods=["GET"]),
         Route("/api/state", state, methods=["GET"]),
         Route("/api/objects3d", objects3d, methods=["GET"]),
         Route("/api/camera", camera_state, methods=["GET"]),
+        Route("/api/annotations", annotations_list, methods=["GET"]),
+        Route("/api/annotations", annotations_create, methods=["POST"]),
+        Route("/api/annotations/{annotation_id}", annotations_update,
+              methods=["PUT"]),
+        Route("/api/annotations/{annotation_id}", annotations_delete,
+              methods=["DELETE"]),
     ]
     if static_dir.is_dir():
         routes.append(Mount("/static", StaticFiles(directory=str(static_dir)), name="static"))
@@ -1696,6 +1827,419 @@ _INDEX_3D_HTML = r"""<!doctype html>
     }
     requestAnimationFrame(loop);
   </script>
+</body>
+</html>
+"""
+
+
+# ── User annotation page (/user) ─────────────────────────────────────────────
+# The end-user map page: SLAM occupancy underlay + LIGHTWEIGHT object overlay
+# + user-drawn room polygons, with a draw-a-room flow talking to the
+# /api/annotations CRUD. Deliberately self-contained (own inline JS, no
+# imports from the debug pages' scripts): the two pages evolve independently
+# and a debug-UI tweak must never break the user page. Kept dependency-free
+# like every other page here (no framework, no build step).
+_USER_HTML = r"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>robonix — map & rooms</title>
+  <style>
+    :root { --fg:#e8eaed; --bg:#0e1015; --panel:#161a22; --acc:#7aa7ff;
+            --muted:#7d828b; --warn:#e6c454; --danger:#e06c75; }
+    html, body { background: var(--bg); color: var(--fg); margin: 0; height: 100%;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    #app { display: flex; flex-direction: column; height: 100vh; }
+    header { display: flex; align-items: center; gap: 14px; padding: 10px 16px;
+      background: var(--panel); border-bottom: 1px solid #232936; flex: none; }
+    header h1 { font-size: 15px; margin: 0; font-weight: 600; }
+    header .meta { font-size: 12px; color: var(--muted); }
+    header .stale-alert { font-size: 12px; color: var(--warn); display: none; }
+    #main { display: flex; flex: 1; min-height: 0; }
+    #panel { width: 260px; flex: none; background: var(--panel);
+      border-right: 1px solid #232936; display: flex; flex-direction: column; }
+    #panel .actions { padding: 12px; border-bottom: 1px solid #232936; }
+    button { background: #222a3a; color: var(--fg); border: 1px solid #33405a;
+      border-radius: 6px; padding: 6px 10px; font-size: 12px; cursor: pointer; }
+    button:hover { background: #2a3550; }
+    button.primary { background: #2b4a86; border-color: #3c62ad; }
+    button.primary.active { background: var(--acc); color: #0e1015; }
+    button.small { padding: 2px 7px; font-size: 11px; }
+    button.danger { border-color: #6b3640; color: var(--danger); }
+    #room-list { flex: 1; overflow-y: auto; padding: 8px 12px; }
+    .room { border: 1px solid #232936; border-radius: 8px; padding: 8px 10px;
+      margin-bottom: 8px; font-size: 13px; }
+    .room.selected { border-color: var(--acc); }
+    .room .name { font-weight: 600; }
+    .room .sub { color: var(--muted); font-size: 11px; margin: 3px 0 6px; }
+    .room .badge { color: #0e1015; background: var(--warn); border-radius: 4px;
+      padding: 0 5px; font-size: 10px; font-weight: 700; margin-left: 6px; }
+    .room .btns { display: flex; gap: 6px; }
+    #canvas-wrap { position: relative; flex: 1; min-width: 0; }
+    canvas { display: block; width: 100%; height: 100%; background: #14171f; }
+    #hint { position: absolute; top: 10px; left: 50%; transform: translateX(-50%);
+      background: rgba(20,23,31,.92); border: 1px solid #33405a; color: var(--fg);
+      font-size: 12px; padding: 6px 12px; border-radius: 6px; display: none; }
+    #toast { position: absolute; bottom: 14px; left: 50%; transform: translateX(-50%);
+      background: rgba(20,23,31,.95); border: 1px solid #6b3640; color: var(--danger);
+      font-size: 12px; padding: 6px 12px; border-radius: 6px; display: none; }
+    .legend { position: absolute; bottom: 8px; left: 12px; font-size: 11px;
+      color: var(--muted); background: rgba(20,23,31,.85); padding: 4px 8px;
+      border-radius: 4px; }
+    #empty { padding: 10px 2px; color: var(--muted); font-size: 12px; }
+  </style>
+</head>
+<body>
+<div id="app">
+  <header>
+    <h1>Map &amp; rooms</h1>
+    <span class="meta" id="meta">map: —</span>
+    <span class="stale-alert" id="stale-alert">⚠ map was rebuilt — review stale rooms</span>
+  </header>
+  <div id="main">
+    <div id="panel">
+      <div class="actions">
+        <button class="primary" id="btn-draw">✏ Annotate room</button>
+      </div>
+      <div id="room-list"><div id="empty">No rooms yet. Click “Annotate room”,
+        then click on the map to outline one (double-click or Enter to finish,
+        Esc to cancel).</div></div>
+    </div>
+    <div id="canvas-wrap">
+      <canvas id="c"></canvas>
+      <div id="hint"></div>
+      <div id="toast"></div>
+      <div class="legend">drag to pan · wheel to zoom · hover a dot for its label</div>
+    </div>
+  </div>
+</div>
+<script>
+const c = document.getElementById('c');
+const ctx = c.getContext('2d');
+function fit() { c.width = c.clientWidth; c.height = c.clientHeight; }
+window.addEventListener('resize', fit); fit();
+
+// ── view transform (world meters ↔ canvas px) ────────────────────────────
+// Unlike the debug page (which chases the robot) the editor keeps a STABLE
+// user-controlled view: drawing needs the map to hold still under the mouse.
+let center = [0, 0];
+let pxPerM = 40;
+let viewInit = false;
+function w2p(x, y) {
+    return [c.width / 2 + (x - center[0]) * pxPerM,
+            c.height / 2 - (y - center[1]) * pxPerM];
+}
+function p2w(px, py) {
+    return [center[0] + (px - c.width / 2) / pxPerM,
+            center[1] - (py - c.height / 2) / pxPerM];
+}
+
+// ── state ────────────────────────────────────────────────────────────────
+let state = null;          // last /api/state payload
+let occImg = null, occMeta = null, occStamp = 0, occLoading = 0;
+let drawMode = false;
+let draft = [];            // in-progress polygon vertices (world coords)
+let mouseWorld = null;     // live cursor position for the rubber-band edge
+let hoverObj = null;
+let selectedId = null;
+
+const hintEl = document.getElementById('hint');
+function setHint(text) {
+    hintEl.style.display = text ? 'block' : 'none';
+    hintEl.textContent = text || '';
+}
+let toastTimer = null;
+function toast(text) {
+    const t = document.getElementById('toast');
+    t.textContent = text; t.style.display = 'block';
+    clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => { t.style.display = 'none'; }, 4000);
+}
+
+// ── rendering ────────────────────────────────────────────────────────────
+function polyCentroid(pts) {
+    let sx = 0, sy = 0;
+    for (const [x, y] of pts) { sx += x; sy += y; }
+    return [sx / pts.length, sy / pts.length];
+}
+
+function draw() {
+    fit();
+    ctx.clearRect(0, 0, c.width, c.height);
+    if (!state) return;
+
+    // occupancy underlay (same decode/anchor math as the debug 2D page:
+    // cell [0,0] at world origin, y flipped because image y grows down).
+    // occStamp only advances on successful decode, so a corrupt frame is
+    // retried on the next poll instead of wedging the underlay.
+    if (state.occupancy && state.occupancy.stamp_ms !== occStamp
+        && state.occupancy.stamp_ms !== occLoading) {
+        occLoading = state.occupancy.stamp_ms;
+        const meta = state.occupancy;
+        const im = new Image();
+        im.onload = () => { occImg = im; occMeta = meta; occStamp = meta.stamp_ms; };
+        im.onerror = () => { occLoading = 0; console.error('occupancy PNG decode failed'); };
+        im.src = 'data:image/png;base64,' + meta.png_b64;
+    }
+    if (occImg && occMeta) {
+        if (!viewInit) {   // first grid: fit it into the viewport once
+            const wM = occMeta.width * occMeta.resolution;
+            const hM = occMeta.height * occMeta.resolution;
+            center = [occMeta.origin_x + wM / 2, occMeta.origin_y + hM / 2];
+            pxPerM = Math.min((c.width - 40) / wM, (c.height - 40) / hM, 120);
+            pxPerM = Math.max(pxPerM, 5);
+            viewInit = true;
+        }
+        const wM = occMeta.width * occMeta.resolution;
+        const hM = occMeta.height * occMeta.resolution;
+        const [x0, y0] = w2p(occMeta.origin_x, occMeta.origin_y + hM);
+        ctx.globalAlpha = 0.9;
+        ctx.imageSmoothingEnabled = false;
+        ctx.drawImage(occImg, x0, y0, wM * pxPerM, hM * pxPerM);
+        ctx.globalAlpha = 1.0;
+    } else {
+        ctx.fillStyle = '#7d828b'; ctx.font = '13px sans-serif';
+        ctx.fillText('no map yet — the SLAM map appears here once mapping publishes it', 20, 30);
+    }
+
+    // saved rooms
+    for (const a of (state.annotations || [])) {
+        if (a.kind !== 'room' || a.points.length < 3) continue;
+        const pts = a.points.map(p => w2p(p[0], p[1]));
+        ctx.beginPath();
+        pts.forEach(([x, y], i) => i ? ctx.lineTo(x, y) : ctx.moveTo(x, y));
+        ctx.closePath();
+        const sel = a.annotation_id === selectedId;
+        ctx.fillStyle = a.stale ? 'rgba(230,196,84,0.10)' : 'rgba(122,167,255,0.12)';
+        ctx.fill();
+        ctx.lineWidth = sel ? 2.5 : 1.5;
+        ctx.strokeStyle = a.stale ? '#e6c454' : (sel ? '#a8c4ff' : '#7aa7ff');
+        ctx.setLineDash(a.stale ? [6, 4] : []);
+        ctx.stroke();
+        ctx.setLineDash([]);
+        const [cx, cy] = w2p(...polyCentroid(a.points));
+        const label = (a.stale ? '⚠ ' : '') + (a.name || '(unnamed)');
+        ctx.font = 'bold 13px sans-serif'; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+        ctx.lineWidth = 3; ctx.strokeStyle = 'rgba(0,0,0,0.85)';
+        ctx.strokeText(label, cx, cy);
+        ctx.fillStyle = a.stale ? '#e6c454' : '#cfe0ff';
+        ctx.fillText(label, cx, cy);
+        ctx.textAlign = 'start';
+    }
+
+    // objects — small translucent dots; label only on hover (readability:
+    // the underlay must stay legible, objects are a light overlay).
+    for (const o of (state.objects || [])) {
+        if (o.cls === 'robot') continue;
+        const [px, py] = w2p(o.pose.x, o.pose.y);
+        ctx.globalAlpha = o.missing ? 0.25 : 0.6;
+        ctx.fillStyle = '#9ab8e8';
+        ctx.beginPath(); ctx.arc(px, py, 3.5, 0, Math.PI * 2); ctx.fill();
+        ctx.globalAlpha = 1;
+        ctx.lineWidth = 1; ctx.strokeStyle = 'rgba(14,16,21,0.9)';
+        ctx.stroke();
+    }
+    if (hoverObj) {
+        const [px, py] = w2p(hoverObj.pose.x, hoverObj.pose.y);
+        ctx.font = '12px ui-monospace, monospace'; ctx.textBaseline = 'middle';
+        ctx.lineWidth = 3; ctx.strokeStyle = 'rgba(0,0,0,0.85)';
+        ctx.strokeText(hoverObj.cls, px + 8, py);
+        ctx.fillStyle = '#cfe0ff';
+        ctx.fillText(hoverObj.cls, px + 8, py);
+    }
+
+    // robot marker (small arrow, subtle)
+    const robot = state.robot;
+    if (robot) {
+        const [rx, ry] = w2p(robot.x, robot.y);
+        const yaw = robot.yaw || 0;
+        ctx.strokeStyle = '#7aa7ff'; ctx.fillStyle = '#7aa7ff'; ctx.lineWidth = 2;
+        ctx.beginPath(); ctx.arc(rx, ry, 5, 0, Math.PI * 2); ctx.stroke();
+        ctx.beginPath();
+        ctx.moveTo(rx, ry);
+        ctx.lineTo(rx + Math.cos(yaw) * 14, ry - Math.sin(yaw) * 14);
+        ctx.stroke();
+    }
+
+    // draft polygon (draw mode)
+    if (drawMode && draft.length) {
+        const pts = draft.map(p => w2p(p[0], p[1]));
+        ctx.beginPath();
+        pts.forEach(([x, y], i) => i ? ctx.lineTo(x, y) : ctx.moveTo(x, y));
+        if (mouseWorld) { const [mx, my] = w2p(...mouseWorld); ctx.lineTo(mx, my); }
+        ctx.strokeStyle = '#8ef0b7'; ctx.lineWidth = 2; ctx.setLineDash([5, 4]);
+        ctx.stroke(); ctx.setLineDash([]);
+        ctx.fillStyle = '#8ef0b7';
+        for (const [x, y] of pts) {
+            ctx.beginPath(); ctx.arc(x, y, 3, 0, Math.PI * 2); ctx.fill();
+        }
+    }
+}
+
+// ── side panel ───────────────────────────────────────────────────────────
+function esc(s) {
+    return String(s).replace(/[&<>"']/g,
+        ch => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch]));
+}
+function renderPanel() {
+    const rooms = (state && state.annotations || []).filter(a => a.kind === 'room');
+    const list = document.getElementById('room-list');
+    const anyStale = rooms.some(a => a.stale);
+    document.getElementById('stale-alert').style.display = anyStale ? 'inline' : 'none';
+    if (!rooms.length) {
+        list.innerHTML = '<div id="empty">No rooms yet. Click “Annotate room”, ' +
+          'then click on the map to outline one (double-click or Enter to ' +
+          'finish, Esc to cancel).</div>';
+        return;
+    }
+    list.innerHTML = rooms.map(a => `
+      <div class="room ${a.annotation_id === selectedId ? 'selected' : ''}"
+           data-id="${a.annotation_id}">
+        <span class="name">${esc(a.name || '(unnamed)')}</span>
+        ${a.stale ? '<span class="badge" title="' + esc(a.stale_reason) + '">STALE</span>' : ''}
+        <div class="sub">${a.points.length} corners</div>
+        <div class="btns">
+          <button class="small" data-act="rename">Rename</button>
+          ${a.stale ? '<button class="small" data-act="confirm">Still valid</button>' : ''}
+          <button class="small danger" data-act="delete">Delete</button>
+        </div>
+      </div>`).join('');
+}
+document.getElementById('room-list').addEventListener('click', async (ev) => {
+    const roomEl = ev.target.closest('.room');
+    if (!roomEl) return;
+    const id = roomEl.dataset.id;
+    const act = ev.target.dataset && ev.target.dataset.act;
+    if (!act) { selectedId = (selectedId === id) ? null : id; renderPanel(); draw(); return; }
+    const room = (state.annotations || []).find(a => a.annotation_id === id);
+    if (!room) return;
+    if (act === 'rename') {
+        const name = prompt('Room name:', room.name);
+        if (name !== null) await api('PUT', '/api/annotations/' + id, { name });
+    } else if (act === 'confirm') {
+        await api('PUT', '/api/annotations/' + id, { stale: false });
+    } else if (act === 'delete') {
+        if (confirm(`Delete room “${room.name}”?`))
+            await api('DELETE', '/api/annotations/' + id);
+    }
+});
+
+// ── draw mode ────────────────────────────────────────────────────────────
+const btnDraw = document.getElementById('btn-draw');
+function setDrawMode(on) {
+    drawMode = on;
+    draft = [];
+    btnDraw.classList.toggle('active', on);
+    btnDraw.textContent = on ? '✕ Cancel drawing' : '✏ Annotate room';
+    c.style.cursor = on ? 'crosshair' : 'grab';
+    setHint(on ? 'Click to add corners · double-click or Enter to finish (≥3) · Esc to cancel' : '');
+    draw();
+}
+btnDraw.addEventListener('click', () => setDrawMode(!drawMode));
+
+async function finishDraft() {
+    if (draft.length < 3) { toast('A room needs at least 3 corners.'); return; }
+    const name = prompt('Room name:', '');
+    if (name === null) return;          // keep drawing
+    const body = { kind: 'room', name, points: draft };
+    if (await api('POST', '/api/annotations', body)) setDrawMode(false);
+}
+
+// ── canvas input: pan / zoom / vertex clicks / hover ─────────────────────
+let dragging = false, dragMoved = false, lastPos = null;
+c.style.cursor = 'grab';
+c.addEventListener('mousedown', (ev) => {
+    dragging = true; dragMoved = false; lastPos = [ev.offsetX, ev.offsetY];
+});
+window.addEventListener('mouseup', () => { dragging = false; });
+c.addEventListener('mousemove', (ev) => {
+    mouseWorld = p2w(ev.offsetX, ev.offsetY);
+    if (dragging && lastPos) {
+        const dx = ev.offsetX - lastPos[0], dy = ev.offsetY - lastPos[1];
+        if (Math.abs(dx) + Math.abs(dy) > 3) dragMoved = true;
+        if (dragMoved) {
+            center = [center[0] - dx / pxPerM, center[1] + dy / pxPerM];
+            lastPos = [ev.offsetX, ev.offsetY];
+        }
+    } else if (!drawMode && state) {
+        hoverObj = null;
+        for (const o of (state.objects || [])) {
+            if (o.cls === 'robot') continue;
+            const [px, py] = w2p(o.pose.x, o.pose.y);
+            if ((px - ev.offsetX) ** 2 + (py - ev.offsetY) ** 2 < 100) { hoverObj = o; break; }
+        }
+    }
+    draw();
+});
+c.addEventListener('click', (ev) => {
+    if (dragMoved) return;              // that was a pan, not a click
+    if (drawMode) { draft.push(p2w(ev.offsetX, ev.offsetY)); draw(); }
+});
+c.addEventListener('dblclick', (ev) => {
+    ev.preventDefault();
+    if (drawMode) {
+        // the dblclick's two single clicks added two duplicate corners at
+        // the same spot — drop one before closing.
+        if (draft.length > 1) draft.pop();
+        finishDraft();
+    }
+});
+window.addEventListener('keydown', (ev) => {
+    if (!drawMode) return;
+    if (ev.key === 'Escape') setDrawMode(false);
+    if (ev.key === 'Enter') finishDraft();
+});
+c.addEventListener('wheel', (ev) => {
+    ev.preventDefault();
+    const factor = ev.deltaY < 0 ? 1.15 : 1 / 1.15;
+    // zoom about the cursor so the point under the mouse stays put
+    const [wx, wy] = p2w(ev.offsetX, ev.offsetY);
+    pxPerM = Math.min(400, Math.max(3, pxPerM * factor));
+    const [nx, ny] = p2w(ev.offsetX, ev.offsetY);
+    center = [center[0] + (wx - nx), center[1] + (wy - ny)];
+    draw();
+}, { passive: false });
+
+// ── API + polling ────────────────────────────────────────────────────────
+async function api(method, path, body) {
+    try {
+        const r = await fetch(path, {
+            method,
+            headers: body !== undefined ? { 'Content-Type': 'application/json' } : {},
+            body: body !== undefined ? JSON.stringify(body) : undefined,
+        });
+        const out = await r.json().catch(() => null);
+        if (!r.ok || !out || out.ok === false) {
+            toast((out && out.detail) || (method + ' failed (' + r.status + ')'));
+            return null;
+        }
+        await refresh();
+        return out;
+    } catch (e) { toast('request failed: ' + e); return null; }
+}
+
+async function refresh() {
+    // Only the network fetch/parse is try-guarded (transient by nature);
+    // a bug thrown by the render functions must surface in the console,
+    // not be swallowed once a second forever.
+    let next = null;
+    try {
+        const r = await fetch('/api/state', { cache: 'no-store' });
+        if (!r.ok) return;
+        next = await r.json();
+    } catch (_) { return; /* transient; next poll retries */ }
+    state = next;
+    const mb = state.map_binding;
+    document.getElementById('meta').textContent = mb
+        ? `map: ${mb.map_id} · ${mb.mode || 'mode unknown'}`
+        : 'map: —';
+    renderPanel();
+    draw();
+}
+// 1 Hz is plenty for an editor page (the debug page polls at 5 Hz).
+setInterval(refresh, 1000);
+refresh();
+</script>
 </body>
 </html>
 """

--- a/system/scene/scene_service/web.py
+++ b/system/scene/scene_service/web.py
@@ -870,6 +870,26 @@ def make_app(*, registry: ObjectRegistry,
         if not map_id:
             return _anno_error(400, "map_id is required")
         out = await asyncio.to_thread(_map_rpc, "delete_map", {"map_id": map_id})
+        if out.get("ok"):
+            annotations_deleted = False
+            objects_deleted = 0
+            cleanup_errors = []
+            if anno_store is not None:
+                try:
+                    annotations_deleted = bool(anno_store.delete_map(map_id))
+                except Exception as e:  # noqa: BLE001
+                    cleanup_errors.append(f"annotations: {e}")
+            if object_store is not None:
+                try:
+                    objects_deleted = int(await asyncio.to_thread(object_store.delete_map, map_id))
+                except Exception as e:  # noqa: BLE001
+                    cleanup_errors.append(f"objects: {e}")
+            out["scene_cleanup"] = {
+                "annotations_deleted": annotations_deleted,
+                "objects_deleted": objects_deleted,
+            }
+            if cleanup_errors:
+                out["scene_cleanup_error"] = "; ".join(cleanup_errors)
         return JSONResponse(out, status_code=200 if out.get("ok") else 502)
 
     async def maps_pose_estimate(request) -> JSONResponse:

--- a/system/scene/scene_service/web.py
+++ b/system/scene/scene_service/web.py
@@ -2231,7 +2231,8 @@ _USER_HTML = r"""<!doctype html>
       border: 1px solid #33405a; color: var(--muted); font-size: 11px; }
     #mode-pill.localization { border-color: #3b633f; color: #8ef0b7; background: rgba(64,150,80,.12); }
     #mode-pill.mapping { border-color: #6a5630; color: var(--warn); background: rgba(230,196,84,.10); }
-    #map-list { display: grid; gap: 6px; max-height: 170px; overflow-y: auto; }
+    #map-list { display: grid; gap: 5px; max-height: min(24vh, 190px); overflow-y: auto;
+      overscroll-behavior: contain; scrollbar-gutter: stable; }
     .mapitem { border: 1px solid #232936; border-radius: 8px; padding: 7px 8px; font-size: 12px; background: #121721; cursor: pointer; }
     .mapitem.selected, .mapitem.busy { border-color: var(--acc); }
     .mapitem .name { font-weight: 700; }
@@ -2245,12 +2246,16 @@ _USER_HTML = r"""<!doctype html>
     button.primary.active { background: var(--acc); color: #0e1015; }
     button.small { padding: 2px 7px; font-size: 11px; }
     button.danger { border-color: #6b3640; color: var(--danger); }
-    #room-list { flex: 1; overflow-y: auto; padding: 8px 12px; }
-    .room { border: 1px solid #232936; border-radius: 8px; padding: 8px 10px;
-      margin-bottom: 8px; font-size: 13px; }
+    #room-list { flex: 1; min-height: 0; overflow-y: auto; padding: 7px 10px;
+      overscroll-behavior: contain; scrollbar-gutter: stable; }
+    .room { --room-color: var(--acc); border: 1px solid #232936;
+      border-left: 3px solid var(--room-color); border-radius: 7px; padding: 6px 8px;
+      margin-bottom: 6px; font-size: 12px; }
     .room.selected { border-color: var(--acc); }
-    .room .name { font-weight: 600; }
-    .room .sub { color: var(--muted); font-size: 11px; margin: 3px 0 6px; }
+    .room .name { font-weight: 650; }
+    .room .swatch { display: inline-block; width: 8px; height: 8px; margin-right: 6px;
+      border-radius: 2px; background: var(--room-color); vertical-align: 1px; }
+    .room .sub { color: var(--muted); font-size: 10px; margin: 2px 0 5px 14px; }
     .room .badge { color: #0e1015; background: var(--warn); border-radius: 4px;
       padding: 0 5px; font-size: 10px; font-weight: 700; margin-left: 6px; }
     .room .btns { display: flex; gap: 6px; }
@@ -2416,9 +2421,42 @@ function setMapItemStatus(id, text) {
 
 // ── rendering ────────────────────────────────────────────────────────────
 function polyCentroid(pts) {
-    let sx = 0, sy = 0;
-    for (const [x, y] of pts) { sx += x; sy += y; }
-    return [sx / pts.length, sy / pts.length];
+    // Area-weighted polygon centroid. Averaging vertices visibly shifts labels
+    // for irregular rooms because densely sampled edges receive extra weight.
+    let twiceArea = 0, sx = 0, sy = 0;
+    for (let i = 0; i < pts.length; i++) {
+        const [x0, y0] = pts[i];
+        const [x1, y1] = pts[(i + 1) % pts.length];
+        const cross = x0 * y1 - x1 * y0;
+        twiceArea += cross;
+        sx += (x0 + x1) * cross;
+        sy += (y0 + y1) * cross;
+    }
+    if (Math.abs(twiceArea) < 1e-9) {
+        const sum = pts.reduce(([x, y], p) => [x + p[0], y + p[1]], [0, 0]);
+        return [sum[0] / pts.length, sum[1] / pts.length];
+    }
+    return [sx / (3 * twiceArea), sy / (3 * twiceArea)];
+}
+
+const ROOM_COLORS = [
+    { stroke:'#63a7ff', fill:'rgba(99,167,255,.18)', label:'#d8e9ff' },
+    { stroke:'#5fd6a7', fill:'rgba(95,214,167,.18)', label:'#d2f8e9' },
+    { stroke:'#f0aa5d', fill:'rgba(240,170,93,.18)', label:'#ffe7cd' },
+    { stroke:'#c58cff', fill:'rgba(197,140,255,.18)', label:'#eedcff' },
+    { stroke:'#ef7f9c', fill:'rgba(239,127,156,.18)', label:'#ffd9e3' },
+    { stroke:'#55c8dd', fill:'rgba(85,200,221,.18)', label:'#d4f7fc' },
+    { stroke:'#d5c456', fill:'rgba(213,196,86,.18)', label:'#fff6bd' },
+    { stroke:'#8fcf66', fill:'rgba(143,207,102,.18)', label:'#e3f8d5' },
+];
+function roomColor(annotation) {
+    const key = String(annotation.annotation_id || annotation.name || 'room');
+    let hash = 2166136261;
+    for (let i = 0; i < key.length; i++) {
+        hash ^= key.charCodeAt(i);
+        hash = Math.imul(hash, 16777619);
+    }
+    return ROOM_COLORS[(hash >>> 0) % ROOM_COLORS.length];
 }
 
 function draw() {
@@ -2468,19 +2506,20 @@ function draw() {
         pts.forEach(([x, y], i) => i ? ctx.lineTo(x, y) : ctx.moveTo(x, y));
         ctx.closePath();
         const sel = a.annotation_id === selectedId;
-        ctx.fillStyle = a.stale ? 'rgba(230,196,84,0.10)' : 'rgba(122,167,255,0.12)';
+        const color = roomColor(a);
+        ctx.fillStyle = a.stale ? 'rgba(230,196,84,0.12)' : color.fill;
         ctx.fill();
         ctx.lineWidth = sel ? 2.5 : 1.5;
-        ctx.strokeStyle = a.stale ? '#e6c454' : (sel ? '#a8c4ff' : '#7aa7ff');
+        ctx.strokeStyle = a.stale ? '#e6c454' : color.stroke;
         ctx.setLineDash(a.stale ? [6, 4] : []);
         ctx.stroke();
         ctx.setLineDash([]);
         const [cx, cy] = w2p(...polyCentroid(a.points));
         const label = (a.stale ? '⚠ ' : '') + (a.name || '(unnamed)');
-        ctx.font = 'bold 13px sans-serif'; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
-        ctx.lineWidth = 3; ctx.strokeStyle = 'rgba(0,0,0,0.85)';
+        ctx.font = '700 15px sans-serif'; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+        ctx.lineWidth = 5; ctx.strokeStyle = 'rgba(0,0,0,0.92)';
         ctx.strokeText(label, cx, cy);
-        ctx.fillStyle = a.stale ? '#e6c454' : '#cfe0ff';
+        ctx.fillStyle = a.stale ? '#f4dc78' : color.label;
         ctx.fillText(label, cx, cy);
         ctx.textAlign = 'start';
     }
@@ -2777,8 +2816,8 @@ function renderPanel() {
     }
     list.innerHTML = rooms.map(a => `
       <div class="room ${a.annotation_id === selectedId ? 'selected' : ''}"
-           data-id="${a.annotation_id}">
-        <span class="name">${esc(a.name || '(unnamed)')}</span>
+           data-id="${a.annotation_id}" style="--room-color:${roomColor(a).stroke}">
+        <span class="swatch" aria-hidden="true"></span><span class="name">${esc(a.name || '(unnamed)')}</span>
         ${a.stale ? '<span class="badge" title="' + esc(a.stale_reason) + '">STALE</span>' : ''}
         <div class="sub">${a.points.length} corners</div>
         <div class="btns">

--- a/system/scene/scene_service/web.py
+++ b/system/scene/scene_service/web.py
@@ -15,9 +15,13 @@ the JSON will grow an `occupancy:` field that the canvas overlays).
 """
 from __future__ import annotations
 
+import asyncio
+import math
 import base64
 import io
+import json
 import logging
+import os
 import time
 from pathlib import Path
 from typing import Any, Optional
@@ -26,6 +30,8 @@ from starlette.applications import Starlette
 from starlette.responses import HTMLResponse, JSONResponse
 from starlette.routing import Mount, Route
 from starlette.staticfiles import StaticFiles
+
+from robonix_api import ATLAS
 
 from .annotations import validate_annotation_fields
 from .state import ObjectRegistry
@@ -454,9 +460,116 @@ def _sync_snapshot(registry: ObjectRegistry):
     return dict(registry._objects), dict(registry._surfaces)  # noqa: SLF001
 
 
+_MAP_RPC = {
+    "list_maps": (
+        "robonix/service/map/list_maps",
+        "RobonixServiceMapListMapsStub",
+        "ListMaps",
+        "ListMaps_Request",
+    ),
+    "save_map": (
+        "robonix/service/map/save_map",
+        "RobonixServiceMapSaveMapStub",
+        "SaveMap",
+        "SaveMap_Request",
+    ),
+    "load_map": (
+        "robonix/service/map/load_map",
+        "RobonixServiceMapLoadMapStub",
+        "LoadMap",
+        "LoadMap_Request",
+    ),
+    "delete_map": (
+        "robonix/service/map/delete_map",
+        "RobonixServiceMapDeleteMapStub",
+        "DeleteMap",
+        "DeleteMap_Request",
+    ),
+    "pose_estimate": (
+        "robonix/service/map/pose_estimate",
+        "RobonixServiceMapPoseEstimateStub",
+        "PoseEstimate",
+        "PoseEstimate_Request",
+    ),
+    "get_pose": (
+        "robonix/service/map/get_pose",
+        "RobonixServiceMapGetPoseStub",
+        "GetPose",
+        "GetPose_Request",
+    ),
+    "get_mode": (
+        "robonix/service/map/get_mode",
+        "RobonixServiceMapGetModeStub",
+        "GetMode",
+        "GetMode_Request",
+    ),
+}
+
+
+def _pb_to_dict(resp: Any) -> dict:
+    out: dict[str, Any] = {}
+    for field, value in resp.ListFields():
+        out[field.name] = value
+    return out
+
+
+def _map_rpc(op: str, payload: Optional[dict] = None, timeout_s: float = 20.0) -> dict:
+    """Call mapping through the standard robonix/service/map capability.
+
+    The user page talks only to scene HTTP. Scene then resolves mapping via
+    Atlas + gRPC so this does not depend on mapping's debug Web UI or shared
+    container paths.
+    """
+    import grpc  # lazy: web debug imports should not fail without grpc
+    import map_pb2  # type: ignore
+    import robonix_contracts_pb2_grpc as contracts_grpc  # type: ignore
+
+    contract_id, stub_name, method_name, req_name = _MAP_RPC[op]
+    caps = ATLAS.find_capability(contract_id=contract_id, transport="grpc")
+    if not caps:
+        return {"ok": False, "detail": f"no provider for {contract_id}"}
+    cap = caps[0]
+    channel_ref = ATLAS.connect_capability(
+        consumer_id="scene",
+        provider_id=cap.provider_id,
+        contract_id=contract_id,
+        transport="grpc",
+    )
+    try:
+        endpoint = (channel_ref.endpoint or "").strip()
+        if not endpoint:
+            return {"ok": False, "detail": f"{contract_id} resolved to an empty endpoint"}
+        with grpc.insecure_channel(endpoint) as grpc_channel:
+            stub = getattr(contracts_grpc, stub_name)(grpc_channel)
+            req = getattr(map_pb2, req_name)(**(payload or {}))
+            resp = getattr(stub, method_name)(req, timeout=timeout_s)
+        return _pb_to_dict(resp)
+    except grpc.RpcError as e:
+        return {"ok": False, "detail": f"{contract_id} rpc failed: {e.code().name}: {e.details()}"}
+    except Exception as e:  # noqa: BLE001
+        log.exception("scene map rpc %s failed", contract_id)
+        return {"ok": False, "detail": str(e)}
+    finally:
+        channel_ref.close()
+
+
+def _maps_payload() -> dict:
+    out = _map_rpc("list_maps", {})
+    maps = []
+    if out.get("ok"):
+        try:
+            maps = json.loads(str(out.get("maps_json") or "[]"))
+            if not isinstance(maps, list):
+                maps = []
+        except Exception as e:  # noqa: BLE001
+            out = {"ok": False, "detail": f"invalid maps_json from mapping: {e}"}
+    return {"ok": bool(out.get("ok")), "detail": out.get("detail", ""), "maps": maps}
+
+
 def make_app(*, registry: ObjectRegistry,
              hub: Any = None, detector: Any = None,
              sg_store: Any = None, anno_store: Any = None,
+             object_store: Any = None,
              map_binding: Optional[dict] = None) -> Starlette:
     """Build the Starlette ASGI app the entrypoint mounts on its own
     uvicorn server.
@@ -472,6 +585,7 @@ def make_app(*, registry: ObjectRegistry,
       GET /api/objects3d   — JSON for the 3D viz (per-object pcd + bbox)
       GET /api/camera      — JSON: latest RGB + depth frames
       /api/annotations[..] — user annotation CRUD (see below)
+      /api/maps[..]        — scene-owned map library façade over map capabilities
 
     `hub` is the SubscribersHub — passed so the JSON state can include
     the latest OccupancyGrid for the 2D canvas underlay.
@@ -480,8 +594,10 @@ def make_app(*, registry: ObjectRegistry,
     just shows an empty world.
     `anno_store` is the AnnotationStore backing the annotation CRUD; when
     None (store init failed / disabled) those routes answer 503.
-    `map_binding` is a static {map_id, mode, generation, source} dict shown
-    by the /user page header.
+    `object_store` is the per-map scene object warm-restore store; Save/Load
+    rebinds it so perceived objects follow the same map id as rooms.
+    `map_binding` is a mutable {map_id, mode, generation, source} dict shown
+    by the /user page header and updated by Save/Load actions.
 
     Annotation API contract (STABLE once shipped — any frontend builds on
     it; see system/scene/README.md):
@@ -501,6 +617,38 @@ def make_app(*, registry: ObjectRegistry,
     meters. Same trust domain as the rest of this LAN debug/UI server —
     no auth.
     """
+    if map_binding is None:
+        map_binding = {}
+
+    async def _persist_scene_objects(map_id: str) -> int:
+        if object_store is None:
+            return 0
+        if hasattr(object_store, "rebind"):
+            object_store.rebind(map_id)
+        objs, _surfs = await registry.snapshot()
+        pairs = [(o, None) for o in objs.values() if not getattr(o, "missing", False)]
+        if not pairs:
+            return 0
+        return int(await asyncio.to_thread(object_store.persist, pairs))
+
+    async def _restore_scene_objects(map_id: str) -> int:
+        if object_store is None:
+            return 0
+        if hasattr(object_store, "rebind"):
+            object_store.rebind(map_id)
+        restored = await asyncio.to_thread(object_store.load_all)
+        async with registry.lock():
+            for o in restored:
+                registry.restore_object(o)
+        return len(restored)
+
+    def _set_map_binding(map_id: str, mode: str, source: str) -> None:
+        map_binding.update({
+            "map_id": map_id,
+            "mode": mode,
+            "generation": None,
+            "source": source,
+        })
 
     async def index(_request) -> HTMLResponse:
         # Combined split layout: 2D map left, 3D viz right, each with
@@ -600,6 +748,192 @@ def make_app(*, registry: ObjectRegistry,
             return _anno_error(404, f"unknown annotation id {ann_id!r}")
         return JSONResponse({"ok": True})
 
+    async def maps_list(_request) -> JSONResponse:
+        return JSONResponse(await asyncio.to_thread(_maps_payload))
+
+    def _map_exists_in_payload(payload: dict, map_id: str) -> tuple[bool, dict]:
+        for item in payload.get("maps", []):
+            if item.get("map_id") == map_id and item.get("has_spatial_artifact"):
+                return True, item
+        return False, {}
+
+    async def maps_save(request) -> JSONResponse:
+        body = await _anno_body(request)
+        if body is None:
+            return _anno_error(400, "request body must be a JSON object")
+        map_id = str(body.get("map_id") or "").strip()
+        if not map_id:
+            return _anno_error(400, "map_id is required")
+        note = str(body.get("note") or "")
+        before_payload = await asyncio.to_thread(_maps_payload)
+        spatial_exists, existing_map = _map_exists_in_payload(before_payload, map_id)
+        current_bound_id = str(map_binding.get("map_id") or "")
+        current_mode = str(map_binding.get("mode") or "")
+        if spatial_exists:
+            if current_bound_id and current_bound_id != map_id:
+                return _anno_error(409, f"spatial map {map_id} already exists; load it before updating scene annotations/objects")
+            out = {
+                "ok": True,
+                "map_id": map_id,
+                "detail": f"spatial map {map_id} already exists; saved scene annotations/objects only",
+                "spatial_unchanged": True,
+            }
+        else:
+            save_timeout_s = float(os.environ.get("SCENE_MAP_SAVE_TIMEOUT_S", "300"))
+            out = await asyncio.to_thread(
+                _map_rpc,
+                "save_map",
+                {"map_id": map_id, "note": note},
+                save_timeout_s,
+            )
+        object_count = 0
+        object_persist_error = None
+        if out.get("ok"):
+            if anno_store is not None:
+                anno_store.rebind(map_id, generation=None, carry_current=True)
+            try:
+                object_count = await _persist_scene_objects(map_id)
+                out["objects"] = object_count
+            except Exception as e:  # noqa: BLE001
+                object_persist_error = str(e)
+                out["object_persist_error"] = object_persist_error
+            mode_after_save = current_mode if spatial_exists and current_bound_id == map_id and current_mode else "mapping"
+            _set_map_binding(map_id, mode_after_save, "ui_save")
+
+        annotations = anno_store.list_json() if anno_store is not None else []
+        out.setdefault("annotations", len(annotations))
+        if out.get("ok"):
+            maps_payload = await asyncio.to_thread(_maps_payload)
+            saved_map = None
+            for item in maps_payload.get("maps", []):
+                if item.get("map_id") == map_id:
+                    saved_map = item
+                    break
+            validation = {
+                "map_id": map_id,
+                "spatial_ok": bool(saved_map and saved_map.get("has_spatial_artifact") and saved_map.get("spatial_ok") is not False),
+                "artifact_detail": (saved_map or {}).get("artifact_detail") or maps_payload.get("detail") or "map not found after save",
+                "artifact_size": (saved_map or {}).get("artifact_size"),
+                "has_preview": bool(saved_map and saved_map.get("has_preview")),
+                "updated": (saved_map or {}).get("updated"),
+                "object_count": int(object_count or 0),
+                "room_count": sum(1 for a in annotations if a.get("kind") == "room"),
+                "annotation_count": len(annotations),
+                "paths": {
+                    "map_artifact": (saved_map or {}).get("artifact_path") or "not exposed by map provider",
+                    "preview": (saved_map or {}).get("preview_path") or "not exposed by map provider",
+                    "scene_annotations": str(anno_store.path) if anno_store is not None else "annotation store unavailable",
+                },
+                "log": [
+                    f"save_map returned ok={bool(out.get('ok'))}: {out.get('detail') or ''}",
+                    f"map list validation ok={bool(maps_payload.get('ok'))}",
+                    f"spatial artifact check: {(saved_map or {}).get('artifact_detail') or maps_payload.get('detail') or 'unknown'}",
+                ],
+            }
+            if object_persist_error:
+                validation["log"].append(f"object persistence error: {object_persist_error}")
+            out["validation"] = validation
+        return JSONResponse(out, status_code=200 if out.get("ok") else 502)
+
+    async def maps_load(request) -> JSONResponse:
+        body = await _anno_body(request)
+        if body is None:
+            return _anno_error(400, "request body must be a JSON object")
+        map_id = str(body.get("map_id") or "").strip()
+        if not map_id:
+            return _anno_error(400, "map_id is required")
+        mode = str(body.get("mode") or "localization")
+        load_timeout_s = float(os.environ.get("SCENE_MAP_LOAD_TIMEOUT_S", "240"))
+        out = await asyncio.to_thread(_map_rpc, "load_map", {
+            "map_id": map_id,
+            "mode": mode,
+            "has_initial_pose": bool(body.get("has_initial_pose", False)),
+            "x": float(body.get("x") or 0.0),
+            "y": float(body.get("y") or 0.0),
+            "theta": float(body.get("theta") or 0.0),
+        }, load_timeout_s)
+        if out.get("ok"):
+            if anno_store is not None:
+                anno_store.rebind(map_id, generation=None, carry_current=False)
+            try:
+                out["objects_restored"] = await _restore_scene_objects(map_id)
+            except Exception as e:  # noqa: BLE001
+                out["object_restore_error"] = str(e)
+            _set_map_binding(map_id, "localization", "ui_load")
+        return JSONResponse(out, status_code=200 if out.get("ok") else 502)
+
+    async def maps_delete(request) -> JSONResponse:
+        body = await _anno_body(request)
+        if body is None:
+            return _anno_error(400, "request body must be a JSON object")
+        map_id = str(body.get("map_id") or "").strip()
+        if not map_id:
+            return _anno_error(400, "map_id is required")
+        out = await asyncio.to_thread(_map_rpc, "delete_map", {"map_id": map_id})
+        return JSONResponse(out, status_code=200 if out.get("ok") else 502)
+
+    async def maps_pose_estimate(request) -> JSONResponse:
+        body = await _anno_body(request)
+        if body is None:
+            return _anno_error(400, "request body must be a JSON object")
+        try:
+            payload = {
+                "x": float(body.get("x")),
+                "y": float(body.get("y")),
+                "theta": float(body.get("theta") or 0.0),
+                "cov_xy": float(body.get("cov_xy") or 0.0),
+                "cov_theta": float(body.get("cov_theta") or 0.0),
+            }
+            if not all(math.isfinite(float(payload[k])) for k in ("x", "y", "theta", "cov_xy", "cov_theta")):
+                raise ValueError("non-finite pose")
+        except Exception:
+            return _anno_error(400, "x/y/theta must be finite numbers")
+
+        def _pose_delta(pose: dict) -> Optional[dict]:
+            if not pose.get("ok"):
+                return None
+            dx = float(pose.get("x", 0.0)) - payload["x"]
+            dy = float(pose.get("y", 0.0)) - payload["y"]
+            dtheta = math.atan2(
+                math.sin(float(pose.get("theta", 0.0)) - payload["theta"]),
+                math.cos(float(pose.get("theta", 0.0)) - payload["theta"]),
+            )
+            return {
+                "dx": dx,
+                "dy": dy,
+                "dtheta": dtheta,
+                "distance_m": math.hypot(dx, dy),
+                "abs_yaw_rad": abs(dtheta),
+            }
+
+        mode_info = await asyncio.to_thread(_map_rpc, "get_mode", {}, 3.0)
+        before = await asyncio.to_thread(_map_rpc, "get_pose", {}, 3.0)
+        out = await asyncio.to_thread(_map_rpc, "pose_estimate", payload)
+        # RTAB-Map relocalization is not instantaneous. Give the pose adapter a
+        # short beat so the UI can show an immediate convergence hint instead
+        # of only "published".
+        await asyncio.sleep(float(os.environ.get("SCENE_POSE_ESTIMATE_FEEDBACK_DELAY_S", "1.2")))
+        after = await asyncio.to_thread(_map_rpc, "get_pose", {}, 3.0)
+        out["requested_pose"] = payload
+        out["mode"] = mode_info
+        out["pose_before"] = before
+        out["pose_after"] = after
+        out["delta_before"] = _pose_delta(before)
+        out["delta_after"] = _pose_delta(after)
+        if out.get("ok"):
+            if after.get("ok") and out["delta_after"]:
+                d = out["delta_after"]
+                mode = str(mode_info.get("mode") or "unknown") if mode_info.get("ok") else "unknown"
+                suffix = "" if mode == "localization" else f"; mode={mode}, pose estimate may not relocalize until a map is loaded in localization mode"
+                out["detail"] = (
+                    f"pose estimate sent to ({payload['x']:.2f}, {payload['y']:.2f}, {payload['theta']:.2f}); "
+                    f"current error {d['distance_m']:.2f} m, yaw {d['abs_yaw_rad']:.2f} rad"
+                    f"{suffix}"
+                )
+            else:
+                out["detail"] = (out.get("detail") or "pose estimate sent") + "; current pose not available yet"
+        return JSONResponse(out, status_code=200 if out.get("ok") else 502)
+
     async def index3d(_request) -> HTMLResponse:
         return HTMLResponse(_INDEX_3D_HTML)
 
@@ -638,6 +972,11 @@ def make_app(*, registry: ObjectRegistry,
               methods=["PUT"]),
         Route("/api/annotations/{annotation_id}", annotations_delete,
               methods=["DELETE"]),
+        Route("/api/maps", maps_list, methods=["GET"]),
+        Route("/api/maps/save", maps_save, methods=["POST"]),
+        Route("/api/maps/load", maps_load, methods=["POST"]),
+        Route("/api/maps/delete", maps_delete, methods=["POST"]),
+        Route("/api/maps/pose_estimate", maps_pose_estimate, methods=["POST"]),
     ]
     if static_dir.is_dir():
         routes.append(Mount("/static", StaticFiles(directory=str(static_dir)), name="static"))
@@ -1859,6 +2198,26 @@ _USER_HTML = r"""<!doctype html>
     #panel { width: 260px; flex: none; background: var(--panel);
       border-right: 1px solid #232936; display: flex; flex-direction: column; }
     #panel .actions { padding: 12px; border-bottom: 1px solid #232936; }
+    #map-tools { padding: 10px 12px; border-bottom: 1px solid #232936; display: grid; gap: 8px; }
+    #map-tools label { display: grid; gap: 4px; color: var(--muted); font-size: 11px; }
+    #map-id { width: 100%; box-sizing: border-box; border: 1px solid #33405a; border-radius: 6px;
+      background: #0f131b; color: var(--fg); padding: 6px 8px; font-size: 12px; }
+    #map-actions, .map-btns { display: flex; gap: 6px; flex-wrap: wrap; }
+    #map-status { min-height: 16px; color: var(--muted); font-size: 11px; overflow-wrap: anywhere; }
+    #map-status.busy { color: var(--acc); }
+    #map-status.ok { color: #8ef0b7; }
+    #map-status.err { color: var(--danger); }
+    #mode-pill { display: inline-block; margin-left: 8px; padding: 1px 6px; border-radius: 999px;
+      border: 1px solid #33405a; color: var(--muted); font-size: 11px; }
+    #mode-pill.localization { border-color: #3b633f; color: #8ef0b7; background: rgba(64,150,80,.12); }
+    #mode-pill.mapping { border-color: #6a5630; color: var(--warn); background: rgba(230,196,84,.10); }
+    #map-list { display: grid; gap: 6px; max-height: 170px; overflow-y: auto; }
+    .mapitem { border: 1px solid #232936; border-radius: 8px; padding: 7px 8px; font-size: 12px; background: #121721; cursor: pointer; }
+    .mapitem.selected, .mapitem.busy { border-color: var(--acc); }
+    .mapitem .name { font-weight: 700; }
+    .mapitem .sub { color: var(--muted); font-size: 10px; margin: 2px 0 6px; overflow-wrap: anywhere; }
+    .mapitem .map-status { color: var(--acc); font-size: 10px; min-height: 12px; margin-top: 4px; }
+    button:disabled { opacity: .55; cursor: progress; }
     button { background: #222a3a; color: var(--fg); border: 1px solid #33405a;
       border-radius: 6px; padding: 6px 10px; font-size: 12px; cursor: pointer; }
     button:hover { background: #2a3550; }
@@ -1887,6 +2246,24 @@ _USER_HTML = r"""<!doctype html>
       color: var(--muted); background: rgba(20,23,31,.85); padding: 4px 8px;
       border-radius: 4px; }
     #empty { padding: 10px 2px; color: var(--muted); font-size: 12px; }
+    dialog.modal { width: min(360px, calc(100vw - 32px)); border: 1px solid #33405a;
+      border-radius: 10px; padding: 0; background: #151a23; color: var(--fg);
+      box-shadow: 0 18px 70px rgba(0,0,0,.55); }
+    dialog.modal::backdrop { background: rgba(0,0,0,.55); }
+    .modal-body { padding: 16px; display: grid; gap: 12px; }
+    .modal-title { font-weight: 700; font-size: 14px; }
+    .modal-message { color: var(--muted); font-size: 12px; line-height: 1.45; }
+    .modal-input { width: 100%; box-sizing: border-box; border: 1px solid #33405a;
+      border-radius: 7px; background: #0f131b; color: var(--fg); padding: 8px 10px;
+      font-size: 13px; outline: none; }
+    .modal-actions { display: flex; justify-content: flex-end; gap: 8px; }
+    dialog.report-modal { width: min(720px, calc(100vw - 32px)); }
+    .save-report-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+    .save-report-preview { width: 100%; max-height: 300px; object-fit: contain; border: 1px solid #33405a; border-radius: 8px; background: #0e1015; }
+    .save-report-kv { display: grid; grid-template-columns: 120px 1fr; gap: 5px 10px; font-size: 12px; align-content: start; }
+    .save-report-kv .k { color: var(--muted); }
+    .save-report-kv .v { overflow-wrap: anywhere; }
+    .save-report-log { margin: 8px 0 0; padding: 8px; border: 1px solid #283243; border-radius: 8px; background: #0f131b; color: #c9d1d9; font: 11px/1.45 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; white-space: pre-wrap; max-height: 130px; overflow: auto; }
   </style>
 </head>
 <body>
@@ -1898,6 +2275,16 @@ _USER_HTML = r"""<!doctype html>
   </header>
   <div id="main">
     <div id="panel">
+      <div id="map-tools">
+        <label>Map ID<input id="map-id" placeholder="apartment_demo" /></label>
+        <div id="map-actions">
+          <button class="primary" id="btn-save-map">Save current</button>
+          <button id="btn-refresh-maps">Refresh</button>
+          <button id="btn-pose-estimate">Pose estimate</button>
+        </div>
+        <div id="map-status"><span id="map-status-msg">Ready.</span><span class="mode-label">Map mode:</span><span id="mode-pill">unknown</span></div>
+        <div id="map-list"><div id="empty">No saved maps listed yet.</div></div>
+      </div>
       <div class="actions">
         <button class="primary" id="btn-draw">✏ Annotate room</button>
       </div>
@@ -1913,6 +2300,30 @@ _USER_HTML = r"""<!doctype html>
     </div>
   </div>
 </div>
+<dialog class="modal" id="room-modal">
+  <form method="dialog" class="modal-body">
+    <div class="modal-title" id="room-modal-title">Room</div>
+    <div class="modal-message" id="room-modal-message"></div>
+    <input class="modal-input" id="room-modal-input" autocomplete="off" />
+    <div class="modal-actions">
+      <button id="room-modal-cancel" value="cancel">Cancel</button>
+      <button class="primary" id="room-modal-ok" value="ok">OK</button>
+    </div>
+  </form>
+</dialog>
+<dialog class="modal report-modal" id="save-modal">
+  <form method="dialog" class="modal-body">
+    <div class="modal-title" id="save-modal-title">Save report</div>
+    <div class="save-report-grid">
+      <img class="save-report-preview" id="save-report-preview" alt="saved map preview" />
+      <div class="save-report-kv" id="save-report-kv"></div>
+    </div>
+    <pre class="save-report-log" id="save-report-log"></pre>
+    <div class="modal-actions">
+      <button class="primary" value="ok">OK</button>
+    </div>
+  </form>
+</dialog>
 <script>
 const c = document.getElementById('c');
 const ctx = c.getContext('2d');
@@ -1942,6 +2353,11 @@ let draft = [];            // in-progress polygon vertices (world coords)
 let mouseWorld = null;     // live cursor position for the rubber-band edge
 let hoverObj = null;
 let selectedId = null;
+let selectedMapId = null;
+let savedMaps = [];
+let mapBusy = false;
+let poseEstimateMode = false;
+let draftSubmitting = false;
 
 const hintEl = document.getElementById('hint');
 function setHint(text) {
@@ -1954,6 +2370,28 @@ function toast(text) {
     t.textContent = text; t.style.display = 'block';
     clearTimeout(toastTimer);
     toastTimer = setTimeout(() => { t.style.display = 'none'; }, 4000);
+}
+function setMapStatus(text, kind = '') {
+    const el = document.getElementById('map-status');
+    const msg = document.getElementById('map-status-msg');
+    if (!el || !msg) return;
+    el.className = kind;
+    msg.textContent = text || 'Ready.';
+}
+function setMapBusy(on, label = '') {
+    mapBusy = on;
+    document.querySelectorAll('#map-tools button, .map-btns button').forEach(b => b.disabled = on);
+    if (label) setMapStatus(label, on ? 'busy' : '');
+}
+function mapItemFor(id) {
+    return Array.from(document.querySelectorAll('.mapitem')).find(el => el.dataset.id === id);
+}
+function setMapItemStatus(id, text) {
+    const item = mapItemFor(id);
+    if (!item) return;
+    item.classList.toggle('busy', Boolean(text));
+    const st = item.querySelector('.map-status');
+    if (st) st.textContent = text || '';
 }
 
 // ── rendering ────────────────────────────────────────────────────────────
@@ -2076,10 +2514,235 @@ function draw() {
     }
 }
 
+function showSaveReport(out, previewDataUrl) {
+    const validation = (out && out.validation) || {};
+    const modal = document.getElementById('save-modal');
+    const title = document.getElementById('save-modal-title');
+    const img = document.getElementById('save-report-preview');
+    const kv = document.getElementById('save-report-kv');
+    const log = document.getElementById('save-report-log');
+    const status = validation.spatial_ok ? 'OK' : 'FAILED';
+    title.textContent = `Save report · ${status}`;
+    img.src = previewDataUrl || '';
+    const paths = validation.paths || {};
+    const rows = [
+        ['Map ID', validation.map_id || out.map_id || '-'],
+        ['Spatial artifact', validation.spatial_ok ? 'ok' : (validation.artifact_detail || 'failed')],
+        ['Artifact size', validation.artifact_size ? `${validation.artifact_size} bytes` : '-'],
+        ['Objects', validation.object_count ?? out.objects ?? '-'],
+        ['Rooms', validation.room_count ?? '-'],
+        ['Annotations', validation.annotation_count ?? out.annotations ?? '-'],
+        ['Updated', validation.updated || '-'],
+        ['Artifact path', paths.map_artifact || '-'],
+        ['Preview path', paths.preview || '-'],
+        ['Room JSON', paths.scene_annotations || '-'],
+    ];
+    kv.innerHTML = rows.map(([k, v]) => `<div class="k">${esc(k)}</div><div class="v">${esc(v)}</div>`).join('');
+    log.textContent = (validation.log || []).join('\n') || 'no save log returned';
+    if (typeof modal.showModal === 'function') modal.showModal();
+    else modal.setAttribute('open', '');
+}
+
+// ── map library ──────────────────────────────────────────────────────────
+function preferredMapId() {
+    const input = document.getElementById('map-id');
+    const typed = input && input.value.trim();
+    const bound = state && state.map_binding && state.map_binding.map_id;
+    return typed || bound || 'default';
+}
+function renderMaps() {
+    const list = document.getElementById('map-list');
+    if (!list) return;
+    if (!savedMaps.length) {
+        list.innerHTML = '<div id="empty">No saved maps listed yet.</div>';
+        return;
+    }
+    list.innerHTML = savedMaps.map(m => {
+        const dbLabel = !m.has_spatial_artifact ? 'no spatial artifact' : (m.spatial_ok === false ? 'invalid artifact' : 'spatial artifact');
+        const dbTitle = m.artifact_detail ? ` title="${esc(m.artifact_detail)}"` : '';
+        const canLoad = m.has_spatial_artifact && m.spatial_ok !== false;
+        return `
+      <div class="mapitem ${m.map_id === selectedMapId ? 'selected' : ''} ${canLoad ? '' : 'bad'}" data-id="${esc(m.map_id)}">
+        <div class="name">${esc(m.map_id)}</div>
+        <div class="sub"${dbTitle}>${dbLabel} · ${m.has_preview ? 'preview' : 'no preview'} · ${m.updated || '-'}</div>
+        <div class="map-btns">
+          <button class="small" data-map-act="load" ${canLoad ? '' : 'disabled'}>Load</button>
+          <button class="small danger" data-map-act="delete">Delete</button>
+        </div>
+        <div class="map-status">${canLoad ? '' : esc(m.artifact_detail || 'not loadable')}</div>
+      </div>`;
+    }).join('');
+}
+async function loadMaps() {
+    try {
+        const r = await fetch('/api/maps', { cache: 'no-store' });
+        const out = await r.json();
+        if (!r.ok || !out.ok) { toast(out.detail || 'list maps failed'); return; }
+        savedMaps = out.maps || [];
+        renderMaps();
+    } catch (e) { toast('list maps failed: ' + e); }
+}
+async function saveCurrentMap() {
+    if (mapBusy) return;
+    const id = preferredMapId();
+    document.getElementById('map-id').value = id;
+    selectedMapId = id; renderMaps();
+    draw();
+    const previewDataUrl = c.toDataURL('image/png');
+    setMapBusy(true, `Saving map ${id}...`);
+    toast(`Saving map ${id}...`);
+    const out = await api('POST', '/api/maps/save', { map_id: id, note: 'saved from scene user page' });
+    setMapBusy(false);
+    if (out) {
+        const validation = out.validation || {};
+        const ok = validation.spatial_ok !== false && validation.has_preview !== false;
+        const semanticOnly = Boolean(out.spatial_unchanged);
+        setMapStatus(`${semanticOnly ? 'Updated scene data for' : 'Saved'} ${out.map_id || id}; spatial artifact ${ok ? 'ok' : 'failed'}; rooms ${validation.room_count ?? '-'}.`, ok ? 'ok' : 'err');
+        toast((semanticOnly ? 'updated scene data for ' : 'saved map ') + (out.map_id || id));
+        await loadMaps();
+        showSaveReport(out, previewDataUrl);
+    }
+    else setMapStatus(`Save ${id} failed. See toast/log for details.`, 'err');
+}
+async function loadSelectedMap(id) {
+    if (mapBusy) return;
+    selectedMapId = id;
+    document.getElementById('map-id').value = id;
+    renderMaps();
+    setMapItemStatus(id, 'loading...');
+    setMapBusy(true, `Loading ${id}; switching mapping to localization mode...`);
+    toast(`Loading ${id}; switching to localization mode...`);
+    const out = await api('POST', '/api/maps/load', { map_id: id, mode: 'localization' });
+    setMapBusy(false);
+    setMapItemStatus(id, '');
+    if (out) {
+        setMapStatus(`Loaded ${id}. Mapping requested localization mode; use Pose estimate if the robot pose is off.`, 'ok');
+        toast('loaded map ' + id + ' · localization mode requested');
+        await loadMaps();
+    } else {
+        setMapStatus(`Load ${id} failed. See toast/log for details.`, 'err');
+    }
+}
+async function deleteSelectedMap(id) {
+    if (mapBusy) return;
+    if (!(await askConfirm('Delete map', `Delete map “${id}”?`))) return;
+    setMapItemStatus(id, 'deleting...');
+    setMapBusy(true, `Deleting map ${id}...`);
+    const out = await api('POST', '/api/maps/delete', { map_id: id });
+    setMapBusy(false);
+    if (out) { setMapStatus(`Deleted ${id}.`, 'ok'); toast('deleted map ' + id); await loadMaps(); }
+    else { setMapItemStatus(id, ''); setMapStatus(`Delete ${id} failed.`, 'err'); }
+}
+function setPoseEstimateMode(on) {
+    poseEstimateMode = on;
+    const btn = document.getElementById('btn-pose-estimate');
+    if (btn) {
+        btn.classList.toggle('primary', on);
+        btn.textContent = on ? 'Click pose on map' : 'Pose estimate';
+    }
+    setHint(on ? 'Click the robot position on the map to publish /initialpose. Heading defaults to 0; refine later with orientation UI.' : '');
+    c.style.cursor = on ? 'crosshair' : (drawMode ? 'crosshair' : 'grab');
+}
+function poseDeltaText(delta) {
+    if (!delta) return 'pose feedback unavailable';
+    return `error ${Number(delta.distance_m || 0).toFixed(2)} m, yaw ${Number(delta.abs_yaw_rad || 0).toFixed(2)} rad`;
+}
+async function sendPoseEstimate(world) {
+    if (mapBusy || !world) return;
+    setPoseEstimateMode(false);
+    const x = world[0], y = world[1], theta = 0.0;
+    setMapBusy(true, `Publishing pose estimate (${x.toFixed(2)}, ${y.toFixed(2)}, ${theta.toFixed(2)})...`);
+    toast(`pose estimate: ${x.toFixed(2)}, ${y.toFixed(2)}`);
+    const out = await api('POST', '/api/maps/pose_estimate', { x, y, theta });
+    setMapBusy(false);
+    if (out) {
+        const msg = `${out.detail || 'Pose estimate sent.'}` +
+            (out.delta_before ? ` · before ${poseDeltaText(out.delta_before)}` : '') +
+            (out.delta_after ? ` · after ${poseDeltaText(out.delta_after)}` : '');
+        setMapStatus(msg, 'ok');
+        toast(out.detail || 'pose estimate sent');
+    } else setMapStatus(`Pose estimate failed for (${x.toFixed(2)}, ${y.toFixed(2)}).`, 'err');
+}
+document.getElementById('btn-save-map').addEventListener('click', saveCurrentMap);
+document.getElementById('btn-refresh-maps').addEventListener('click', async () => { setMapStatus('Refreshing maps...', 'busy'); await loadMaps(); setMapStatus('Map list refreshed.', 'ok'); });
+document.getElementById('btn-pose-estimate').addEventListener('click', () => setPoseEstimateMode(!poseEstimateMode));
+document.getElementById('map-list').addEventListener('click', (ev) => {
+    const item = ev.target.closest('.mapitem');
+    if (!item) return;
+    const id = item.dataset.id;
+    const act = ev.target.dataset && ev.target.dataset.mapAct;
+    if (!act) {
+        selectedMapId = id;
+        document.getElementById('map-id').value = id;
+        renderMaps();
+        setMapStatus(`Selected ${id}. Click Load to enter localization mode.`, 'ok');
+        return;
+    }
+    if (act === 'load') {
+        const m = savedMaps.find(x => x.map_id === id);
+        if (m && (!m.has_spatial_artifact || m.spatial_ok === false)) {
+            setMapStatus(`Map ${id} is not loadable: ${m.artifact_detail || 'invalid spatial artifact'}`, 'err');
+            return;
+        }
+        loadSelectedMap(id);
+    }
+    if (act === 'delete') deleteSelectedMap(id);
+});
+
 // ── side panel ───────────────────────────────────────────────────────────
 function esc(s) {
     return String(s).replace(/[&<>"']/g,
         ch => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch]));
+}
+
+const roomModal = document.getElementById('room-modal');
+const roomModalTitle = document.getElementById('room-modal-title');
+const roomModalMessage = document.getElementById('room-modal-message');
+const roomModalInput = document.getElementById('room-modal-input');
+const roomModalOk = document.getElementById('room-modal-ok');
+const roomModalCancel = document.getElementById('room-modal-cancel');
+
+function askModal({ title, message = '', defaultValue = '', input = true, okText = 'OK', danger = false }) {
+    return new Promise((resolve) => {
+        roomModalTitle.textContent = title;
+        roomModalMessage.textContent = message;
+        roomModalMessage.style.display = message ? 'block' : 'none';
+        roomModalInput.value = defaultValue || '';
+        roomModalInput.style.display = input ? 'block' : 'none';
+        roomModalOk.textContent = okText;
+        roomModalOk.classList.toggle('danger', danger);
+        let done = false;
+        const finish = (value) => {
+            if (done) return;
+            done = true;
+            roomModal.removeEventListener('close', onClose);
+            resolve(value);
+        };
+        const onClose = () => {
+            if (roomModal.returnValue === 'ok') {
+                finish(input ? roomModalInput.value.trim() : true);
+            } else {
+                finish(null);
+            }
+        };
+        roomModal.addEventListener('close', onClose, { once: true });
+        if (typeof roomModal.showModal === 'function') roomModal.showModal();
+        else roomModal.setAttribute('open', '');
+        if (input) {
+            roomModalInput.focus();
+            roomModalInput.select();
+        } else {
+            roomModalOk.focus();
+        }
+    });
+}
+
+function askRoomName(title, defaultValue = '') {
+    return askModal({ title, defaultValue, input: true, okText: 'Save' });
+}
+
+function askConfirm(title, message, okText = 'Delete') {
+    return askModal({ title, message, input: false, okText, danger: true });
 }
 function renderPanel() {
     const rooms = (state && state.annotations || []).filter(a => a.kind === 'room');
@@ -2114,12 +2777,12 @@ document.getElementById('room-list').addEventListener('click', async (ev) => {
     const room = (state.annotations || []).find(a => a.annotation_id === id);
     if (!room) return;
     if (act === 'rename') {
-        const name = prompt('Room name:', room.name);
-        if (name !== null) await api('PUT', '/api/annotations/' + id, { name });
+        const name = await askRoomName('Rename room', room.name);
+        if (name !== null && name) await api('PUT', '/api/annotations/' + id, { name });
     } else if (act === 'confirm') {
         await api('PUT', '/api/annotations/' + id, { stale: false });
     } else if (act === 'delete') {
-        if (confirm(`Delete room “${room.name}”?`))
+        if (await askConfirm('Delete room', `Delete room “${room.name}”?`))
             await api('DELETE', '/api/annotations/' + id);
     }
 });
@@ -2138,11 +2801,22 @@ function setDrawMode(on) {
 btnDraw.addEventListener('click', () => setDrawMode(!drawMode));
 
 async function finishDraft() {
+    if (draftSubmitting) return;
     if (draft.length < 3) { toast('A room needs at least 3 corners.'); return; }
-    const name = prompt('Room name:', '');
-    if (name === null) return;          // keep drawing
-    const body = { kind: 'room', name, points: draft };
-    if (await api('POST', '/api/annotations', body)) setDrawMode(false);
+    draftSubmitting = true;
+    try {
+        const points = draft.map(p => [p[0], p[1]]);
+        const name = await askRoomName('Create room', '');
+        if (name === null) return;          // keep drawing
+        if (!name) { toast('Room name is required.'); return; }
+        const body = { kind: 'room', name, points };
+        draft = [];
+        const created = await api('POST', '/api/annotations', body);
+        if (created) setDrawMode(false);
+        else { draft = points; draw(); }
+    } finally {
+        draftSubmitting = false;
+    }
 }
 
 // ── canvas input: pan / zoom / vertex clicks / hover ─────────────────────
@@ -2173,6 +2847,7 @@ c.addEventListener('mousemove', (ev) => {
 });
 c.addEventListener('click', (ev) => {
     if (dragMoved) return;              // that was a pan, not a click
+    if (poseEstimateMode) { sendPoseEstimate(p2w(ev.offsetX, ev.offsetY)); return; }
     if (drawMode) { draft.push(p2w(ev.offsetX, ev.offsetY)); draw(); }
 });
 c.addEventListener('dblclick', (ev) => {
@@ -2187,7 +2862,7 @@ c.addEventListener('dblclick', (ev) => {
 window.addEventListener('keydown', (ev) => {
     if (!drawMode) return;
     if (ev.key === 'Escape') setDrawMode(false);
-    if (ev.key === 'Enter') finishDraft();
+    if (ev.key === 'Enter' && !ev.repeat) finishDraft();
 });
 c.addEventListener('wheel', (ev) => {
     ev.preventDefault();
@@ -2230,15 +2905,31 @@ async function refresh() {
     } catch (_) { return; /* transient; next poll retries */ }
     state = next;
     const mb = state.map_binding;
+    const unsavedLive = mb && mb.source === 'default' && !mb.mode;
     document.getElementById('meta').textContent = mb
-        ? `map: ${mb.map_id} · ${mb.mode || 'mode unknown'}`
+        ? (unsavedLive ? 'map: live session · unsaved' : `map: ${mb.map_id} · ${mb.mode || 'mode unknown'}`)
         : 'map: —';
+    const modePill = document.getElementById('mode-pill');
+    if (modePill) {
+        const mode = unsavedLive ? 'unsaved live' : ((mb && mb.mode) || 'unknown');
+        modePill.textContent = mode;
+        modePill.className = unsavedLive ? 'mapping' : mode;
+    }
+    const msg = document.getElementById('map-status-msg');
+    if (unsavedLive && msg && (msg.textContent === 'Ready.' || msg.textContent === 'Map list refreshed.')) {
+        setMapStatus('Live mapping session is not saved yet. Enter a Map ID, then Save current.', 'busy');
+    } else if (mb && mb.mode === 'localization' && msg && (msg.textContent === 'Ready.' || msg.textContent === 'Map list refreshed.')) {
+        setMapStatus('Localization mode is active. Use Pose estimate if the robot pose is off.', 'ok');
+    }
+    const mapInput = document.getElementById('map-id');
+    if (mapInput && !mapInput.value && mb && mb.map_id && !unsavedLive) mapInput.value = mb.map_id;
     renderPanel();
     draw();
 }
 // 1 Hz is plenty for an editor page (the debug page polls at 5 Hz).
 setInterval(refresh, 1000);
 refresh();
+loadMaps();
 </script>
 </body>
 </html>

--- a/system/scene/scene_service/web.py
+++ b/system/scene/scene_service/web.py
@@ -844,6 +844,10 @@ def make_app(*, registry: ObjectRegistry,
             return _anno_error(400, "map_id is required")
         mode = str(body.get("mode") or "localization")
         load_timeout_s = float(os.environ.get("SCENE_MAP_LOAD_TIMEOUT_S", "240"))
+        before_stamp = 0.0
+        before_count = 0
+        if hub is not None and hub.has("occupancy_grid"):
+            _before_msg, before_stamp, before_count = hub.latest("occupancy_grid")
         out = await asyncio.to_thread(_map_rpc, "load_map", {
             "map_id": map_id,
             "mode": mode,
@@ -853,6 +857,42 @@ def make_app(*, registry: ObjectRegistry,
             "theta": float(body.get("theta") or 0.0),
         }, load_timeout_s)
         if out.get("ok"):
+            # Mapping's LoadMap response means RTAB-Map accepted the database
+            # and PublishMap request. Do not restore semantic state until Scene
+            # has actually observed the resulting occupancy grid; otherwise the
+            # first click only switches the database and a second click appears
+            # necessary to refresh rooms/objects against the loaded map.
+            ready_timeout_s = float(os.environ.get("SCENE_MAP_READY_TIMEOUT_S", "20"))
+            deadline = time.monotonic() + ready_timeout_s
+            occupancy_ready = False
+            while time.monotonic() < deadline:
+                if hub is not None and hub.has("occupancy_grid"):
+                    msg, stamp, count = hub.latest("occupancy_grid")
+                    if (
+                        msg is not None
+                        and int(getattr(msg.info, "width", 0)) > 0
+                        and int(getattr(msg.info, "height", 0)) > 0
+                        and (count > before_count or stamp > before_stamp)
+                    ):
+                        occupancy_ready = True
+                        out["occupancy"] = {
+                            "count": int(count),
+                            "stamp_unix": float(stamp),
+                            "width": int(msg.info.width),
+                            "height": int(msg.info.height),
+                        }
+                        break
+                await asyncio.sleep(0.1)
+            if not occupancy_ready:
+                out = {
+                    **out,
+                    "ok": False,
+                    "detail": (
+                        f"mapping loaded {map_id}, but Scene did not observe a new "
+                        f"occupancy grid within {ready_timeout_s:.1f}s"
+                    ),
+                }
+                return JSONResponse(out, status_code=502)
             if anno_store is not None:
                 anno_store.rebind(map_id, generation=None, carry_current=False)
             try:

--- a/system/scene/scene_service/web.py
+++ b/system/scene/scene_service/web.py
@@ -2694,17 +2694,45 @@ function draw() {
         ctx.fillText(hoverObj.cls, px + 8, py);
     }
 
-    // robot marker (small arrow, subtle)
+    // Robot marker: fixed-size, high-contrast body plus a long directional
+    // nose. Keeping it in screen pixels makes the pose readable at every map
+    // zoom level, including over dark occupied cells and pale free space.
     const robot = state.robot;
     if (robot) {
         const [rx, ry] = w2p(robot.x, robot.y);
         const yaw = robot.yaw || 0;
-        ctx.strokeStyle = '#7aa7ff'; ctx.fillStyle = '#7aa7ff'; ctx.lineWidth = 2;
-        ctx.beginPath(); ctx.arc(rx, ry, 5, 0, Math.PI * 2); ctx.stroke();
+        const robotMarkerNose = 24;
+        ctx.save();
+        ctx.translate(rx, ry);
+        ctx.rotate(-yaw);
+
+        // Dark halo separates the marker from any occupancy-grid tone.
         ctx.beginPath();
-        ctx.moveTo(rx, ry);
-        ctx.lineTo(rx + Math.cos(yaw) * 14, ry - Math.sin(yaw) * 14);
+        ctx.arc(0, 0, 12, 0, Math.PI * 2);
+        ctx.fillStyle = 'rgba(7, 10, 16, 0.92)';
+        ctx.fill();
+        ctx.lineWidth = 4;
+        ctx.strokeStyle = '#ffffff';
         ctx.stroke();
+
+        // The asymmetric arrowhead makes forward direction unambiguous.
+        ctx.beginPath();
+        ctx.moveTo(robotMarkerNose, 0);
+        ctx.lineTo(-7, -10);
+        ctx.lineTo(-3, 0);
+        ctx.lineTo(-7, 10);
+        ctx.closePath();
+        ctx.fillStyle = '#ff5a1f';
+        ctx.fill();
+        ctx.lineWidth = 3;
+        ctx.strokeStyle = '#ffffff';
+        ctx.stroke();
+
+        ctx.beginPath();
+        ctx.arc(0, 0, 4, 0, Math.PI * 2);
+        ctx.fillStyle = '#ffe45c';
+        ctx.fill();
+        ctx.restore();
     }
 
     // draft polygon (draw mode)

--- a/system/scene/scene_service/web.py
+++ b/system/scene/scene_service/web.py
@@ -2329,6 +2329,27 @@ _USER_HTML = r"""<!doctype html>
     .save-report-kv .k { color: var(--muted); }
     .save-report-kv .v { overflow-wrap: anywhere; }
     .save-report-log { margin: 8px 0 0; padding: 8px; border: 1px solid #283243; border-radius: 8px; background: #0f131b; color: #c9d1d9; font: 11px/1.45 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; white-space: pre-wrap; max-height: 130px; overflow: auto; }
+    dialog.operation-modal { width: min(460px, calc(100vw - 32px)); }
+    .operation-head { display: flex; align-items: center; gap: 10px; }
+    .operation-spinner { width: 16px; height: 16px; border: 2px solid #33405a;
+      border-top-color: var(--acc); border-radius: 50%; animation: operation-spin .8s linear infinite; }
+    .operation-modal.finished .operation-spinner { animation: none; border-color: #3b633f;
+      background: #8ef0b7; box-shadow: inset 0 0 0 4px #151a23; }
+    .operation-modal.failed .operation-spinner { animation: none; border-color: var(--danger);
+      background: var(--danger); box-shadow: inset 0 0 0 4px #151a23; }
+    @keyframes operation-spin { to { transform: rotate(360deg); } }
+    .operation-steps { display: grid; gap: 7px; margin: 2px 0; }
+    .operation-step { display: grid; grid-template-columns: 16px 1fr; gap: 8px;
+      align-items: center; color: var(--muted); font-size: 12px; }
+    .operation-step::before { content: '○'; color: #526078; }
+    .operation-step.active { color: var(--fg); }
+    .operation-step.active::before { content: '●'; color: var(--acc); }
+    .operation-step.done { color: #8ef0b7; }
+    .operation-step.done::before { content: '✓'; }
+    .operation-detail { margin: 0; padding: 8px; border: 1px solid #283243;
+      border-radius: 8px; background: #0f131b; color: #c9d1d9;
+      font: 11px/1.45 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      white-space: pre-wrap; max-height: 120px; overflow: auto; display: none; }
   </style>
 </head>
 <body>
@@ -2389,6 +2410,21 @@ _USER_HTML = r"""<!doctype html>
     </div>
   </form>
 </dialog>
+<dialog class="modal operation-modal" id="map-operation-modal">
+  <div class="modal-body">
+    <div class="operation-head">
+      <span class="operation-spinner" aria-hidden="true"></span>
+      <div class="modal-title" id="map-operation-title">Working...</div>
+    </div>
+    <div class="modal-message" id="map-operation-message"></div>
+    <div class="operation-steps" id="map-operation-steps"></div>
+    <pre class="operation-detail" id="map-operation-detail"></pre>
+    <div class="modal-actions">
+      <button id="map-operation-close" type="button">Close</button>
+      <button class="primary" id="map-operation-primary" type="button" disabled>Working...</button>
+    </div>
+  </div>
+</dialog>
 <script>
 const c = document.getElementById('c');
 const ctx = c.getContext('2d');
@@ -2423,6 +2459,8 @@ let savedMaps = [];
 let mapBusy = false;
 let poseEstimateMode = false;
 let draftSubmitting = false;
+let mapOperationRetry = null;
+let mapOperationDone = null;
 
 const hintEl = document.getElementById('hint');
 function setHint(text) {
@@ -2445,9 +2483,80 @@ function setMapStatus(text, kind = '') {
 }
 function setMapBusy(on, label = '') {
     mapBusy = on;
-    document.querySelectorAll('#map-tools button, .map-btns button').forEach(b => b.disabled = on);
+    document.querySelectorAll('#map-tools button, #map-tools input, .map-btns button, #btn-draw, #room-list button')
+        .forEach(el => el.disabled = on);
+    if (!on) {
+        renderMaps();
+        renderPanel();
+    }
     if (label) setMapStatus(label, on ? 'busy' : '');
 }
+const mapOperationModal = document.getElementById('map-operation-modal');
+const mapOperationTitle = document.getElementById('map-operation-title');
+const mapOperationMessage = document.getElementById('map-operation-message');
+const mapOperationSteps = document.getElementById('map-operation-steps');
+const mapOperationDetail = document.getElementById('map-operation-detail');
+const mapOperationClose = document.getElementById('map-operation-close');
+const mapOperationPrimary = document.getElementById('map-operation-primary');
+
+function beginMapOperation({ title, message, status, steps }) {
+    mapOperationRetry = null;
+    mapOperationDone = null;
+    mapOperationModal.classList.remove('finished', 'failed');
+    mapOperationTitle.textContent = title;
+    mapOperationMessage.textContent = message;
+    mapOperationSteps.innerHTML = (steps || []).map((step, index) =>
+        `<div class="operation-step ${index === 0 ? 'active' : ''}">${esc(step)}</div>`).join('');
+    mapOperationDetail.textContent = '';
+    mapOperationDetail.style.display = 'none';
+    mapOperationClose.hidden = true;
+    mapOperationPrimary.disabled = true;
+    mapOperationPrimary.textContent = 'Working...';
+    setMapBusy(true, status || message);
+    if (!mapOperationModal.open) {
+        if (typeof mapOperationModal.showModal === 'function') mapOperationModal.showModal();
+        else mapOperationModal.setAttribute('open', '');
+    }
+}
+
+function finishMapOperation({ ok, title, message, detail = '', retry = null, done = null, primaryText = '' }) {
+    setMapBusy(false);
+    mapOperationModal.classList.toggle('finished', ok);
+    mapOperationModal.classList.toggle('failed', !ok);
+    mapOperationTitle.textContent = title;
+    mapOperationMessage.textContent = message;
+    mapOperationSteps.querySelectorAll('.operation-step').forEach(step => {
+        step.classList.remove('active');
+        if (ok) step.classList.add('done');
+    });
+    mapOperationDetail.textContent = detail;
+    mapOperationDetail.style.display = detail ? 'block' : 'none';
+    mapOperationRetry = ok ? null : retry;
+    mapOperationDone = done;
+    mapOperationClose.hidden = ok;
+    mapOperationPrimary.disabled = false;
+    mapOperationPrimary.textContent = primaryText || (ok ? 'Done' : 'Retry');
+}
+
+mapOperationModal.addEventListener('cancel', ev => {
+    if (mapBusy) ev.preventDefault();
+});
+mapOperationClose.addEventListener('click', () => {
+    if (!mapBusy) mapOperationModal.close();
+});
+mapOperationPrimary.addEventListener('click', () => {
+    if (mapBusy) return;
+    if (mapOperationRetry) {
+        const retry = mapOperationRetry;
+        mapOperationRetry = null;
+        retry();
+        return;
+    }
+    const done = mapOperationDone;
+    mapOperationDone = null;
+    mapOperationModal.close();
+    if (done) done();
+});
 function mapItemFor(id) {
     return Array.from(document.querySelectorAll('.mapitem')).find(el => el.dataset.id === id);
 }
@@ -2665,8 +2774,8 @@ function renderMaps() {
         <div class="name">${esc(m.map_id)}</div>
         <div class="sub"${dbTitle}>${dbLabel} · ${m.has_preview ? 'preview' : 'no preview'} · ${m.updated || '-'}</div>
         <div class="map-btns">
-          <button class="small" data-map-act="load" ${canLoad ? '' : 'disabled'}>Load</button>
-          <button class="small danger" data-map-act="delete">Delete</button>
+          <button class="small" data-map-act="load" ${canLoad && !mapBusy ? '' : 'disabled'}>Load</button>
+          <button class="small danger" data-map-act="delete" ${mapBusy ? 'disabled' : ''}>Delete</button>
         </div>
         <div class="map-status">${canLoad ? '' : esc(m.artifact_detail || 'not loadable')}</div>
       </div>`;
@@ -2681,6 +2790,27 @@ async function loadMaps() {
         renderMaps();
     } catch (e) { toast('list maps failed: ' + e); }
 }
+async function mapRequest(path, body) {
+    try {
+        const response = await fetch(path, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        });
+        const out = await response.json().catch(() => null);
+        if (!response.ok || !out || out.ok === false) {
+            return {
+                ok: false,
+                out,
+                detail: (out && out.detail) || `request failed (${response.status})`,
+            };
+        }
+        await refresh();
+        return { ok: true, out, detail: out.detail || '' };
+    } catch (error) {
+        return { ok: false, out: null, detail: `request failed: ${error}` };
+    }
+}
 async function saveCurrentMap() {
     if (mapBusy) return;
     const id = preferredMapId();
@@ -2688,20 +2818,48 @@ async function saveCurrentMap() {
     selectedMapId = id; renderMaps();
     draw();
     const previewDataUrl = c.toDataURL('image/png');
-    setMapBusy(true, `Saving map ${id}...`);
-    toast(`Saving map ${id}...`);
-    const out = await api('POST', '/api/maps/save', { map_id: id, note: 'saved from scene user page' });
-    setMapBusy(false);
-    if (out) {
+    const existing = savedMaps.find(item => item.map_id === id && item.has_spatial_artifact);
+    beginMapOperation({
+        title: existing ? `Updating ${id}` : `Saving ${id}`,
+        message: existing
+            ? 'The spatial map already exists. Scene rooms and objects will be updated under the same Map ID.'
+            : 'Keep this page open while the spatial map and Scene data are made reusable.',
+        status: existing ? `Updating Scene data for ${id}...` : `Saving map ${id}...`,
+        steps: existing
+            ? ['Validate existing spatial artifact', 'Persist rooms and Scene objects', 'Verify reusable map entry']
+            : ['Snapshot the live spatial map', 'Persist rooms and Scene objects', 'Verify artifact and preview'],
+    });
+    const result = await mapRequest('/api/maps/save', { map_id: id, note: 'saved from scene user page' });
+    if (result.ok) {
+        const out = result.out;
         const validation = out.validation || {};
         const ok = validation.spatial_ok !== false && validation.has_preview !== false;
         const semanticOnly = Boolean(out.spatial_unchanged);
         setMapStatus(`${semanticOnly ? 'Updated scene data for' : 'Saved'} ${out.map_id || id}; spatial artifact ${ok ? 'ok' : 'failed'}; rooms ${validation.room_count ?? '-'}.`, ok ? 'ok' : 'err');
         toast((semanticOnly ? 'updated scene data for ' : 'saved map ') + (out.map_id || id));
         await loadMaps();
-        showSaveReport(out, previewDataUrl);
+        finishMapOperation({
+            ok,
+            title: ok ? (semanticOnly ? 'Scene data updated' : 'Map saved') : 'Save validation failed',
+            message: ok
+                ? `${out.map_id || id} is ready to load after a stack restart.`
+                : `${out.map_id || id} was written, but artifact validation did not pass.`,
+            detail: (validation.log || []).join('\n') || out.detail || '',
+            retry: ok ? null : saveCurrentMap,
+            done: ok ? () => showSaveReport(out, previewDataUrl) : null,
+            primaryText: ok ? 'View report' : 'Retry',
+        });
     }
-    else setMapStatus(`Save ${id} failed. See toast/log for details.`, 'err');
+    else {
+        setMapStatus(`Save ${id} failed: ${result.detail}`, 'err');
+        finishMapOperation({
+            ok: false,
+            title: 'Save failed',
+            message: `Nothing was confirmed reusable for Map ID ${id}.`,
+            detail: result.detail,
+            retry: saveCurrentMap,
+        });
+    }
 }
 async function loadSelectedMap(id) {
     if (mapBusy) return;
@@ -2709,17 +2867,40 @@ async function loadSelectedMap(id) {
     document.getElementById('map-id').value = id;
     renderMaps();
     setMapItemStatus(id, 'loading...');
-    setMapBusy(true, `Loading ${id}; switching mapping to localization mode...`);
-    toast(`Loading ${id}; switching to localization mode...`);
-    const out = await api('POST', '/api/maps/load', { map_id: id, mode: 'localization' });
-    setMapBusy(false);
+    beginMapOperation({
+        title: `Loading ${id}`,
+        message: 'The editor is locked until Mapping publishes the loaded occupancy grid and Scene restores the matching semantic data.',
+        status: `Loading ${id}; switching Mapping to localization mode...`,
+        steps: ['Validate saved spatial artifact', 'Switch Mapping to localization mode', 'Wait for a fresh occupancy grid', 'Restore rooms and Scene objects'],
+    });
+    const result = await mapRequest('/api/maps/load', { map_id: id, mode: 'localization' });
     setMapItemStatus(id, '');
-    if (out) {
+    if (result.ok) {
+        const out = result.out;
         setMapStatus(`Loaded ${id}. Mapping requested localization mode; use Pose estimate if the robot pose is off.`, 'ok');
         toast('loaded map ' + id + ' · localization mode requested');
         await loadMaps();
+        const occupancy = out.occupancy || {};
+        finishMapOperation({
+            ok: true,
+            title: 'Map loaded',
+            message: `${id} is active in localization mode. Rooms and Scene objects now use the same Map ID.`,
+            detail: [
+                out.detail || '',
+                occupancy.width ? `occupancy ${occupancy.width} × ${occupancy.height}` : '',
+                Number.isFinite(Number(out.objects_restored)) ? `objects restored: ${out.objects_restored}` : '',
+                out.object_restore_error ? `object restore warning: ${out.object_restore_error}` : '',
+            ].filter(Boolean).join('\n'),
+        });
     } else {
-        setMapStatus(`Load ${id} failed. See toast/log for details.`, 'err');
+        setMapStatus(`Load ${id} failed: ${result.detail}`, 'err');
+        finishMapOperation({
+            ok: false,
+            title: 'Load failed',
+            message: `${id} was not confirmed ready. The editor has not switched its Scene binding.`,
+            detail: result.detail,
+            retry: () => loadSelectedMap(id),
+        });
     }
 }
 async function deleteSelectedMap(id) {
@@ -2766,6 +2947,7 @@ document.getElementById('btn-save-map').addEventListener('click', saveCurrentMap
 document.getElementById('btn-refresh-maps').addEventListener('click', async () => { setMapStatus('Refreshing maps...', 'busy'); await loadMaps(); setMapStatus('Map list refreshed.', 'ok'); });
 document.getElementById('btn-pose-estimate').addEventListener('click', () => setPoseEstimateMode(!poseEstimateMode));
 document.getElementById('map-list').addEventListener('click', (ev) => {
+    if (mapBusy) return;
     const item = ev.target.closest('.mapitem');
     if (!item) return;
     const id = item.dataset.id;
@@ -2861,13 +3043,14 @@ function renderPanel() {
         ${a.stale ? '<span class="badge" title="' + esc(a.stale_reason) + '">STALE</span>' : ''}
         <div class="sub">${a.points.length} corners</div>
         <div class="btns">
-          <button class="small" data-act="rename">Rename</button>
-          ${a.stale ? '<button class="small" data-act="confirm">Still valid</button>' : ''}
-          <button class="small danger" data-act="delete">Delete</button>
+          <button class="small" data-act="rename" ${mapBusy ? 'disabled' : ''}>Rename</button>
+          ${a.stale ? `<button class="small" data-act="confirm" ${mapBusy ? 'disabled' : ''}>Still valid</button>` : ''}
+          <button class="small danger" data-act="delete" ${mapBusy ? 'disabled' : ''}>Delete</button>
         </div>
       </div>`).join('');
 }
 document.getElementById('room-list').addEventListener('click', async (ev) => {
+    if (mapBusy) return;
     const roomEl = ev.target.closest('.room');
     if (!roomEl) return;
     const id = roomEl.dataset.id;
@@ -2900,7 +3083,7 @@ function setDrawMode(on) {
 btnDraw.addEventListener('click', () => setDrawMode(!drawMode));
 
 async function finishDraft() {
-    if (draftSubmitting) return;
+    if (mapBusy || draftSubmitting) return;
     if (draft.length < 3) { toast('A room needs at least 3 corners.'); return; }
     draftSubmitting = true;
     try {
@@ -2922,6 +3105,7 @@ async function finishDraft() {
 let dragging = false, dragMoved = false, lastPos = null;
 c.style.cursor = 'grab';
 c.addEventListener('mousedown', (ev) => {
+    if (mapBusy) return;
     dragging = true; dragMoved = false; lastPos = [ev.offsetX, ev.offsetY];
 });
 window.addEventListener('mouseup', () => { dragging = false; });
@@ -2945,11 +3129,13 @@ c.addEventListener('mousemove', (ev) => {
     draw();
 });
 c.addEventListener('click', (ev) => {
+    if (mapBusy) return;
     if (dragMoved) return;              // that was a pan, not a click
     if (poseEstimateMode) { sendPoseEstimate(p2w(ev.offsetX, ev.offsetY)); return; }
     if (drawMode) { draft.push(p2w(ev.offsetX, ev.offsetY)); draw(); }
 });
 c.addEventListener('dblclick', (ev) => {
+    if (mapBusy) return;
     ev.preventDefault();
     if (drawMode) {
         // the dblclick's two single clicks added two duplicate corners at
@@ -2959,12 +3145,14 @@ c.addEventListener('dblclick', (ev) => {
     }
 });
 window.addEventListener('keydown', (ev) => {
+    if (mapBusy) return;
     if (!drawMode) return;
     if (ev.key === 'Escape') setDrawMode(false);
     if (ev.key === 'Enter' && !ev.repeat) finishDraft();
 });
 c.addEventListener('wheel', (ev) => {
     ev.preventDefault();
+    if (mapBusy) return;
     const factor = ev.deltaY < 0 ? 1.15 : 1 / 1.15;
     // zoom about the cursor so the point under the mouse stays put
     const [wx, wy] = p2w(ev.offsetX, ev.offsetY);

--- a/system/scene/scripts/build.sh
+++ b/system/scene/scripts/build.sh
@@ -71,7 +71,13 @@ fi
 mkdir -p "$BUILD/data"
 
 # ── 1. Codegen (.proto + grpc stubs + MCP dataclasses → rbnx-build/codegen/) ─
-FLAGS=(--mcp)
+# --ros2 also emits rbnx-build/codegen/ros2_idl: the generated ROS 2
+# interface overlay carrying map/msg/MapLifecycle (mapping's latched map
+# identity broadcast, which scene's map binding subscribes to). It is
+# colcon-built inside the scene image after the docker build below and
+# sourced by docker/entrypoint.sh; without it scene falls back to static
+# map binding (SCENE_MAP_ID / config) with a warning.
+FLAGS=(--mcp --ros2)
 [[ "$CLEAN" == "1" ]] && FLAGS+=(--clean)
 
 echo "[build] rbnx codegen ${FLAGS[*]}"
@@ -369,5 +375,25 @@ esac
 
 echo "[build] docker build -f $SCENE_DOCKERFILE -t $IMG docker/  (target=$TARGET)"
 docker build "${DOCKER_BUILD_FLAGS[@]}" -f "$SCENE_DOCKERFILE" -t "$IMG" docker/
+
+# colcon-build the ros2_idl overlay (map interface package for the
+# lifecycle broadcast) inside the image we just built, so the install
+# tree lands on the host bind mount at the SAME path the runtime
+# container sees (/scene/rbnx-build/...). Skipped when codegen was
+# skipped — scene then runs with static map binding only.
+IDL="$PKG/rbnx-build/codegen/ros2_idl"
+if [[ -d "$IDL/src/map" ]]; then
+    echo "[build] colcon build ros2_idl (map interface pkg) in $IMG"
+    # --user: build/ install/ land on the HOST bind mount — as root they
+    # would survive a later non-root `rm -rf rbnx-build` (RBNX_BUILD_CLEAN).
+    # HOME=/tmp gives colcon a writable home for its metadata as that uid.
+    docker run --rm --entrypoint bash --user "$(id -u):$(id -g)" -e HOME=/tmp \
+        -v "$PKG":/scene "$IMG" -lc \
+        "source /opt/ros/\${ROS_DISTRO:-humble}/setup.bash && \
+         cd /scene/rbnx-build/codegen/ros2_idl && \
+         colcon build --packages-up-to map"
+else
+    echo "[build] WARNING: ros2_idl/src/map missing — dynamic map binding disabled"
+fi
 
 echo "[build] done."

--- a/system/scene/scripts/build.sh
+++ b/system/scene/scripts/build.sh
@@ -280,8 +280,17 @@ classes = [
 model = YOLO("$WEIGHTS_DIR/yolov8l-world.pt")
 model.set_classes(classes)
 PY
-    if [[ ! -s "$UWD/clip/ViT-B-32.pt" ]]; then
-        echo "[build] warning: missing $UWD/clip/ViT-B-32.pt after ultralytics prefetch; scene start will fail fast" >&2
+    ULTRALYTICS_CLIP="$UWD/clip/ViT-B-32.pt"
+    HF_CLIP="$HFD/clip/ViT-B-32.pt"
+    if [[ ! -s "$ULTRALYTICS_CLIP" && -s "$HF_CLIP" ]]; then
+        mkdir -p "$(dirname "$ULTRALYTICS_CLIP")"
+        ln "$HF_CLIP" "$ULTRALYTICS_CLIP" 2>/dev/null \
+            || cp "$HF_CLIP" "$ULTRALYTICS_CLIP"
+        echo "[build] staged Ultralytics CLIP weight: $ULTRALYTICS_CLIP"
+    fi
+    if [[ ! -s "$ULTRALYTICS_CLIP" ]]; then
+        echo "[build] error: missing $ULTRALYTICS_CLIP after prefetch" >&2
+        exit 1
     fi
     "$PY" -c "import torch,torchvision,ultralytics; print('[build] torch',torch.__version__,'cuda',torch.cuda.is_available())" || true
     echo "[build] done (jetson-native)."

--- a/system/scene/scripts/start.sh
+++ b/system/scene/scripts/start.sh
@@ -35,8 +35,7 @@ CT="${ROBONIX_SCENE_CONTAINER:-robonix_scene}"
 IMG="${ROBONIX_SCENE_IMAGE:-robonix-scene}"
 
 cleanup() {
-    docker stop "$CT" >/dev/null 2>&1 || true
-    kill -- "-$$" 2>/dev/null || true
+    timeout 15s docker stop "$CT" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT INT TERM
 
@@ -63,6 +62,11 @@ if [[ -n "${ROBONIX_ZENOH_MODE:-}" ]]; then
 fi
 if [[ -n "${ROBONIX_ZENOH_LISTEN:-}" ]]; then
     ZENOH_ARGS+=(-e "ROBONIX_ZENOH_LISTEN=${ROBONIX_ZENOH_LISTEN}")
+fi
+
+declare -a MAP_ID_ARGS=()
+if [[ -n "${SCENE_MAP_ID:-}" ]]; then
+    MAP_ID_ARGS=(-e "SCENE_MAP_ID=${SCENE_MAP_ID}")
 fi
 
 # GPU passthrough: ConceptGraphs perception (YOLO-World + MobileSAM +
@@ -126,12 +130,13 @@ exec docker run --rm \
     -e SCENE_GRAPH_RELATION_ENABLED="${SCENE_GRAPH_RELATION_ENABLED:-true}" \
     -e SCENE_GRAPH_INTERVAL_SEC="${SCENE_GRAPH_INTERVAL_SEC:-30}" \
     -e SCENE_GRAPH_CACHE_DIR="${SCENE_GRAPH_CACHE_DIR:-/data/robonix/scene_graph/cache}" \
+    -e SCENE_MAP_LOAD_TIMEOUT_S="${SCENE_MAP_LOAD_TIMEOUT_S:-240}" \
     -e SCENE_GRAPH_MIN_OBSERVATIONS="${SCENE_GRAPH_MIN_OBSERVATIONS:-2}" \
     -e SCENE_GRAPH_MAX_OBJECTS="${SCENE_GRAPH_MAX_OBJECTS:-80}" \
     -e SCENE_GRAPH_MAX_LLM_RELATIONS_PER_CYCLE="${SCENE_GRAPH_MAX_LLM_RELATIONS_PER_CYCLE:-20}" \
     -e SCENE_OBJECT_MEMORY_ENABLED="${SCENE_OBJECT_MEMORY_ENABLED:-true}" \
     -e SCENE_OBJECT_MEMORY_DB="${SCENE_OBJECT_MEMORY_DB:-/data/robonix/scene_memory/objects.db}" \
-    -e SCENE_MAP_ID="${SCENE_MAP_ID:-default}" \
+    "${MAP_ID_ARGS[@]}" \
     -e RBNX_CONFIG_FILE="${RBNX_CONFIG_FILE:-}" \
     -e ROS_DOMAIN_ID="${ROS_DOMAIN_ID:-0}" \
     -e RMW_IMPLEMENTATION="${RMW_IMPLEMENTATION:-rmw_zenoh_cpp}" \

--- a/system/scene/scripts/start_native.sh
+++ b/system/scene/scripts/start_native.sh
@@ -59,6 +59,8 @@ done
 # Host-persisted scene state (object-memory DB + scene-graph caches).
 mkdir -p "$PKG/rbnx-build/data/robonix"
 export SCENE_GRAPH_CACHE_DIR="${SCENE_GRAPH_CACHE_DIR:-$PKG/rbnx-build/data/robonix/scene_graph/cache}"
+export SCENE_ANNOTATIONS_DIR="${SCENE_ANNOTATIONS_DIR:-$PKG/rbnx-build/data/robonix/scene_annotations}"
+mkdir -p "$SCENE_ANNOTATIONS_DIR"
 
 # Service knobs (same defaults the docker run wires via -e).
 export SCENE_WEB_PORT="${SCENE_WEB_PORT:-50107}"

--- a/system/scene/tests/test_annotations.py
+++ b/system/scene/tests/test_annotations.py
@@ -294,7 +294,7 @@ def test_rest_crud_roundtrip():
         assert (st, out) == (200, {"ok": True, "annotations": []})
 
         st, out = _call(app, "POST", "/api/annotations",
-                        {"kind": "room", "name": "厨房", "points": ROOM_PTS})
+                        {"kind": "room", "name": "kitchen-draft", "points": ROOM_PTS})
         assert st == 200 and out["ok"]
         ann_id = out["annotation"]["annotation_id"]
 

--- a/system/scene/tests/test_annotations.py
+++ b/system/scene/tests/test_annotations.py
@@ -12,6 +12,7 @@ import json
 import os
 import sys
 import tempfile
+from types import SimpleNamespace
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -246,7 +247,7 @@ def test_from_json_drops_unknown_keys():
 
 # ── REST API (hand-rolled ASGI, no httpx needed) ────────────────────────────
 
-def _make_web_app(anno_store):
+def _make_web_app(anno_store, **overrides):
     """Import scene_service.web lazily and build an app with only the
     pieces the annotation routes need. When the web import chain is
     unavailable (bare environment): under pytest the caller's test is
@@ -265,11 +266,14 @@ def _make_web_app(anno_store):
         _objects: dict = {}
         _surfaces: dict = {}
 
-    return web_mod.make_app(
-        registry=_StubRegistry(), anno_store=anno_store,
-        map_binding={"map_id": "lab", "mode": "mapping",
-                     "generation": 1, "source": "lifecycle"},
-    )
+    options = {
+        "registry": _StubRegistry(),
+        "anno_store": anno_store,
+        "map_binding": {"map_id": "lab", "mode": "mapping",
+                        "generation": 1, "source": "lifecycle"},
+    }
+    options.update(overrides)
+    return web_mod.make_app(**options)
 
 
 def _call(app, method: str, path: str, body=None):
@@ -342,6 +346,56 @@ def test_rest_crud_roundtrip():
         assert (st, out) == (200, {"ok": True})
         assert store.list() == []
     print("  [PASS] test_rest_crud_roundtrip")
+
+
+def test_map_load_waits_for_new_occupancy_before_rebinding(monkeypatch):
+    try:
+        from scene_service import web as web_mod
+    except ImportError as e:
+        import pytest
+        pytest.skip(f"web deps unavailable: {e}")
+
+    class Hub:
+        loaded = False
+
+        @staticmethod
+        def has(_name):
+            return True
+
+        def latest(self, _name):
+            count = 2 if self.loaded else 1
+            msg = SimpleNamespace(info=SimpleNamespace(width=20, height=12))
+            return msg, float(count), count
+
+    hub = Hub()
+
+    def map_rpc(op, payload, _timeout=30.0):
+        assert op == "load_map"
+        assert payload["map_id"] == "saved_lab"
+        hub.loaded = True
+        return {"ok": True, "detail": "loaded once"}
+
+    monkeypatch.setattr(web_mod, "_map_rpc", map_rpc)
+    with tempfile.TemporaryDirectory() as base:
+        AnnotationStore(base, map_id="saved_lab", generation=1).create(
+            kind="room", name="restored", points=ROOM_PTS,
+        )
+        store = AnnotationStore(base, map_id="live", generation=1)
+        binding = {"map_id": "live", "mode": "mapping",
+                   "generation": 1, "source": "lifecycle"}
+        app = _make_web_app(store, hub=hub, map_binding=binding)
+
+        status, out = _call(
+            app, "POST", "/api/maps/load",
+            {"map_id": "saved_lab", "mode": "localization"},
+        )
+
+        assert status == 200 and out["ok"] is True
+        assert out["occupancy"]["count"] == 2
+        assert binding["map_id"] == "saved_lab"
+        assert binding["mode"] == "localization"
+        assert [room.name for room in store.list()] == ["restored"]
+    print("  [PASS] test_map_load_waits_for_new_occupancy_before_rebinding")
 
 
 def test_rest_validation_and_errors():

--- a/system/scene/tests/test_annotations.py
+++ b/system/scene/tests/test_annotations.py
@@ -1,0 +1,424 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+"""Unit tests for user annotations (scene_service.annotations) and the
+annotation CRUD REST API (scene_service.web).
+
+The store tests are pure Python + tmp dirs and always run. The web tests
+drive the Starlette app through a hand-rolled ASGI call (no httpx /
+TestClient dependency); they need starlette + the scene_service.web import
+chain and skip loudly when that is unavailable (e.g. a bare mac checkout).
+"""
+import asyncio
+import json
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from scene_service.annotations import (  # noqa: E402
+    AnnotationStore,
+    validate_annotation_fields,
+)
+
+ROOM_PTS = [[0.0, 0.0], [2.0, 0.0], [2.0, 1.5], [0.0, 1.5]]
+
+
+# ── validation ──────────────────────────────────────────────────────────────
+
+def test_validation_rules():
+    ok = validate_annotation_fields
+    assert ok("room", "kitchen", ROOM_PTS, None) is None
+    assert ok("poi", "dock", [[1.0, 2.0]], 1.57) is None
+    assert ok("no_go", "x", ROOM_PTS, None)           # unknown kind
+    assert ok("room", 7, ROOM_PTS, None)              # non-string name
+    assert ok("room", "x" * 200, ROOM_PTS, None)      # name too long
+    assert ok("room", "x", ROOM_PTS[:2], None)        # polygon < 3 points
+    assert ok("poi", "x", ROOM_PTS[:2], None)         # poi != 1 point
+    assert ok("room", "x", [[0.0, float("nan")]] * 3, None)   # NaN point
+    assert ok("room", "x", [[0.0], [1.0], [2.0]], None)       # not pairs
+    assert ok("room", "x", "not-a-list", None)
+    assert ok("poi", "x", [[0.0, 0.0]], float("inf"))         # inf theta
+    assert ok("poi", "x", [[0.0, 0.0]], "north")              # non-number theta
+    assert ok("poi", "x", [[True, 0.0]], None)                # bool is not a coord
+    assert ok("room", "x", ROOM_PTS, 1.57)                    # heading on a room
+    print("  [PASS] test_validation_rules")
+
+
+# ── store ───────────────────────────────────────────────────────────────────
+
+def test_store_roundtrip_across_reopen():
+    with tempfile.TemporaryDirectory() as base:
+        s1 = AnnotationStore(base, map_id="lab", generation=2)
+        room = s1.create(kind="room", name="kitchen", points=ROOM_PTS)
+        poi = s1.create(kind="poi", name="dock", points=[[1.0, 2.0]], theta=0.5)
+        assert room.annotation_id.startswith("anno.")
+        assert room.created_at > 0 and room.updated_at >= room.created_at
+
+        s2 = AnnotationStore(base, map_id="lab", generation=2)
+        got = {a.annotation_id: a for a in s2.list()}
+        assert got[room.annotation_id].points == ROOM_PTS
+        assert got[room.annotation_id].name == "kitchen"
+        assert got[poi.annotation_id].theta == 0.5
+        assert not any(a.stale for a in got.values())
+    print("  [PASS] test_store_roundtrip_across_reopen")
+
+
+def test_update_and_delete():
+    with tempfile.TemporaryDirectory() as base:
+        s = AnnotationStore(base, map_id="lab", generation=1)
+        a = s.create(kind="room", name="old", points=ROOM_PTS)
+        u = s.update(a.annotation_id, name="new")
+        assert u.name == "new" and u.updated_at >= a.updated_at
+        assert s.update("anno.missing", name="x") is None
+        assert s.delete(a.annotation_id) is True
+        assert s.delete(a.annotation_id) is False
+        assert s.list() == []
+    print("  [PASS] test_update_and_delete")
+
+
+def test_map_id_partition_isolation_and_sanitize():
+    with tempfile.TemporaryDirectory() as base:
+        s_a = AnnotationStore(base, map_id="lab_a", generation=1)
+        s_b = AnnotationStore(base, map_id="lab_b", generation=1)
+        s_a.create(kind="room", name="only-in-a", points=ROOM_PTS)
+        assert s_b.list() == []
+        assert AnnotationStore(base, map_id="lab_b", generation=1).list() == []
+        assert len(AnnotationStore(base, map_id="lab_a", generation=1).list()) == 1
+
+        # Hostile map_id chars are squashed to "_" — same rule as the
+        # object store, so the two partitions always agree on the key.
+        s_evil = AnnotationStore(base, map_id="we ird/../id", generation=1)
+        assert s_evil.map_id == "we_ird_.._id"
+        assert s_evil.path.parent == s_a.path.parent  # no path escape
+    print("  [PASS] test_map_id_partition_isolation_and_sanitize")
+
+
+def test_atomic_write_leaves_no_tmp():
+    with tempfile.TemporaryDirectory() as base:
+        s = AnnotationStore(base, map_id="lab", generation=1)
+        s.create(kind="room", name="r", points=ROOM_PTS)
+        s.mark_all_stale("test", new_generation=2)
+        leftovers = [p for p in os.listdir(base) if p.endswith(".tmp")]
+        assert leftovers == []
+        data = json.loads(open(os.path.join(base, "lab.json")).read())
+        assert set(data) == {"map_id", "generation", "annotations"}
+    print("  [PASS] test_atomic_write_leaves_no_tmp")
+
+
+def test_generation_mismatch_marks_stale_on_load():
+    with tempfile.TemporaryDirectory() as base:
+        s1 = AnnotationStore(base, map_id="lab", generation=2)
+        a = s1.create(kind="room", name="kitchen", points=ROOM_PTS)
+
+        # Same generation → untouched.
+        assert not AnnotationStore(base, map_id="lab", generation=2).list()[0].stale
+
+        # Bumped generation → stale + reason, and the flag is persisted.
+        s3 = AnnotationStore(base, map_id="lab", generation=3)
+        got = s3.get(a.annotation_id)
+        assert got.stale and "2→3" in got.stale_reason
+        raw = json.loads(open(s3.path).read())
+        assert raw["annotations"][0]["stale"] is True
+
+        # User confirms it is still valid → stale cleared, persisted.
+        s3.update(a.annotation_id, clear_stale=True)
+        assert not AnnotationStore(base, map_id="lab", generation=3).get(
+            a.annotation_id).stale
+    print("  [PASS] test_generation_mismatch_marks_stale_on_load")
+
+
+def test_unknown_generation_preserves_stored_epoch():
+    with tempfile.TemporaryDirectory() as base:
+        AnnotationStore(base, map_id="lab", generation=5).create(
+            kind="room", name="r", points=ROOM_PTS)
+        # A static-binding boot (no broadcast → generation None) cannot
+        # judge staleness: nothing is flagged AND the stored epoch must
+        # survive the session so a later bound boot still can.
+        s = AnnotationStore(base, map_id="lab", generation=None)
+        assert not s.list()[0].stale
+        s.update(s.list()[0].annotation_id, name="renamed")   # forces a save
+        assert json.loads(open(s.path).read())["generation"] == 5
+        assert AnnotationStore(base, map_id="lab", generation=6).list()[0].stale
+    print("  [PASS] test_unknown_generation_preserves_stored_epoch")
+
+
+def test_reconcile_generation_learns_and_flags():
+    with tempfile.TemporaryDirectory() as base:
+        AnnotationStore(base, map_id="lab", generation=None).create(
+            kind="room", name="r", points=ROOM_PTS)
+        # A file written under an unknown epoch adopts the confirmed one
+        # without flagging anything (there is nothing to disagree with).
+        s = AnnotationStore(base, map_id="lab", generation=None)
+        assert s.reconcile_generation(5) == 0
+        assert not s.list()[0].stale
+        assert json.loads(open(s.path).read())["generation"] == 5
+        assert s.reconcile_generation(5) == 0        # same epoch: no-op
+
+        # A recorded epoch that DIFFERS from the confirmed one means the
+        # map frame moved since the annotations were drawn → all stale.
+        s2 = AnnotationStore(base, map_id="lab", generation=None)
+        assert s2.reconcile_generation(7) == 1
+        got = s2.list()[0]
+        assert got.stale and "5→7" in got.stale_reason
+    print("  [PASS] test_reconcile_generation_learns_and_flags")
+
+
+def test_redraw_clears_stale_and_mark_all_stale_counts():
+    with tempfile.TemporaryDirectory() as base:
+        s = AnnotationStore(base, map_id="lab", generation=1)
+        a = s.create(kind="room", name="r", points=ROOM_PTS)
+        b = s.create(kind="poi", name="p", points=[[0.0, 0.0]])
+        assert s.mark_all_stale("epoch flip", new_generation=2) == 2
+        assert s.mark_all_stale("epoch flip", new_generation=2) == 0  # idempotent
+        # Redrawing geometry re-authors it against the CURRENT frame →
+        # staleness no longer applies.
+        assert s.update(a.annotation_id, points=ROOM_PTS).stale is False
+        assert s.get(b.annotation_id).stale is True
+    print("  [PASS] test_redraw_clears_stale_and_mark_all_stale_counts")
+
+
+def test_corrupt_file_set_aside_not_destroyed():
+    # Every bad-file shape must take the same quarantine path: parse
+    # error, valid-JSON-but-not-an-object, non-object annotation entry,
+    # non-numeric generation, and a record that fails field validation
+    # (per-map files are user-visible JSON, hand edits happen).
+    bad_files = [
+        "{not json",
+        "[1, 2, 3]",
+        '"just a string"',
+        '{"map_id": "lab", "generation": 1, "annotations": [3]}',
+        '{"map_id": "lab", "generation": "three", "annotations": []}',
+        '{"map_id": "lab", "generation": 1, "annotations": '
+        '[{"annotation_id": "anno.x", "kind": "castle", "name": "x", '
+        '"points": [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]]}]}',
+    ]
+    for content in bad_files:
+        with tempfile.TemporaryDirectory() as base:
+            path = os.path.join(base, "lab.json")
+            with open(path, "w") as f:
+                f.write(content)
+            s = AnnotationStore(base, map_id="lab", generation=1)
+            assert s.list() == [], content
+            aside = [p for p in os.listdir(base) if ".corrupt-" in p]
+            assert len(aside) == 1, content
+            assert open(os.path.join(base, aside[0])).read() == content
+    print("  [PASS] test_corrupt_file_set_aside_not_destroyed")
+
+
+def test_from_json_drops_unknown_keys():
+    from scene_service.annotations import Annotation
+    a = Annotation.from_json({
+        "annotation_id": "anno.x", "kind": "room", "name": "r",
+        "points": [[0.0, 0.0]], "written_by_future_scene": True,
+    })
+    assert a.annotation_id == "anno.x" and not hasattr(a, "written_by_future_scene")
+    print("  [PASS] test_from_json_drops_unknown_keys")
+
+
+# ── REST API (hand-rolled ASGI, no httpx needed) ────────────────────────────
+
+def _make_web_app(anno_store):
+    """Import scene_service.web lazily and build an app with only the
+    pieces the annotation routes need. When the web import chain is
+    unavailable (bare environment): under pytest the caller's test is
+    SKIPPED (visible in the report, not a hollow pass); standalone it
+    prints and returns None."""
+    try:
+        from scene_service import web as web_mod
+    except ImportError as e:
+        if os.environ.get("PYTEST_CURRENT_TEST"):
+            import pytest
+            pytest.skip(f"web deps unavailable: {e}")
+        print(f"  [SKIP] web tests unavailable: {e}")
+        return None
+
+    class _StubRegistry:  # annotation routes never touch the registry
+        _objects: dict = {}
+        _surfaces: dict = {}
+
+    return web_mod.make_app(
+        registry=_StubRegistry(), anno_store=anno_store,
+        map_binding={"map_id": "lab", "mode": "mapping",
+                     "generation": 1, "source": "lifecycle"},
+    )
+
+
+def _call(app, method: str, path: str, body=None):
+    """Drive the ASGI app directly with one JSON request; return
+    (status, parsed-body). Avoids the TestClient→httpx dependency.
+
+    Runs on a PRIVATE event loop (not asyncio.run, which unsets the
+    thread's current loop on exit and would starve later test files
+    that still use the ambient-loop pattern — the exact cross-file
+    pollution test_scene_graph._ensure_loop guards against)."""
+    raw = json.dumps(body).encode() if body is not None else b""
+    scope = {
+        "type": "http", "http_version": "1.1", "method": method,
+        "scheme": "http", "path": path, "raw_path": path.encode(),
+        "root_path": "", "query_string": b"", "client": ("test", 0),
+        "server": ("test", 80),
+        "headers": [(b"content-type", b"application/json"),
+                    (b"content-length", str(len(raw)).encode())],
+    }
+    sent, done = [], {"body": False}
+
+    async def receive():
+        if done["body"]:
+            return {"type": "http.disconnect"}
+        done["body"] = True
+        return {"type": "http.request", "body": raw, "more_body": False}
+
+    async def send(message):
+        sent.append(message)
+
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(app(scope, receive, send))
+    finally:
+        loop.close()
+    status = next(m["status"] for m in sent
+                  if m["type"] == "http.response.start")
+    payload = b"".join(m.get("body", b"") for m in sent
+                       if m["type"] == "http.response.body")
+    return status, (json.loads(payload) if payload else None)
+
+
+def test_rest_crud_roundtrip():
+    with tempfile.TemporaryDirectory() as base:
+        store = AnnotationStore(base, map_id="lab", generation=1)
+        app = _make_web_app(store)
+        if app is None:
+            return
+
+        st, out = _call(app, "GET", "/api/annotations")
+        assert (st, out) == (200, {"ok": True, "annotations": []})
+
+        st, out = _call(app, "POST", "/api/annotations",
+                        {"kind": "room", "name": "厨房", "points": ROOM_PTS})
+        assert st == 200 and out["ok"]
+        ann_id = out["annotation"]["annotation_id"]
+
+        st, out = _call(app, "PUT", f"/api/annotations/{ann_id}",
+                        {"name": "kitchen"})
+        assert st == 200 and out["annotation"]["name"] == "kitchen"
+
+        # stale confirm flow: flag via the store (what the lifecycle
+        # watcher does), clear via the API (what the UI button does).
+        store.mark_all_stale("epoch flip", new_generation=2)
+        st, out = _call(app, "PUT", f"/api/annotations/{ann_id}",
+                        {"stale": False})
+        assert st == 200 and out["annotation"]["stale"] is False
+
+        st, out = _call(app, "DELETE", f"/api/annotations/{ann_id}")
+        assert (st, out) == (200, {"ok": True})
+        assert store.list() == []
+    print("  [PASS] test_rest_crud_roundtrip")
+
+
+def test_rest_validation_and_errors():
+    with tempfile.TemporaryDirectory() as base:
+        store = AnnotationStore(base, map_id="lab", generation=1)
+        app = _make_web_app(store)
+        if app is None:
+            return
+
+        st, out = _call(app, "POST", "/api/annotations",
+                        {"kind": "castle", "name": "x", "points": ROOM_PTS})
+        assert st == 400 and not out["ok"] and "kind" in out["detail"]
+
+        st, _ = _call(app, "POST", "/api/annotations",
+                      {"kind": "room", "name": "x", "points": ROOM_PTS[:2]})
+        assert st == 400
+
+        st, out = _call(app, "POST", "/api/annotations",
+                        {"kind": "room", "name": "x", "points": ROOM_PTS,
+                         "theta": 1.57})
+        assert st == 400 and "poi" in out["detail"]  # headings are poi-only
+
+        st, _ = _call(app, "PUT", "/api/annotations/anno.nope", {"name": "x"})
+        assert st == 404
+        st, _ = _call(app, "DELETE", "/api/annotations/anno.nope")
+        assert st == 404
+
+        # A partial update may not sneak in an invalid merged state.
+        _, created = _call(app, "POST", "/api/annotations",
+                           {"kind": "room", "name": "x", "points": ROOM_PTS})
+        st, _ = _call(app, "PUT",
+                      f"/api/annotations/{created['annotation']['annotation_id']}",
+                      {"points": [[0.0, 0.0]]})
+        assert st == 400
+
+        # Store unavailable → 503 on every verb.
+        app_off = _make_web_app(None)
+        for method, path in [("GET", "/api/annotations"),
+                             ("POST", "/api/annotations"),
+                             ("PUT", "/api/annotations/x"),
+                             ("DELETE", "/api/annotations/x")]:
+            st, out = _call(app_off, method, path, {})
+            assert st == 503 and not out["ok"]
+    print("  [PASS] test_rest_validation_and_errors")
+
+
+def test_user_page_served():
+    with tempfile.TemporaryDirectory() as base:
+        app = _make_web_app(AnnotationStore(base, map_id="lab", generation=1))
+        if app is None:
+            return
+        sent = []
+
+        async def receive():
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        async def send(message):
+            sent.append(message)
+
+        scope = {"type": "http", "http_version": "1.1", "method": "GET",
+                 "scheme": "http", "path": "/user", "raw_path": b"/user",
+                 "root_path": "", "query_string": b"", "headers": [],
+                 "client": ("test", 0), "server": ("test", 80)}
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(app(scope, receive, send))
+        finally:
+            loop.close()
+        status = next(m["status"] for m in sent
+                      if m["type"] == "http.response.start")
+        body = b"".join(m.get("body", b"") for m in sent
+                        if m["type"] == "http.response.body")
+        assert status == 200
+        assert b"Annotate room" in body and b"/api/annotations" in body
+    print("  [PASS] test_user_page_served")
+
+
+def test_state_payload_carries_annotations_and_binding():
+    with tempfile.TemporaryDirectory() as base:
+        store = AnnotationStore(base, map_id="lab", generation=1)
+        store.create(kind="room", name="kitchen", points=ROOM_PTS)
+        app = _make_web_app(store)
+        if app is None:
+            return
+        st, out = _call(app, "GET", "/api/state")
+        assert st == 200
+        assert out["map_binding"]["map_id"] == "lab"
+        assert len(out["annotations"]) == 1
+        assert out["annotations"][0]["name"] == "kitchen"
+    print("  [PASS] test_state_payload_carries_annotations_and_binding")
+
+
+if __name__ == "__main__":
+    test_validation_rules()
+    test_store_roundtrip_across_reopen()
+    test_update_and_delete()
+    test_map_id_partition_isolation_and_sanitize()
+    test_atomic_write_leaves_no_tmp()
+    test_generation_mismatch_marks_stale_on_load()
+    test_unknown_generation_preserves_stored_epoch()
+    test_reconcile_generation_learns_and_flags()
+    test_redraw_clears_stale_and_mark_all_stale_counts()
+    test_corrupt_file_set_aside_not_destroyed()
+    test_from_json_drops_unknown_keys()
+    test_rest_crud_roundtrip()
+    test_rest_validation_and_errors()
+    test_user_page_served()
+    test_state_payload_carries_annotations_and_binding()
+    print("test_annotations: all tests passed")

--- a/system/scene/tests/test_annotations.py
+++ b/system/scene/tests/test_annotations.py
@@ -107,6 +107,21 @@ def test_map_id_partition_isolation_and_sanitize():
     print("  [PASS] test_map_id_partition_isolation_and_sanitize")
 
 
+def test_delete_map_removes_only_target_partition():
+    with tempfile.TemporaryDirectory() as base:
+        target = AnnotationStore(base, map_id="target", generation=1)
+        other = AnnotationStore(base, map_id="other", generation=1)
+        target.create(kind="room", name="target room", points=ROOM_PTS)
+        other.create(kind="room", name="other room", points=ROOM_PTS)
+
+        assert target.delete_map("target") is True
+        assert target.list() == []
+        assert AnnotationStore(base, map_id="target", generation=1).list() == []
+        assert len(AnnotationStore(base, map_id="other", generation=1).list()) == 1
+        assert target.delete_map("target") is False
+    print("  [PASS] test_delete_map_removes_only_target_partition")
+
+
 def test_atomic_write_leaves_no_tmp():
     with tempfile.TemporaryDirectory() as base:
         s = AnnotationStore(base, map_id="lab", generation=1)
@@ -425,6 +440,7 @@ if __name__ == "__main__":
     test_room_create_is_idempotent_by_name()
     test_update_and_delete()
     test_map_id_partition_isolation_and_sanitize()
+    test_delete_map_removes_only_target_partition()
     test_atomic_write_leaves_no_tmp()
     test_generation_mismatch_marks_stale_on_load()
     test_unknown_generation_preserves_stored_epoch()

--- a/system/scene/tests/test_annotations.py
+++ b/system/scene/tests/test_annotations.py
@@ -63,6 +63,20 @@ def test_store_roundtrip_across_reopen():
     print("  [PASS] test_store_roundtrip_across_reopen")
 
 
+def test_room_create_is_idempotent_by_name():
+    with tempfile.TemporaryDirectory() as base:
+        s = AnnotationStore(base, map_id="lab", generation=1)
+        a = s.create(kind="room", name="Bathroom", points=ROOM_PTS)
+        b = s.create(kind="room", name="  bathroom  ",
+                     points=[[1.0, 1.0], [2.0, 1.0], [2.0, 2.0]])
+        assert a.annotation_id == b.annotation_id
+        assert len(s.list()) == 1
+        assert s.list()[0].points == [[1.0, 1.0], [2.0, 1.0], [2.0, 2.0]]
+        raw = json.loads(open(s.path).read())
+        assert len(raw["annotations"]) == 1
+    print("  [PASS] test_room_create_is_idempotent_by_name")
+
+
 def test_update_and_delete():
     with tempfile.TemporaryDirectory() as base:
         s = AnnotationStore(base, map_id="lab", generation=1)
@@ -408,6 +422,7 @@ def test_state_payload_carries_annotations_and_binding():
 if __name__ == "__main__":
     test_validation_rules()
     test_store_roundtrip_across_reopen()
+    test_room_create_is_idempotent_by_name()
     test_update_and_delete()
     test_map_id_partition_isolation_and_sanitize()
     test_atomic_write_leaves_no_tmp()

--- a/system/scene/tests/test_geometry.py
+++ b/system/scene/tests/test_geometry.py
@@ -1,0 +1,28 @@
+import pytest
+
+from scene_service.geometry import disc_inside_polygon, point_in_polygon, polygon_centroid
+
+
+ROOM_315 = [
+    (-4.653655402257238, 0.771744687675239),
+    (2.0362935039927557, 1.456772135591905),
+    (2.7504710560760888, -2.4201917185747583),
+    (-3.779152277257239, -3.3384199998247572),
+    (-4.609930246007238, 0.7425945835085723),
+]
+
+
+def test_room_centroid_is_area_weighted_and_inside():
+    x, y = polygon_centroid(ROOM_315)
+    assert x == pytest.approx(-0.9369215188)
+    assert y == pytest.approx(-0.8818296313)
+    assert point_in_polygon(x, y, ROOM_315)
+
+
+def test_rejects_the_goal_returned_outside_room_315():
+    assert not point_in_polygon(-0.9148793979, -3.7743059028, ROOM_315)
+
+
+def test_robot_footprint_must_remain_inside_room():
+    assert disc_inside_polygon(-0.94, -0.88, 0.3, ROOM_315)
+    assert not disc_inside_polygon(-3.75, -3.25, 0.3, ROOM_315)

--- a/system/scene/tests/test_goal_hints.py
+++ b/system/scene/tests/test_goal_hints.py
@@ -4,11 +4,14 @@ from scene_service import mcp_tools
 
 
 class _Store:
-    def list(self):
-        return [
+    def __init__(self, rooms=None):
+        self._rooms = rooms or [
             SimpleNamespace(annotation_id="anno.315", kind="room", name="room 315"),
             SimpleNamespace(annotation_id="anno.100", kind="room", name="room 100"),
         ]
+
+    def list(self):
+        return self._rooms
 
 
 def _object(object_id: str, label: str):
@@ -35,3 +38,23 @@ def test_object_hint_ranks_similar_label_first():
     )
     assert hint.index("cardboard box") < hint.index("chair")
     assert "scene.object.cardboard_box_001" in hint
+
+
+def test_room_reference_resolves_stable_id_name_and_short_alias():
+    mcp_tools.attach_annotation_store(_Store())
+    for reference in ("scene.room.anno.315", "room 315", "ROOM   315", "315"):
+        room, ambiguous = mcp_tools._resolve_room_target(reference)
+        assert room is not None
+        assert room.annotation_id == "anno.315"
+        assert ambiguous == []
+
+
+def test_room_reference_reports_ambiguous_aliases_without_guessing():
+    rooms = [
+        SimpleNamespace(annotation_id="anno.a", kind="room", name="room 315"),
+        SimpleNamespace(annotation_id="anno.b", kind="room", name="315"),
+    ]
+    mcp_tools.attach_annotation_store(_Store(rooms))
+    room, ambiguous = mcp_tools._resolve_room_target("315")
+    assert room is None
+    assert [item.annotation_id for item in ambiguous] == ["anno.a", "anno.b"]

--- a/system/scene/tests/test_goal_hints.py
+++ b/system/scene/tests/test_goal_hints.py
@@ -1,0 +1,37 @@
+from types import SimpleNamespace
+
+from scene_service import mcp_tools
+
+
+class _Store:
+    def list(self):
+        return [
+            SimpleNamespace(annotation_id="anno.315", kind="room", name="room 315"),
+            SimpleNamespace(annotation_id="anno.100", kind="room", name="room 100"),
+        ]
+
+
+def _object(object_id: str, label: str):
+    return SimpleNamespace(object_id=object_id, cls=label)
+
+
+def test_room_hint_lists_names_and_exact_ids():
+    mcp_tools.attach_annotation_store(_Store())
+    hint = mcp_tools._room_id_hint()
+    assert "room 315" in hint
+    assert "scene.room.anno.315" in hint
+    assert "room 100" in hint
+    assert "scene.room.anno.100" in hint
+
+
+def test_object_hint_ranks_similar_label_first():
+    hint = mcp_tools._object_id_hint(
+        "cardbord box",
+        [
+            _object("scene.object.chair_001", "chair"),
+            _object("scene.object.cardboard_box_001", "cardboard box"),
+            _object("scene.object.table_001", "table"),
+        ],
+    )
+    assert hint.index("cardboard box") < hint.index("chair")
+    assert "scene.object.cardboard_box_001" in hint

--- a/system/scene/tests/test_map_binding.py
+++ b/system/scene/tests/test_map_binding.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+"""Unit tests for the map identity binding (scene_service.map_binding).
+
+The precedence rule is pure Python and always runs. The latched-read
+probe test exercises the graceful-degradation path: on a machine without
+rclpy / the generated `map` interface package it must return None (not
+raise); on a full ROS container it still returns None because nothing
+publishes the probe topic within the short timeout.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from scene_service.map_binding import (  # noqa: E402
+    MapBinding,
+    choose_map_binding,
+    read_latched_lifecycle,
+)
+
+
+def test_broadcast_wins_over_config_and_env():
+    b = choose_map_binding(
+        {"map_id": "lab_a", "mode": "localization", "generation": 4},
+        "cfg_map", "env_map",
+    )
+    assert b == MapBinding(
+        map_id="lab_a", source="lifecycle", mode="localization", generation=4
+    )
+    print("  [PASS] test_broadcast_wins_over_config_and_env")
+
+
+def test_empty_broadcast_map_id_falls_through():
+    # mapping running ephemeral broadcasts map_id="" — that is "no named
+    # identity", static levers must win.
+    b = choose_map_binding({"map_id": "", "mode": "mapping", "generation": 1},
+                           "cfg_map", "env_map")
+    assert (b.map_id, b.source) == ("cfg_map", "config")
+    print("  [PASS] test_empty_broadcast_map_id_falls_through")
+
+
+def test_config_beats_env_then_env_then_default():
+    assert choose_map_binding(None, "cfg_map", "env_map").source == "config"
+    b = choose_map_binding(None, None, "env_map")
+    assert (b.map_id, b.source) == ("env_map", "env")
+    b = choose_map_binding(None, None, None)
+    assert (b.map_id, b.source) == ("default", "default")
+    # static sources carry no generation — the runtime watcher treats
+    # None as "match any generation" until P3 tightens this.
+    assert b.generation is None
+    print("  [PASS] test_config_beats_env_then_env_then_default")
+
+
+def test_probe_degrades_to_none_without_publisher():
+    # No rclpy / no `map` interface package → None with a warning;
+    # with ROS available → None after the (short) timeout since nothing
+    # publishes this probe-only topic. Either way: no exception.
+    assert read_latched_lifecycle("/robonix/test/map_binding_probe",
+                                  timeout_s=0.3) is None
+    print("  [PASS] test_probe_degrades_to_none_without_publisher")
+
+
+if __name__ == "__main__":
+    test_broadcast_wins_over_config_and_env()
+    test_empty_broadcast_map_id_falls_through()
+    test_config_beats_env_then_env_then_default()
+    test_probe_degrades_to_none_without_publisher()
+    print("test_map_binding: all tests passed")

--- a/system/scene/tests/test_map_operation_ui.py
+++ b/system/scene/tests/test_map_operation_ui.py
@@ -41,3 +41,11 @@ def test_embedded_user_script_is_valid_javascript():
         handle.write(script)
         handle.flush()
         subprocess.run([node, "--check", handle.name], check=True)
+
+
+def test_robot_marker_is_high_contrast_and_directional():
+    html = _user_html()
+    assert "const robotMarkerNose = 24" in html
+    assert "ctx.rotate(-yaw)" in html
+    assert "ctx.strokeStyle = '#ffffff'" in html
+    assert "ctx.fillStyle = '#ff5a1f'" in html

--- a/system/scene/tests/test_map_operation_ui.py
+++ b/system/scene/tests/test_map_operation_ui.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+"""Structural checks for the blocking Save/Load operation dialog."""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def _user_html():
+    try:
+        from scene_service.web import _USER_HTML
+    except ImportError as exc:
+        pytest.skip(f"web deps unavailable: {exc}")
+    return _USER_HTML
+
+
+def test_map_operations_have_one_blocking_dialog_and_retry_path():
+    html = _user_html()
+    assert 'id="map-operation-modal"' in html
+    assert "function beginMapOperation" in html
+    assert "function finishMapOperation" in html
+    assert "if (mapBusy) ev.preventDefault()" in html
+    assert "Wait for a fresh occupancy grid" in html
+    assert "Restore rooms and Scene objects" in html
+    assert "retry: () => loadSelectedMap(id)" in html
+
+
+def test_embedded_user_script_is_valid_javascript():
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is not installed")
+    html = _user_html()
+    script = html.rsplit("<script>", 1)[1].split("</script>", 1)[0]
+    with tempfile.NamedTemporaryFile("w", suffix=".js") as handle:
+        handle.write(script)
+        handle.flush()
+        subprocess.run([node, "--check", handle.name], check=True)

--- a/system/scene/tests/test_robot_context.py
+++ b/system/scene/tests/test_robot_context.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+import time
+from types import SimpleNamespace
+
+import asyncio
+
+from scene_service import mcp_tools
+from scene_service.state.object_registry import BBox3D, Pose3D, SceneObject
+
+
+class Registry:
+    def __init__(self, objects):
+        self.objects = objects
+
+    async def snapshot(self):
+        return self.objects, {}
+
+
+class Annotations:
+    map_id = "floor-3"
+
+    def list(self):
+        return [
+            SimpleNamespace(
+                annotation_id="315",
+                kind="room",
+                name="room 315",
+                points=[[-1.0, -1.0], [2.0, -1.0], [2.0, 2.0], [-1.0, 2.0]],
+            ),
+            SimpleNamespace(
+                annotation_id="open",
+                kind="area",
+                name="open area",
+                points=[[-2.0, -2.0], [3.0, -2.0], [3.0, 3.0], [-2.0, 3.0]],
+            ),
+        ]
+
+
+def scene_object(object_id, label, x, y, last_seen):
+    return SceneObject(
+        object_id=object_id,
+        cls=label,
+        pose=Pose3D(x, y, 0.0, yaw=0.4),
+        bbox=BBox3D(),
+        confidence=1.0,
+        first_seen=last_seen,
+        last_seen=last_seen,
+    )
+
+
+def test_robot_context_combines_pose_room_area_and_nearby_objects():
+    now = time.time()
+    objects = {
+        "robot": scene_object("scene.object.robot_001", "robot", 0.5, 0.5, now),
+        "banana": scene_object("scene.object.banana_001", "banana", 1.0, 0.5, now),
+        "far": scene_object("scene.object.chair_001", "chair", 10.0, 10.0, now),
+    }
+    mcp_tools.attach_state(registry=Registry(objects))
+    mcp_tools.attach_annotation_store(Annotations())
+
+    response = asyncio.run(
+        mcp_tools.get_robot_context(mcp_tools.GetRobotContext_Request())
+    )
+
+    assert response.pose_known and not response.stale
+    assert response.map_id == "floor-3"
+    assert response.room_id == "scene.room.315"
+    assert response.room_name == "room 315"
+    assert response.containing_area_names == ["open area", "room 315"]
+    assert [item.id for item in response.nearby_objects] == [
+        "scene.object.banana_001"
+    ]

--- a/system/scene/tests/test_scene_graph.py
+++ b/system/scene/tests/test_scene_graph.py
@@ -30,6 +30,20 @@ _LLM_ENV_VARS = (
 )
 
 
+def _ensure_loop() -> asyncio.AbstractEventLoop:
+    """Current event loop, creating (and installing) one when the thread has
+    none. Bare `asyncio.get_event_loop()` is unreliable across the suite:
+    running the milvus-lite tests (test_persistence) first leaves the main
+    thread without a current loop, and the deprecated implicit-creation path
+    then raises "There is no current event loop"."""
+    try:
+        return asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        return loop
+
+
 def _pop_llm_env() -> dict:
     """Pop all LLM-related env vars and return them for restoration."""
     return {k: os.environ.pop(k, None) for k in _LLM_ENV_VARS}
@@ -156,7 +170,7 @@ def test_captioner():
     node = SceneGraphNode("obj_1", "cup", (0, 0, 0), (0.1, 0.1, 0.1))
     assert node.caption is None
 
-    result = asyncio.get_event_loop().run_until_complete(cap.caption_node(node))
+    result = _ensure_loop().run_until_complete(cap.caption_node(node))
     assert result.caption == "cup"
     assert result.caption_updated_at is not None
     print("  [PASS] test_captioner")
@@ -257,7 +271,7 @@ def test_llm_client_no_key():
         client = SceneGraphLLMClient(api_key="", base_url="")
         assert not client.available
 
-        result = asyncio.get_event_loop().run_until_complete(
+        result = _ensure_loop().run_until_complete(
             client.chat_json("system", "user")
         )
         assert result == {}
@@ -281,7 +295,7 @@ def test_relation_inferer_no_llm():
         b = SceneGraphNode("obj_2", "table", (1.0, 0.5, 0.4), (1.2, 0.8, 0.05), caption="table")
         hint = GeometryHint(0.4, 0.6, "a_above_b", "none")
 
-        edge = asyncio.get_event_loop().run_until_complete(
+        edge = _ensure_loop().run_until_complete(
             inferer.infer_relation(a, b, hint)
         )
         assert edge.relation == "unknown"
@@ -318,7 +332,7 @@ def test_builder_rebuild_no_objects():
             config=config,
         )
 
-        snap = asyncio.get_event_loop().run_until_complete(builder.rebuild_once())
+        snap = _ensure_loop().run_until_complete(builder.rebuild_once())
         assert len(snap.nodes) == 0
         assert len(snap.edges) == 0
         assert snap.updated_at > 0
@@ -346,7 +360,7 @@ def _run_builder_rebuild_with_objects_body():
     with tempfile.TemporaryDirectory() as tmpdir:
         registry = ObjectRegistry()
 
-        loop = asyncio.get_event_loop()
+        loop = _ensure_loop()
 
         async def populate():
             async with registry.lock():
@@ -619,7 +633,7 @@ def test_infer_semantic_relation():
     a = SceneGraphNode("a", "handle", (0.0, 0.0, 0.5), (0.1, 0.1, 0.1))
     b = SceneGraphNode("b", "door", (0.0, 0.0, 0.5), (1.0, 0.1, 2.0))
     hint = GeometryHint(0.0, 0.5, "same_level", "a_inside_b")
-    run = asyncio.get_event_loop().run_until_complete
+    run = _ensure_loop().run_until_complete
 
     # A spatial answer is rejected — geometry owns the spatial slot → none.
     inf = RelationInferer(_FakeClient({"relation": "on_top_of", "confidence": 0.9}))
@@ -701,7 +715,7 @@ def test_llm_client_request_body():
         k.setdefault("transport", httpx.MockTransport(handler))
         return orig(*a, **k)
 
-    run = asyncio.get_event_loop().run_until_complete
+    run = _ensure_loop().run_until_complete
     httpx.AsyncClient = patched
     try:
         c = SceneGraphLLMClient(

--- a/system/soma/build.rs
+++ b/system/soma/build.rs
@@ -24,7 +24,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=build.rs");
     let _ = std::fs::remove_dir_all(&selected_contracts);
     std::fs::create_dir_all(&selected_contracts)?;
-    for name in ["get_yaml.v1.toml", "get_urdf.v1.toml", "footprint.v1.toml"] {
+    for name in [
+        "get_yaml.v1.toml",
+        "get_urdf.v1.toml",
+        "footprint.v1.toml",
+        "get_health.v1.toml",
+        "health.v1.toml",
+    ] {
         std::fs::copy(contracts_root.join(name), selected_contracts.join(name))?;
     }
 

--- a/system/soma/src/lib.rs
+++ b/system/soma/src/lib.rs
@@ -5,10 +5,14 @@ pub mod deployment;
 pub mod launcher;
 pub mod pb;
 pub mod report;
+pub mod runtime_monitor;
+pub mod runtime_state;
 pub mod service;
 pub mod store;
 
 pub const GET_YAML_CONTRACT: &str = "robonix/system/soma/get_yaml";
 pub const GET_URDF_CONTRACT: &str = "robonix/system/soma/get_urdf";
 pub const GET_FOOTPRINT_CONTRACT: &str = "robonix/system/soma/footprint";
+pub const GET_HEALTH_CONTRACT: &str = "robonix/system/soma/get_health";
+pub const HEALTH_CONTRACT: &str = "robonix/system/soma/health";
 pub const SOMA_NAMESPACE: &str = "robonix/system/soma";

--- a/system/soma/src/main.rs
+++ b/system/soma/src/main.rs
@@ -36,12 +36,17 @@ use robonix_soma::deployment::Deployment;
 use robonix_soma::launcher::PackageLauncher;
 use robonix_soma::pb::contracts::{
     robonix_system_soma_footprint_server::RobonixSystemSomaFootprintServer,
+    robonix_system_soma_get_health_server::RobonixSystemSomaGetHealthServer,
     robonix_system_soma_get_urdf_server::RobonixSystemSomaGetUrdfServer,
     robonix_system_soma_get_yaml_server::RobonixSystemSomaGetYamlServer,
+    robonix_system_soma_health_server::RobonixSystemSomaHealthServer,
 };
 use robonix_soma::service::SomaService;
 use robonix_soma::store::SomaBody;
-use robonix_soma::{GET_FOOTPRINT_CONTRACT, GET_URDF_CONTRACT, GET_YAML_CONTRACT, SOMA_NAMESPACE};
+use robonix_soma::{
+    GET_FOOTPRINT_CONTRACT, GET_HEALTH_CONTRACT, GET_URDF_CONTRACT, GET_YAML_CONTRACT,
+    HEALTH_CONTRACT, SOMA_NAMESPACE,
+};
 use std::os::fd::{FromRawFd, RawFd};
 use std::sync::Arc;
 use std::time::Duration;
@@ -50,6 +55,8 @@ use tokio::signal::unix::{SignalKind, signal};
 const GET_YAML_TOML: &str = "capabilities/system/soma/get_yaml.v1.toml";
 const GET_URDF_TOML: &str = "capabilities/system/soma/get_urdf.v1.toml";
 const GET_FOOTPRINT_TOML: &str = "capabilities/system/soma/footprint.v1.toml";
+const GET_HEALTH_TOML: &str = "capabilities/system/soma/get_health.v1.toml";
+const HEALTH_TOML: &str = "capabilities/system/soma/health.v1.toml";
 /// Line rbnx writes to the stage-trigger pipe to release soma's
 /// stage 2. Match this exactly in rbnx's `cmd::deploy.rs` — they're
 /// a contract pair, not configurable per deployment.
@@ -104,12 +111,25 @@ async fn main() -> Result<()> {
     // unregistered and non-ACTIVE in Atlas. Robot-state primitives use this
     // single source to publish the URDF-defined ROS TF tree.
     let svc = Arc::new(SomaService::new(Arc::clone(&body)));
+    let runtime_state = svc.runtime();
+    let snapshot_service = Arc::clone(&svc);
+    let snapshot_task = tokio::spawn(async move {
+        let mut tick = tokio::time::interval(Duration::from_millis(500));
+        let mut seq = 0_u64;
+        loop {
+            tick.tick().await;
+            seq += 1;
+            snapshot_service.publish_runtime_snapshot(seq).await;
+        }
+    });
     let (body_shutdown_tx, body_shutdown_rx) = tokio::sync::oneshot::channel();
     let mut body_server = tokio::spawn(async move {
         tonic::transport::Server::builder()
             .add_service(RobonixSystemSomaGetYamlServer::from_arc(Arc::clone(&svc)))
             .add_service(RobonixSystemSomaGetUrdfServer::from_arc(Arc::clone(&svc)))
-            .add_service(RobonixSystemSomaFootprintServer::from_arc(svc))
+            .add_service(RobonixSystemSomaFootprintServer::from_arc(Arc::clone(&svc)))
+            .add_service(RobonixSystemSomaGetHealthServer::from_arc(Arc::clone(&svc)))
+            .add_service(RobonixSystemSomaHealthServer::from_arc(svc))
             .serve_with_shutdown(listen_addr, async {
                 let _ = body_shutdown_rx.await;
             })
@@ -122,7 +142,7 @@ async fn main() -> Result<()> {
     );
 
     let mut launcher = PackageLauncher::new(
-        log_dir,
+        log_dir.clone(),
         config.atlas_endpoint.clone(),
         config.listen.clone(),
     )
@@ -194,6 +214,34 @@ async fn main() -> Result<()> {
         .await
         .context("declare Soma footprint gRPC capability")?;
     atlas
+        .declare_capability(
+            &config.provider_id,
+            GET_HEALTH_CONTRACT,
+            atlas_pb::Transport::Grpc,
+            &advertised,
+            atlas_client::grpc_params(
+                GET_HEALTH_TOML,
+                "robonix.contracts.RobonixSystemSomaGetHealth",
+                "/robonix.contracts.RobonixSystemSomaGetHealth/GetHealth",
+            ),
+        )
+        .await
+        .context("declare Soma get_health gRPC capability")?;
+    atlas
+        .declare_capability(
+            &config.provider_id,
+            HEALTH_CONTRACT,
+            atlas_pb::Transport::Grpc,
+            &advertised,
+            atlas_client::grpc_params(
+                HEALTH_TOML,
+                "robonix.contracts.RobonixSystemSomaHealth",
+                "/robonix.contracts.RobonixSystemSomaHealth/StreamHealth",
+            ),
+        )
+        .await
+        .context("declare Soma health stream gRPC capability")?;
+    atlas
         .set_lifecycle_state(
             &config.provider_id,
             atlas_pb::LifecycleState::StateActive,
@@ -201,6 +249,21 @@ async fn main() -> Result<()> {
         )
         .await
         .context("set Soma lifecycle ACTIVE")?;
+    let runtime_dir = log_dir.join("soma-runtime");
+    let runtime_monitor = match robonix_soma::runtime_monitor::start(
+        &mut atlas,
+        &config.provider_id,
+        runtime_state,
+        &runtime_dir,
+    )
+    .await
+    {
+        Ok(monitor) => monitor,
+        Err(error) => {
+            warn!("[soma/state] runtime monitor unavailable: {error:#}");
+            None
+        }
+    };
     let heartbeat_failure = {
         let mut hb = atlas.clone();
         let provider_id = config.provider_id.clone();
@@ -277,6 +340,10 @@ async fn main() -> Result<()> {
     // so its pipe read doesn't come back and try to reuse a torn-down
     // launcher.
     stage2_task.abort();
+    snapshot_task.abort();
+    if let Some(runtime_monitor) = runtime_monitor {
+        runtime_monitor.shutdown(&mut atlas).await;
+    }
     stage2_launcher.lock().await.stop_all().await?;
     serve_result?;
     Ok(())

--- a/system/soma/src/runtime_monitor.rs
+++ b/system/soma/src/runtime_monitor.rs
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: MulanPSL-2.0
+
+use crate::runtime_state::RuntimeStateStore;
+use anyhow::{Context, Result};
+use robonix_atlas::client::AtlasClient;
+use robonix_atlas::pb as atlas_pb;
+use robonix_scribe::{info, warn};
+use serde::Serialize;
+use std::path::Path;
+use std::process::Stdio;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::{Child, Command};
+
+const JOINT_STATES: &str = "robonix/primitive/arm/joint_states";
+const CHASSIS_ODOM: &str = "robonix/primitive/chassis/odom";
+
+#[derive(Debug, Serialize)]
+struct Source {
+    kind: &'static str,
+    provider_id: String,
+    topic: String,
+    qos: String,
+}
+
+pub struct RuntimeMonitor {
+    child: Child,
+    channel_ids: Vec<String>,
+}
+
+pub async fn start(
+    atlas: &mut AtlasClient,
+    consumer_id: &str,
+    state: RuntimeStateStore,
+    runtime_dir: &Path,
+) -> Result<Option<RuntimeMonitor>> {
+    let mut sources = Vec::new();
+    let mut channel_ids = Vec::new();
+    for (contract_id, kind) in [(JOINT_STATES, "joint_state"), (CHASSIS_ODOM, "odom")] {
+        let providers = atlas
+            .query_capabilities("", contract_id, atlas_pb::Transport::Ros2)
+            .await
+            .with_context(|| format!("discover {contract_id}"))?;
+        for provider in providers {
+            if provider.state != atlas_pb::LifecycleState::StateActive as i32 {
+                continue;
+            }
+            match atlas
+                .connect_capability(
+                    consumer_id,
+                    &provider.id,
+                    contract_id,
+                    atlas_pb::Transport::Ros2,
+                )
+                .await
+            {
+                Ok((channel_id, topic, params)) if !topic.trim().is_empty() => {
+                    let qos = match params.kind {
+                        Some(atlas_pb::transport_params::Kind::Ros2(value)) => value.qos_profile,
+                        _ => String::new(),
+                    };
+                    sources.push(Source {
+                        kind,
+                        provider_id: provider.id,
+                        topic,
+                        qos,
+                    });
+                    channel_ids.push(channel_id);
+                }
+                Ok((channel_id, _, _)) => {
+                    let _ = atlas.disconnect_capability(&channel_id).await;
+                }
+                Err(error) => warn!("[soma/state] connect {contract_id} failed: {error:#}"),
+            }
+        }
+    }
+    if sources.is_empty() {
+        warn!("[soma/state] no ROS 2 arm joint-state or chassis odometry sources discovered");
+        return Ok(None);
+    }
+
+    std::fs::create_dir_all(runtime_dir)
+        .with_context(|| format!("create runtime directory {}", runtime_dir.display()))?;
+    let script = runtime_dir.join("soma_runtime_ros.py");
+    let config = runtime_dir.join("soma_runtime_sources.json");
+    std::fs::write(&script, include_str!("runtime_ros.py"))
+        .with_context(|| format!("write {}", script.display()))?;
+    std::fs::write(
+        &config,
+        serde_json::to_vec_pretty(&serde_json::json!({ "sources": sources }))?,
+    )
+    .with_context(|| format!("write {}", config.display()))?;
+
+    let mut child = Command::new("python3")
+        .arg("-u")
+        .arg(&script)
+        .arg(&config)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .context("spawn Soma ROS 2 runtime reader")?;
+    let stdout = child
+        .stdout
+        .take()
+        .context("capture runtime reader stdout")?;
+    let stderr = child
+        .stderr
+        .take()
+        .context("capture runtime reader stderr")?;
+    tokio::spawn({
+        let state = state.clone();
+        async move {
+            let mut lines = BufReader::new(stdout).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                if let Err(error) = state.apply_line(&line).await {
+                    warn!("[soma/state] invalid runtime event: {error}: {line}");
+                }
+            }
+        }
+    });
+    tokio::spawn(async move {
+        let mut lines = BufReader::new(stderr).lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            warn!("[soma/state/ros] {line}");
+        }
+    });
+    info!(
+        "[soma/state] runtime reader started with {} source(s)",
+        sources.len()
+    );
+    Ok(Some(RuntimeMonitor { child, channel_ids }))
+}
+
+impl RuntimeMonitor {
+    pub async fn shutdown(mut self, atlas: &mut AtlasClient) {
+        let _ = self.child.kill().await;
+        for channel_id in self.channel_ids {
+            let _ = atlas.disconnect_capability(&channel_id).await;
+        }
+    }
+}

--- a/system/soma/src/runtime_ros.py
+++ b/system/soma/src/runtime_ros.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Internal Soma ROS 2 reader. Endpoints come exclusively from Atlas."""
+from __future__ import annotations
+
+import json
+import sys
+import time
+
+
+def emit(payload: dict) -> None:
+    print(json.dumps(payload, separators=(",", ":")), flush=True)
+
+
+def main() -> int:
+    config = json.loads(open(sys.argv[1], encoding="utf-8").read())
+    try:
+        import rclpy
+        from nav_msgs.msg import Odometry
+        from rclpy.qos import QoSProfile, ReliabilityPolicy
+        from sensor_msgs.msg import JointState
+    except Exception as exc:
+        emit({"kind": "warning", "message": f"ROS 2 runtime reader unavailable: {exc}"})
+        return 2
+
+    rclpy.init(args=None)
+    node = rclpy.create_node("robonix_soma_runtime_state")
+    subscriptions = []
+
+    def qos(source: dict):
+        profile = QoSProfile(depth=10)
+        if str(source.get("qos", "")).lower() == "best_effort":
+            profile.reliability = ReliabilityPolicy.BEST_EFFORT
+        return profile
+
+    for source in config.get("sources", []):
+        provider = str(source["provider_id"])
+        topic = str(source["topic"])
+        kind = str(source["kind"])
+        if kind == "joint_state":
+            def on_joint(msg, provider_id=provider):
+                emit({
+                    "kind": "joint_state",
+                    "provider_id": provider_id,
+                    "received_at_unix": time.time(),
+                    "names": list(msg.name),
+                    "positions": list(msg.position),
+                })
+            subscriptions.append(node.create_subscription(JointState, topic, on_joint, qos(source)))
+        elif kind == "odom":
+            def on_odom(msg, provider_id=provider):
+                linear = msg.twist.twist.linear
+                angular = msg.twist.twist.angular
+                emit({
+                    "kind": "odom",
+                    "provider_id": provider_id,
+                    "received_at_unix": time.time(),
+                    "linear": [linear.x, linear.y, linear.z],
+                    "angular": [angular.x, angular.y, angular.z],
+                })
+            subscriptions.append(node.create_subscription(Odometry, topic, on_odom, qos(source)))
+
+    emit({"kind": "warning", "message": f"runtime reader subscribed to {len(subscriptions)} source(s)"})
+    try:
+        rclpy.spin(node)
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/system/soma/src/runtime_state.rs
+++ b/system/soma/src/runtime_state.rs
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: MulanPSL-2.0
+
+use crate::store::GripperConfig;
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::sync::RwLock;
+
+pub const FRESHNESS_SECS: f64 = 2.0;
+
+#[derive(Clone, Debug, Default)]
+pub struct RuntimeStateStore {
+    inner: Arc<RwLock<RuntimeState>>,
+    grippers: Arc<Vec<GripperConfig>>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct RuntimeState {
+    arms: BTreeMap<String, JointSample>,
+    chassis: BTreeMap<String, OdomSample>,
+    warnings: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct JointSample {
+    pub provider_id: String,
+    pub received_at_unix: f64,
+    #[serde(default)]
+    pub names: Vec<String>,
+    #[serde(default)]
+    pub positions: Vec<f64>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct OdomSample {
+    pub provider_id: String,
+    pub received_at_unix: f64,
+    #[serde(default)]
+    pub linear: [f64; 3],
+    #[serde(default)]
+    pub angular: [f64; 3],
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum MonitorEvent {
+    JointState(JointSample),
+    Odom(OdomSample),
+    Warning { message: String },
+}
+
+#[derive(Clone, Debug)]
+pub struct RuntimeSnapshot {
+    pub observed_at_unix: f64,
+    pub arms: Vec<ArmSnapshot>,
+    pub chassis: Vec<ChassisSnapshot>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ArmSnapshot {
+    pub provider_id: String,
+    pub names: Vec<String>,
+    pub positions: Vec<f64>,
+    pub grippers: Vec<GripperSnapshot>,
+    pub fresh: bool,
+    pub age_sec: f64,
+}
+
+#[derive(Clone, Debug)]
+pub struct GripperSnapshot {
+    pub config: GripperConfig,
+    pub position_m: f64,
+    pub likely_holding: bool,
+    pub state: String,
+    pub fresh: bool,
+    pub age_sec: f64,
+}
+
+#[derive(Clone, Debug)]
+pub struct ChassisSnapshot {
+    pub sample: OdomSample,
+    pub moving: bool,
+    pub fresh: bool,
+    pub age_sec: f64,
+}
+
+impl RuntimeStateStore {
+    pub fn new(grippers: Vec<GripperConfig>) -> Self {
+        Self {
+            inner: Arc::default(),
+            grippers: Arc::new(grippers),
+        }
+    }
+
+    pub async fn apply_line(&self, line: &str) -> Result<(), serde_json::Error> {
+        let event: MonitorEvent = serde_json::from_str(line)?;
+        let mut state = self.inner.write().await;
+        match event {
+            MonitorEvent::JointState(sample) => {
+                state.arms.insert(sample.provider_id.clone(), sample);
+            }
+            MonitorEvent::Odom(sample) => {
+                state.chassis.insert(sample.provider_id.clone(), sample);
+            }
+            MonitorEvent::Warning { message } => {
+                if !state.warnings.contains(&message) {
+                    state.warnings.push(message);
+                    state.warnings.truncate(32);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn snapshot(&self) -> RuntimeSnapshot {
+        let now = now_unix();
+        let state = self.inner.read().await;
+        let mut warnings = state.warnings.clone();
+        let arms: Vec<ArmSnapshot> = state
+            .arms
+            .values()
+            .map(|sample| {
+                let age_sec = (now - sample.received_at_unix).max(0.0);
+                let fresh = age_sec <= FRESHNESS_SECS;
+                let grippers = self
+                    .grippers
+                    .iter()
+                    .filter(|cfg| cfg.provider_id == sample.provider_id)
+                    .map(|cfg| {
+                        let position = sample
+                            .names
+                            .iter()
+                            .position(|name| name == &cfg.joint_name)
+                            .and_then(|index| sample.positions.get(index).copied());
+                        match position {
+                            Some(position_m) if fresh => {
+                                let open = (position_m - cfg.open_position_m).abs()
+                                    <= cfg.open_tolerance_m;
+                                GripperSnapshot {
+                                    config: cfg.clone(),
+                                    position_m,
+                                    likely_holding: !open,
+                                    state: if open {
+                                        "open"
+                                    } else {
+                                        "holding_or_partially_closed"
+                                    }
+                                    .to_string(),
+                                    fresh,
+                                    age_sec,
+                                }
+                            }
+                            Some(position_m) => GripperSnapshot {
+                                config: cfg.clone(),
+                                position_m,
+                                likely_holding: false,
+                                state: "unknown_stale".into(),
+                                fresh: false,
+                                age_sec,
+                            },
+                            None => GripperSnapshot {
+                                config: cfg.clone(),
+                                position_m: 0.0,
+                                likely_holding: false,
+                                state: "unknown_missing_joint".into(),
+                                fresh: false,
+                                age_sec,
+                            },
+                        }
+                    })
+                    .collect();
+                ArmSnapshot {
+                    provider_id: sample.provider_id.clone(),
+                    names: sample.names.clone(),
+                    positions: sample.positions.clone(),
+                    grippers,
+                    fresh,
+                    age_sec,
+                }
+            })
+            .collect();
+        let chassis: Vec<ChassisSnapshot> = state
+            .chassis
+            .values()
+            .cloned()
+            .map(|sample| {
+                let age_sec = (now - sample.received_at_unix).max(0.0);
+                let fresh = age_sec <= FRESHNESS_SECS;
+                let linear_speed = sample.linear.iter().map(|v| v * v).sum::<f64>().sqrt();
+                let angular_speed = sample.angular.iter().map(|v| v * v).sum::<f64>().sqrt();
+                ChassisSnapshot {
+                    moving: fresh && (linear_speed > 0.02 || angular_speed > 0.03),
+                    sample,
+                    fresh,
+                    age_sec,
+                }
+            })
+            .collect();
+        if arms.is_empty() {
+            warnings.push("no arm joint-state sample is available".into());
+        }
+        if chassis.is_empty() {
+            warnings.push("no chassis odometry sample is available".into());
+        }
+        RuntimeSnapshot {
+            observed_at_unix: now,
+            arms,
+            chassis,
+            warnings,
+        }
+    }
+}
+
+fn now_unix() -> f64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs_f64()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gripper() -> GripperConfig {
+        GripperConfig {
+            component_id: "gripper".into(),
+            provider_id: "piper_ctl".into(),
+            joint_name: "gripper".into(),
+            open_position_m: 0.06937,
+            open_tolerance_m: 0.002,
+        }
+    }
+
+    #[tokio::test]
+    async fn calibrated_open_gripper_is_not_reported_as_holding() {
+        let store = RuntimeStateStore::new(vec![gripper()]);
+        let now = now_unix();
+        store
+            .apply_line(&format!(
+                r#"{{"kind":"joint_state","provider_id":"piper_ctl","received_at_unix":{now},"names":["joint1","gripper"],"positions":[0.0,0.06937]}}"#
+            ))
+            .await
+            .unwrap();
+        let snapshot = store.snapshot().await;
+        assert_eq!(snapshot.arms[0].grippers[0].state, "open");
+        assert!(!snapshot.arms[0].grippers[0].likely_holding);
+    }
+
+    #[tokio::test]
+    async fn closed_gripper_is_reported_as_likely_holding() {
+        let store = RuntimeStateStore::new(vec![gripper()]);
+        let now = now_unix();
+        store
+            .apply_line(&format!(
+                r#"{{"kind":"joint_state","provider_id":"piper_ctl","received_at_unix":{now},"names":["gripper"],"positions":[0.03]}}"#
+            ))
+            .await
+            .unwrap();
+        let snapshot = store.snapshot().await;
+        assert!(snapshot.arms[0].grippers[0].likely_holding);
+    }
+
+    #[tokio::test]
+    async fn chassis_velocity_drives_motion_state() {
+        let store = RuntimeStateStore::new(vec![]);
+        let now = now_unix();
+        store
+            .apply_line(&format!(
+                r#"{{"kind":"odom","provider_id":"ranger_chassis","received_at_unix":{now},"linear":[0.2,0.0,0.0],"angular":[0.0,0.0,0.0]}}"#
+            ))
+            .await
+            .unwrap();
+        assert!(store.snapshot().await.chassis[0].moving);
+    }
+}

--- a/system/soma/src/service.rs
+++ b/system/soma/src/service.rs
@@ -2,26 +2,52 @@
 
 use crate::pb::contracts::{
     robonix_system_soma_footprint_server::RobonixSystemSomaFootprint,
+    robonix_system_soma_get_health_server::RobonixSystemSomaGetHealth,
     robonix_system_soma_get_urdf_server::RobonixSystemSomaGetUrdf,
     robonix_system_soma_get_yaml_server::RobonixSystemSomaGetYaml,
+    robonix_system_soma_health_server::RobonixSystemSomaHealth,
 };
 use crate::pb::geometry_msgs::Point;
 use crate::pb::soma::{
-    GetFootprintRequest, GetFootprintResponse, GetUrdfRequest, GetUrdfResponse, GetYamlRequest,
-    GetYamlResponse,
+    ActuatorState, ComponentStatus, GetFootprintRequest, GetFootprintResponse, GetHealthRequest,
+    GetHealthResponse, GetUrdfRequest, GetUrdfResponse, GetYamlRequest, GetYamlResponse, Metric,
+    Scalar, SomaHealthSnapshot, StreamHealthRequest,
 };
+use crate::runtime_state::RuntimeStateStore;
 use crate::store::{SomaBody, StoreError};
 use std::sync::Arc;
+use tokio::sync::{RwLock, broadcast};
+use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status};
 
 #[derive(Debug)]
 pub struct SomaService {
     body: Arc<SomaBody>,
+    runtime: RuntimeStateStore,
+    latest_snapshot: Arc<RwLock<Option<SomaHealthSnapshot>>>,
+    snapshot_tx: broadcast::Sender<SomaHealthSnapshot>,
 }
 
 impl SomaService {
     pub fn new(body: Arc<SomaBody>) -> Self {
-        Self { body }
+        let runtime = RuntimeStateStore::new(body.grippers.clone());
+        let (snapshot_tx, _) = broadcast::channel(16);
+        Self {
+            body,
+            runtime,
+            latest_snapshot: Arc::default(),
+            snapshot_tx,
+        }
+    }
+
+    pub fn runtime(&self) -> RuntimeStateStore {
+        self.runtime.clone()
+    }
+
+    pub async fn publish_runtime_snapshot(&self, seq: u64) {
+        let snapshot = self.to_health_snapshot(seq).await;
+        *self.latest_snapshot.write().await = Some(snapshot.clone());
+        let _ = self.snapshot_tx.send(snapshot);
     }
 
     fn map_lookup_error(error: StoreError) -> Status {
@@ -29,6 +55,260 @@ impl SomaService {
             StoreError::NotFound(_) => Status::not_found(error.to_string()),
             StoreError::MissingFootprint(_) => Status::failed_precondition(error.to_string()),
         }
+    }
+
+    async fn to_health_snapshot(&self, seq: u64) -> SomaHealthSnapshot {
+        const HEALTH_OK: u32 = 0;
+        const HEALTH_STALE: u32 = 3;
+        const KIND_BODY: u32 = 1;
+        const KIND_ARM: u32 = 2;
+        const KIND_JOINT: u32 = 4;
+        const KIND_GRIPPER: u32 = 6;
+        const KIND_WHEEL: u32 = 5;
+        const OP_IDLE: u32 = 3;
+        const OP_ACTIVE: u32 = 4;
+        const QUALITY_VALID: u32 = 0;
+        const QUALITY_STALE: u32 = 1;
+        let runtime = self.runtime.snapshot().await;
+        let runtime_detail = runtime.warnings.join("; ");
+        let mut components = vec![component(
+            "body",
+            &runtime_detail,
+            KIND_BODY,
+            &self.body.robot_id,
+            HEALTH_OK,
+            OP_ACTIVE,
+            "",
+        )];
+        let mut actuators = Vec::new();
+        let mut metrics = Vec::new();
+        for arm in runtime.arms {
+            let arm_id = format!("body/arm/{}", arm.provider_id);
+            let quality = if arm.fresh {
+                QUALITY_VALID
+            } else {
+                QUALITY_STALE
+            };
+            components.push(component(
+                &arm_id,
+                "body",
+                KIND_ARM,
+                &arm.provider_id,
+                if arm.fresh { HEALTH_OK } else { HEALTH_STALE },
+                OP_ACTIVE,
+                &format!("age_sec={:.3}", arm.age_sec),
+            ));
+            for (index, name) in arm.names.iter().enumerate() {
+                let joint_id = format!("{arm_id}/{name}");
+                let gripper = arm
+                    .grippers
+                    .iter()
+                    .find(|item| item.config.joint_name == *name);
+                components.push(component(
+                    &joint_id,
+                    &arm_id,
+                    if gripper.is_some() {
+                        KIND_GRIPPER
+                    } else {
+                        KIND_JOINT
+                    },
+                    name,
+                    if arm.fresh { HEALTH_OK } else { HEALTH_STALE },
+                    if gripper.is_some_and(|item| item.likely_holding) {
+                        OP_ACTIVE
+                    } else {
+                        OP_IDLE
+                    },
+                    gripper.map(|item| item.state.as_str()).unwrap_or(""),
+                ));
+                actuators.push(ActuatorState {
+                    component_id: joint_id.clone(),
+                    joint_name: name.clone(),
+                    position: Some(scalar(
+                        arm.positions.get(index).copied().unwrap_or_default(),
+                        if gripper.is_some() { "m" } else { "rad" },
+                        quality,
+                    )),
+                    velocity: None,
+                    effort: None,
+                    current: None,
+                    voltage: None,
+                    motor_temp: None,
+                    driver_temp: None,
+                    torque_enabled: true,
+                    brake_engaged: false,
+                    communication_ok: arm.fresh,
+                    vendor_mode: 0,
+                    vendor_error_code: 0,
+                    status_flags: 0,
+                });
+                if let Some(gripper) = gripper {
+                    metrics.push(metric(
+                        &joint_id,
+                        "likely_holding",
+                        if gripper.likely_holding { 1.0 } else { 0.0 },
+                        "bool",
+                        if gripper.fresh {
+                            QUALITY_VALID
+                        } else {
+                            QUALITY_STALE
+                        },
+                    ));
+                }
+            }
+        }
+        for chassis in runtime.chassis {
+            let id = format!("body/chassis/{}", chassis.sample.provider_id);
+            let quality = if chassis.fresh {
+                QUALITY_VALID
+            } else {
+                QUALITY_STALE
+            };
+            components.push(component(
+                &id,
+                "body",
+                KIND_WHEEL,
+                &chassis.sample.provider_id,
+                if chassis.fresh {
+                    HEALTH_OK
+                } else {
+                    HEALTH_STALE
+                },
+                if chassis.moving { OP_ACTIVE } else { OP_IDLE },
+                &format!("age_sec={:.3}", chassis.age_sec),
+            ));
+            let linear_speed = chassis
+                .sample
+                .linear
+                .iter()
+                .map(|v| v * v)
+                .sum::<f64>()
+                .sqrt();
+            let angular_speed = chassis
+                .sample
+                .angular
+                .iter()
+                .map(|v| v * v)
+                .sum::<f64>()
+                .sqrt();
+            metrics.extend([
+                metric(&id, "linear_speed", linear_speed, "m/s", quality),
+                metric(&id, "angular_speed", angular_speed, "rad/s", quality),
+                metric(
+                    &id,
+                    "moving",
+                    if chassis.moving { 1.0 } else { 0.0 },
+                    "bool",
+                    quality,
+                ),
+            ]);
+        }
+        let timestamp_ns = (runtime.observed_at_unix * 1_000_000_000.0) as i64;
+        SomaHealthSnapshot {
+            schema_version: 1,
+            body_id: self.body.robot_id.clone(),
+            seq,
+            source_ts_ns: timestamp_ns,
+            soma_ts_ns: timestamp_ns,
+            ttl_ms: 2_000,
+            components,
+            actuators,
+            power_sources: Vec::new(),
+            // joint_states and odometry do not prove that motion is safe.
+            // A health primitive may populate this once it has real e-stop and
+            // protective-stop inputs; until then the safety state is unknown.
+            safety: None,
+            safety_endpoints: Vec::new(),
+            faults: Vec::new(),
+            metrics,
+        }
+    }
+}
+
+fn scalar(value: f64, unit: &str, quality: u32) -> Scalar {
+    Scalar {
+        value,
+        unit: unit.into(),
+        quality,
+    }
+}
+
+fn metric(component_id: &str, name: &str, value: f64, unit: &str, quality: u32) -> Metric {
+    Metric {
+        component_id: component_id.into(),
+        name: name.into(),
+        value: Some(scalar(value, unit, quality)),
+        source_key: "soma_runtime_state".into(),
+    }
+}
+
+fn component(
+    id: &str,
+    parent_id: &str,
+    kind: u32,
+    name: &str,
+    health: u32,
+    operational_state: u32,
+    detail: &str,
+) -> ComponentStatus {
+    ComponentStatus {
+        id: id.into(),
+        parent_id: parent_id.into(),
+        kind,
+        name: name.into(),
+        frame_id: String::new(),
+        model: String::new(),
+        serial: String::new(),
+        health,
+        operational_state,
+        present: true,
+        online: health != 3,
+        detail: detail.into(),
+    }
+}
+
+#[tonic::async_trait]
+impl RobonixSystemSomaGetHealth for SomaService {
+    async fn get_health(
+        &self,
+        _request: Request<GetHealthRequest>,
+    ) -> Result<Response<GetHealthResponse>, Status> {
+        Ok(Response::new(GetHealthResponse {
+            snapshot: self.latest_snapshot.read().await.clone(),
+        }))
+    }
+}
+
+#[tonic::async_trait]
+impl RobonixSystemSomaHealth for SomaService {
+    type StreamHealthStream = ReceiverStream<Result<SomaHealthSnapshot, Status>>;
+
+    async fn stream_health(
+        &self,
+        _request: Request<StreamHealthRequest>,
+    ) -> Result<Response<Self::StreamHealthStream>, Status> {
+        let mut input = self.snapshot_tx.subscribe();
+        let latest = self.latest_snapshot.clone();
+        let (output, receiver) = tokio::sync::mpsc::channel(16);
+        tokio::spawn(async move {
+            if let Some(snapshot) = latest.read().await.clone()
+                && output.send(Ok(snapshot)).await.is_err()
+            {
+                return;
+            }
+            loop {
+                match input.recv().await {
+                    Ok(snapshot) => {
+                        if output.send(Ok(snapshot)).await.is_err() {
+                            break;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        });
+        Ok(Response::new(ReceiverStream::new(receiver)))
     }
 }
 
@@ -154,6 +434,20 @@ mod tests {
         assert_eq!(response.points[0].x, 0.2);
         assert_eq!(response.points[0].y, 0.1);
         assert!((response.inscribed_radius_m - 0.1).abs() < 1e-9);
+    }
+
+    #[tokio::test]
+    async fn health_snapshot_is_explicit_when_no_samples_exist() {
+        let service = SomaService::new(fixture_body());
+        service.publish_runtime_snapshot(1).await;
+        let response = service
+            .get_health(Request::new(GetHealthRequest {}))
+            .await
+            .expect("get health")
+            .into_inner();
+        let snapshot = response.snapshot.expect("snapshot");
+        assert_eq!(snapshot.body_id, "test_ci_robot");
+        assert_eq!(snapshot.seq, 1);
     }
 
     #[tokio::test]

--- a/system/soma/src/store.rs
+++ b/system/soma/src/store.rs
@@ -22,6 +22,16 @@ pub struct SomaBody {
     pub urdf_path: PathBuf,
     pub urdf_xml: String,
     pub footprint: Option<Footprint>,
+    pub grippers: Vec<GripperConfig>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct GripperConfig {
+    pub component_id: String,
+    pub provider_id: String,
+    pub joint_name: String,
+    pub open_position_m: f64,
+    pub open_tolerance_m: f64,
 }
 
 #[derive(Debug, Clone)]
@@ -94,6 +104,10 @@ impl SomaBody {
         let urdf_xml = std::fs::read_to_string(&urdf_path)
             .with_context(|| format!("read URDF '{}'", urdf_path.display()))?;
         let footprint = doc.robot.footprint.map(Footprint::from_doc).transpose()?;
+        let yaml_value: serde_yaml::Value = serde_yaml::from_str(&yaml_text)
+            .with_context(|| format!("parse runtime state config in '{}'", yaml_path.display()))?;
+        let mut grippers = Vec::new();
+        collect_grippers(&yaml_value, None, &mut grippers);
         Ok(Self {
             robot_id: doc.robot.id,
             yaml_path: yaml_path.to_path_buf(),
@@ -101,6 +115,7 @@ impl SomaBody {
             urdf_path,
             urdf_xml,
             footprint,
+            grippers,
         })
     }
 
@@ -122,6 +137,102 @@ impl SomaBody {
             .as_ref()
             .ok_or_else(|| StoreError::MissingFootprint(self.robot_id.clone()))
     }
+}
+
+fn collect_grippers(
+    value: &serde_yaml::Value,
+    inherited_joint_provider: Option<&str>,
+    out: &mut Vec<GripperConfig>,
+) {
+    let Some(map) = value.as_mapping() else {
+        if let Some(items) = value.as_sequence() {
+            for item in items {
+                collect_grippers(item, inherited_joint_provider, out);
+            }
+        }
+        return;
+    };
+
+    let provider =
+        joint_state_provider(map).or_else(|| inherited_joint_provider.map(str::to_string));
+    let component_type = yaml_str(map, "type")
+        .or_else(|| yaml_str(map, "part_type"))
+        .unwrap_or_default();
+    if matches!(
+        component_type.as_str(),
+        "parallel_jaw_gripper" | "end_effector"
+    ) {
+        let state = map
+            .get(serde_yaml::Value::String("state".into()))
+            .and_then(serde_yaml::Value::as_mapping);
+        let open_position_m = state.and_then(|m| yaml_f64(m, "open_position_m"));
+        if let (Some(provider_id), Some(open_position_m)) = (provider.clone(), open_position_m) {
+            out.push(GripperConfig {
+                component_id: yaml_str(map, "id").unwrap_or_else(|| "gripper".into()),
+                provider_id,
+                joint_name: state
+                    .and_then(|m| yaml_str(m, "joint_name"))
+                    .unwrap_or_else(|| "gripper".into()),
+                open_position_m,
+                open_tolerance_m: state
+                    .and_then(|m| yaml_f64(m, "open_tolerance_m"))
+                    .unwrap_or(0.002),
+            });
+        }
+    }
+
+    for child_key in ["robot", "tree", "components", "children"] {
+        if let Some(child) = map.get(serde_yaml::Value::String(child_key.into())) {
+            collect_grippers(child, provider.as_deref(), out);
+        }
+    }
+}
+
+fn joint_state_provider(map: &serde_yaml::Mapping) -> Option<String> {
+    for key in ["exports", "provided_by"] {
+        let Some(rows) = map
+            .get(serde_yaml::Value::String(key.into()))
+            .and_then(serde_yaml::Value::as_sequence)
+        else {
+            continue;
+        };
+        for row in rows {
+            let Some(row) = row.as_mapping() else {
+                continue;
+            };
+            let direct_contract = yaml_str(row, "contract");
+            if direct_contract.as_deref() == Some("robonix/primitive/arm/joint_states") {
+                return yaml_str(row, "provider_id");
+            }
+            let provider_id = yaml_str(row, "provider_id");
+            let has_contract = row
+                .get(serde_yaml::Value::String("capabilities".into()))
+                .and_then(serde_yaml::Value::as_sequence)
+                .is_some_and(|caps| {
+                    caps.iter().any(|cap| {
+                        cap.as_mapping()
+                            .and_then(|m| yaml_str(m, "path"))
+                            .as_deref()
+                            == Some("robonix/primitive/arm/joint_states")
+                    })
+                });
+            if has_contract && provider_id.is_some() {
+                return provider_id;
+            }
+        }
+    }
+    None
+}
+
+fn yaml_str(map: &serde_yaml::Mapping, key: &str) -> Option<String> {
+    map.get(serde_yaml::Value::String(key.into()))
+        .and_then(serde_yaml::Value::as_str)
+        .map(str::to_string)
+}
+
+fn yaml_f64(map: &serde_yaml::Mapping, key: &str) -> Option<f64> {
+    map.get(serde_yaml::Value::String(key.into()))
+        .and_then(serde_yaml::Value::as_f64)
 }
 
 impl Footprint {
@@ -209,5 +320,31 @@ mod tests {
         let body = SomaBody::load(&fixture_yaml()).expect("load body");
         let err = body.resolve("someone_else").expect_err("must not match");
         assert!(matches!(err, StoreError::NotFound(_)));
+    }
+
+    #[test]
+    fn reads_calibrated_gripper_state_config() {
+        let value: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+robot:
+  components:
+    - id: arm
+      exports:
+        - provider_id: piper_ctl
+          capabilities:
+            - { path: robonix/primitive/arm/joint_states }
+      components:
+        - id: gripper
+          type: parallel_jaw_gripper
+          state: { joint_name: gripper, open_position_m: 0.06937, open_tolerance_m: 0.002 }
+"#,
+        )
+        .unwrap();
+        let mut grippers = Vec::new();
+        collect_grippers(&value, None, &mut grippers);
+        assert_eq!(grippers.len(), 1);
+        assert_eq!(grippers[0].provider_id, "piper_ctl");
+        assert_eq!(grippers[0].joint_name, "gripper");
+        assert!((grippers[0].open_position_m - 0.06937).abs() < 1e-9);
     }
 }

--- a/tools/rbnx/src/cmd/boot_watchdog.rs
+++ b/tools/rbnx/src/cmd/boot_watchdog.rs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MulanPSL-2.0
+// Detached `rbnx boot` watchdog.
+//
+// The foreground boot process owns the terminal and can disappear without a
+// catchable signal (terminal close, SIGKILL, IDE cancellation). This helper is
+// re-execed in a new session, watches the exact parent PID identity, and runs
+// the same persisted teardown path if that parent disappears unexpectedly.
+
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::Duration;
+
+use super::teardown;
+
+pub fn spawn(state_path: &Path, boot_pid: u32, boot_start_time_ticks: Option<u64>) -> Result<()> {
+    use std::os::unix::process::CommandExt;
+
+    let exe = std::env::current_exe().context("resolve rbnx binary for boot watchdog")?;
+    let mut command = std::process::Command::new(exe);
+    command
+        .arg("__watch-boot")
+        .arg("--state")
+        .arg(state_path)
+        .arg("--boot-pid")
+        .arg(boot_pid.to_string())
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    if let Some(ticks) = boot_start_time_ticks {
+        command
+            .arg("--boot-start-time-ticks")
+            .arg(ticks.to_string());
+    }
+    // Safety: pre_exec runs after fork and before exec. setsid(2) is
+    // async-signal-safe and detaches the watcher from the boot PTY/session.
+    unsafe {
+        command.pre_exec(|| {
+            nix::unistd::setsid()
+                .map(|_| ())
+                .map_err(std::io::Error::other)
+        });
+    }
+    command.spawn().context("spawn detached boot watchdog")?;
+    Ok(())
+}
+
+pub async fn execute(
+    state_path: PathBuf,
+    boot_pid: u32,
+    boot_start_time_ticks: Option<u64>,
+) -> Result<()> {
+    loop {
+        if !state_path.exists() {
+            return Ok(());
+        }
+        let alive = match boot_start_time_ticks {
+            Some(expected) => {
+                robonix_cli::launch::proc_start_time_ticks(boot_pid) == Some(expected)
+            }
+            None => robonix_cli::launch::proc_start_time_ticks(boot_pid).is_some(),
+        };
+        if !alive {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+
+    let state = teardown::read_state(&state_path)?;
+    if !matches_watched_boot(&state, boot_pid, boot_start_time_ticks) {
+        return Ok(());
+    }
+    let boot_id = (!state.boot_id.is_empty()).then_some(state.boot_id.as_str());
+    let complete =
+        teardown::teardown(Some(&state.atlas_endpoint), &state.components, boot_id).await;
+    if !complete {
+        return Ok(());
+    }
+
+    // A new boot may have replaced state.json while cleanup was running. Only
+    // remove the file if it still belongs to the parent we watched.
+    if teardown::read_state(&state_path)
+        .ok()
+        .is_some_and(|current| matches_watched_boot(&current, boot_pid, boot_start_time_ticks))
+    {
+        let _ = std::fs::remove_file(&state_path);
+    }
+    Ok(())
+}
+
+fn matches_watched_boot(
+    state: &teardown::BootState,
+    boot_pid: u32,
+    boot_start_time_ticks: Option<u64>,
+) -> bool {
+    state.boot_pid == boot_pid
+        && match (boot_start_time_ticks, state.boot_start_time_ticks) {
+            (Some(expected), Some(actual)) => expected == actual,
+            (Some(_), None) => false,
+            (None, _) => true,
+        }
+}

--- a/tools/rbnx/src/cmd/deploy.rs
+++ b/tools/rbnx/src/cmd/deploy.rs
@@ -42,6 +42,7 @@ use tokio::process::{Child, Command};
 use tokio::signal::unix::{SignalKind, signal};
 use tonic::Request;
 use tonic::transport::Endpoint;
+use uuid::Uuid;
 
 use robonix_scribe as scribe;
 
@@ -941,6 +942,12 @@ pub async fn execute(
 
     let mut children: Vec<Spawned> = Vec::new();
     let state_path = teardown::state_path(&manifest_dir);
+    let boot_id = Uuid::new_v4().to_string();
+    // Every wrapper and provider inherits this marker. Persisted teardown
+    // verifies it against /proc before signalling a PGID, preventing stale
+    // state from killing an unrelated process after PID reuse.
+    unsafe { std::env::set_var("RBNX_BOOT_ID", &boot_id) };
+    let boot_start_time_ticks = robonix_cli::launch::proc_start_time_ticks(std::process::id());
     let started_at_ms = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
@@ -953,6 +960,19 @@ pub async fn execute(
         .and_then(|v| v.as_str())
         .unwrap_or("127.0.0.1:50051")
         .to_string();
+    teardown::write_state(
+        &state_path,
+        &teardown::BootState {
+            manifest_path: manifest_path.display().to_string(),
+            boot_pid: std::process::id(),
+            boot_start_time_ticks,
+            boot_id: boot_id.clone(),
+            started_at_ms,
+            atlas_endpoint: atlas_endpoint.clone(),
+            components: Vec::new(),
+        },
+    )?;
+    super::boot_watchdog::spawn(&state_path, std::process::id(), boot_start_time_ticks)?;
     let spawn_env = PackageSpawnEnv {
         log_dir: &log_dir,
         cache_root: &cache_root,
@@ -1106,8 +1126,10 @@ pub async fn execute(
                 if *name == "soma" {
                     if !deploy.primitive.is_empty() {
                         output::boot_section("primitive");
-                        for entry in &deploy.primitive {
-                            output::boot_note(&entry.name, "delegated to soma stage 1");
+                        if output::boot_verbose() {
+                            for entry in &deploy.primitive {
+                                output::boot_wait(&entry.name, "waiting for registration");
+                            }
                         }
                     }
                     let mut stage1_atlas = AtlasClient::connect_with_retry(
@@ -1117,7 +1139,7 @@ pub async fn execute(
                     )
                     .await
                     .with_context(|| {
-                        format!("connect to atlas at '{atlas_endpoint}' for soma stage 1 wait")
+                        format!("connect to atlas at '{atlas_endpoint}' for primitive readiness")
                     })?;
                     // We just pushed the soma `Spawned` above; grab a
                     // mutable borrow on its Child so the stage-1 waiter
@@ -1131,7 +1153,11 @@ pub async fn execute(
                         .child;
                     wait_for_soma_stage1(
                         &mut stage1_atlas,
-                        deploy.primitive.len(),
+                        &deploy
+                            .primitive
+                            .iter()
+                            .map(|entry| entry.name.clone())
+                            .collect::<Vec<_>>(),
                         soma_child,
                         &log_dir,
                     )
@@ -1166,7 +1192,7 @@ pub async fn execute(
                         .keys()
                         .any(|k| !bin_map.iter().any(|(n, _)| n == k));
                     if builtin_after_soma || has_non_builtin_system {
-                        output::boot_section("system service");
+                        output::boot_section("system");
                     }
                 }
             }
@@ -1295,12 +1321,28 @@ pub async fn execute(
         // two-stage bring-up vocabulary just to read boot output.
         if deploy.system.contains_key("soma") && !skip_system {
             output::boot_section("skill");
+            if output::boot_verbose() {
+                for entry in &deploy.skill {
+                    output::boot_wait(&entry.name, "waiting for registration");
+                }
+            }
             if let Err(e) = write_stage2_trigger(&mut soma_stage_writer) {
                 failures.push((
                     "system".to_string(),
                     "soma".to_string(),
-                    format!("write stage 2 trigger: {e:#}"),
+                    format!("start skill packages: {e:#}"),
                 ));
+            } else if let Err(e) = wait_for_soma_skills(
+                &mut atlas,
+                &deploy
+                    .skill
+                    .iter()
+                    .map(|entry| entry.name.clone())
+                    .collect::<Vec<_>>(),
+            )
+            .await
+            {
+                failures.push(("skill".to_string(), "soma".to_string(), format!("{e:#}")));
             }
         }
         Ok(failures)
@@ -1340,7 +1382,13 @@ pub async fn execute(
             &children,
         );
         let providers = component_records(&children);
-        teardown::teardown(Some(&atlas_endpoint), &providers).await;
+        let complete = teardown::teardown(Some(&atlas_endpoint), &providers, Some(&boot_id)).await;
+        if !complete {
+            anyhow::bail!(
+                "interrupted boot left identity-mismatched process groups; preserving {}",
+                state_path.display()
+            );
+        }
         for sp in &mut children {
             let _ = sp.child.wait().await;
         }
@@ -1363,8 +1411,16 @@ pub async fn execute(
                 &children,
             );
             let providers = component_records(&children);
-            teardown::teardown(Some(&atlas_endpoint), &providers).await;
-            let _ = std::fs::remove_file(&state_path);
+            let complete =
+                teardown::teardown(Some(&atlas_endpoint), &providers, Some(&boot_id)).await;
+            if complete {
+                let _ = std::fs::remove_file(&state_path);
+            } else {
+                return Err(e.context(format!(
+                    "cleanup refused identity-mismatched process groups; preserving {}",
+                    state_path.display()
+                )));
+            }
             return Err(e);
         }
     };
@@ -1409,7 +1465,13 @@ pub async fn execute(
         ),
     );
     let providers = component_records(&children);
-    teardown::teardown(Some(&atlas_endpoint), &providers).await;
+    let complete = teardown::teardown(Some(&atlas_endpoint), &providers, Some(&boot_id)).await;
+    if !complete {
+        anyhow::bail!(
+            "shutdown refused identity-mismatched process groups; preserving {}",
+            state_path.display()
+        );
+    }
     // Best-effort wait so we get clean "exited" lines in our own log.
     for sp in &mut children {
         let _ = sp.child.wait().await;
@@ -1445,6 +1507,8 @@ fn persist_state(
     let state = teardown::BootState {
         manifest_path: manifest_path.display().to_string(),
         boot_pid: std::process::id(),
+        boot_start_time_ticks: robonix_cli::launch::proc_start_time_ticks(std::process::id()),
+        boot_id: std::env::var("RBNX_BOOT_ID").unwrap_or_default(),
         started_at_ms,
         atlas_endpoint: atlas_endpoint.to_string(),
         components: component_records(children),
@@ -1905,7 +1969,7 @@ where
 
 async fn wait_for_soma_stage1(
     atlas: &mut AtlasClient,
-    primitive_count: usize,
+    primitive_names: &[String],
     soma_child: &mut Child,
     log_dir: &Path,
 ) -> Result<()> {
@@ -1917,22 +1981,27 @@ async fn wait_for_soma_stage1(
     let started = Instant::now();
     let deadline = started + SOMA_STAGE1_TIMEOUT;
     let mut frame: usize = 0;
+    let mut observed_states: HashMap<String, i32> = HashMap::new();
+    let mut active_primitives: HashSet<String> = HashSet::new();
     if output::boot_verbose() {
-        output::boot_wait("soma stage 1", "waiting for primitive readiness");
+        output::boot_wait("primitive", "waiting for Soma-managed providers");
     }
     loop {
         let elapsed_s = started.elapsed().as_secs_f32();
-        let detail = if primitive_count == 0 {
+        let detail = if primitive_names.is_empty() {
             format!("waiting for Soma gRPC readiness… {elapsed_s:>4.1}s")
         } else {
-            format!("starting {primitive_count} primitive package(s)… {elapsed_s:>4.1}s")
+            format!(
+                "starting {} primitive package(s)… {elapsed_s:>4.1}s",
+                primitive_names.len()
+            )
         };
         if output::boot_verbose() {
             if frame > 0 && frame.is_multiple_of(50) {
-                output::boot_note("soma stage 1", &detail);
+                output::boot_note("primitive", &detail);
             }
         } else {
-            output::boot_progress("soma stage 1", &detail, frame);
+            output::boot_progress("primitive", &detail, frame);
         }
         // Check every tick whether soma is still alive. If it exited
         // (typically: `missing robot_yaml`, `read Soma config`, port
@@ -1945,7 +2014,7 @@ async fn wait_for_soma_stage1(
             let log_file = log_dir.join("soma.log");
             let tail = read_log_tail(&log_file, 20);
             output::boot_fail(
-                "soma stage 1",
+                "primitive",
                 &format!(
                     "soma exited before becoming ACTIVE (status={status:?}); see {}",
                     log_file.display()
@@ -1957,45 +2026,136 @@ async fn wait_for_soma_stage1(
                 format!("\n--- soma.log tail ---\n{tail}\n--- end ---")
             };
             anyhow::bail!(
-                "soma exited with {status:?} before stage 1 became ACTIVE; \
+                "soma exited with {status:?} before primitive readiness; \
                  log: {}{hint}",
                 log_file.display()
             );
         }
         if frame.is_multiple_of(POLLS_PER_TICK) {
+            for name in primitive_names {
+                let providers = atlas
+                    .query_capabilities(name, "", atlas_pb::Transport::Unspecified)
+                    .await
+                    .with_context(|| format!("poll primitive '{name}' during Soma bring-up"))?;
+                let Some(provider) = providers.into_iter().find(|provider| provider.id == *name)
+                else {
+                    continue;
+                };
+                let previous = observed_states.insert(name.clone(), provider.state);
+                if previous != Some(provider.state) {
+                    let state = lifecycle_state_label(provider.state);
+                    if provider.state == atlas_pb::LifecycleState::StateActive as i32 {
+                        output::boot_ok(name, "ACTIVE");
+                        active_primitives.insert(name.clone());
+                    } else if provider.state == atlas_pb::LifecycleState::StateError as i32 {
+                        output::boot_fail(name, "ERROR; see soma.log and provider log");
+                    } else if output::boot_verbose() {
+                        output::boot_note(name, state);
+                    }
+                }
+            }
             let providers = atlas
                 .query_capabilities("soma", SOMA_GET_YAML_CONTRACT, atlas_pb::Transport::Grpc)
                 .await
-                .context("wait for soma stage 1 readiness")?;
+                .context("wait for Soma primitive readiness")?;
             if let Some(soma) = providers.into_iter().find(|p| p.id == "soma")
                 && soma.state == atlas_pb::LifecycleState::StateActive as i32
                 && soma_grpc_ready(atlas, SOMA_GET_YAML_CONTRACT).await
             {
-                let ready_detail = if primitive_count == 0 {
-                    "Soma gRPC ready".to_string()
-                } else {
-                    format!("{primitive_count} primitive package(s) handled by soma")
-                };
-                output::boot_ok("soma stage 1", &ready_detail);
+                for name in primitive_names {
+                    if !active_primitives.contains(name) {
+                        output::boot_ok(name, "ACTIVE");
+                    }
+                }
                 return Ok(());
             }
         }
         if Instant::now() >= deadline {
             output::boot_fail(
-                "soma stage 1",
+                "primitive",
                 &format!(
                     "timeout after {:?}; service bring-up needs primitives ACTIVE first",
                     SOMA_STAGE1_TIMEOUT
                 ),
             );
             anyhow::bail!(
-                "soma stage 1 did not become ACTIVE within {:?}; refusing to start service packages before primitives are ready",
+                "Soma primitive bring-up did not become ready within {:?}; refusing to start service packages before primitives are ready",
                 SOMA_STAGE1_TIMEOUT
             );
         }
         tokio::time::sleep(SPINNER_TICK).await;
         frame = frame.wrapping_add(1);
     }
+}
+
+fn lifecycle_state_label(state: i32) -> &'static str {
+    if state == atlas_pb::LifecycleState::StateRegistered as i32 {
+        "REGISTERED"
+    } else if state == atlas_pb::LifecycleState::StateInactive as i32 {
+        "INACTIVE"
+    } else if state == atlas_pb::LifecycleState::StateActive as i32 {
+        "ACTIVE"
+    } else if state == atlas_pb::LifecycleState::StateError as i32 {
+        "ERROR"
+    } else if state == atlas_pb::LifecycleState::StateTerminated as i32 {
+        "TERMINATED"
+    } else {
+        "STARTING"
+    }
+}
+
+async fn wait_for_soma_skills(atlas: &mut AtlasClient, skill_names: &[String]) -> Result<()> {
+    const TIMEOUT: Duration = Duration::from_secs(180);
+    if skill_names.is_empty() {
+        return Ok(());
+    }
+    let deadline = Instant::now() + TIMEOUT;
+    let mut observed_states: HashMap<String, i32> = HashMap::new();
+    let mut ready: HashSet<String> = HashSet::new();
+    while Instant::now() < deadline {
+        for name in skill_names {
+            let providers = atlas
+                .query_capabilities(name, "", atlas_pb::Transport::Unspecified)
+                .await
+                .with_context(|| format!("poll skill '{name}' during soma bring-up"))?;
+            let Some(provider) = providers.into_iter().find(|provider| provider.id == *name) else {
+                continue;
+            };
+            if observed_states.insert(name.clone(), provider.state) != Some(provider.state) {
+                let state = lifecycle_state_label(provider.state);
+                if provider.state == atlas_pb::LifecycleState::StateInactive as i32
+                    || provider.state == atlas_pb::LifecycleState::StateActive as i32
+                {
+                    output::boot_ok(name, state);
+                    ready.insert(name.clone());
+                } else if provider.state == atlas_pb::LifecycleState::StateError as i32 {
+                    output::boot_fail(name, "ERROR; see soma.log and provider log");
+                    anyhow::bail!("skill '{name}' entered ERROR during Soma bring-up");
+                } else if output::boot_verbose() {
+                    output::boot_note(name, state);
+                }
+            }
+        }
+        if ready.len() == skill_names.len() {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    let pending = skill_names
+        .iter()
+        .filter(|name| !ready.contains(*name))
+        .cloned()
+        .collect::<Vec<_>>();
+    for name in &pending {
+        output::boot_fail(
+            name,
+            "registration/INIT timeout; see soma.log and provider log",
+        );
+    }
+    anyhow::bail!(
+        "Soma skill bring-up timed out after {TIMEOUT:?}: {}",
+        pending.join(", ")
+    )
 }
 
 /// Read the last `max_lines` lines of a file for embedding into an
@@ -2055,8 +2215,8 @@ fn write_stage2_trigger(writer: &mut Option<std::fs::File>) -> Result<()> {
     use std::io::Write;
     let Some(mut w) = writer.take() else {
         output::boot_skip(
-            "soma",
-            "stage 2 trigger skipped: no stage-fd writer (soma not spawned by this rbnx)",
+            "skill",
+            "start skipped: no trigger writer (Soma was not spawned by this rbnx)",
         );
         return Ok(());
     };
@@ -2067,7 +2227,6 @@ fn write_stage2_trigger(writer: &mut Option<std::fs::File>) -> Result<()> {
     // the bytes hit the pipe. Actual delivery (soma reads the line,
     // spawns skills, and their MCP tools/caps register) is verified
     // downstream by the boot-poll cap-wait loop, not here.
-    output::boot_ok("soma", "stage 2 trigger written");
     Ok(())
 }
 

--- a/tools/rbnx/src/cmd/deploy.rs
+++ b/tools/rbnx/src/cmd/deploy.rs
@@ -191,6 +191,48 @@ mod tests {
 
         assert_eq!(manifest_arg, Some(selected.to_string_lossy().as_ref()));
     }
+
+    #[test]
+    fn provider_failure_ignores_later_shutdown_noise() {
+        let path = std::env::temp_dir().join(format!(
+            "rbnx-provider-failure-{}.log",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::write(
+            &path,
+            concat!(
+                "{\"level\":\"info\",\"msg\":\"ready -- awaiting Driver(CMD_INIT)\"}\n",
+                "{\"level\":\"info\",\"msg\":\"[ranger_chassis] state REGISTERED -> ERROR (CAN setup failed: sudo password required)\"}\n",
+                "{\"level\":\"info\",\"msg\":\"shutdown hook completed\"}\n",
+            ),
+        )
+        .unwrap();
+
+        assert_eq!(
+            read_provider_failure(&path).as_deref(),
+            Some("CAN setup failed: sudo password required")
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn provider_failure_accepts_error_level_records() {
+        let path = std::env::temp_dir().join(format!(
+            "rbnx-provider-error-level-{}.log",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::write(
+            &path,
+            "{\"level\":\"error\",\"msg\":\"camera device disconnected\"}\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            read_provider_failure(&path).as_deref(),
+            Some("camera device disconnected")
+        );
+        let _ = std::fs::remove_file(path);
+    }
 }
 
 /// Boot-time prerequisites check:
@@ -1983,6 +2025,7 @@ async fn wait_for_soma_stage1(
     let mut frame: usize = 0;
     let mut observed_states: HashMap<String, i32> = HashMap::new();
     let mut active_primitives: HashSet<String> = HashSet::new();
+    let mut reported_failures: HashSet<String> = HashSet::new();
     if output::boot_verbose() {
         output::boot_wait("primitive", "waiting for Soma-managed providers");
     }
@@ -2011,6 +2054,39 @@ async fn wait_for_soma_stage1(
         // and blocks CI. try_wait is non-blocking; Ok(Some(_)) means
         // the child has been reaped and the OS-level status is known.
         if let Ok(Some(status)) = soma_child.try_wait() {
+            let mut provider_failures = Vec::new();
+            for name in primitive_names {
+                let log_file = log_dir.join(format!("{name}.log"));
+                if let Some(cause) = read_provider_failure(&log_file) {
+                    if reported_failures.insert(name.clone()) {
+                        output::boot_fail(
+                            name,
+                            &format!("ERROR; {cause}; log {}", log_file.display()),
+                        );
+                    }
+                    provider_failures.push((name, cause, log_file));
+                }
+            }
+            if !provider_failures.is_empty() {
+                let names = provider_failures
+                    .iter()
+                    .map(|(name, _, _)| name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let logs = provider_failures
+                    .iter()
+                    .map(|(_, _, path)| path.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                output::boot_fail(
+                    "primitive",
+                    &format!("soma exited after provider failure(s): {names}"),
+                );
+                anyhow::bail!(
+                    "Soma exited with {status:?} after provider failure(s): {names}; logs: {logs}"
+                );
+            }
+
             let log_file = log_dir.join("soma.log");
             let tail = read_log_tail(&log_file, 20);
             output::boot_fail(
@@ -2048,7 +2124,13 @@ async fn wait_for_soma_stage1(
                         output::boot_ok(name, "ACTIVE");
                         active_primitives.insert(name.clone());
                     } else if provider.state == atlas_pb::LifecycleState::StateError as i32 {
-                        output::boot_fail(name, "ERROR; see soma.log and provider log");
+                        let log_file = log_dir.join(format!("{name}.log"));
+                        let detail = read_provider_failure(&log_file).map_or_else(
+                            || format!("ERROR; log {}", log_file.display()),
+                            |cause| format!("ERROR; {cause}; log {}", log_file.display()),
+                        );
+                        output::boot_fail(name, &detail);
+                        reported_failures.insert(name.clone());
                     } else if output::boot_verbose() {
                         output::boot_note(name, state);
                     }
@@ -2172,6 +2254,32 @@ fn read_log_tail(path: &Path, max_lines: usize) -> String {
     let lines: Vec<&str> = contents.lines().collect();
     let start = lines.len().saturating_sub(max_lines);
     lines[start..].join("\n")
+}
+
+/// Return the provider's actual lifecycle failure rather than whichever
+/// shutdown record happened to be written last. Scribe records are JSONL;
+/// providers commonly report lifecycle transitions at info level, so prefer
+/// `-> ERROR (...)` messages before falling back to an error-level record.
+fn read_provider_failure(path: &Path) -> Option<String> {
+    let contents = std::fs::read_to_string(path).ok()?;
+    let mut error_level_fallback = None;
+    for line in contents.lines().rev() {
+        let Ok(record) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        let Some(message) = record.get("msg").and_then(|value| value.as_str()) else {
+            continue;
+        };
+        if let Some((_, cause)) = message.split_once(" -> ERROR (") {
+            return Some(cause.strip_suffix(')').unwrap_or(cause).to_string());
+        }
+        if error_level_fallback.is_none()
+            && record.get("level").and_then(|value| value.as_str()) == Some("error")
+        {
+            error_level_fallback = Some(message.to_string());
+        }
+    }
+    error_level_fallback
 }
 
 async fn soma_grpc_ready(atlas: &mut AtlasClient, contract_id: &str) -> bool {

--- a/tools/rbnx/src/cmd/mod.rs
+++ b/tools/rbnx/src/cmd/mod.rs
@@ -51,6 +51,10 @@ pub enum Commands {
         /// Clean build (remove rbnx-build before building). Default: incremental.
         #[arg(long)]
         clean: bool,
+        /// Skip the remote-provider freshness check before building cached packages.
+        /// Useful when offline or when the deployment cache is intentionally pinned.
+        #[arg(long)]
+        no_update_check: bool,
     },
     /// Start one package (runs its `start` block; blocks until it exits)
     ///
@@ -397,7 +401,8 @@ pub async fn execute(command: Commands, config: Config) -> Result<()> {
             path,
             global,
             clean,
-        } => run_package::execute_build(config, file, path, global, clean).await,
+            no_update_check,
+        } => run_package::execute_build(config, file, path, global, clean, no_update_check).await,
         Commands::Start {
             package,
             endpoint,

--- a/tools/rbnx/src/cmd/mod.rs
+++ b/tools/rbnx/src/cmd/mod.rs
@@ -10,6 +10,7 @@ use std::path::PathBuf;
 use robonix_cli::Config;
 
 mod ask;
+pub(crate) mod boot_watchdog;
 mod build;
 mod chat;
 mod check_remotes;
@@ -117,6 +118,16 @@ pub enum Commands {
         /// like a Linux/FreeBSD kernel boot log or Android logcat.
         #[arg(short, long)]
         verbose: bool,
+    },
+    /// Internal detached cleanup process for one `rbnx boot` invocation.
+    #[command(name = "__watch-boot", hide = true)]
+    WatchBoot {
+        #[arg(long)]
+        state: PathBuf,
+        #[arg(long)]
+        boot_pid: u32,
+        #[arg(long)]
+        boot_start_time_ticks: Option<u64>,
     },
     /// Update remote (`url:`) providers to their latest upstream commit
     ///
@@ -427,6 +438,11 @@ pub async fn execute(command: Commands, config: Config) -> Result<()> {
             no_update_check,
             verbose,
         } => deploy::execute(config, file, log_dir, skip_system, no_update_check, verbose).await,
+        Commands::WatchBoot {
+            state,
+            boot_pid,
+            boot_start_time_ticks,
+        } => boot_watchdog::execute(state, boot_pid, boot_start_time_ticks).await,
         Commands::Update { path, file } => update::execute(config, path, file).await,
         Commands::Shutdown { file } => shutdown::execute(file).await,
         Commands::Clean {

--- a/tools/rbnx/src/cmd/run_package.rs
+++ b/tools/rbnx/src/cmd/run_package.rs
@@ -141,13 +141,14 @@ pub async fn execute_build(
     path: Option<PathBuf>,
     global: Option<String>,
     clean: bool,
+    no_update_check: bool,
 ) -> Result<()> {
     if let Some(file) = file {
         let manifest_path = resolve_local_path_for_filesystem(&file)?;
         if !manifest_path.is_file() {
             anyhow::bail!("deployment manifest not found: {}", manifest_path.display());
         }
-        return build_deploy_manifest(&manifest_path, &config, clean);
+        return build_deploy_manifest(&manifest_path, &config, clean, no_update_check);
     }
 
     // Deploy-manifest mode: if `path` (or cwd, when -p is omitted)
@@ -165,7 +166,7 @@ pub async fn execute_build(
     if let Some(dir) = candidate_dir {
         let deploy_manifest = dir.join("robonix_manifest.yaml");
         if deploy_manifest.is_file() {
-            return build_deploy_manifest(&deploy_manifest, &config, clean);
+            return build_deploy_manifest(&deploy_manifest, &config, clean, no_update_check);
         }
     }
     let package_root = resolve_package_path(&config, path, global)?;
@@ -184,7 +185,12 @@ pub async fn execute_build(
 /// "fetch → build" be a controlled offline step the user can run
 /// when they have network / time, then `rbnx boot` is a fast,
 /// online-optional bring-up.
-fn build_deploy_manifest(manifest_path: &Path, config: &Config, clean: bool) -> Result<()> {
+fn build_deploy_manifest(
+    manifest_path: &Path,
+    config: &Config,
+    clean: bool,
+    no_update_check: bool,
+) -> Result<()> {
     use serde_yaml::Value;
     let manifest_dir = manifest_path
         .parent()
@@ -203,7 +209,9 @@ fn build_deploy_manifest(manifest_path: &Path, config: &Config, clean: bool) -> 
         &format!("packages declared in {}", manifest_path.display()),
     );
     // Notice (non-fatal) if any cloned remote provider is behind upstream.
-    super::check_remotes::report_outdated(manifest_path);
+    if !no_update_check {
+        super::check_remotes::report_outdated(manifest_path);
+    }
 
     // Collect (section, name, pkg_dir, url_to_clone) for every entry.
     struct Resolved {

--- a/tools/rbnx/src/cmd/shutdown.rs
+++ b/tools/rbnx/src/cmd/shutdown.rs
@@ -56,13 +56,24 @@ pub async fn execute(file: PathBuf) -> Result<()> {
         ),
     );
 
-    teardown::teardown(Some(&state.atlas_endpoint), &state.components).await;
+    let boot_id = (!state.boot_id.is_empty()).then_some(state.boot_id.as_str());
+    let complete =
+        teardown::teardown(Some(&state.atlas_endpoint), &state.components, boot_id).await;
+    if !complete {
+        anyhow::bail!(
+            "shutdown refused one or more stale/mismatched process groups; preserving {}",
+            state_path.display()
+        );
+    }
 
     // Best-effort: also signal the boot process itself (which is probably
     // already dead because we just killed all its children, but if the
     // user ran `rbnx boot` in the foreground and `rbnx shutdown` from
     // another shell, this lets boot exit its signal-wait loop cleanly).
-    if state.boot_pid != 0 && state.boot_pid != std::process::id() {
+    let boot_identity_matches = state.boot_start_time_ticks.is_none_or(|expected| {
+        robonix_cli::launch::proc_start_time_ticks(state.boot_pid) == Some(expected)
+    });
+    if state.boot_pid != 0 && state.boot_pid != std::process::id() && boot_identity_matches {
         let pid = nix::unistd::Pid::from_raw(state.boot_pid as i32);
         let _ = nix::sys::signal::kill(pid, nix::sys::signal::Signal::SIGTERM);
     }

--- a/tools/rbnx/src/cmd/teardown.rs
+++ b/tools/rbnx/src/cmd/teardown.rs
@@ -14,7 +14,7 @@
 // always reach the same teardown helper.
 
 use anyhow::{Context, Result};
-use robonix_cli::launch::{PackageRuntimeRecord, shutdown_package_runtime};
+use robonix_cli::launch::{PackageRuntimeRecord, shutdown_package_runtime_checked};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -23,6 +23,10 @@ use std::time::Duration;
 pub struct BootState {
     pub manifest_path: String,
     pub boot_pid: u32,
+    #[serde(default)]
+    pub boot_start_time_ticks: Option<u64>,
+    #[serde(default)]
+    pub boot_id: String,
     pub started_at_ms: u64,
     pub atlas_endpoint: String,
     pub components: Vec<ComponentRecord>,
@@ -41,7 +45,10 @@ pub fn write_state(path: &Path, state: &BootState) -> Result<()> {
         std::fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
     }
     let text = serde_json::to_string_pretty(state)?;
-    std::fs::write(path, text).with_context(|| format!("write {}", path.display()))?;
+    let temp = path.with_extension(format!("json.{}.tmp", std::process::id()));
+    std::fs::write(&temp, text).with_context(|| format!("write {}", temp.display()))?;
+    std::fs::rename(&temp, path)
+        .with_context(|| format!("replace {} with {}", path.display(), temp.display()))?;
     Ok(())
 }
 
@@ -54,13 +61,21 @@ pub fn read_state(path: &Path) -> Result<BootState> {
 
 /// Stop each component with the canonical runtime order. Idempotent: missing
 /// providers, stop hooks, or PGIDs are treated as best-effort shutdown noise.
-pub async fn teardown(atlas_endpoint: Option<&str>, components: &[ComponentRecord]) {
+pub async fn teardown(
+    atlas_endpoint: Option<&str>,
+    components: &[ComponentRecord],
+    boot_id: Option<&str>,
+) -> bool {
+    let mut complete = true;
     // Reverse order so services/skills/primitives die before pilot/atlas.
     for c in components.iter().rev() {
         robonix_cli::output::sub_step(&format!(
             "[shutdown] {} stopping (pid={}, pgid={})",
             c.name, c.pid, c.pgid
         ));
-        shutdown_package_runtime(atlas_endpoint, c, Duration::from_secs(30)).await;
+        complete &=
+            shutdown_package_runtime_checked(atlas_endpoint, c, Duration::from_secs(30), boot_id)
+                .await;
     }
+    complete
 }

--- a/tools/rbnx/src/launch.rs
+++ b/tools/rbnx/src/launch.rs
@@ -112,6 +112,32 @@ pub async fn shutdown_package_runtime(
     record: &PackageRuntimeRecord,
     term_wait: Duration,
 ) {
+    let _ = shutdown_package_runtime_checked(atlas_endpoint, record, term_wait, None).await;
+}
+
+/// Checked variant used by persisted boot-state teardown. A boot id is
+/// inherited by every wrapper and provider through `RBNX_BOOT_ID`; requiring a
+/// matching process in the recorded PGID prevents a stale state file from
+/// killing an unrelated process group after PID/PGID reuse.
+pub async fn shutdown_package_runtime_checked(
+    atlas_endpoint: Option<&str>,
+    record: &PackageRuntimeRecord,
+    term_wait: Duration,
+    boot_id: Option<&str>,
+) -> bool {
+    if let Some(boot_id) = boot_id {
+        if !process_group_has_members(record.pgid).await {
+            return true;
+        }
+        if !process_group_has_boot_id(record.pgid, boot_id).await {
+            warn!(
+                "refusing to stop {} pgid {}: no process carries RBNX_BOOT_ID={}",
+                record.name, record.pgid, boot_id
+            );
+            return false;
+        }
+    }
+
     if let (Some(endpoint), Some(provider_id), Some(driver_contract)) = (
         atlas_endpoint,
         record.provider_id.as_deref(),
@@ -162,6 +188,42 @@ pub async fn shutdown_package_runtime(
     }
 
     terminate_process_group(record.pgid, term_wait).await;
+    !process_group_has_members(record.pgid).await
+}
+
+async fn process_group_has_boot_id(pgid: u32, boot_id: &str) -> bool {
+    let output = match Command::new("pgrep")
+        .arg("-g")
+        .arg(pgid.to_string())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+        .await
+    {
+        Ok(output) if output.status.success() => output,
+        _ => return false,
+    };
+    let expected = format!("RBNX_BOOT_ID={boot_id}");
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.trim().parse::<u32>().ok())
+        .any(|pid| {
+            std::fs::read(format!("/proc/{pid}/environ"))
+                .ok()
+                .is_some_and(|env| {
+                    env.split(|byte| *byte == 0)
+                        .any(|entry| entry == expected.as_bytes())
+                })
+        })
+}
+
+/// Linux `/proc/<pid>/stat` field 22. The value is stable for the lifetime of
+/// a process and lets the watchdog distinguish its boot parent from a reused
+/// PID. Returns `None` when procfs is unavailable or the process exited.
+pub fn proc_start_time_ticks(pid: u32) -> Option<u64> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let after_comm = stat.get(stat.rfind(')')? + 1..)?.trim_start();
+    after_comm.split_whitespace().nth(19)?.parse().ok()
 }
 
 async fn run_package_stop_hook(

--- a/tools/rbnx/src/main.rs
+++ b/tools/rbnx/src/main.rs
@@ -95,6 +95,17 @@ async fn main() -> Result<()> {
     ensure_loopback_bypasses_proxy();
 
     let cli = Cli::parse();
+    // The detached boot watchdog must not depend on user config, package DB
+    // sync, a terminal, or Scribe initialization. It only reads the persisted
+    // boot state and performs teardown if the exact parent process vanishes.
+    if let cmd::Commands::WatchBoot {
+        state,
+        boot_pid,
+        boot_start_time_ticks,
+    } = &cli.command
+    {
+        return cmd::boot_watchdog::execute(state.clone(), *boot_pid, *boot_start_time_ticks).await;
+    }
     let verbose_boot = matches!(&cli.command, cmd::Commands::Boot { verbose: true, .. });
     prepare_boot_log_dir(&cli.command)?;
 

--- a/tools/rbnx/src/main.rs
+++ b/tools/rbnx/src/main.rs
@@ -166,6 +166,25 @@ mod tests {
     }
 
     #[test]
+    fn build_accepts_no_update_check() {
+        let cli = Cli::try_parse_from([
+            "rbnx",
+            "build",
+            "-f",
+            "robot/robonix_manifest.yaml",
+            "--no-update-check",
+        ])
+        .expect("build --no-update-check should parse");
+        assert!(matches!(
+            cli.command,
+            cmd::Commands::Build {
+                no_update_check: true,
+                ..
+            }
+        ));
+    }
+
+    #[test]
     fn boot_accepts_verbose_mode() {
         let cli = Cli::try_parse_from(["rbnx", "boot", "-v"]).expect("boot -v should parse");
         assert!(matches!(

--- a/tools/rbnx/src/output.rs
+++ b/tools/rbnx/src/output.rs
@@ -217,7 +217,8 @@ pub fn boot_skip(name: &str, detail: &str) {
 /// (cache hit, fetched a remote package, …). Neither up nor skipped.
 pub fn boot_note(name: &str, detail: &str) {
     println!(
-        "{} {}  {:<width$}  {}",
+        "{}{} {}  {:<width$}  {}",
+        clear_progress_prefix(),
         boot_now().cyan(),
         "[ →  ]".cyan(),
         name,
@@ -245,7 +246,8 @@ pub fn boot_update_avail(name: &str, detail: &str) {
 /// `[  ssss.mmm] [....] name              detail` — component is starting.
 pub fn boot_wait(name: &str, detail: &str) {
     println!(
-        "{} {}  {:<width$}  {}",
+        "{}{} {}  {:<width$}  {}",
+        clear_progress_prefix(),
         boot_now().cyan(),
         "[....]".cyan(),
         name,
@@ -257,7 +259,8 @@ pub fn boot_wait(name: &str, detail: &str) {
 /// Group header above a run of boot lines. FreeBSD-rc-style ":: stage ::".
 pub fn boot_section(label: &str) {
     println!(
-        "\n{} {} {} {}",
+        "{}\n{} {} {} {}",
+        clear_progress_prefix(),
         boot_now().cyan(),
         "::".dimmed(),
         label.bold().yellow(),


### PR DESCRIPTION
## Problem

Pilot plans from conversation history and active RTDL trees, but it does not refresh the robot body or spatial state before each planning round. This allows stale assumptions such as treating an open gripper as holding an object or ignoring that the chassis is already moving.

## Design

- Extend Soma with the `GetHealth` and `StreamHealth` snapshot API defined by #111.
- Aggregate Atlas-selected arm joint states and chassis odometry by provider ID, including freshness, speed, `moving`, and calibrated gripper `likely_holding` metrics.
- Add one Scene snapshot for map pose, containing room/areas, and nearby objects.
- Refresh Soma, Scene, provider availability, and the RTDL forest before every initial plan, steer, and replan.
- Keep missing or stale state explicitly unknown. No manipulation skill is used as a body-state source.

## Validation

- Pilot: 42 tests
- Soma: 27 tests
- Scene: 85 tests
- `cargo clippy -p robonix-soma -p robonix-pilot --all-targets -- -D warnings`

## Discussion

This PR intentionally reuses the Soma health schema from #111 so Vitals can consume the same stream. The current schema has no chassis kind, so chassis providers use a stable `body/chassis/<provider_id>` component path with WHEEL kind and motion metrics. #142 separately adds the standard arm primitive contracts used by the collector.

Hardware validation remains required on the Ranger/Piper integration branch.
