### PR TITLE
feat(rbnx): improve init/package-new templates and validate skill CAP…

### DIFF
--- a/tools/rbnx/src/cmd/init.rs
+++ b/tools/rbnx/src/cmd/init.rs
@@ -21,6 +21,102 @@ fn robot_catalog_name(name: &str) -> String {
     format!("robonix.robot.{}", suffix.replace('-', "."))
 }
 
+fn robot_slug(name: &str) -> String {
+    name.replace('-', "_")
+}
+
+fn deployment_manifest(name: &str, catalog_name: &str) -> String {
+    format!(
+        r#"manifestVersion: 1
+name: {name}
+
+catalog:
+  name: {catalog_name}
+  version: 0.1.0
+  description: "TODO: describe this robot deployment."
+  license: Apache-2.0
+  tags:
+    - robot
+    - deploy
+    - robonix
+  maintainers:
+    - Your Name <you@example.com>
+
+env: {{}}
+
+system:
+  atlas:
+    listen: 127.0.0.1:50051
+    log: info
+  executor:
+    listen: 127.0.0.1:50061
+    log: info
+  soma:
+    robot_yaml: ./soma.yaml
+  vitals:
+    listen: 127.0.0.1:50093
+  pilot:
+    listen: 127.0.0.1:50071
+    log: info
+    vlm:
+      upstream: ${{VLM_BASE_URL}}
+      api_key: ${{VLM_API_KEY}}
+      model: ${{VLM_MODEL}}
+  liaison:
+    listen: 127.0.0.1:50081
+    log: info
+
+primitive: []
+
+service: []
+
+skill: []
+"#
+    )
+}
+
+fn soma_manifest(name: &str, robot_file: &str, robot_id: &str) -> String {
+    format!(
+        r#"urdf:
+  path: ./urdf/{robot_file}
+  root_link: base_link
+  model_name: {robot_id}
+
+robot:
+  id: {robot_id}
+  display_name: "{name}"
+  family: mobile_robot
+  root_part: base
+  dimensions: {{ length_m: 0.50, width_m: 0.50, height_m: 1.00 }}
+  mass_kg: 20.0
+  exports: []
+  components:
+    - id: base
+      type: mobile_base
+      urdf_link: base_link
+      exports: []
+
+description:
+  summary: "TODO: describe this robot deployment."
+  can_do: []
+  cannot_do: []
+  notes:
+    - "Fill in robot.exports and robot.components as you add primitives, services, and skills."
+    - "Keep provider_id values in soma.yaml aligned with the corresponding name entries in robonix_manifest.yaml."
+"#
+    )
+}
+
+fn minimal_urdf(robot_id: &str) -> String {
+    format!(
+        r#"<?xml version="1.0"?>
+<robot name="{robot_id}">
+  <link name="base_link"/>
+</robot>
+"#
+    )
+}
+
 pub async fn execute(name: &str, path: Option<&Path>) -> Result<()> {
     validate_name(name)?;
 
@@ -37,64 +133,36 @@ pub async fn execute(name: &str, path: Option<&Path>) -> Result<()> {
     output::action("Init", &format!("creating robot deployment '{name}'"));
 
     std::fs::create_dir_all(&project_dir).context("failed to create deployment directory")?;
+    for subdir in ["primitives", "services", "skills", "urdf"] {
+        std::fs::create_dir_all(project_dir.join(subdir))
+            .with_context(|| format!("failed to create {subdir}/ directory"))?;
+    }
+    for subdir in ["primitives", "services", "skills"] {
+        std::fs::write(project_dir.join(subdir).join(".gitkeep"), "")
+            .with_context(|| format!("failed to write {subdir}/.gitkeep"))?;
+    }
 
-    // robonix_manifest.yaml (deployment manifest).
     let catalog_name = robot_catalog_name(name);
-    let manifest = format!(
-        r#"catalog:
-  name: {catalog_name}
-  version: 0.1.0
-  description: TODO: describe this robot deployment.
-  tags:
-    - robot
-    - deploy
-    - robonix
-  maintainers:
-    - Your Name <you@example.com>
+    let robot_id = robot_slug(name);
+    let robot_file = format!("{name}.urdf");
+    std::fs::write(
+        project_dir.join("robonix_manifest.yaml"),
+        deployment_manifest(name, &catalog_name),
+    )
+    .context("failed to write robonix_manifest.yaml")?;
+    std::fs::write(
+        project_dir.join("soma.yaml"),
+        soma_manifest(name, &robot_file, &robot_id),
+    )
+    .context("failed to write soma.yaml")?;
+    std::fs::write(
+        project_dir.join("urdf").join(&robot_file),
+        minimal_urdf(&robot_id),
+    )
+    .context("failed to write URDF template")?;
 
-name: {name}
-
-env:
-  LOG: "INFO"
-
-system:
-  atlas:
-    listen: 127.0.0.1:50051
-    log: info
-  executor:
-    listen: 127.0.0.1:50061
-    log: info
-  pilot:
-    listen: 127.0.0.1:50071
-    log: info
-    vlm:
-      upstream: ${{VLM_BASE_URL}}
-      api_key: ${{VLM_API_KEY}}
-      model: ${{VLM_MODEL}}
-      api_format: openai
-  liaison:
-    listen: 0.0.0.0:50081
-    log: info
-  memory: []
-
-primitive: []
-
-service: []
-
-skill: []
-"#
-    );
-    std::fs::write(project_dir.join("robonix_manifest.yaml"), manifest)
-        .context("failed to write robonix_manifest.yaml")?;
-
-    // .gitignore
     let gitignore = "\
-rbnx-build/
-rbnx-boot/
-__pycache__/
-*.pyc
-.venv/
-";
+rbnx-build/\nrbnx-boot/\nlogs/\n__pycache__/\n*.pyc\n.venv/\n";
     std::fs::write(project_dir.join(".gitignore"), gitignore)
         .context("failed to write .gitignore")?;
 
@@ -103,6 +171,11 @@ __pycache__/
         project_dir.display()
     ));
     output::sub_step("robonix_manifest.yaml");
+    output::sub_step("soma.yaml");
+    output::sub_step(&format!("urdf/{robot_file}"));
+    output::sub_step("primitives/");
+    output::sub_step("services/");
+    output::sub_step("skills/");
     output::sub_step(".gitignore");
 
     Ok(())

--- a/tools/rbnx/src/cmd/mod.rs
+++ b/tools/rbnx/src/cmd/mod.rs
@@ -343,7 +343,8 @@ pub enum Commands {
         /// Package type: primitive, service, or skill
         #[arg(short = 't', long = "type", default_value = "service")]
         pkg_type: String,
-        /// Target package directory to create (when given, --type is ignored)
+        /// Parent directory in which `<name>/` will be created.
+        /// When omitted, defaults to `<cwd>/{primitives|services|skills}`.
         #[arg(long)]
         path: Option<PathBuf>,
     },

--- a/tools/rbnx/src/cmd/package_new.rs
+++ b/tools/rbnx/src/cmd/package_new.rs
@@ -2,8 +2,9 @@
 // `rbnx package-new <name>` — scaffold a new package.
 //
 // Two modes:
-//   1. `rbnx package-new my_cam --path ./primitives/my_cam`
-//       → creates directly at the given path (--type is ignored).
+//   1. `rbnx package-new my_cam --path ./primitives`
+//       → creates at `./primitives/my_cam` and infers primitive/service/skill
+//         from the parent path when possible.
 //   2. `rbnx package-new my_cam -t primitive`
 //       → creates at `<cwd>/<role_dir>/my_cam` where role_dir is
 //         derived from --type (primitives/ services/ skills/).
@@ -32,57 +33,126 @@ fn python_module_name(name: &str) -> String {
     name.replace('-', "_")
 }
 
-pub async fn execute(name: &str, pkg_type: &str, path: Option<&Path>) -> Result<()> {
-    validate_name(name)?;
-
-    let pkg_dir: PathBuf = if let Some(p) = path {
-        // --path given: use it directly, no type inference needed.
-        if p.is_absolute() {
-            p.to_path_buf()
-        } else {
-            std::env::current_dir()?.join(p)
-        }
-    } else {
-        // No --path: derive from --type.
-        let role_dir = match pkg_type {
-            "primitive" => "primitives",
-            "service" => "services",
-            "skill" => "skills",
-            other => {
-                anyhow::bail!("unknown package type '{other}'; expected: primitive, service, skill")
+fn infer_pkg_type(pkg_type: &str, path: Option<&Path>) -> Result<&'static str> {
+    if let Some(path) = path {
+        for component in path.components() {
+            if let Some(part) = component.as_os_str().to_str() {
+                match part {
+                    "primitives" => return Ok("primitive"),
+                    "services" => return Ok("service"),
+                    "skills" => return Ok("skill"),
+                    _ => {}
+                }
             }
-        };
-        std::env::current_dir()?.join(role_dir).join(name)
+        }
+    }
+    match pkg_type {
+        "primitive" => Ok("primitive"),
+        "service" => Ok("service"),
+        "skill" => Ok("skill"),
+        other => {
+            anyhow::bail!("unknown package type '{other}'; expected: primitive, service, skill")
+        }
+    }
+}
+
+fn role_dir(pkg_type: &str) -> &'static str {
+    match pkg_type {
+        "primitive" => "primitives",
+        "service" => "services",
+        "skill" => "skills",
+        _ => unreachable!("pkg_type is validated by infer_pkg_type"),
+    }
+}
+
+fn provider_class(pkg_type: &str) -> &'static str {
+    match pkg_type {
+        "primitive" => "Primitive",
+        "service" => "Service",
+        "skill" => "Skill",
+        _ => unreachable!("pkg_type is validated by infer_pkg_type"),
+    }
+}
+
+fn config_spec(pkg_type: &str) -> String {
+    format!(
+        r#"# Documentation-only template for the `config:` block in robonix_manifest.yaml.
+# `rbnx` does not parse this file; your provider's `on_init(cfg)` does.
+fields:
+  example_field:
+    type: string
+    required: false
+    default: ""
+    description: "TODO: describe the config accepted by this {pkg_type} package."
+"#
+    )
+}
+
+fn capability_md_template(name: &str) -> String {
+    format!(
+        r#"---
+description: "TODO: describe when and why the agent should use the `{name}` skill."
+---
+
+# Overview
+
+TODO: describe this skill's purpose, expected inputs, side effects, and operator notes.
+"#
+    )
+}
+
+fn driver_contract(ns_kind: &str, name: &str) -> String {
+    format!(
+        r#"[contract]
+id      = "robonix/{ns_kind}/{name}/driver"
+version = "1"
+kind    = "{ns_kind}"
+idl     = "lifecycle/srv/Driver.srv"
+
+[mode]
+type = "rpc"
+"#
+    )
+}
+
+fn skill_run_contract(name: &str, idl_lib_name: &str) -> String {
+    format!(
+        r#"[contract]
+id      = "robonix/skill/{name}/run"
+version = "1"
+kind    = "skill"
+idl     = "{idl_lib_name}/srv/Run.srv"
+
+[mode]
+type = "rpc"
+
+[semantics]
+user_invocable = true
+"#
+    )
+}
+
+fn skill_run_srv() -> &'static str {
+    r#"string instruction
+---
+bool accepted
+string message
+"#
+}
+
+fn package_manifest(name: &str, ns_kind: &str, package_name: &str, skill_idl_lib: &str) -> String {
+    let capabilities = if ns_kind == "skill" {
+        format!(
+            "capabilities:\n  - name: robonix/{ns_kind}/{name}/driver\n    path: capabilities/driver.v1.toml\n  - name: robonix/{ns_kind}/{name}/run\n    path: capabilities/run.v1.toml"
+        )
+    } else {
+        format!(
+            "capabilities:\n  - name: robonix/{ns_kind}/{name}/driver\n    path: capabilities/driver.v1.toml"
+        )
     };
 
-    if pkg_dir.exists() {
-        anyhow::bail!("directory '{}' already exists", pkg_dir.display());
-    }
-
-    output::action("PackageNew", &format!("creating package '{name}'"));
-
-    // Provider class + namespace segment for the generated skeleton.
-    // `--path` mode leaves pkg_type at its clap default ("service").
-    let (provider_class, ns_kind) = match pkg_type {
-        "service" => ("Service", "service"),
-        "skill" => ("Skill", "skill"),
-        _ => ("Primitive", "primitive"),
-    };
-    let package_name = package_name(name, ns_kind);
-    let module_name = python_module_name(name);
-
-    // Create directory structure; put .gitkeep in empty dirs.
-    for sub in ["scripts", "capabilities"] {
-        let dir = pkg_dir.join(sub);
-        std::fs::create_dir_all(&dir)
-            .with_context(|| format!("failed to create {sub}/ directory"))?;
-        // .gitkeep so git tracks the empty directory.
-        std::fs::write(dir.join(".gitkeep"), "")
-            .with_context(|| format!("failed to write {sub}/.gitkeep"))?;
-    }
-
-    // package_manifest.yaml — capabilities default to empty.
-    let manifest = format!(
+    let _ = skill_idl_lib;
+    format!(
         r#"manifestVersion: 1
 
 build: bash scripts/build.sh
@@ -91,55 +161,37 @@ start: bash scripts/start.sh
 
 package:
   name: "{package_name}"
-  version: 0.0.1
-  description: TODO: describe what this {ns_kind} package provides.
+  version: 0.1.0
+  description: "TODO: describe what this {ns_kind} package provides."
   tags:
     - {ns_kind}
+    - example
     - robonix
   maintainers:
     - Your Name <you@example.com>
   license: Apache-2.0
 
-capabilities: []
+{capabilities}
 
 depends: []
 "#
-    );
-    std::fs::write(pkg_dir.join("package_manifest.yaml"), manifest)
-        .context("failed to write package_manifest.yaml")?;
+    )
+}
 
-    // scripts/build.sh — generate the gRPC / MCP stubs for the contracts
-    // this package declares. `robonix-api` auto-discovers the output under
-    // <pkg>/rbnx-build/codegen/, so nothing else is needed for a pure
-    // Python package. Append your own steps (cargo, pip install -e, docker
-    // build, ...) after this line if your package needs them.
-    let build_sh = format!(
+fn build_sh(name: &str) -> String {
+    format!(
         r#"#!/usr/bin/env bash
 set -euo pipefail
 PKG="${{RBNX_PACKAGE_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}}"
 
-rbnx codegen -p "$PKG"
+rbnx codegen --mcp -p "$PKG"
 echo "[{name}] build done"
 "#
-    );
-    std::fs::write(pkg_dir.join("scripts/build.sh"), build_sh)
-        .context("failed to write scripts/build.sh")?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(
-            pkg_dir.join("scripts/build.sh"),
-            std::fs::Permissions::from_mode(0o755),
-        )?;
-    }
+    )
+}
 
-    // scripts/start.sh — launch the provider process. `rbnx path
-    // robonix-api` prints the path to the in-tree client library
-    // (`<robonix>/pylib/robonix-api`), which start.sh puts on PYTHONPATH so
-    // `from robonix_api import ...` resolves. Edit the final line if your
-    // entrypoint module differs, or replace it entirely (docker run, ssh,
-    // a compiled binary, ...).
-    let start_sh = format!(
+fn start_sh(source_module: &str) -> String {
+    format!(
         r#"#!/usr/bin/env bash
 set -eo pipefail
 PKG_ROOT="${{RBNX_PACKAGE_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}}"
@@ -147,42 +199,37 @@ cd "$PKG_ROOT"
 
 export PYTHONPATH="$(rbnx path robonix-api):$PKG_ROOT:${{PYTHONPATH:-}}"
 
-exec python3 -m {module_name}.main
+exec python3 -m {source_module}.main
 "#
-    );
-    std::fs::write(pkg_dir.join("scripts/start.sh"), start_sh)
-        .context("failed to write scripts/start.sh")?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(
-            pkg_dir.join("scripts/start.sh"),
-            std::fs::Permissions::from_mode(0o755),
-        )?;
-    }
+    )
+}
 
-    // Remove .gitkeep from scripts/ since it now has real files.
-    let _ = std::fs::remove_file(pkg_dir.join("scripts/.gitkeep"));
-
-    // Minimal Python provider skeleton: <pkg>/<name>/{__init__.py, main.py}
-    // so `python3 -m {name}.main` (from start.sh) runs out of the box. The
-    // author fills in lifecycle handlers + capability declarations.
-    let module_dir = pkg_dir.join(&module_name);
-    std::fs::create_dir_all(&module_dir).context("failed to create python module directory")?;
-    std::fs::write(module_dir.join("__init__.py"), "").context("failed to write __init__.py")?;
-    let main_py = format!(
+fn provider_main(name: &str, ns_kind: &str, provider_class: &str) -> String {
+    format!(
         r#"#!/usr/bin/env python3
 """{name} — Robonix {provider_class_lower} provider."""
 from robonix_api import {provider_class}, Ok
 
 # `id` must equal this entry's `name:` in the deploy robonix_manifest.yaml.
-# `namespace` groups the capabilities this provider declares.
+# Adjust `namespace` if you later switch to a shared contract family.
 provider = {provider_class}(id="{name}", namespace="robonix/{ns_kind}/{name}")
 
 
 @provider.on_init
 def init(cfg: dict):
-    # TODO: initialise hardware / resources; declare capabilities to atlas.
+    # TODO: validate config and perform light dependency checks here.
+    return Ok()
+
+
+@provider.on_activate
+def activate():
+    # TODO: acquire hot resources and declare business capabilities here.
+    return Ok()
+
+
+@provider.on_deactivate
+def deactivate():
+    # TODO: release any resources acquired in on_activate.
     return Ok()
 
 
@@ -190,10 +237,152 @@ if __name__ == "__main__":
     provider.run()
 "#,
         provider_class_lower = provider_class.to_lowercase(),
-    );
+    )
+}
+
+fn skill_main(name: &str, idl_lib_name: &str) -> String {
+    format!(
+        r#"#!/usr/bin/env python3
+"""{name} — Robonix skill provider."""
+from robonix_api import Skill, Ok
+from {idl_lib_name}_mcp import Run_Request, Run_Response
+
+# `id` must equal this entry's `name:` in the deploy robonix_manifest.yaml.
+provider = Skill(id="{name}", namespace="robonix/skill/{name}")
+
+
+@provider.on_init
+def init(cfg: dict):
+    # TODO: parse config and validate light dependencies here.
+    return Ok()
+
+
+@provider.on_activate
+def activate():
+    # Skills must allocate heavy resources lazily here.
+    return Ok()
+
+
+@provider.on_deactivate
+def deactivate():
+    # Skills must release the resources acquired in on_activate here.
+    return Ok()
+
+
+@provider.mcp("robonix/skill/{name}/run")
+def run(req: Run_Request) -> Run_Response:
+    """Execute this skill's main task."""
+    instruction = (req.instruction or "").strip()
+    if not instruction:
+        return Run_Response(accepted=False, message="instruction is empty")
+    return Run_Response(
+        accepted=True,
+        message=f"TODO: implement skill logic for {{instruction}}",
+    )
+
+
+if __name__ == "__main__":
+    provider.run()
+"#
+    )
+}
+
+pub async fn execute(name: &str, pkg_type: &str, path: Option<&Path>) -> Result<()> {
+    validate_name(name)?;
+    let pkg_type = infer_pkg_type(pkg_type, path)?;
+
+    let base_dir: PathBuf = if let Some(p) = path {
+        if p.is_absolute() {
+            p.to_path_buf()
+        } else {
+            std::env::current_dir()?.join(p)
+        }
+    } else {
+        std::env::current_dir()?.join(role_dir(pkg_type))
+    };
+    let pkg_dir = base_dir.join(name);
+
+    if pkg_dir.exists() {
+        anyhow::bail!("directory '{}' already exists", pkg_dir.display());
+    }
+
+    output::action("PackageNew", &format!("creating package '{name}'"));
+
+    let ns_kind = pkg_type;
+    let provider_class = provider_class(pkg_type);
+    let package_name = package_name(name, ns_kind);
+    let package_stem = python_module_name(name);
+    let source_module = if pkg_type == "skill" {
+        format!("{package_stem}_skill")
+    } else {
+        package_stem.clone()
+    };
+
+    std::fs::create_dir_all(&pkg_dir).context("failed to create package directory")?;
+    std::fs::create_dir_all(pkg_dir.join("scripts"))
+        .context("failed to create scripts/ directory")?;
+    std::fs::create_dir_all(pkg_dir.join("capabilities"))
+        .context("failed to create capabilities/ directory")?;
+
+    let module_dir = pkg_dir.join(&source_module);
+    std::fs::create_dir_all(&module_dir).context("failed to create python module directory")?;
+    std::fs::write(module_dir.join("__init__.py"), "").context("failed to write __init__.py")?;
+
+    std::fs::write(
+        pkg_dir.join("package_manifest.yaml"),
+        package_manifest(name, ns_kind, &package_name, &package_stem),
+    )
+    .context("failed to write package_manifest.yaml")?;
+    std::fs::write(pkg_dir.join("config.spec"), config_spec(pkg_type))
+        .context("failed to write config.spec")?;
+    std::fs::write(pkg_dir.join("scripts/build.sh"), build_sh(name))
+        .context("failed to write scripts/build.sh")?;
+    std::fs::write(pkg_dir.join("scripts/start.sh"), start_sh(&source_module))
+        .context("failed to write scripts/start.sh")?;
+    std::fs::write(
+        pkg_dir.join("capabilities/driver.v1.toml"),
+        driver_contract(ns_kind, name),
+    )
+    .context("failed to write capabilities/driver.v1.toml")?;
+
+    let main_py = if pkg_type == "skill" {
+        skill_main(name, &package_stem)
+    } else {
+        provider_main(name, ns_kind, provider_class)
+    };
     std::fs::write(module_dir.join("main.py"), main_py).context("failed to write main.py")?;
 
-    // .gitignore
+    if pkg_type == "skill" {
+        let skill_srv_dir = pkg_dir
+            .join("capabilities/lib")
+            .join(&package_stem)
+            .join("srv");
+        std::fs::create_dir_all(&skill_srv_dir)
+            .context("failed to create skill capabilities lib directory")?;
+        std::fs::write(
+            pkg_dir.join("capabilities/run.v1.toml"),
+            skill_run_contract(name, &package_stem),
+        )
+        .context("failed to write capabilities/run.v1.toml")?;
+        std::fs::write(skill_srv_dir.join("Run.srv"), skill_run_srv())
+            .context("failed to write capabilities/lib/.../Run.srv")?;
+        std::fs::write(pkg_dir.join("CAPABILITY.md"), capability_md_template(name))
+            .context("failed to write CAPABILITY.md")?;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(
+            pkg_dir.join("scripts/build.sh"),
+            std::fs::Permissions::from_mode(0o755),
+        )?;
+        std::fs::set_permissions(
+            pkg_dir.join("scripts/start.sh"),
+            std::fs::Permissions::from_mode(0o755),
+        )?;
+    }
+
     std::fs::write(
         pkg_dir.join(".gitignore"),
         "rbnx-build/\n__pycache__/\n*.pyc\n.venv/\n",
@@ -205,10 +394,16 @@ if __name__ == "__main__":
         pkg_dir.display()
     ));
     output::sub_step("package_manifest.yaml");
+    output::sub_step("config.spec");
     output::sub_step("scripts/build.sh");
     output::sub_step("scripts/start.sh");
-    output::sub_step(&format!("{module_name}/main.py  (provider skeleton)"));
-    output::sub_step("capabilities/  (.gitkeep)");
+    output::sub_step(&format!("capabilities/driver.v1.toml"));
+    if pkg_type == "skill" {
+        output::sub_step("capabilities/run.v1.toml");
+        output::sub_step(&format!("capabilities/lib/{package_stem}/srv/Run.srv"));
+        output::sub_step("CAPABILITY.md");
+    }
+    output::sub_step(&format!("{source_module}/main.py  (provider skeleton)"));
     output::sub_step(".gitignore");
 
     Ok(())

--- a/tools/rbnx/src/cmd/validate.rs
+++ b/tools/rbnx/src/cmd/validate.rs
@@ -24,6 +24,18 @@ pub async fn execute(path: Option<PathBuf>) -> Result<()> {
     let detected = manifest::detect_and_load(&package_root, None)?;
     let summary = detected.manifest.validate_and_summarize()?;
 
+    let is_skill_package = summary.name.starts_with("robonix.skill.")
+        || summary
+            .capabilities
+            .iter()
+            .any(|cap| cap.starts_with("robonix/skill/"));
+    if is_skill_package && !package_root.join("CAPABILITY.md").is_file() {
+        anyhow::bail!(
+            "Skill package is missing CAPABILITY.md at {}",
+            package_root.join("CAPABILITY.md").display()
+        );
+    }
+
     output::check(&format!("Manifest: {}", detected.path.display()));
     output::check(&format!("Package: {} {}", summary.name, summary.version));
 


### PR DESCRIPTION
…ABILITY.md

- init/package-new: emit YAML-safe manifests (quote description with colons) and align skill provider/IDL lib directory naming (test_skill_skill, capabilities/lib/<name>).
- package-new: generate CAPABILITY.md for skill packages.
- package-new: clarify --path semantics (parent dir for <name>/).
- validate: require CAPABILITY.md for skill packages.