### PR TITLE
Make the Webots deployment self-contained

### DIFF
--- a/examples/webots/config/nav2_params.yaml
+++ b/examples/webots/config/nav2_params.yaml
@@ -1,0 +1,333 @@
+amcl:
+  ros__parameters:
+    use_sim_time: True
+    transform_tolerance: 0.3
+    tf_broadcast: true
+    scan_topic: /scanner_normalized
+    min_particles: 300
+    max_particles: 2000
+    odom_frame_id: "odom"
+    base_frame_id: "base_link"  # match costmap robot_base_frame
+    global_frame_id: "map"
+    laser_max_range: -1.0
+    laser_min_range: -1.0
+    update_min_d: 0.05
+    update_min_a: 0.05
+    resample_interval: 1
+    set_initial_pose: true
+    initial_pose:
+      x: 0.0
+      y: 0.0
+      z: 0.0
+      yaw: 0.0
+map_server:
+  ros__parameters:
+    use_sim_time: True
+    # Overridden in launch by the "map" launch configuration or provided default value.
+    # To use in yaml, remove the default "map" value in the tb3_simulation_launch.py file & provide full path to map below.
+    yaml_filename: ""
+bt_navigator:
+  ros__parameters:
+    use_sim_time: True
+    # map frame: rtabmap provides the map->odom TF (online SLAM), so the BT
+    # navigator plans in the same map frame as the costmaps.
+    global_frame: map
+    robot_base_frame: base_link
+    odom_topic: "__ROBONIX_ODOM_TOPIC__"
+    bt_loop_duration: 50
+    default_server_timeout: 20
+    # 'default_nav_through_poses_bt_xml' and 'default_nav_to_pose_bt_xml' are use defaults:
+    # nav2_bt_navigator/navigate_to_pose_w_replanning_and_recovery.xml
+    # nav2_bt_navigator/navigate_through_poses_w_replanning_and_recovery.xml
+    # They can be set here or via a RewrittenYaml remap from a parent launch file to Nav2.
+    plugin_lib_names:
+    - nav2_compute_path_to_pose_action_bt_node
+    - nav2_compute_path_through_poses_action_bt_node
+    - nav2_smooth_path_action_bt_node
+    - nav2_follow_path_action_bt_node
+    - nav2_spin_action_bt_node
+    - nav2_wait_action_bt_node
+    - nav2_assisted_teleop_action_bt_node
+    - nav2_back_up_action_bt_node
+    - nav2_drive_on_heading_bt_node
+    - nav2_clear_costmap_service_bt_node
+    - nav2_is_stuck_condition_bt_node
+    - nav2_goal_reached_condition_bt_node
+    - nav2_goal_updated_condition_bt_node
+    - nav2_globally_updated_goal_condition_bt_node
+    - nav2_is_path_valid_condition_bt_node
+    - nav2_initial_pose_received_condition_bt_node
+    - nav2_reinitialize_global_localization_service_bt_node
+    - nav2_rate_controller_bt_node
+    - nav2_distance_controller_bt_node
+    - nav2_speed_controller_bt_node
+    - nav2_truncate_path_action_bt_node
+    - nav2_truncate_path_local_action_bt_node
+    - nav2_goal_updater_node_bt_node
+    - nav2_recovery_node_bt_node
+    - nav2_pipeline_sequence_bt_node
+    - nav2_round_robin_node_bt_node
+    - nav2_transform_available_condition_bt_node
+    - nav2_time_expired_condition_bt_node
+    - nav2_path_expiring_timer_condition
+    - nav2_distance_traveled_condition_bt_node
+    - nav2_single_trigger_bt_node
+    - nav2_goal_updated_controller_bt_node
+    - nav2_is_battery_low_condition_bt_node
+    - nav2_navigate_through_poses_action_bt_node
+    - nav2_navigate_to_pose_action_bt_node
+    - nav2_remove_passed_goals_action_bt_node
+    - nav2_planner_selector_bt_node
+    - nav2_controller_selector_bt_node
+    - nav2_goal_checker_selector_bt_node
+    - nav2_controller_cancel_bt_node
+    - nav2_path_longer_on_approach_bt_node
+    - nav2_wait_cancel_bt_node
+    - nav2_spin_cancel_bt_node
+    - nav2_back_up_cancel_bt_node
+    - nav2_assisted_teleop_cancel_bt_node
+    - nav2_drive_on_heading_cancel_bt_node
+
+bt_navigator_navigate_through_poses_rclcpp_node:
+  ros__parameters:
+    use_sim_time: True
+
+bt_navigator_navigate_to_pose_rclcpp_node:
+  ros__parameters:
+    use_sim_time: True
+
+controller_server:
+  ros__parameters:
+    use_sim_time: True
+    controller_frequency: 20.0
+    min_x_velocity_threshold: 0.001
+    min_y_velocity_threshold: 0.5
+    min_theta_velocity_threshold: 0.001
+    failure_tolerance: 0.3
+    progress_checker_plugin: "progress_checker"
+    goal_checker_plugins: ["general_goal_checker"] # "precise_goal_checker"
+    controller_plugins: ["FollowPath"]
+
+    # Progress checker parameters
+    progress_checker:
+      plugin: "nav2_controller::SimpleProgressChecker"
+      required_movement_radius: 0.5
+      movement_time_allowance: 10.0
+    # Goal checker parameters
+    #precise_goal_checker:
+    #  plugin: "nav2_controller::SimpleGoalChecker"
+    #  xy_goal_tolerance: 0.25
+    #  yaw_goal_tolerance: 0.25
+    #  stateful: True
+    general_goal_checker:
+      stateful: True
+      plugin: "nav2_controller::SimpleGoalChecker"
+      xy_goal_tolerance: 0.25
+      yaw_goal_tolerance: 0.25
+    # DWB parameters
+    FollowPath:
+      plugin: "dwb_core::DWBLocalPlanner"
+      debug_trajectory_details: True
+      min_vel_x: 0.0
+      min_vel_y: 0.0
+      max_vel_x: 0.26
+      max_vel_y: 0.0
+      max_vel_theta: 1.0
+      min_speed_xy: 0.0
+      max_speed_xy: 0.26
+      min_speed_theta: 0.0
+      # Add high threshold velocity for turtlebot 3 issue.
+      # https://github.com/ROBOTIS-GIT/turtlebot3_simulations/issues/75
+      acc_lim_x: 2.5
+      acc_lim_y: 0.0
+      acc_lim_theta: 3.2
+      decel_lim_x: -2.5
+      decel_lim_y: 0.0
+      decel_lim_theta: -3.2
+      vx_samples: 20
+      vy_samples: 5
+      vtheta_samples: 20
+      sim_time: 1.7
+      linear_granularity: 0.05
+      angular_granularity: 0.025
+      transform_tolerance: 0.2
+      xy_goal_tolerance: 0.25
+      trans_stopped_velocity: 0.25
+      short_circuit_trajectory_evaluation: True
+      stateful: True
+      critics: ["RotateToGoal", "Oscillation", "BaseObstacle", "GoalAlign", "PathAlign", "PathDist", "GoalDist"]
+      BaseObstacle.scale: 0.02
+      PathAlign.scale: 32.0
+      PathAlign.forward_point_distance: 0.1
+      GoalAlign.scale: 24.0
+      GoalAlign.forward_point_distance: 0.1
+      PathDist.scale: 32.0
+      GoalDist.scale: 24.0
+      RotateToGoal.scale: 32.0
+      RotateToGoal.slowing_factor: 5.0
+      RotateToGoal.lookahead_time: -1.0
+
+local_costmap:
+  local_costmap:
+    ros__parameters:
+      update_frequency: 5.0
+      publish_frequency: 2.0
+      transform_tolerance: 0.3
+      # map frame: rtabmap publishes both /map and a map->odom TF, so the
+      # costmap is anchored in the SLAM map (same as the proven tiago_demo
+      # config). The rolling window crops the map around the robot.
+      global_frame: map
+      robot_base_frame: base_link
+      use_sim_time: true
+      rolling_window: true
+      width: 5
+      height: 5
+      resolution: 0.05
+      robot_radius: 0.22
+      # static_layer first: the rolling local window is cropped from the live
+      # rtabmap /map, so the local controller (DWB) sees mapped walls and
+      # avoids them reactively. obstacle_layer adds anything not yet mapped.
+      plugins: ["static_layer", "obstacle_layer", "inflation_layer"]
+      static_layer:
+        plugin: "nav2_costmap_2d::StaticLayer"
+        map_subscribe_transient_local: True
+        map_topic: "__ROBONIX_MAP_TOPIC__"
+      obstacle_layer:
+        plugin: "nav2_costmap_2d::ObstacleLayer"
+        enabled: True
+        observation_sources: scan
+        scan:
+          topic: "__ROBONIX_SCAN_TOPIC__"
+          max_obstacle_height: 2.0
+          clearing: True
+          marking: True
+          data_type: "LaserScan"
+          raytrace_max_range: 3.0
+          raytrace_min_range: 0.0
+          obstacle_max_range: 2.5
+          obstacle_min_range: 0.0
+      inflation_layer:
+        plugin: "nav2_costmap_2d::InflationLayer"
+        cost_scaling_factor: 1.0
+        inflation_radius: 1.50
+      always_send_full_costmap: True
+      
+global_costmap:
+  global_costmap:
+    ros__parameters:
+      update_frequency: 1.0
+      publish_frequency: 1.0
+      # map frame, online SLAM: rtabmap publishes a live /map (growing as the
+      # robot explores) plus a map->odom TF. The static_layer tracks /map
+      # updates (map_subscribe_transient_local) so the costmap follows the
+      # map as it grows — mapping and navigating at the same time. The
+      # obstacle_layer adds anything not yet in the map; allow_unknown lets
+      # the planner route through not-yet-mapped space.
+      global_frame: map
+      robot_base_frame: base_link
+      rolling_window: false
+      width: 12
+      height: 12
+      use_sim_time: True
+      robot_radius: 0.22
+      resolution: 0.05
+      track_unknown_space: true
+      plugins: ["static_layer", "obstacle_layer", "inflation_layer"]
+      obstacle_layer:
+        plugin: "nav2_costmap_2d::ObstacleLayer"
+        enabled: True
+        observation_sources: scan
+        scan:
+          topic: "__ROBONIX_SCAN_TOPIC__"
+          max_obstacle_height: 2.0
+          clearing: True
+          marking: True
+          data_type: "LaserScan"
+          raytrace_max_range: 3.0
+          raytrace_min_range: 0.0
+          obstacle_max_range: 2.5
+          obstacle_min_range: 0.0
+      static_layer:
+        plugin: "nav2_costmap_2d::StaticLayer"
+        map_subscribe_transient_local: True
+      inflation_layer:
+        plugin: "nav2_costmap_2d::InflationLayer"
+        cost_scaling_factor: 3.0
+        inflation_radius: 0.55
+      always_send_full_costmap: True
+      
+planner_server:
+  ros__parameters:
+    expected_planner_frequency: 20.0
+    use_sim_time: True
+    planner_plugins: ["GridBased"]
+    GridBased:
+      plugin: "nav2_navfn_planner/NavfnPlanner"
+      tolerance: 0.5
+      use_astar: false
+      allow_unknown: true
+
+smoother_server:
+  ros__parameters:
+    use_sim_time: True
+    smoother_plugins: ["simple_smoother"]
+    simple_smoother:
+      plugin: "nav2_smoother::SimpleSmoother"
+      tolerance: 1.0e-10
+      max_its: 1000
+      do_refinement: True
+
+behavior_server:
+  ros__parameters:
+    costmap_topic: local_costmap/costmap_raw
+    footprint_topic: local_costmap/published_footprint
+    cycle_frequency: 10.0
+    behavior_plugins: ["spin", "backup", "drive_on_heading", "assisted_teleop", "wait"]
+    spin:
+      plugin: "nav2_behaviors/Spin"
+    backup:
+      plugin: "nav2_behaviors/BackUp"
+    drive_on_heading:
+      plugin: "nav2_behaviors/DriveOnHeading"
+    wait:
+      plugin: "nav2_behaviors/Wait"
+    assisted_teleop:
+      plugin: "nav2_behaviors/AssistedTeleop"
+    global_frame: map
+    robot_base_frame: base_link
+    transform_tolerance: 0.1
+    use_sim_time: true
+    simulate_ahead_time: 2.0
+    max_rotational_vel: 1.0
+    min_rotational_vel: 0.4
+    rotational_acc_lim: 3.2
+
+robot_state_publisher:
+  ros__parameters:
+    use_sim_time: True
+
+waypoint_follower:
+  ros__parameters:
+    use_sim_time: True
+    loop_rate: 20
+    stop_on_failure: false
+    waypoint_task_executor_plugin: "wait_at_waypoint"
+    wait_at_waypoint:
+      plugin: "nav2_waypoint_follower::WaitAtWaypoint"
+      enabled: True
+      waypoint_pause_duration: 200
+
+velocity_smoother:
+  ros__parameters:
+    use_sim_time: True
+    smoothing_frequency: 20.0
+    scale_velocities: False
+    feedback: "OPEN_LOOP"
+    max_velocity: [0.26, 0.0, 1.0]
+    min_velocity: [-0.26, 0.0, -1.0]
+    max_accel: [2.5, 0.0, 3.2]
+    max_decel: [-2.5, 0.0, -3.2]
+    odom_topic: "__ROBONIX_ODOM_TOPIC__"
+    odom_duration: 0.1
+    deadband_velocity: [0.0, 0.0, 0.0]
+    velocity_timeout: 1.0

--- a/examples/webots/config/rtabmap_params.yaml
+++ b/examples/webots/config/rtabmap_params.yaml
@@ -1,0 +1,22 @@
+# Webots Tiago RTAB-Map parameters. This file is owned by this deployment.
+RGBD/CreateOccupancyGrid: true
+Grid/RangeMax: 6.0
+Grid/CellSize: 0.05
+Grid/RayTracing: true
+Grid/3D: false
+Grid/NormalsSegmentation: false
+Grid/MaxObstacleHeight: 1.0
+Grid/MaxGroundHeight: 0.1
+Reg/Strategy: 0
+Reg/Force3DoF: true
+Optimizer/Strategy: 1
+RGBD/NeighborLinkRefining: false
+RGBD/ProximityBySpace: false
+RGBD/AngularUpdate: 0.03
+RGBD/LinearUpdate: 0.03
+Mem/NotLinkedNodesKept: true
+Vis/MinInliers: 12
+Rtabmap/DetectionRate: 5.0
+Icp/MaxCorrespondenceDistance: 0.2
+Icp/MaxTranslation: 0.5
+Icp/MaxRotation: 0.78

--- a/examples/webots/primitives/audio_client_bridge/config.spec
+++ b/examples/webots/primitives/audio_client_bridge/config.spec
@@ -1,13 +1,31 @@
-# Client audio uses reverse transport by default: this provider listens and
-# robonix-client connects to it. A normal deployment needs no config.
+# Runtime configuration accepted by the client audio bridge primitive.
+#
+# This documents the mapping passed as the package instance's `config:` value.
+# It is not loaded as a schema. Values below are runtime defaults.
 
 config:
-  transport: reverse       # Default. The only named transport mode.
+  # string, default: reverse; accepted value: reverse.
+  # In reverse mode the robot listens and robonix-client connects to it, so a
+  # normal remote-client deployment does not need the client's IP address.
+  transport: reverse
+
+  # string IP address or interface name, default: 0.0.0.0.
+  # Bind address for the reverse WebSocket endpoint. Keep 0.0.0.0 when the
+  # client runs on another host; use a loopback address only for local tests.
   listen_host: 0.0.0.0
+
+  # integer TCP port, default: 60002; valid range: 1..65535.
+  # Port exposed by the reverse WebSocket endpoint. The same port must be
+  # reachable from robonix-client.
   listen_port: 60002
 
-# Backward-compatible client-owned server mode. Setting host selects it;
-# transport is omitted in that mode.
+# Deprecated client-owned-server transport. Existing deployments remain
+# compatible: setting `host` selects this mode when `transport` is omitted.
 legacy_config:
+  # string hostname or IP address, no default in reverse mode.
+  # Address of the legacy client_audio_server process.
   host: 127.0.0.1
+
+  # integer TCP port, default: 60000; valid range: 1..65535.
+  # Port of the legacy client_audio_server process.
   port: 60000

--- a/examples/webots/primitives/audio_client_bridge/config.spec
+++ b/examples/webots/primitives/audio_client_bridge/config.spec
@@ -1,0 +1,13 @@
+# Client audio uses reverse transport by default: this provider listens and
+# robonix-client connects to it. A normal deployment needs no config.
+
+config:
+  transport: reverse       # Default. The only named transport mode.
+  listen_host: 0.0.0.0
+  listen_port: 60002
+
+# Backward-compatible client-owned server mode. Setting host selects it;
+# transport is omitted in that mode.
+legacy_config:
+  host: 127.0.0.1
+  port: 60000

--- a/examples/webots/primitives/audio_driver/config.spec
+++ b/examples/webots/primitives/audio_driver/config.spec
@@ -1,14 +1,41 @@
-# ALSA audio provider runtime config. Device fields may be omitted for
-# automatic discovery. Explicit device names are recommended on robots with
-# more than one USB audio interface.
+# Runtime configuration accepted by the Linux ALSA audio primitive.
+#
+# This documents the mapping passed as the package instance's `config:` value.
+# It is not loaded as a schema. Values below are runtime defaults.
 
 config:
-  mic_device: auto
-  mic_sample_rate: probe
+  # string ALSA device id or null, default: null.
+  # Examples: hw:1,0 or plughw:1,0. Null selects the detected default input.
+  mic_device: null
+
+  # integer hertz or null, default: null.
+  # Null probes the selected microphone and prefers 16000 Hz when supported.
+  mic_sample_rate: null
+
+  # integer channel count, default: 1; must be supported by the device.
+  # ASR input is normally mono.
   mic_channels: 1
+
+  # integer bits per sample, default: 16; accepted: 8, 16, 24, 32.
+  # Selects the raw signed PCM format passed to arecord.
   mic_bits: 16
+
+  # integer milliseconds, default: 100; must be greater than zero.
+  # Duration of each microphone chunk returned by the streaming capability.
   mic_chunk_ms: 100
-  speaker_device: auto
+
+  # string ALSA device id or null, default: null.
+  # Examples: hw:1,0 or plughw:1,0. Null selects the detected default output.
+  speaker_device: null
+
+  # integer hertz, default: 24000; must be supported by the output device.
+  # It must match the PCM rate produced by the configured TTS path.
   speaker_sample_rate: 24000
+
+  # integer channel count, default: 1; must be supported by the device.
+  # Robonix TTS output is normally mono.
   speaker_channels: 1
+
+  # integer bits per sample, default: 16; accepted: 8, 16, 24, 32.
+  # Selects the raw signed PCM format passed to aplay.
   speaker_bits: 16

--- a/examples/webots/primitives/audio_driver/config.spec
+++ b/examples/webots/primitives/audio_driver/config.spec
@@ -1,0 +1,14 @@
+# ALSA audio provider runtime config. Device fields may be omitted for
+# automatic discovery. Explicit device names are recommended on robots with
+# more than one USB audio interface.
+
+config:
+  mic_device: auto
+  mic_sample_rate: probe
+  mic_channels: 1
+  mic_bits: 16
+  mic_chunk_ms: 100
+  speaker_device: auto
+  speaker_sample_rate: 24000
+  speaker_channels: 1
+  speaker_bits: 16

--- a/examples/webots/primitives/tiago_camera/config.spec
+++ b/examples/webots/primitives/tiago_camera/config.spec
@@ -1,0 +1,22 @@
+# Webots Tiago RGB-D camera topic and calibration config.
+# The simulator normally provides the topics and TF. Intrinsics may come from
+# CameraInfo or from width/height/fx/fy/cx/cy below.
+
+config:
+  rgb_topic: /head_front_camera/rgb/image_raw
+  depth_topic: /head_front_camera/depth_registered/image_raw
+  camera_info_topic: /head_front_camera/rgb/camera_info
+  intrinsics_topic: /tiago/camera/intrinsics
+  extrinsics_topic: /tiago/camera/extrinsics
+  base_frame: base_link
+  cam_frame: head_front_camera_rgb_optical_frame
+  width: 0
+  height: 0
+  fx: 0.0
+  fy: 0.0
+  cx: 0.0
+  cy: 0.0
+  horizontal_fov_rad: 0.0
+  sentinel_timeout_s: 60.0
+  camera_info_source_timeout_s: 1.0
+  intrinsics_publish_interval_s: 0.5

--- a/examples/webots/primitives/tiago_camera/config.spec
+++ b/examples/webots/primitives/tiago_camera/config.spec
@@ -1,22 +1,66 @@
-# Webots Tiago RGB-D camera topic and calibration config.
-# The simulator normally provides the topics and TF. Intrinsics may come from
-# CameraInfo or from width/height/fx/fy/cx/cy below.
+# Runtime configuration accepted by the Webots Tiago RGB-D camera primitive.
+#
+# This documents the mapping passed as the package instance's `config:` value.
+# It is not loaded as a schema. Values below are runtime defaults.
 
 config:
+  # string absolute ROS 2 topic, default shown below.
+  # sensor_msgs/Image source exposed through the RGB capability.
   rgb_topic: /head_front_camera/rgb/image_raw
+
+  # string absolute ROS 2 topic, default shown below.
+  # Registered sensor_msgs/Image source exposed through the depth capability.
   depth_topic: /head_front_camera/depth_registered/image_raw
+
+  # string absolute ROS 2 topic, default shown below.
+  # Preferred sensor_msgs/CameraInfo source for camera intrinsics.
   camera_info_topic: /head_front_camera/rgb/camera_info
+
+  # string absolute ROS 2 topic, default: /tiago/camera/intrinsics.
+  # Latched CameraInfo output that backs the Robonix intrinsics capability.
   intrinsics_topic: /tiago/camera/intrinsics
+
+  # string absolute ROS 2 topic, default: /tiago/camera/extrinsics.
+  # Latched TransformStamped output from base_frame to cam_frame.
   extrinsics_topic: /tiago/camera/extrinsics
+
+  # string TF frame, default: base_link.
+  # Robot frame used as the parent of the published camera extrinsics.
   base_frame: base_link
+
+  # string TF frame, default: head_front_camera_rgb_optical_frame.
+  # Camera optical frame used as the child of the published extrinsics.
   cam_frame: head_front_camera_rgb_optical_frame
+
+  # integer pixels, default: 0; width and height must both be positive when
+  # deployment-provided intrinsics are used instead of CameraInfo.
   width: 0
   height: 0
+
+  # float pixels, default: 0.0.
+  # Focal lengths. Positive fx and fy select explicit calibration; otherwise
+  # fx may be derived from width and horizontal_fov_rad.
   fx: 0.0
   fy: 0.0
+
+  # float pixels, default: 0.0.
+  # Principal point. Zero values are resolved from the configured image size.
   cx: 0.0
   cy: 0.0
+
+  # float radians, default: 0.0; valid useful range: 0 < value < pi.
+  # Horizontal field of view used to derive fx when explicit focal lengths
+  # are unavailable.
   horizontal_fov_rad: 0.0
+
+  # float seconds, default: 60.0; must be greater than zero.
+  # Maximum startup wait for the first RGB image before init fails.
   sentinel_timeout_s: 60.0
+
+  # float seconds, default: 1.0; must be non-negative.
+  # Time allowed for CameraInfo before configured intrinsics are used.
   camera_info_source_timeout_s: 1.0
+
+  # float seconds, default: 0.5; minimum effective value: 0.1.
+  # Republish interval for configured intrinsics until CameraInfo is observed.
   intrinsics_publish_interval_s: 0.5

--- a/examples/webots/primitives/tiago_chassis/config.spec
+++ b/examples/webots/primitives/tiago_chassis/config.spec
@@ -1,5 +1,13 @@
-# Webots Tiago chassis topic bindings. Values shown are defaults.
+# Runtime configuration accepted by the Webots Tiago chassis primitive.
+#
+# This documents the mapping passed as the package instance's `config:` value.
+# It is not loaded as a schema. Values below are runtime defaults.
 
 config:
+  # string absolute ROS 2 topic, default: /odom.
+  # nav_msgs/Odometry source exposed through the chassis odometry capability.
   odom_topic: /odom
+
+  # string absolute ROS 2 topic, default: /cmd_vel.
+  # geometry_msgs/Twist command target used by chassis movement capabilities.
   twist_in_topic: /cmd_vel

--- a/examples/webots/primitives/tiago_chassis/config.spec
+++ b/examples/webots/primitives/tiago_chassis/config.spec
@@ -1,0 +1,5 @@
+# Webots Tiago chassis topic bindings. Values shown are defaults.
+
+config:
+  odom_topic: /odom
+  twist_in_topic: /cmd_vel

--- a/examples/webots/primitives/tiago_lidar/config.spec
+++ b/examples/webots/primitives/tiago_lidar/config.spec
@@ -1,0 +1,5 @@
+# Webots Tiago planar lidar topic binding. Values shown are defaults.
+
+config:
+  scan_topic: /scanner_normalized
+  sentinel_timeout_s: 15.0

--- a/examples/webots/primitives/tiago_lidar/config.spec
+++ b/examples/webots/primitives/tiago_lidar/config.spec
@@ -1,5 +1,13 @@
-# Webots Tiago planar lidar topic binding. Values shown are defaults.
+# Runtime configuration accepted by the Webots Tiago planar lidar primitive.
+#
+# This documents the mapping passed as the package instance's `config:` value.
+# It is not loaded as a schema. Values below are runtime defaults.
 
 config:
+  # string absolute ROS 2 topic, default: /scanner_normalized.
+  # sensor_msgs/LaserScan source exposed through the planar lidar capability.
   scan_topic: /scanner_normalized
+
+  # float seconds, default: 15.0; must be greater than zero.
+  # Maximum startup wait for the first LaserScan message before init fails.
   sentinel_timeout_s: 15.0

--- a/examples/webots/robonix_manifest.yaml
+++ b/examples/webots/robonix_manifest.yaml
@@ -16,7 +16,6 @@ system:
   # basic layer
   atlas:
     listen: 0.0.0.0:50051
-    log: info
   soma:
     # Webots keeps ROS 2 inside the simulator container. Soma still owns and
     # exposes the state; only its private topic reader runs beside ROS 2.
@@ -27,9 +26,10 @@ system:
       - bash
       - -lc
       - source /opt/ros/humble/setup.bash && exec python3 -u /robonix_runtime/soma/soma_runtime_ros.py /robonix_runtime/soma/soma_runtime_sources.json
+  vitals:
+    listen: 0.0.0.0:50093
   # soma+scene layer
   scene:
-    log: info
     camera_frame: head_front_camera_rgb_optical_frame
     camera_provider_id: tiago_camera
   # execution layer
@@ -37,40 +37,25 @@ system:
     # robonix-client polls Executor for authoritative active RTDL plans.
     # Bind externally on trusted LAN/Tailscale deployments.
     listen: 0.0.0.0:50061
-    log: info
   # interaction layer
   pilot:
     listen: 127.0.0.1:50071
-    log: debug
     vlm:
       upstream: ${VLM_BASE_URL}
       api_key: ${VLM_API_KEY}
       model: ${VLM_MODEL}
-      api_format: openai
   liaison:
     listen: 0.0.0.0:50081
-    log: info
-    # Disabled until the operator enables it from robonix-client. The client
-    # then supplies its persisted input/output provider selection; no client
-    # address is stored in this deployment.
-    handsfree_enabled: false
 
 # after booted all the system components, start the devices (primitives)
 # the robonix boot "device tree"
 primitive:
   - name: tiago_chassis
     path: ./primitives/tiago_chassis
-    config:
-      # example place holders
-      can_port: /dev/can0
-      odom_frame: odom
-      base_frame: base_link
+    config: {}
   - name: tiago_camera
     path: ./primitives/tiago_camera
     config:
-      # example place holders
-      serial_no: 1234567890
-      fps: 30
       width: 640
       height: 480
       # Webots Tiago head camera calibration for the intrinsics contract.
@@ -80,7 +65,6 @@ primitive:
       fy: 554.0
       cx: 320.0
       cy: 240.0
-      frame_id: head_front_camera_rgb_optical_frame
       # First-RGB-frame wait at INIT. Webots under a CPU-starved boot (all
       # drivers initialising at once) can take well over a minute to deliver
       # the first frame — lidar alone routinely needs ~70s — so the default
@@ -89,9 +73,7 @@ primitive:
   - name: tiago_lidar
     path: ./primitives/tiago_lidar
     config:
-      # example place holders
-      update_rate: 10
-      frame_id: lidar
+      sentinel_timeout_s: 150
   # ── audio mic/speaker source ─────────────────────────────────────────────
   # Local ALSA provider. It remains available for robot-local audio.
   - name: audio_driver
@@ -102,9 +84,7 @@ primitive:
   # this manifest nor Liaison stores a client IP.
   - name: audio_client_bridge
     path: ./primitives/audio_client_bridge
-    config:
-      transport: reverse
-      listen_port: 60002
+    config: {}
 
 # after booted all the primitives, start the services
 service:
@@ -113,8 +93,7 @@ service:
   # queries it for relevant past context when planning.
   - name: memory
     path: ${ROBONIX_SOURCE_PATH}/services/memsearch
-    config:
-      backend: sqlite
+    config: {}
 
   # speech — ASR + TTS. Provides robonix/service/speech/asr_stream + tts that
   # liaison's voice loop connects to. The selected audio provider is supplied
@@ -128,17 +107,9 @@ service:
       speech_backend: ${SPEECH_BACKEND}
       disable_whisper: true
       funasr_device: cuda
-      tts_voice: zh-CN-XiaoxiaoNeural
       default_speaker_provider_id: audio_driver
       tencent_asr_appid: ${TENCENT_ASR_APPID}
-      # Use the basic realtime-ASR engine so Tencent's monthly free realtime
-      # quota applies. 16k_zh_en is a separately billed large-model engine.
-      tencent_asr_engine: 16k_zh
       tencent_tts_voice_type: 502003
-      tencent_tts_region: ap-guangzhou
-      tencent_tts_model_type: 1
-      tencent_tts_sample_rate: 16000
-      tencent_tts_codec: pcm
 
   # voiceprint — ECAPA-TDNN speaker identification. Provides
   # robonix/service/voiceprint/{identify,enroll,list}: liaison's voice gate
@@ -149,35 +120,24 @@ service:
     path: ${ROBONIX_SOURCE_PATH}/services/voiceprint
     config: {}
 
-  # mapping_rbnx — SLAM service. Listed FIRST because simple_nav
-  # depends on `service/map/occupancy_grid` and rbnx-cli currently
-  # boots services in manifest order; until the defer-queue lands
-  # consumers must come after their providers.
+  # Mapping publishes the occupancy, point cloud, pose, and map-management
+  # contracts consumed by Navigation and Scene.
   - name: mapping
     url: https://github.com/syswonder/service-map-rbnx
     branch: main
     config:
-      algo: rtabmap
-      platform: x86_desktop
-      map_mode: mapping
-      rtabmap_profile: webots_tiago
-      rtabmap_inputs: [lidar, rgbd, odom]
+      use_sim_time: true
       # The simulator's planar lidar is deterministic and aligned to odom.
       # Keep RGB-D available to RTAB-Map without mixing approximately synced
       # depth rays into the authoritative 2D occupancy grid.
       occupancy_sources: [lidar]
+      # Complete simulator tuning is owned by this deployment repository.
+      params_file: config/rtabmap_params.yaml
       sensor_providers:
         lidar2d: tiago_lidar
         rgb: tiago_camera
         depth: tiago_camera
         odom: tiago_chassis
-      sensors:
-        lidar2d: true # webots do not have 3d pointcloud, so we use 2d lidar
-        lidar3d: false
-        rgb: true # color image — rtabmap fuses RGB for visual loop closure
-        depth: true # depth image — fills below-lidar-plane obstacles (rgb+depth = RGB-D)
-        imu: false
-        odom: true
 
   # nav2_wrapper_rbnx IS the navigation service for this deploy.
   #
@@ -185,16 +145,15 @@ service:
   # (mapping/occupancy_grid), /odom (chassis/odom), /scan (lidar/lidar) —
   # and drives /cmd_vel via Nav2's navigate_to_pose action. Runs in the
   # `robonix-nav2` docker image (built by `rbnx build`, so the host needs
-  # no ROS2). The `sim` params profile navigates in the odom frame with a
-  # rolling-window costmap, so it needs only odom + a 2D scan and no SLAM
-  # map->odom TF — which is what makes it work in Webots. Listed after
+  # no ROS2). The complete simulator Nav2 configuration is deployment-owned
+  # under config/. Listed after
   # mapping (its /map provider); on_init returns Deferred until mapping is
   # up, so order is a convenience, not a hard requirement.
   - name: nav2
     url: https://github.com/syswonder/service-navigation-rbnx
     branch: main
     config:
-      params_profile: sim
+      params_file: config/nav2_params.yaml
       use_sim_time: true
       action_wait_s: 240.0
       # The simulation goal checker enters at 0.25 m. Keep the terminal
@@ -212,7 +171,4 @@ skill:
   - name: explore
     url: https://github.com/syswonder/skill-explore-rbnx
     branch: main
-    config:
-      # example place holders
-      explore_mode: frontier
-      timeout_s: 600
+    config: {}

--- a/examples/webots/test_manifest_config.py
+++ b/examples/webots/test_manifest_config.py
@@ -1,0 +1,61 @@
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parent
+
+
+def entries(document, section):
+    return {entry["name"]: entry for entry in document.get(section, [])}
+
+
+class WebotsDeployConfigTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.document = yaml.safe_load((ROOT / "robonix_manifest.yaml").read_text())
+
+    def test_removed_defaults_do_not_return(self):
+        self.assertNotIn("log", self.document["system"]["pilot"])
+        self.assertNotIn("api_format", self.document["system"]["pilot"]["vlm"])
+        self.assertNotIn("handsfree_enabled", self.document["system"]["liaison"])
+        primitive = entries(self.document, "primitive")
+        self.assertEqual(primitive["tiago_chassis"]["config"], {})
+        self.assertEqual(primitive["audio_client_bridge"]["config"], {})
+
+    def test_mapping_uses_deploy_owned_file(self):
+        mapping = entries(self.document, "service")["mapping"]["config"]
+        self.assertEqual(mapping["params_file"], "config/rtabmap_params.yaml")
+        self.assertNotIn("rtabmap_profile", mapping)
+        self.assertNotIn("rtabmap_params", mapping)
+        params = yaml.safe_load((ROOT / mapping["params_file"]).read_text())
+        self.assertEqual(params["Reg/Strategy"], 0)
+        self.assertEqual(params["Rtabmap/DetectionRate"], 5.0)
+
+    def test_navigation_uses_deploy_owned_file(self):
+        navigation = entries(self.document, "service")["nav2"]["config"]
+        self.assertEqual(navigation["params_file"], "config/nav2_params.yaml")
+        self.assertNotIn("params_profile", navigation)
+        self.assertTrue((ROOT / navigation["params_file"]).is_file())
+
+    def test_vitals_has_a_non_conflicting_external_listener(self):
+        self.assertEqual(self.document["system"]["vitals"]["listen"], "0.0.0.0:50093")
+        self.assertNotEqual(
+            self.document["system"]["vitals"]["listen"],
+            self.document["system"]["soma"].get("listen", "127.0.0.1:50091"),
+        )
+
+    def test_documented_config_specs_exist(self):
+        for relative in (
+            "primitives/audio_client_bridge/config.spec",
+            "primitives/audio_driver/config.spec",
+            "primitives/tiago_camera/config.spec",
+            "primitives/tiago_chassis/config.spec",
+            "primitives/tiago_lidar/config.spec",
+        ):
+            self.assertTrue((ROOT / relative).is_file(), relative)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/services/speech/README.md
+++ b/services/speech/README.md
@@ -29,7 +29,7 @@ service:
     config:
       speech_backend: tencent
       tencent_asr_appid: "1234567890"
-      tencent_asr_engine: 16k_zh_en
+      tencent_asr_engine: 16k_zh
       tencent_tts_voice_type: 502003
       tencent_tts_region: ap-guangzhou
 ```
@@ -44,7 +44,7 @@ export TENCENTCLOUD_SECRET_KEY=...
 Do not commit Tencent credentials. Put them in the operator shell, a local
 ignored env file, or a machine-local boot wrapper. The AppID and non-secret
 backend settings belong in the deployment manifest. Useful optional knobs:
-`TENCENT_ASR_ENGINE` (default `16k_zh_en`), `TENCENT_TTS_VOICE_TYPE` (default
+`TENCENT_ASR_ENGINE` (default `16k_zh`), `TENCENT_TTS_VOICE_TYPE` (default
 `1001`), and `TENCENT_TTS_REGION` (default `ap-guangzhou`).
 
 With `SPEECH_BACKEND=tencent`, the build installs only the cloud client and

--- a/services/speech/config.spec
+++ b/services/speech/config.spec
@@ -1,23 +1,135 @@
-# Speech service runtime config. Only select a backend and configure values
-# that differ from that backend's defaults. Credentials remain environment
-# variables and are never stored in the deployment manifest.
+# Runtime configuration accepted by the Speech service.
+#
+# This documents the mapping passed as the service instance's `config:` value.
+# It is not loaded as a schema. Credentials remain environment variables and
+# must not be committed to a robot deployment manifest.
 
 config:
-  speech_backend: local       # local | tencent | mock | custom
+  # string, default: local; accepted: local, tencent, mock, custom.
+  # Selects the ASR/TTS backend family initialized by the service.
+  speech_backend: local
+
+  # string provider id, default: empty.
+  # Speaker primitive used by speak requests that do not specify a target.
   default_speaker_provider_id: ""
-  wake_words: ["罗伯特"]
+
+  # boolean, default: false.
+  # Disable one-shot Whisper initialization in the local backend. Streaming
+  # FunASR and TTS can remain available.
   disable_whisper: false
 
-  # Local backend
+  # list of non-empty strings, default: ["罗伯特"].
+  # Wake phrases compiled into the runtime keyword file.
+  wake_words: ["罗伯特"]
+
+  # string path or null, default: bundled build artifact.
+  # Directory containing the sherpa-onnx keyword-spotting model.
+  wake_word_model_dir: null
+
+  # string path or null, default: generated from wake_words.
+  # Prebuilt sherpa-onnx keywords file. Set only when managing it externally.
+  wake_word_keywords_file: null
+
+  # float, default: 2.0; must be positive.
+  # Decoder score boost applied while generating wake-word keywords.
+  wake_word_boost: 2.0
+
+  # float probability-like score, default: 0.45; valid range: 0.0 < value <= 1.0.
+  # Minimum wake-word detection score.
+  wake_word_threshold: 0.45
+
+  # integer threads, default: 2; minimum effective value: 1.
+  # CPU threads used by the wake-word backend.
+  wake_word_num_threads: 2
+
+  # list of non-empty strings, default: ["我在"].
+  # Short phrases synthesized during initialization to warm the TTS backend.
+  tts_warm_phrases: ["我在"]
+
+  # Local backend ----------------------------------------------------------
+
+  # string model id or path, default: openai/whisper-large-v3.
+  # One-shot Whisper model used by the local backend.
+  asr_model: openai/whisper-large-v3
+
+  # string device, default: cuda.
+  # Compute device passed to the Whisper pipeline, for example cuda or cpu.
+  asr_device: cuda
+
+  # float seconds, default: 30.0; must be positive.
+  # Audio chunk length used by one-shot Whisper inference.
+  asr_chunk_length: 30.0
+
+  # integer, default: 4; must be positive.
+  # Whisper inference batch size; lower it when GPU memory is constrained.
+  asr_batch_size: 4
+
+  # string model id or path, default: paraformer-zh-streaming.
+  # FunASR model used for streaming recognition in the local backend.
+  funasr_model: paraformer-zh-streaming
+
+  # string device, default: auto; accepted by FunASR: auto, cpu, cuda.
+  # Auto uses CUDA when available and otherwise falls back to CPU.
   funasr_device: auto
+
+  # list of three integers, default: [0, 10, 5].
+  # FunASR streaming chunk configuration in the model's native format.
+  funasr_chunk_size: [0, 10, 5]
+
+  # string Edge TTS voice, default: zh-CN-XiaoxiaoNeural.
+  # Voice selected by the local TTS backend when a request has no override.
   tts_voice: zh-CN-XiaoxiaoNeural
 
-  # Tencent backend. TENCENTCLOUD_SECRET_ID and
-  # TENCENTCLOUD_SECRET_KEY are environment variables.
+  # Tencent backend --------------------------------------------------------
+
+  # string numeric application id, no default.
+  # Tencent ASR AppID. Secret ID and Secret Key remain in
+  # TENCENTCLOUD_SECRET_ID and TENCENTCLOUD_SECRET_KEY environment variables.
   tencent_asr_appid: ""
+
+  # string engine id, default: 16k_zh.
+  # 16k_zh uses the basic real-time Mandarin product. 16k_zh_en is a
+  # separately billed large-model engine and does not consume its free quota.
   tencent_asr_engine: 16k_zh
+
+  # string hostname, default: asr.cloud.tencent.com.
+  # Tencent signed WebSocket host. Normally leave unchanged.
+  tencent_asr_host: asr.cloud.tencent.com
+
+  # integer Tencent voice type, default: 1001.
+  # The selected voice must be enabled for the Tencent account/product.
   tencent_tts_voice_type: 1001
+
+  # string Tencent region, default: ap-guangzhou.
+  # Region sent to the TextToVoice API.
   tencent_tts_region: ap-guangzhou
+
+  # integer Tencent model type, default: 1.
+  # Tencent TextToVoice model selector; availability depends on the voice.
   tencent_tts_model_type: 1
+
+  # integer hertz, default: 16000; supported values depend on Tencent TTS.
+  # Output rate advertised to downstream speaker primitives.
   tencent_tts_sample_rate: 16000
+
+  # string codec, default: pcm.
+  # Keep pcm for the Robonix 16-bit PCM speaker path.
   tencent_tts_codec: pcm
+
+  # integer language selector, default: 1.
+  # Tencent TextToVoice PrimaryLanguage request value.
+  tencent_tts_primary_language: 1
+
+  # Custom backend ---------------------------------------------------------
+
+  # string module:Class or empty, default: empty.
+  # One-shot ASR implementation loaded when speech_backend is custom.
+  speech_asr_backend_class: ""
+
+  # string module:Class or empty, default: speech_asr_backend_class.
+  # Streaming ASR implementation loaded for custom mode.
+  speech_asr_stream_backend_class: ""
+
+  # string module:Class or empty, default: empty.
+  # TTS implementation loaded for custom mode.
+  speech_tts_backend_class: ""

--- a/services/speech/config.spec
+++ b/services/speech/config.spec
@@ -1,0 +1,23 @@
+# Speech service runtime config. Only select a backend and configure values
+# that differ from that backend's defaults. Credentials remain environment
+# variables and are never stored in the deployment manifest.
+
+config:
+  speech_backend: local       # local | tencent | mock | custom
+  default_speaker_provider_id: ""
+  wake_words: ["罗伯特"]
+  disable_whisper: false
+
+  # Local backend
+  funasr_device: auto
+  tts_voice: zh-CN-XiaoxiaoNeural
+
+  # Tencent backend. TENCENTCLOUD_SECRET_ID and
+  # TENCENTCLOUD_SECRET_KEY are environment variables.
+  tencent_asr_appid: ""
+  tencent_asr_engine: 16k_zh
+  tencent_tts_voice_type: 1001
+  tencent_tts_region: ap-guangzhou
+  tencent_tts_model_type: 1
+  tencent_tts_sample_rate: 16000
+  tencent_tts_codec: pcm

--- a/services/speech/package_manifest.yaml
+++ b/services/speech/package_manifest.yaml
@@ -18,7 +18,7 @@
 #   default_speaker_provider_id: str — provider id used by speech/speak when
 #       its request target is empty; explicit request target overrides this
 #   tencent_asr_appid: str   — Tencent Cloud ASR AppID (secret id/key stay in env)
-#   tencent_asr_engine: str  — default 16k_zh_en
+#   tencent_asr_engine: str  — default 16k_zh
 #   tencent_asr_host: str    — default asr.cloud.tencent.com
 #   tencent_tts_voice_type: int — default 1001
 #   tencent_tts_region: str — default ap-guangzhou

--- a/services/speech/speech_service/tencent_cloud.py
+++ b/services/speech/speech_service/tencent_cloud.py
@@ -69,7 +69,7 @@ class TencentRealtimeASRBackend:
 
     def __init__(self):
         self.creds = TencentCredentials.from_env()
-        self.engine = os.environ.get("TENCENT_ASR_ENGINE", "16k_zh_en")
+        self.engine = os.environ.get("TENCENT_ASR_ENGINE", "16k_zh")
         self.host = os.environ.get("TENCENT_ASR_HOST", "asr.cloud.tencent.com")
         self.needvad = int(os.environ.get("TENCENT_ASR_NEEDVAD", "1"))
         self.voice_format = int(os.environ.get("TENCENT_ASR_VOICE_FORMAT", "1"))
@@ -161,7 +161,7 @@ class TencentRealtimeASRBackend:
         # snapshot here so a long-lived backend never signs with stale AppID
         # or credentials captured by an earlier initialization attempt.
         self.creds = TencentCredentials.from_env()
-        self.engine = os.environ.get("TENCENT_ASR_ENGINE", "16k_zh_en")
+        self.engine = os.environ.get("TENCENT_ASR_ENGINE", "16k_zh")
         now = int(time.time())
         params = {
             "engine_model_type": self.engine,

--- a/system/vitals/README.md
+++ b/system/vitals/README.md
@@ -117,7 +117,7 @@ robonix-vitals --log info \
 | Flag | Env var | Default |
 |------|---------|---------|
 | `--atlas` | `ROBONIX_ATLAS_ENDPOINT` | `127.0.0.1:50051` |
-| `--listen` | `ROBONIX_VITALS_LISTEN` | `127.0.0.1:50091` |
+| `--listen` | `ROBONIX_VITALS_LISTEN` | `127.0.0.1:50093` |
 | `--id` | `ROBONIX_VITALS_PROVIDER_ID` | `vitals` |
 | `--thresholds-path` | `ROBONIX_VITALS_THRESHOLDS_PATH` | `thresholds/example_thresholds.yaml` |
 | `--soma-endpoint` | `ROBONIX_SOMA_ENDPOINT` | — |

--- a/system/vitals/src/config.rs
+++ b/system/vitals/src/config.rs
@@ -15,7 +15,7 @@ pub const VITALS_NAMESPACE: &str = "robonix/system/vitals";
 /// Default Atlas control-plane endpoint.
 pub const DEFAULT_ATLAS_ENDPOINT: &str = "127.0.0.1:50051";
 /// Default Vitals gRPC listen address.
-pub const DEFAULT_LISTEN: &str = "127.0.0.1:50091";
+pub const DEFAULT_LISTEN: &str = "127.0.0.1:50093";
 /// Default mock Soma gRPC listen address.
 pub const DEFAULT_MOCK_SOMA_LISTEN: &str = "127.0.0.1:50092";
 /// Default mock Soma stream update interval in milliseconds.
@@ -126,6 +126,11 @@ pub struct VitalsConfig {
     about = "Robonix Vitals — health monitoring: power state, component health, threshold alerts"
 )]
 pub struct Args {
+    /// Full system manifest block forwarded by rbnx. Typed flags below remain
+    /// authoritative; accepting this keeps the standard builtin interface.
+    #[arg(long, hide = true)]
+    pub config_json: Option<String>,
+
     /// Atlas control-plane endpoint.
     #[arg(long, env = "ROBONIX_ATLAS_ENDPOINT")]
     pub atlas: Option<String>,
@@ -407,6 +412,7 @@ mod tests {
         assert!(args.atlas.is_none());
         assert!(args.listen.is_none());
         assert!(args.soma_endpoint.is_none());
+        assert!(args.config_json.is_none());
     }
 
     #[test]

--- a/tools/rbnx/src/cmd/clean.rs
+++ b/tools/rbnx/src/cmd/clean.rs
@@ -151,7 +151,7 @@ fn clean_deploy(config: &Config, manifest_path: &Path, also_cache: bool) -> Resu
     }
     // system: section — non-builtin entries are real packages under
     // `<robonix_source>/system/<key>/` (memory/scene/speech/…).
-    const SYSTEM_BUILTINS: &[&str] = &["atlas", "executor", "pilot", "liaison", "soma"];
+    const SYSTEM_BUILTINS: &[&str] = &["atlas", "executor", "pilot", "liaison", "soma", "vitals"];
     if let Some(map) = root.get("system").and_then(|v| v.as_mapping())
         && let Some(source_root) = config.robonix_source_path.as_ref()
     {

--- a/tools/rbnx/src/cmd/deploy.rs
+++ b/tools/rbnx/src/cmd/deploy.rs
@@ -193,6 +193,36 @@ mod tests {
     }
 
     #[test]
+    fn vitals_receives_typed_manifest_fields() {
+        let cfg: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+listen: 0.0.0.0:50093
+provider_id: vitals
+thresholds_path: config/vitals.yaml
+soma_endpoint: 127.0.0.1:50091
+"#,
+        )
+        .unwrap();
+        let args = system_cli_args("vitals", Some(&cfg), Some("0.0.0.0:50051"));
+
+        for expected in [
+            ["--listen", "0.0.0.0:50093"],
+            ["--atlas", "0.0.0.0:50051"],
+            ["--id", "vitals"],
+            ["--thresholds-path", "config/vitals.yaml"],
+            ["--soma-endpoint", "127.0.0.1:50091"],
+        ] {
+            assert!(
+                args.windows(2)
+                    .any(|pair| pair[0] == expected[0] && pair[1] == expected[1]),
+                "missing {:?} in {:?}",
+                expected,
+                args
+            );
+        }
+    }
+
+    #[test]
     fn provider_failure_ignores_later_shutdown_noise() {
         let path = std::env::temp_dir().join(format!(
             "rbnx-provider-failure-{}.log",
@@ -1083,6 +1113,13 @@ pub async fn execute(
                 .and_then(|m| m.get(serde_yaml::Value::String("listen".into())))
                 .and_then(|v| v.as_str())
                 .map(str::to_string);
+            let soma_listen = deploy
+                .system
+                .get("soma")
+                .and_then(|v| v.as_mapping())
+                .and_then(|m| m.get(serde_yaml::Value::String("listen".into())))
+                .and_then(|v| v.as_str())
+                .map(|s| s.replacen("0.0.0.0", "127.0.0.1", 1));
             // Atlas's contract registry walks every dir in
             // --capabilities at startup. We seed it with:
             //   1. <robonix_source>/capabilities — the global tree
@@ -1119,6 +1156,7 @@ pub async fn execute(
                 ("atlas", "robonix-atlas"),
                 ("executor", "robonix-executor"),
                 ("soma", "robonix-soma"),
+                ("vitals", "robonix-vitals"),
                 ("pilot", "robonix-pilot"),
                 ("liaison", "robonix-liaison"),
             ];
@@ -1128,6 +1166,13 @@ pub async fn execute(
                 }
                 let mut args =
                     system_cli_args(name, deploy.system.get(*name), atlas_listen.as_deref());
+                if *name == "vitals"
+                    && !args.iter().any(|arg| arg == "--soma-endpoint")
+                    && let Some(endpoint) = soma_listen.as_ref()
+                {
+                    args.push("--soma-endpoint".into());
+                    args.push(endpoint.clone());
+                }
                 if *name == "atlas"
                     && !args.iter().any(|a| a == "--capabilities")
                     && let Some(p) = atlas_caps_default.as_ref()
@@ -1293,7 +1338,8 @@ pub async fn execute(
         let mut failures: Vec<(String, String, String)> = Vec::new(); // (component, name, err)
 
         if !skip_system {
-            let builtin_names: &[&str] = &["atlas", "executor", "pilot", "liaison", "soma"];
+            let builtin_names: &[&str] =
+                &["atlas", "executor", "pilot", "liaison", "soma", "vitals"];
             for (key, value) in &deploy.system {
                 if builtin_names.contains(&key.as_str()) {
                     continue;
@@ -1704,7 +1750,12 @@ fn system_listen(name: &str, cfg: Option<&serde_yaml::Value>) -> Option<String> 
         .get(serde_yaml::Value::String("listen".into()))?
         .as_str()?;
     let trimmed = s.trim();
-    if trimmed.is_empty() || !matches!(name, "atlas" | "executor" | "pilot" | "liaison" | "soma") {
+    if trimmed.is_empty()
+        || !matches!(
+            name,
+            "atlas" | "executor" | "pilot" | "liaison" | "soma" | "vitals"
+        )
+    {
         return None;
     }
     Some(trimmed.to_string())
@@ -1839,6 +1890,19 @@ fn system_cli_args(
             push_pair(&mut out, "--provider-id", s("provider_id"));
             push_pair(&mut out, "--robot-yaml", s("robot_yaml"));
             push_pair(&mut out, "--deployment-manifest", s("deployment_manifest"));
+            push_pair(&mut out, "--config", s("config"));
+            push_pair(&mut out, "--log", s("log"));
+        }
+        "vitals" => {
+            push_pair(&mut out, "--listen", s("listen"));
+            push_pair(
+                &mut out,
+                "--atlas",
+                s("atlas").or_else(|| atlas_listen.map(str::to_string)),
+            );
+            push_pair(&mut out, "--id", s("provider_id").or_else(|| s("id")));
+            push_pair(&mut out, "--thresholds-path", s("thresholds_path"));
+            push_pair(&mut out, "--soma-endpoint", s("soma_endpoint"));
             push_pair(&mut out, "--config", s("config"));
             push_pair(&mut out, "--log", s("log"));
         }

--- a/tools/rbnx/src/cmd/run_package.rs
+++ b/tools/rbnx/src/cmd/run_package.rs
@@ -273,9 +273,9 @@ fn build_deploy_manifest(
     // `system:` non-builtin entries are real packages too (memory / scene
     // / speech / …), they just live under `<robonix_source>/system/<key>/`
     // instead of being declared with an explicit `path:` / `url:`. The
-    // builtin Rust binaries (atlas / executor / pilot / liaison / soma) are
+    // builtin Rust binaries (atlas / executor / pilot / liaison / soma / vitals) are
     // shipped via `cargo install` and skipped here.
-    const SYSTEM_BUILTINS: &[&str] = &["atlas", "executor", "pilot", "liaison", "soma"];
+    const SYSTEM_BUILTINS: &[&str] = &["atlas", "executor", "pilot", "liaison", "soma", "vitals"];
     if let Some(map) = root.get("system").and_then(|v| v.as_mapping()) {
         let source_root = config.robonix_source_path.as_ref();
         for (key, _value) in map {


### PR DESCRIPTION
## Problem
The Webots deployment contained ignored or placeholder fields, selected robot-specific profiles from shared Mapping and Navigation packages, did not boot Vitals, and defaulted Tencent ASR to the separately billed `16k_zh_en` engine. Package configuration was also undocumented at the provider boundary.

## Design
- Keep only runtime-consumed, non-default Webots manifest fields.
- Store complete RTAB-Map and Nav2 files under `examples/webots/config/` and reference them with `params_file`.
- Add field-by-field `config.spec` files with type, unit, default, meaning, and constraints for Webots audio/camera/chassis/lidar providers and Speech.
- Boot Vitals as a first-class builtin on port 50093 and inject Soma's dialable endpoint.
- Default Tencent real-time ASR to the basic `16k_zh` engine.

## Compatibility
Legacy Mapping/Nav2 selectors remain supported by the upstream providers with migration warnings. Existing Speech deployments can explicitly select another Tencent engine. `config.spec` is documentation only and does not change runtime parsing.

## Tests
- WorkPC Debian/Webots cold build: 12/12 packages.
- WorkPC full boot: 12/12 components up; Mapping, Nav2, Vitals, Scene, Speech, Soma, and Pilot ACTIVE.
- Live `/map`: fresh 0.05 m occupancy grid.
- Live Nav2: compute-path, follow-path, and navigate-to-pose action servers available.
- Webots deployment tests: 5/5.
- Speech tests: 4/4.
- Vitals tests: 44/44.
- `config.spec` YAML parse: 6/6.
- `cargo fmt --all -- --check` and Vitals manifest forwarding test: passed.
- No navigation goal or robot movement was issued.

## Discussion
The commits remain separated by deployment configuration, Speech default, Vitals lifecycle integration, and specification documentation so later stable-branch PRs can review them independently.

Related: syswonder/service-map-rbnx#4 and syswonder/service-navigation-rbnx#3.