### PR TITLE
feat(scene): epoch-safe semantic map persistence keyed by save tokens

### DIFF
--- a/system/scene/README.md
+++ b/system/scene/README.md
@@ -253,32 +253,44 @@ plain `humble`.
 | `SCENE_GRAPH_IMAGE_RELATIONS` | `true` | VLM-primary relations: one image-grounded VLM call (projected numbered boxes) owns relational + semantic edges. `false` forces the legacy text-only per-pair inference (also the automatic fallback when no camera frame bundle is available) |
 | `SCENE_GRAPH_IMAGE_MAX_DIM` | `960` | longest-side pixel cap for the annotated frame sent to the VLM; bounds image token cost |
 | `SCENE_PORT` / `SCENE_WEB_PORT` | `50106` / `50107` | gRPC + web UI ports |
-| `SCENE_OBJECT_MEMORY_ENABLED` | `true` | persist stable objects + warm-restore the registry on boot |
+| `SCENE_OBJECT_MEMORY_ENABLED` | `true` | enable the object snapshot DB backing the map UI's Save/Load (boot warm-restore only under `SCENE_RESTORE_ON_START`) |
 | `SCENE_OBJECT_MEMORY_DB` | `/data/robonix/scene_memory/objects.db` | milvus-lite DB path (inside container; host-mounted via `rbnx-build/data/robonix`) |
 | `SCENE_MAP_ID` | `default` | FALLBACK map binding: mapping's latched `robonix/service/map/lifecycle` broadcast wins when present at startup; this env (below manifest `map_id`) applies when mapping isn't up yet (normal full-boot order) or doesn't broadcast |
 | `SCENE_MAP_BINDING_WAIT_S` | `3.0` | how long the startup probe waits for the lifecycle contract to appear on atlas before falling back to static binding; `0` disables the probe |
 | `SCENE_ANNOTATIONS_DIR` | `/data/robonix/scene_annotations` | per-map JSON files holding user annotations (rooms / POIs); host-mounted like the object DB |
+| `SCENE_MAP_META_DIR` | sibling `scene_maps/` of the annotations dir | epoch sidecar files pairing each saved map with the object-snapshot partition written at its Save (see "Map library") |
+| `SCENE_RESTORE_ON_START` | `false` | LEGACY mode: bind the startup map id, restore its objects at boot, and let the scene-graph builder persist continuously. Default off — a boot starts a fresh live session and objects are only persisted by an explicit Save |
 | `VLM_REASONING_EFFORT` | `` (unset) | opt-in, forwarded to all scene VLM/LLM calls (relation inference + VLM perception): `minimal`\|`low`\|`medium`\|`high`. **Unset → the field is omitted**, so non-reasoning models and strict endpoints are unaffected. Set `minimal` (= no thinking) to keep a reasoning `VLM_MODEL` (e.g. `doubao-seed-2-1-pro`) answering in ~2 s instead of timing out |
 
-## Object memory (warm restore)
+## Object memory (Save/Load snapshots)
 
-When `SCENE_OBJECT_MEMORY_ENABLED` is on, scene persists its stable objects to a
-small embedded milvus-lite DB (`SCENE_OBJECT_MEMORY_DB`) at the scene-graph
-builder cadence, and reloads them into the registry at boot. After a restart the
-graph is populated immediately instead of re-accumulating every object through
-the `min_observations` filter; re-observation re-confirms restored objects in
-place (no duplicate ids). Each row carries a caption vector embedded with the
-open_clip text encoder already loaded for perception (512-d, shared with the
-per-object image features), so a future object-search layer can reuse the table.
-The DB is scene-owned — a separate file/process from `system/memory`'s memsearch
-DB — and lives under the host-mounted `/data/robonix`, which also makes the
-scene-graph JSON caches survive boots. Writes are driven by the scene-graph
-builder, so disabling `SCENE_GRAPH_ENABLED` stops new writes (restore still runs).
+When `SCENE_OBJECT_MEMORY_ENABLED` is on, scene keeps an embedded milvus-lite
+DB (`SCENE_OBJECT_MEMORY_DB`) for its stable objects. By default a boot starts
+a **fresh live session** that is never persisted; objects reach the DB only
+when the operator **saves a map** in the map UI, which snapshots the live
+registry together with the spatial artifact, and come back only when that map
+is **loaded** (see "Map library" below for the epoch rules). Each row carries
+a caption vector embedded with the open_clip text encoder already loaded for
+perception (512-d, shared with the per-object image features), so a future
+object-search layer can reuse the table. The DB is scene-owned — a separate
+file/process from `system/memory`'s memsearch DB — and lives under the
+host-mounted `/data/robonix`, which also makes the scene-graph JSON caches
+survive boots.
 
-Persistence is partitioned by the map binding: an object's pose is only
-meaningful in the `map` frame of the SLAM map it was observed on, so restore
-loads exactly the current map's objects and never mixes two maps. The same
-`object_id` may exist on different maps without colliding.
+`SCENE_RESTORE_ON_START=true` selects the LEGACY mode instead: the registry
+warm-restores the startup binding's partition at boot and the scene-graph
+builder persists continuously under it. This mode assumes the map frame never
+changes across those boots — the operator owns that guarantee. Don't mix it
+with map-UI Saves: a Save purges the bare partition the legacy restore reads
+(its rows move into the Save's snapshot), so the next legacy boot restores
+nothing until the builder repopulates.
+
+An object's pose is only meaningful in the exact `map` frame it was observed
+in, so persistence is partitioned by **snapshot**, not merely by map name:
+every Save writes into a fresh partition and restore loads exactly the
+partition saved with the loaded artifact — two builds of a same-named map can
+never mix. The same `object_id` may exist in several snapshots without
+colliding.
 
 The binding itself (`scene_service/map_binding.py`) is learned at startup with
 this precedence: mapping's latched `robonix/service/map/lifecycle` broadcast
@@ -287,11 +299,17 @@ this precedence: mapping's latched `robonix/service/map/lifecycle` broadcast
 `"default"`. The broadcast needs the generated `map` interface package
 (`rbnx codegen --ros2` → colcon overlay, built by `scripts/build.sh`, sourced
 by the container entrypoint); without it scene falls back to static binding
-with a warning. At runtime scene only WATCHES the broadcast: if mapping's
-identity or `generation` (bumped when the map origin may have changed: reset /
-mapping-mode session start) drifts from the startup binding, scene logs a
-warning and keeps its binding — reacting (flush + re-anchor) is the planned
-lifecycle linkage (P3).
+with a warning. At runtime scene WATCHES the broadcast and reacts to a frame
+epoch change: a `generation` bump on the bound map (mapping reset / re-init
+under scene) **flushes the derived objects** from the registry — their stored
+map-frame coordinates are no longer anchored, and re-observation rebuilds them
+in the new frame — and flags room annotations stale for user confirmation
+(user assets are never deleted automatically). A broadcast naming a different
+map (loaded outside scene's map UI) also flushes stale objects, but scene
+cannot restore the new map's semantic state from there — the log tells the
+operator to Load it in the map UI (or restart scene). A Load performed through
+the map UI updates the same live binding the watcher tracks, so it never
+registers as drift.
 
 ## User annotations (rooms / POIs)
 
@@ -329,6 +347,35 @@ as breaking.** The full annotation list also rides along in `GET /api/state`
 (field `annotations`, next to `map_binding`) so map pages get everything in
 one poll. There is deliberately no atlas/MCP surface yet — exposing rooms to
 Pilot (scene-graph `in_room` edges) is a planned follow-up.
+
+## Map library (Save / Load / Delete)
+
+The `/user` page's map panel drives a scene-owned facade over the map
+capabilities (`POST /api/maps/{save,load,delete}`, `GET /api/maps`,
+`POST /api/maps/pose_estimate`): mapping keeps the spatial artifact, scene
+keeps the matching semantic state, and the facade moves both together so "a
+map" means geometry + objects + rooms as one unit.
+
+**Epoch rule** — the invariant behind every path here: *objects are only ever
+restored from the snapshot written together with the loaded artifact.* Each
+Save allocates a fresh object partition (`<map_id>__s<seq>`), writes the live
+registry into it, commits a sidecar file (`SCENE_MAP_META_DIR`) pointing at
+it only after the write verifies complete, and then purges the previous
+snapshot. Each Load reads the sidecar and restores exactly that partition. A
+map without a sidecar (saved before this mechanism, or a foreign DB) restores
+**no objects** — response field `semantic_snapshot` says so — because rows of
+unknown epoch may anchor to a map frame that no longer exists (the off-map
+"ghost object" bug). Re-save the map to create its snapshot.
+
+Save refuses (409) two epoch hazards rather than corrupting state silently:
+updating an existing map's semantics **from a still-running mapping session**
+(the artifact froze at the original Save while the live frame kept drifting —
+load it in localization mode instead, or delete and re-save), and saving onto
+a map **whose annotations this session never loaded** (the carry would
+overwrite previously saved rooms; load first). Load is transactional on the
+occupancy grid: scene rebinds rooms/objects only after observing a fresh grid
+from the loaded map, and Delete removes the artifact, the annotation file,
+the sidecar, and every object partition of the map.
 
 ## Capabilities exposed
 

--- a/system/scene/scene_service/annotations.py
+++ b/system/scene/scene_service/annotations.py
@@ -163,6 +163,15 @@ class AnnotationStore:
     def path(self) -> Path:
         return self._path
 
+    def has_saved(self, map_id: str) -> bool:
+        """True when a persisted annotation file already exists for `map_id`.
+
+        Guards the Save path: `rebind(carry_current=True)` onto a partition
+        this store never loaded would OVERWRITE that file with the live
+        session's annotations — silently destroying previously saved rooms
+        (user assets). Callers refuse the save instead (load first)."""
+        return (self._base / f"{sanitize_map_id(map_id)}.json").exists()
+
     def rebind(self, map_id: str, *, generation: Optional[int] = None,
                carry_current: bool = False) -> None:
         """Switch this store to another map partition.

--- a/system/scene/scene_service/map_binding.py
+++ b/system/scene/scene_service/map_binding.py
@@ -12,8 +12,9 @@ scene starts (the normal full-boot order) or does not broadcast at all.
 
 `generation` is mapping's map-frame epoch: it bumps whenever the map
 origin may have changed (mapping-mode session start, reset_map) and stays
-put across localization round-trips. P2 records it and warns on runtime
-change; acting on it (flush + re-anchor) is the P3 lifecycle linkage.
+put across localization round-trips. The lifecycle watcher in service.py
+acts on a runtime change: derived objects are flushed (re-observation
+rebuilds them in the new frame) and room annotations are flagged stale.
 
 Split from service.py so the pure precedence rule and the one-shot ROS
 read are unit-testable without atlas.

--- a/system/scene/scene_service/map_meta.py
+++ b/system/scene/scene_service/map_meta.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+"""Scene-owned per-map semantic snapshot metadata (the epoch sidecar).
+
+mapping owns a saved map's spatial artifact; scene owns the matching semantic
+snapshot (objects + room annotations). The sidecar records, per `map_id`,
+WHICH object partition holds the snapshot written by the Save that produced
+the artifact on disk. Every Save allocates a fresh partition token
+(`"<map_id>__s<seq>"`) and repoints the sidecar at it, so:
+
+- Load restores exactly the rows written together with the loaded artifact —
+  never rows from an earlier build of a same-named map, whose map frame no
+  longer exists (the mis-anchored / off-map restore bug).
+- A map with NO sidecar (saved before this mechanism, or a foreign DB)
+  restores nothing rather than coordinates in a dead frame.
+
+One JSON file per map under `base_dir`, written atomically (tmp + replace).
+`mapping_generation` / `mapping_mode` are recorded for diagnostics when the
+lifecycle broadcast is available at save time; the mechanism itself never
+depends on them.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Optional
+
+from .map_binding import sanitize_map_id
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class MapSemanticMeta:
+    """Sidecar record for one saved map's semantic snapshot."""
+    map_id: str
+    object_partition: str        # milvus partition holding the snapshot rows
+    save_seq: int                # monotonic per map; allocates the partition
+    saved_at_unix: float
+    mapping_generation: Optional[int] = None  # broadcast gen at save (diagnostic)
+    mapping_mode: str = ""                    # broadcast mode at save (diagnostic)
+
+    def to_json(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_json(cls, d: dict) -> "MapSemanticMeta":
+        known = set(cls.__dataclass_fields__)
+        return cls(**{k: v for k, v in d.items() if k in known})
+
+
+class MapMetaStore:
+    """Per-map sidecar files: `<base_dir>/<map_id>.json`.
+
+    All methods are synchronous; the internal lock guards individual file
+    ops only — the `next_partition` → persist rows → `write` sequence is NOT
+    atomic here, and callers serialize whole Save/Load/Delete operations
+    (the web facade's `ops_lock`). A file that cannot be parsed is treated
+    as absent with a WARNING: restoring nothing is the safe outcome, and the
+    bytes are left in place for inspection."""
+
+    def __init__(self, base_dir: str) -> None:
+        self._lock = threading.Lock()
+        self._base = Path(base_dir).expanduser()
+        self._base.mkdir(parents=True, exist_ok=True)
+
+    def _path(self, map_id: str) -> Path:
+        return self._base / f"{sanitize_map_id(map_id)}.json"
+
+    def read(self, map_id: str) -> Optional[MapSemanticMeta]:
+        """The sidecar for `map_id`, or None when absent/unreadable. A
+        malformed record must never crash a Load — it degrades to
+        "no snapshot", which restores nothing."""
+        path = self._path(map_id)
+        with self._lock:
+            if not path.exists():
+                return None
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+                meta = MapSemanticMeta.from_json(data)
+                if not meta.object_partition:
+                    raise ValueError("empty object_partition")
+                return meta
+            except Exception as e:  # noqa: BLE001
+                log.warning(
+                    "[scene-mapmeta] unreadable sidecar %s (%s) — treating as "
+                    "absent; the map's objects will not be restored", path, e,
+                )
+                return None
+
+    def next_partition(self, map_id: str) -> tuple[str, int]:
+        """The partition token for the NEXT snapshot of `map_id`, without
+        touching the sidecar (the caller commits via `write` only after the
+        snapshot rows are safely persisted). The sequence advances only on
+        commit, so a FAILED attempt's token is handed out again — callers
+        clear that partition before writing into it."""
+        clean = sanitize_map_id(map_id)
+        prev = self.read(clean)
+        seq = (prev.save_seq + 1) if prev is not None else 1
+        return f"{clean}__s{seq}", seq
+
+    def write(self, meta: MapSemanticMeta) -> None:
+        """Atomically persist `meta` as its map's sidecar. Raises on I/O
+        failure — a Save must not report success while the sidecar still
+        points at the previous snapshot."""
+        path = self._path(meta.map_id)
+        tmp = path.with_suffix(".json.tmp")
+        with self._lock:
+            tmp.write_text(
+                json.dumps(meta.to_json(), ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+            os.replace(tmp, path)
+
+    def delete(self, map_id: str) -> bool:
+        """Remove `map_id`'s sidecar (map deletion). True when one existed."""
+        path = self._path(map_id)
+        with self._lock:
+            existed = path.exists()
+            if existed:
+                path.unlink()
+            return existed
+
+
+def make_meta(map_id: str, partition: str, seq: int, *,
+              generation: Optional[int] = None, mode: str = "") -> MapSemanticMeta:
+    """Convenience constructor stamping `saved_at_unix` now."""
+    return MapSemanticMeta(
+        map_id=sanitize_map_id(map_id),
+        object_partition=partition,
+        save_seq=seq,
+        saved_at_unix=time.time(),
+        mapping_generation=generation,
+        mapping_mode=mode,
+    )

--- a/system/scene/scene_service/persistence.py
+++ b/system/scene/scene_service/persistence.py
@@ -11,13 +11,16 @@ layer can reuse the same table; when no embedder is wired (e.g. the VLM-fallback
 perception path that has no CLIP), a fixed placeholder vector is stored so the
 collection stays well-formed.
 
-Rows are partitioned by `map_id`: an object's pose is only meaningful in the
-`map` frame of the SLAM map it was observed on, so warm-restore loads exactly
-the current map's objects and never mixes two maps. The primary key is the
-composite `"{map_id}::{object_id}"` so the same `object_id` may exist on
-different maps without colliding on upsert. Until mapping emits a real map
-identity, `map_id` is a deploy-controlled string (`SCENE_MAP_ID`, default
-`"default"`) — this stays internal to scene and touches no atlas/MCP contract.
+Rows are partitioned by the scalar `map_id` field: an object's pose is only
+meaningful in the `map` frame it was observed in, so a restore must load rows
+written in that exact frame and nothing else. The web facade's Save writes
+each snapshot under a fresh partition token (`"<map_id>__s<seq>"`, allocated
+by `map_meta`) rather than the bare map id — two saves of the same-named map
+belong to two different frames, and the token keeps them apart where a shared
+`map_id` partition would silently mix epochs. The primary key is the
+composite `"{partition}::{object_id}"` so the same `object_id` may exist in
+several partitions without colliding on upsert. All of this stays internal
+to scene and touches no atlas/MCP contract.
 """
 from __future__ import annotations
 
@@ -77,14 +80,12 @@ class ObjectStore:
         """The sanitized map id this store is scoped to."""
         return self._map_id
 
-    def rebind(self, map_id: str) -> None:
-        """Switch subsequent reads/writes to another map partition.
-
-        The Milvus collection is shared across maps; rows are filtered by the
-        scalar ``map_id`` field and keyed by ``{map_id}::{object_id}``, so a
-        rebind only changes the partition used by ``persist`` / ``load_all``.
-        """
-        self._map_id = _sanitize_map_id(map_id)
+    def _partition(self, partition: Optional[str]) -> str:
+        """Resolve the partition an operation targets: the explicit argument
+        when given, else this store's bound `map_id`. Explicit partitions keep
+        one-shot operations (the web facade's Save/Load snapshots) from
+        mutating the store-wide binding that the builder shares."""
+        return self._map_id if partition is None else _sanitize_map_id(partition)
 
     # ── schema ───────────────────────────────────────────────────────────
     def _ensure_collection(self) -> None:
@@ -99,8 +100,10 @@ class ObjectStore:
         left by an earlier draft (legacy `object_id` primary key, before
         per-map partitioning) is dropped and recreated: that schema keys upsert
         on `object_id` alone, so two maps' identical ids would silently
-        overwrite each other. The store is a best-effort warm-restore cache, so
-        recreating it just forces a one-time cold start — never a boot failure."""
+        overwrite each other. Note the DB now durably holds saved maps' object
+        snapshots — the drop only ever hits those pre-partitioning legacy
+        collections (which cannot contain valid snapshots); it must stay a
+        warning-loud one-time event, never a boot failure."""
         if self._client.has_collection(_COLLECTION):
             if self._schema_current():
                 self._client.load_collection(_COLLECTION)
@@ -161,9 +164,9 @@ class ObjectStore:
     def _schema_current(self) -> bool:
         """True iff the existing collection matches what we'd create now: the
         composite `pk` primary key AND the `bbox_yaw` field (added after the
-        first persistence draft). A collection failing either check is dropped
-        and recreated — cheap, since the store is a best-effort warm-restore
-        cache and a recreate just forces a one-time cold start."""
+        first persistence draft). A collection failing either check predates
+        snapshot partitioning — it cannot hold valid snapshots — and is
+        dropped and recreated as a one-time, warning-loud cold start."""
         return self._has_composite_pk() and self._has_field("bbox_yaw")
 
     def _has_composite_pk(self) -> bool:
@@ -211,23 +214,26 @@ class ObjectStore:
         return vecs
 
     # ── write ────────────────────────────────────────────────────────────
-    def persist(self, pairs: list[tuple[SceneObject, Optional[str]]]) -> int:
-        """Upsert `(SceneObject, caption)` pairs under this store's `map_id`
-        (composite pk `"{map_id}::{object_id}"`). Caption falls back to the
-        class name when None. Returns the number of rows written;
-        a milvus error is swallowed (logged) so a bad write never kills the
-        builder tick."""
+    def persist(self, pairs: list[tuple[SceneObject, Optional[str]]],
+                *, partition: Optional[str] = None) -> int:
+        """Upsert `(SceneObject, caption)` pairs under `partition` (default:
+        this store's `map_id`; composite pk `"{partition}::{object_id}"`).
+        Caption falls back to the class name when None. Returns the number of
+        rows written; a milvus error is swallowed (logged) so a bad write
+        never kills the builder tick — callers that need write integrity
+        (the Save snapshot) compare the return value against `len(pairs)`."""
         if not pairs:
             return 0
+        target = self._partition(partition)
         captions = [(cap or obj.cls) for obj, cap in pairs]
         vecs = self._embed_captions(captions)
         rows = []
         for (obj, _cap), caption, vec in zip(pairs, captions, vecs):
             rows.append(
                 {
-                    "pk": f"{self._map_id}::{obj.object_id}",
+                    "pk": f"{target}::{obj.object_id}",
                     "object_id": obj.object_id,
-                    "map_id": self._map_id,
+                    "map_id": target,
                     "embedding": vec,
                     "cls": obj.cls,
                     "caption": caption,
@@ -256,22 +262,27 @@ class ObjectStore:
         return len(rows)
 
     # ── read ─────────────────────────────────────────────────────────────
-    def load_all(self, *, limit: int = 16384) -> list[SceneObject]:
-        """Return this map's persisted objects as `SceneObject`s for warm
-        restore (rows of other maps are filtered out by `map_id`).
+    def load_all(self, *, partition: Optional[str] = None,
+                 limit: int = 16384, strict: bool = False) -> list[SceneObject]:
+        """Return one partition's persisted objects as `SceneObject`s for warm
+        restore (default: this store's `map_id`; rows of other partitions are
+        filtered out).
 
         Restored objects come back `missing=True` (known but not currently
         observed) with their persisted `last_seen`; re-observation flips them
         back via data association. The embedding column is intentionally not
         read back — restore needs only scalar state. A query *error* is logged
-        at error level and yields an empty list rather than failing boot — this
-        is distinct from a genuinely empty DB, which returns `[]` silently."""
+        at error level and yields an empty list rather than failing boot —
+        UNLESS `strict` is set (the facade's Load path), where the caller must
+        be able to tell "snapshot unreadable" from "snapshot empty": a Save on
+        top of an unnoticed failed restore would commit an empty snapshot."""
+        target = self._partition(partition)
         try:
-            # map_id is sanitized to a quote-free identifier in __init__, so
-            # interpolating it into the predicate is injection-safe.
+            # Partitions are sanitized to quote-free identifiers, so
+            # interpolating into the predicate is injection-safe.
             rows = self._client.query(
                 collection_name=_COLLECTION,
-                filter=f'map_id == "{self._map_id}"',
+                filter=f'map_id == "{target}"',
                 output_fields=[
                     "object_id", "cls", "caption", "x", "y", "z", "yaw",
                     "frame_id", "size_x", "size_y", "size_z", "bbox_yaw",
@@ -281,6 +292,8 @@ class ObjectStore:
                 limit=limit,
             )
         except Exception as e:  # noqa: BLE001
+            if strict:
+                raise RuntimeError(f"load_all({target}) failed: {e}") from e
             # Not a cold start: the DB may hold rows we failed to read (bad
             # path, missing volume, schema mismatch). Surface it as an error so
             # a silently-empty graph isn't mistaken for "nothing persisted yet".
@@ -320,7 +333,10 @@ class ObjectStore:
         """Delete persisted scene objects belonging to one map partition.
 
         The collection is shared, so the filter is mandatory: deleting a map
-        must never affect objects captured for another spatial map.
+        must never affect objects captured for another spatial map. The
+        return value counts rows found by a query capped at 16384 — a "how
+        much was there" signal, possibly lower than what the (uncapped)
+        delete removed.
         """
         target = _sanitize_map_id(map_id)
         predicate = f'map_id == "{target}"'
@@ -336,6 +352,28 @@ class ObjectStore:
             return len(rows)
         except Exception as e:  # noqa: BLE001
             raise RuntimeError(f"delete_map({target}) failed: {e}") from e
+
+    def purge_live_partitions(self) -> int:
+        """Best-effort deletion of leftover `.live*` partitions.
+
+        Earlier builds persisted the live session under a unique
+        `.live-<pid>-<ts>` partition every boot and never cleaned it, so a
+        long-lived DB accumulates dead rows without bound. Live sessions are
+        no longer persisted at all; this reclaims what old boots left behind.
+        Returns the number of rows deleted (0 on any error — cleanup must
+        never block a boot)."""
+        predicate = 'map_id like ".live%"'
+        try:
+            rows = self._client.query(
+                collection_name=_COLLECTION, filter=predicate,
+                output_fields=["pk"], limit=16384,
+            )
+            if rows:
+                self._client.delete(collection_name=_COLLECTION, filter=predicate)
+            return len(rows)
+        except Exception as e:  # noqa: BLE001
+            log.warning("[scene-persist] live-partition cleanup failed: %s", e)
+            return 0
 
     # ── lifecycle ────────────────────────────────────────────────────────
     def close(self) -> None:

--- a/system/scene/scene_service/scene_graph/builder.py
+++ b/system/scene/scene_service/scene_graph/builder.py
@@ -117,8 +117,10 @@ class SceneGraphBuilder:
         self.store = store
         self.cfg = config or SceneGraphConfig()
         # Optional persistence layer (scene_service.persistence.ObjectStore).
-        # When set, each rebuild upserts the current stable objects so the
-        # registry can warm-restore after a restart. None disables persistence.
+        # Only wired in the legacy SCENE_RESTORE_ON_START mode: each rebuild
+        # then upserts the current stable objects so the registry can
+        # warm-restore at boot. The default Save/Load snapshot path never
+        # goes through the builder — service.py passes None.
         self.object_store = object_store
         # Optional perception detector exposing latest_frame_bundle() (the
         # concept-graphs metric-tier detector). When present + enabled, the
@@ -250,7 +252,8 @@ class SceneGraphBuilder:
             updated_at=time.time(),
         )
 
-        # 8. Persist current stable objects for warm restore. `nodes` is
+        # 8. Persist current stable objects for the legacy boot warm
+        # restore (object_store is None outside that mode). `nodes` is
         # built from `stable` in order, so zip pairs each object with the
         # caption just computed for it. Offloaded to a thread because the
         # caption embedding + milvus write are synchronous and must not

--- a/system/scene/scene_service/service.py
+++ b/system/scene/scene_service/service.py
@@ -39,6 +39,7 @@ from . import web as web_ui
 from .annotations import AnnotationStore
 from .ingest.capabilities import plan_perception
 from .map_binding import MapBinding, choose_map_binding, read_latched_lifecycle
+from .map_meta import MapMetaStore
 from .ingest.perception_concept_graphs import ConceptGraphsDetector
 from .ingest.perception_vlm import VLMObjectDetector, _CamIntrinsics
 from .ingest.ros_subscribers import (
@@ -905,34 +906,72 @@ async def _lifecycle_watch(
     hub: SubscribersHub,
     binding: MapBinding,
     anno_store: Optional[AnnotationStore] = None,
+    *,
+    registry: Optional[ObjectRegistry] = None,
+    live_binding: Optional[dict] = None,
+    ops_lock: Optional[asyncio.Lock] = None,
+    interval_s: float = 5.0,
 ) -> None:
-    """P2 guard: scene binds its map_id ONCE at startup; when mapping's
-    broadcast later disagrees (map loaded/reset/switched at runtime), warn
-    loudly — reacting to it (flush + re-anchor the semantic state) is the
-    P3 lifecycle linkage, not guesswork here. Also confirms a static
-    binding the first time the broadcast appears and agrees.
+    """Lifecycle linkage: track mapping's latched identity broadcast against
+    the session's LIVE binding (`live_binding` — the same dict the web
+    facade's Save/Load update, so a facade-initiated load never reads as
+    drift) and REACT to a frame-epoch change instead of only warning:
 
-    One reaction IS taken already: a generation bump on the SAME map flags
-    the user's annotations stale (flag-only — user assets are never
-    deleted automatically). That is a marker write, not a flush, so it is
-    safe ahead of P3; and because it is best-effort, a failing marker
-    write must never kill this watcher — the drift WARNING itself is the
-    load-bearing part.
+    - generation bump on the SAME map (reset / mapping re-init underneath
+      scene): every stored map-frame coordinate just went stale. Derived
+      objects are flushed from the registry (re-observation rebuilds them
+      in the new frame); room annotations are user assets — flagged stale
+      for confirmation, never deleted. The live binding's generation is
+      advanced so the response fires exactly once per epoch.
+    - a DIFFERENT map_id (map loaded/switched outside scene's facade):
+      the registry's objects belong to the previous frame and are flushed,
+      but scene cannot restore the new map's semantic state from here —
+      that stays a WARNING telling the operator to Load via the map UI
+      (or restart scene). The live binding is left pointing at what scene
+      last knowingly bound.
 
-    A static binding (config/env — the normal full-boot order, scene up
-    before mapping) carries no generation, so the epoch reference is
+    Every reaction is best-effort: a failing marker write / flush must
+    never kill the watcher — the drift detection itself is load-bearing.
+
+    A static binding carries no generation, so the epoch reference is
     learned from the FIRST confirming broadcast: without that, `gen_ok`
     would stay vacuously true and runtime bumps would be invisible."""
-    confirmed = False
+    if live_binding is None:
+        live_binding = {
+            "map_id": binding.map_id,
+            "mode": binding.mode,
+            "generation": binding.generation,
+            "source": binding.source,
+        }
+    if ops_lock is None:
+        ops_lock = asyncio.Lock()
+    confirmed_key: Optional[tuple] = None
     warned_ephemeral = False
     last_warned: Optional[tuple] = None
-    ref_gen = binding.generation
-    while True:
-        await asyncio.sleep(5.0)
-        msg, stamp_unix, _count = hub.latest("map_lifecycle")
+
+    async def _flush_registry(why: str) -> None:
+        """Best-effort registry flush; a failure is loud but non-fatal."""
+        if registry is None:
+            return
+        try:
+            async with registry.lock():
+                dropped = registry.clear_objects()
+            log.warning("[scene] flushed %d mis-anchored object(s) %s",
+                        dropped, why)
+        except Exception as e:  # noqa: BLE001
+            log.error(
+                "[scene] object flush failed — mis-anchored objects remain "
+                "until re-observation or restart: %s", e,
+            )
+
+    async def _tick() -> None:
+        nonlocal confirmed_key, warned_ephemeral, last_warned
+        msg, _stamp, _count = hub.latest("map_lifecycle")
         if msg is None:
-            continue
+            return
         live_id, live_gen = str(msg.map_id), int(msg.generation)
+        bound_id = str(live_binding.get("map_id") or "")
+        ref_gen = live_binding.get("generation")
         if not live_id:
             # Ephemeral broadcast: no named identity to compare — but if
             # scene statically bound a NAMED map, that named partition is
@@ -946,21 +985,18 @@ async def _lifecycle_watch(
                     binding.source,
                 )
                 warned_ephemeral = True
-            continue
-        id_ok = live_id == binding.map_id
-        gen_ok = ref_gen is None or live_gen == ref_gen
-        if id_ok and gen_ok:
-            if not confirmed:
+            return
+        if live_id == bound_id and (ref_gen is None or live_gen == ref_gen):
+            if confirmed_key != (live_id, live_gen):
                 log.info(
                     "[scene] map binding confirmed by mapping lifecycle: "
                     "id=%s gen=%d mode=%s", live_id, live_gen, str(msg.mode),
                 )
-                confirmed = True
-                # Static bindings learn their epoch here; from now on a
-                # bump IS detectable. The annotation store gets to compare
-                # the confirmed epoch against the one its file recorded
-                # (it too may have loaded under an unknown generation).
-                ref_gen = live_gen
+                confirmed_key = (live_id, live_gen)
+                # Learn the epoch (static bindings start without one); from
+                # now on a bump IS detectable. The annotation store compares
+                # the confirmed epoch against the one its file recorded.
+                live_binding["generation"] = live_gen
                 if anno_store is not None:
                     try:
                         anno_store.reconcile_generation(live_gen)
@@ -972,48 +1008,83 @@ async def _lifecycle_watch(
                             "(annotation staleness may be outdated): %s", e,
                         )
             last_warned = None
-            continue
+            return
+        if live_id == bound_id:
+            # Same map, new frame epoch. Respond, don't just warn — under
+            # the shared ops lock so the reaction can't interleave with a
+            # facade Save/Load that is mid-flight.
+            async with ops_lock:
+                # Re-read under the lock: a facade op may have advanced the
+                # binding while we waited — its update IS the new truth.
+                ref_gen = live_binding.get("generation")
+                if (str(live_binding.get("map_id") or "") != live_id
+                        or live_gen == ref_gen):
+                    return
+                log.warning(
+                    "[scene] map %s frame epoch changed under scene (gen "
+                    "%s→%d, mode=%s) — flushing derived objects "
+                    "(re-observation rebuilds them in the new frame); room "
+                    "annotations are flagged stale for confirmation",
+                    live_id, ref_gen, live_gen, str(msg.mode),
+                )
+                await _flush_registry("after epoch bump")
+                if anno_store is not None:
+                    try:
+                        n = anno_store.mark_all_stale(
+                            f"map generation {ref_gen}→{live_gen}",
+                            new_generation=live_gen,
+                        )
+                        if n:
+                            log.warning(
+                                "[scene-anno] %d annotation(s) marked stale "
+                                "— confirm or redraw them in the map UI", n,
+                            )
+                    except Exception as e:  # noqa: BLE001
+                        # Losing the stale marker is recoverable (next
+                        # boot's load-time epoch check re-judges); losing
+                        # this watcher would silence ALL drift handling.
+                        log.error(
+                            "[scene-anno] stale marking failed (annotations "
+                            "may show as fresh until restart): %s", e,
+                        )
+                # Advance the live epoch: the response fired once for this
+                # bump and the next bump is measured against it.
+                live_binding["generation"] = live_gen
+                if str(msg.mode):
+                    live_binding["mode"] = str(msg.mode)
+                confirmed_key = (live_id, live_gen)
+            return
         key = (live_id, live_gen)
         if key != last_warned:
-            log.warning(
-                "[scene] mapping's live map identity (id=%s gen=%d mode=%s) "
-                "no longer matches scene's startup binding (id=%s gen=%s "
-                "source=%s) — semantic state may be mis-anchored. Scene keeps "
-                "its startup binding until lifecycle linkage (P3) lands; "
-                "restart scene to rebind.",
-                live_id, live_gen, str(msg.mode),
-                binding.map_id, ref_gen, binding.source,
-            )
-            if anno_store is not None and id_ok and not gen_ok:
-                # Same map, new frame epoch: user-drawn geometry may no
-                # longer line up with the rebuilt map. Flag it for user
-                # confirmation (marker-only; deletion is never automatic).
-                try:
-                    n = anno_store.mark_all_stale(
-                        f"map generation {ref_gen}→{live_gen}",
-                        new_generation=live_gen,
-                    )
-                    if n:
-                        log.warning(
-                            "[scene-anno] %d annotation(s) marked stale — "
-                            "confirm or redraw them in the map UI", n,
-                        )
-                except Exception as e:  # noqa: BLE001
-                    # Losing the stale marker is recoverable (next boot's
-                    # load-time epoch check re-judges); losing this watcher
-                    # would silence ALL drift warnings for the session.
-                    log.error(
-                        "[scene-anno] stale marking failed (annotations "
-                        "may show as fresh until restart): %s", e,
-                    )
-            if id_ok:
-                # Acknowledge the new epoch so a THIRD epoch is reported
-                # against this one (accurate from→to in reason/log), and
-                # each bump warns exactly once. The registry's semantic
-                # state stays anchored to the startup binding until the
-                # lifecycle linkage (P3) actually re-anchors it.
-                ref_gen = live_gen
+            async with ops_lock:
+                if str(live_binding.get("map_id") or "") == live_id:
+                    # A facade Load bound this map while we waited — the
+                    # mismatch we saw is already resolved, not drift.
+                    return
+                log.warning(
+                    "[scene] mapping's live map identity (id=%s gen=%d "
+                    "mode=%s) no longer matches scene's binding (id=%s "
+                    "gen=%s source=%s) — flushing stale objects; Load the "
+                    "map in the map UI (or restart scene) to bind its "
+                    "semantic state.",
+                    live_id, live_gen, str(msg.mode),
+                    bound_id, ref_gen, live_binding.get("source"),
+                )
+                await _flush_registry("after external map switch")
             last_warned = key
+
+    while True:
+        await asyncio.sleep(interval_s)
+        try:
+            await _tick()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:  # noqa: BLE001
+            # The watcher is the session's only runtime epoch guard — one
+            # malformed sample / failed reaction must never end it.
+            log.error(
+                "[scene] lifecycle watch tick failed (watch continues): %s", e,
+            )
 
 
 # ── main ───────────────────────────────────────────────────────────────────
@@ -1034,17 +1105,16 @@ async def _run() -> None:
     registry = ObjectRegistry(grace_period_s=5.0)
     self_tracker = _SelfTracker(registry)
 
-    # Object persistence (warm restore across restarts). Created before
-    # perception so the registry is repopulated before the first detections
-    # arrive; the embedder is wired in later (only needed for writes). The
-    # store is independent of SCENE_GRAPH_ENABLED — restore always runs if a
-    # prior boot wrote rows — but writes are driven by the scene-graph builder.
+    # Object persistence. The store backs the map UI's Save/Load snapshots;
+    # boot-time warm restore and builder-driven continuous writes exist only
+    # under the legacy SCENE_RESTORE_ON_START mode. Created before
+    # perception so a legacy restore repopulates the registry before the
+    # first detections arrive; the embedder is wired in later.
     # Which SLAM map this scene session belongs to. This is the join key
-    # against mapping and the scope key for ALL of scene's persistent state:
-    # object poses are only valid in their own map's frame, and so are the
-    # scene-graph caption/relation caches. Computed once here so the object
-    # store (below) and the scene-graph cache (further down) partition on
-    # the same value.
+    # against mapping (lifecycle watch) and, in legacy mode, the partition
+    # key for scene's persistent state; the default mode partitions session
+    # state under the constant `.live` label and persists object snapshots
+    # under per-Save tokens instead.
     #
     # Binding precedence (choose_map_binding): mapping's latched lifecycle
     # broadcast — the authoritative map identity, probed briefly here —
@@ -1060,12 +1130,30 @@ async def _run() -> None:
     )
     map_id = binding.map_id
     restore_on_start = os.environ.get("SCENE_RESTORE_ON_START", "false").lower() in ("true", "1", "yes")
-    scene_state_map_id = map_id if restore_on_start else f".live-{os.getpid()}-{int(time.time())}"
+    # A live (unsaved) session is NEVER persisted — objects only reach the
+    # DB via an explicit Save snapshot (web facade) or, in the legacy
+    # restore_on_start mode, the builder's continuous writes under the bound
+    # map id. The constant `.live` name is just the in-memory partition label
+    # for the annotation/scene-graph session state below.
+    scene_state_map_id = map_id if restore_on_start else ".live"
     log.info(
         "[scene] map binding: id=%s gen=%s source=%s mode=%s restore_on_start=%s state_partition=%s",
         binding.map_id, binding.generation, binding.source, binding.mode,
         restore_on_start, scene_state_map_id,
     )
+    # The session's LIVE binding view — one mutable dict shared by the web
+    # facade (Save/Load update it), the /user page header (reads it), and
+    # the lifecycle watcher (epoch bumps update it + flush derived state).
+    # `binding` above stays the immutable startup record. `map_ops_lock`
+    # serializes the facade's Save/Load/Delete with the watcher's epoch
+    # response — both suspend at awaits mid-critical-section.
+    map_ops_lock = asyncio.Lock()
+    live_binding: dict = {
+        "map_id": binding.map_id,
+        "mode": binding.mode if restore_on_start else "",
+        "generation": binding.generation if restore_on_start else None,
+        "source": binding.source if restore_on_start else "default",
+    }
     if broadcast is not None and not str(broadcast.get("map_id") or ""):
         # mapping is provably UP but running ephemeral (no map_id) — its
         # frame resets every boot, so the named partition scene just bound
@@ -1087,6 +1175,12 @@ async def _run() -> None:
         )
         try:
             obj_store = ObjectStore(db_path, map_id=scene_state_map_id)
+            purged = obj_store.purge_live_partitions()
+            if purged:
+                log.info(
+                    "[scene-persist] purged %d leftover live-session row(s) "
+                    "from earlier boots", purged,
+                )
             restored = obj_store.load_all() if restore_on_start else []
             if restored:
                 async with registry.lock():
@@ -1109,16 +1203,32 @@ async def _run() -> None:
 
     # User annotations (rooms / POIs) — user-authored semantics on the same
     # map_id partition rule as the object store; validity is additionally
-    # tracked against mapping's generation epoch (annotations only — the
-    # object store has no epoch concept). A failure here disables the
-    # annotation API for the session (web answers 503) but never blocks
-    # scene itself.
+    # tracked against mapping's generation epoch (recorded in the file —
+    # objects get their epoch guarantee from snapshot partitions + the
+    # watcher's flush instead). A failure here disables the annotation API
+    # for the session (web answers 503) but never blocks scene itself.
+    anno_dir = os.environ.get(
+        "SCENE_ANNOTATIONS_DIR", "/data/robonix/scene_annotations"
+    )
+    if not restore_on_start:
+        # Fresh live session: drop unsaved annotations left by previous
+        # live sessions (constant `.live` partition) and the per-boot
+        # files earlier builds leaked (`.live-<pid>-<ts>.json`). Saved
+        # rooms were carried into their map's own file at Save time.
+        # Best-effort in its OWN guard: a cleanup failure must not take
+        # the whole annotation API down with a misattributed init error.
+        try:
+            for leftover in Path(anno_dir).expanduser().glob(".live*.json"):
+                leftover.unlink(missing_ok=True)
+        except Exception as e:  # noqa: BLE001
+            log.warning(
+                "[scene-anno] live-session file cleanup failed (leftovers "
+                "may resurface next boot): %s", e,
+            )
     anno_store: Optional[AnnotationStore] = None
     try:
         anno_store = AnnotationStore(
-            os.environ.get(
-                "SCENE_ANNOTATIONS_DIR", "/data/robonix/scene_annotations"
-            ),
+            anno_dir,
             map_id=scene_state_map_id,
             generation=binding.generation if restore_on_start else None,
         )
@@ -1133,6 +1243,23 @@ async def _run() -> None:
         log.error(
             "[scene-anno] annotation store init failed — annotation API "
             "disabled for this session: %s", e,
+        )
+
+    # Epoch sidecar (map_id → object snapshot partition; see map_meta.py).
+    # Defaults next to the annotation dir so docker (/data/robonix) and
+    # native ($PKG/rbnx-build/data/robonix) deployments both get a writable
+    # location without new script plumbing. Without it, Save/Load degrade
+    # to annotations-only (loudly, in the web response).
+    map_meta: Optional[MapMetaStore] = None
+    try:
+        meta_dir = os.environ.get("SCENE_MAP_META_DIR") or os.path.join(
+            os.path.dirname(anno_dir.rstrip("/")) or ".", "scene_maps"
+        )
+        map_meta = MapMetaStore(meta_dir)
+    except Exception as e:  # noqa: BLE001
+        log.error(
+            "[scene-mapmeta] sidecar store init failed — Save/Load will not "
+            "snapshot/restore objects this session: %s", e,
         )
     # mcp_tools v0 only needs the registry + the ROS hub (the latter is
     # supplied later in _start_ros_ingest). The geometric relation loop +
@@ -1195,10 +1322,13 @@ async def _run() -> None:
         obj_store.set_embedder(getattr(perception, "embed_text", None))
     bg_tasks = [
         asyncio.create_task(_stale_tick(registry), name="scene-stale-tick"),
-        # P2 guard: warn when mapping's live map identity drifts from the
-        # binding scene started with (P3 will act on it instead).
+        # Lifecycle linkage: on a runtime epoch bump (mapping reset / re-init
+        # under scene's feet) flush derived objects and stale-mark rooms —
+        # tracking the live binding the web facade also updates.
         asyncio.create_task(
-            _lifecycle_watch(hub, binding, anno_store),
+            _lifecycle_watch(hub, binding, anno_store,
+                             registry=registry, live_binding=live_binding,
+                             ops_lock=map_ops_lock),
             name="scene-lifecycle-watch",
         ),
         # Background reconciler: keeps scene's hub adding subscriptions
@@ -1233,13 +1363,14 @@ async def _run() -> None:
     sg_cache_dir = os.environ.get(
         "SCENE_GRAPH_CACHE_DIR", "/data/robonix/scene_graph/cache"
     )
-    # Partition the scene-graph caches by the same runtime state partition as
-    # the object store. Startup defaults to a live session; explicit Load rebinds
-    # persistent room/object state through the web map facade.
+    # Partition the scene-graph caches by the session state label (`.live`
+    # by default, the bound map id in legacy mode). The web facade's Load
+    # rebinds the annotation store and restores objects into the registry;
+    # this cache is session state and stays on its label.
     sg_store = SceneGraphStore(cache_dir=sg_cache_dir, map_id=scene_state_map_id)
     log.info(
         "[scene-graph] cache base=%s partitioned by map_id=%s",
-        sg_cache_dir, map_id,
+        sg_cache_dir, scene_state_map_id,
     )
     mcp_tools.attach_scene_graph_store(sg_store)
     geo_loop = GeometricRelationLoop(registry, sg_store)
@@ -1263,7 +1394,10 @@ async def _run() -> None:
             relation_inferer=sg_inferer,
             store=sg_store,
             config=sg_cfg,
-            object_store=obj_store,
+            # Live sessions are not persisted (objects reach the DB only via
+            # an explicit Save snapshot); the builder's continuous writes are
+            # the LEGACY warm-restore mode's mechanism and follow its switch.
+            object_store=obj_store if restore_on_start else None,
             perception=perception,
         )
         sg_stop = asyncio.Event()
@@ -1299,12 +1433,9 @@ async def _run() -> None:
             sg_store=sg_store,
             anno_store=anno_store,
             object_store=obj_store,
-            map_binding={
-                "map_id": binding.map_id,
-                "mode": binding.mode if restore_on_start else "",
-                "generation": binding.generation if restore_on_start else None,
-                "source": binding.source if restore_on_start else "default",
-            },
+            map_meta=map_meta,
+            map_binding=live_binding,
+            ops_lock=map_ops_lock,
         )
         web_uv = uvicorn.Config(
             app=web_app,

--- a/system/scene/scene_service/state/object_registry.py
+++ b/system/scene/scene_service/state/object_registry.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 """SceneObject registry — the canonical store for everything `system/scene`
-tracks about the world. Pure-Python in-memory at runtime. By default the next
-boot starts fresh, but when scene's object-persistence layer is enabled the
-registry is warm-restored at boot via `restore_object()` (see
-`scene_service/persistence.py`), so stable objects survive a restart instead of
-being re-accumulated through the `min_observations` filter from scratch.
+tracks about the world. Pure-Python in-memory at runtime. A boot starts
+fresh; stable objects come back via `restore_object()` when the operator
+Loads a saved map in the map UI (or, in the legacy `SCENE_RESTORE_ON_START`
+mode, at boot) — see `scene_service/persistence.py` — instead of being
+re-accumulated through the `min_observations` filter from scratch.
 """
 from __future__ import annotations
 
@@ -30,7 +30,8 @@ OBJECT_ATTRIBUTE_KEYS = (
     # Internal tracking keys (not semantic object properties):
     "cg_uuid",       # str  — the concept-graphs MapObjectList uuid currently
                      #        bound to this record (per-process, ephemeral)
-    "restored",      # bool — warm-restored at boot and not yet re-observed;
+    "restored",      # bool — restored from persistence (map Load / legacy
+                     #        boot restore) and not yet re-observed;
                      #        perception re-binds it by class+pose, then clears
 )
 
@@ -163,6 +164,20 @@ class ObjectRegistry:
     def _alloc_surface_id(self) -> str:
         self._surface_counter += 1
         return f"scene.surface.{self._surface_counter:03d}"
+
+    def clear_objects(self) -> int:
+        """Drop every object and surface. Caller MUST hold `lock()`.
+
+        Used by the lifecycle linkage when the map frame epoch changes
+        (mapping reset / re-init): every stored map-frame coordinate is no
+        longer anchored, and this state is derived — re-observation rebuilds
+        it in the new frame. Id counters are NOT reset, so ids stay unique
+        across the flush (restored/old ids never collide with new ones).
+        Returns the number of objects dropped."""
+        n = len(self._objects)
+        self._objects.clear()
+        self._surfaces.clear()
+        return n
 
     # ── object CRUD (caller MUST hold the lock) ────────────────────────────
     def insert_object(

--- a/system/scene/scene_service/web.py
+++ b/system/scene/scene_service/web.py
@@ -22,6 +22,7 @@ import io
 import json
 import logging
 import os
+import re
 import time
 from pathlib import Path
 from typing import Any, Optional
@@ -34,6 +35,8 @@ from starlette.staticfiles import StaticFiles
 from robonix_api import ATLAS
 
 from .annotations import validate_annotation_fields
+from .map_binding import sanitize_map_id as _sanitize_map_id
+from .map_meta import make_meta
 from .state import ObjectRegistry
 
 log = logging.getLogger(__name__)
@@ -569,8 +572,9 @@ def _maps_payload() -> dict:
 def make_app(*, registry: ObjectRegistry,
              hub: Any = None, detector: Any = None,
              sg_store: Any = None, anno_store: Any = None,
-             object_store: Any = None,
-             map_binding: Optional[dict] = None) -> Starlette:
+             object_store: Any = None, map_meta: Any = None,
+             map_binding: Optional[dict] = None,
+             ops_lock: Optional[asyncio.Lock] = None) -> Starlette:
     """Build the Starlette ASGI app the entrypoint mounts on its own
     uvicorn server.
 
@@ -594,10 +598,18 @@ def make_app(*, registry: ObjectRegistry,
     just shows an empty world.
     `anno_store` is the AnnotationStore backing the annotation CRUD; when
     None (store init failed / disabled) those routes answer 503.
-    `object_store` is the per-map scene object warm-restore store; Save/Load
-    rebinds it so perceived objects follow the same map id as rooms.
+    `object_store` is the scene-object snapshot store. Save writes the live
+    registry into a fresh partition token; Load restores the token the
+    sidecar (`map_meta`) points at. Neither touches the store's own binding.
+    `map_meta` is the MapMetaStore sidecar pairing each saved map with its
+    object partition; when None, Save/Load degrade to annotations-only.
     `map_binding` is a mutable {map_id, mode, generation, source} dict shown
-    by the /user page header and updated by Save/Load actions.
+    by the /user page header, updated by Save/Load actions and by the
+    lifecycle watcher (service.py) on a runtime epoch bump.
+    `ops_lock` serializes Save/Load/Delete with each other AND with the
+    watcher's epoch response (service.py shares the same lock): the handlers
+    suspend at RPC awaits mid-critical-section, and an interleaved flush or
+    second Save would mix sessions/epochs in one snapshot.
 
     Annotation API contract (STABLE once shipped — any frontend builds on
     it; see system/scene/README.md):
@@ -619,34 +631,94 @@ def make_app(*, registry: ObjectRegistry,
     """
     if map_binding is None:
         map_binding = {}
+    if ops_lock is None:
+        ops_lock = asyncio.Lock()
 
-    async def _persist_scene_objects(map_id: str) -> int:
+    async def _persist_scene_objects(partition: str) -> tuple[int, int]:
+        """Snapshot the registry into `partition` — EVERY object, including
+        `missing` ones (known but not currently observed): after a Load the
+        whole restored set is `missing` until re-observed, and filtering it
+        out would commit an empty snapshot over the previous one. Anything
+        in the registry is anchored to the current frame (the watcher and
+        Load flush on epoch changes), so all of it belongs in the snapshot.
+        The ONE exclusion is the self-object (`is_robot`, same predicate as
+        the builder's persist gate): the pose tracker re-creates it from the
+        live pose stream every session, so a restored copy would just sit as
+        a second, frozen robot marker at wherever the robot stood at Save.
+        Returns (written, expected); written < expected means the milvus
+        upsert failed and the snapshot is incomplete — the caller must NOT
+        commit the sidecar to it. Never rebinds the shared store."""
         if object_store is None:
-            return 0
-        if hasattr(object_store, "rebind"):
-            object_store.rebind(map_id)
+            return 0, 0
         objs, _surfs = await registry.snapshot()
-        pairs = [(o, None) for o in objs.values() if not getattr(o, "missing", False)]
+        pairs = [
+            (o, None) for o in objs.values()
+            if not o.attributes.get("is_robot", False)
+        ]
         if not pairs:
-            return 0
-        return int(await asyncio.to_thread(object_store.persist, pairs))
+            return 0, 0
+        written = int(await asyncio.to_thread(
+            object_store.persist, pairs, partition=partition
+        ))
+        return written, len(pairs)
 
-    async def _restore_scene_objects(map_id: str) -> int:
+    async def _restore_scene_objects(partition: str) -> int:
+        """Restore one snapshot partition into the live registry. Raises on
+        a DB read error (strict) — the facade must distinguish "snapshot is
+        empty" from "could not read the snapshot", or a transient error
+        followed by a Save would silently commit an empty snapshot.
+        Never rebinds the shared store."""
         if object_store is None:
             return 0
-        if hasattr(object_store, "rebind"):
-            object_store.rebind(map_id)
-        restored = await asyncio.to_thread(object_store.load_all)
+        restored = await asyncio.to_thread(
+            object_store.load_all, partition=partition, strict=True
+        )
         async with registry.lock():
             for o in restored:
                 registry.restore_object(o)
         return len(restored)
 
-    def _set_map_binding(map_id: str, mode: str, source: str) -> None:
+    def _latched_lifecycle(expected_map_id: str) -> tuple[Optional[int], str]:
+        """(generation, mode) from mapping's latched lifecycle broadcast, or
+        (None, "") when mapping doesn't broadcast (upstream main), no sample
+        arrived yet, or the sample names a DIFFERENT map — a latch lagging
+        behind a Save/Load must not stamp the wrong map's epoch into the
+        sidecar / live binding (the watcher would read the real broadcast as
+        a bump and flush). Enrichment only — the epoch machinery must work
+        without it."""
+        if hub is None or not hub.has("map_lifecycle"):
+            return None, ""
+        try:
+            msg, _stamp, count = hub.latest("map_lifecycle")
+            if msg is None or count == 0:
+                return None, ""
+            if str(msg.map_id) != _sanitize_map_id(expected_map_id):
+                return None, ""
+            return int(msg.generation), str(msg.mode)
+        except Exception:  # noqa: BLE001
+            # Malformed/foreign sample — enrichment only, never a failure.
+            return None, ""
+
+    _RESERVED_MAP_ID = re.compile(r"^\.|__s\d+$")
+
+    def _reserved_map_id_error(map_id: str) -> Optional[JSONResponse]:
+        """400 for map ids colliding with scene-internal namespaces: leading
+        `.` (live-session state, purged at boot) and the `__s<N>` snapshot
+        suffix (a map named `foo__s1` would alias — and Save would purge —
+        map `foo`'s committed snapshot partition)."""
+        if _RESERVED_MAP_ID.search(_sanitize_map_id(map_id)):
+            return _anno_error(400, (
+                f"map_id {map_id!r} uses a reserved scene-internal form "
+                "(leading '.' or '__s<N>' suffix) — pick another name"
+            ))
+        return None
+
+    def _set_map_binding(map_id: str, mode: str, source: str,
+                         generation: Optional[int] = None) -> None:
         map_binding.update({
             "map_id": map_id,
             "mode": mode,
-            "generation": None,
+            "generation": generation,
             "source": source,
         })
 
@@ -764,14 +836,46 @@ def make_app(*, registry: ObjectRegistry,
         map_id = str(body.get("map_id") or "").strip()
         if not map_id:
             return _anno_error(400, "map_id is required")
+        reserved = _reserved_map_id_error(map_id)
+        if reserved is not None:
+            return reserved
+        async with ops_lock:
+            return await _maps_save_locked(map_id, body)
+
+    async def _maps_save_locked(map_id: str, body: dict) -> JSONResponse:
+        """Save body — runs under `ops_lock` (see maps_save)."""
         note = str(body.get("note") or "")
         before_payload = await asyncio.to_thread(_maps_payload)
         spatial_exists, existing_map = _map_exists_in_payload(before_payload, map_id)
         current_bound_id = str(map_binding.get("map_id") or "")
         current_mode = str(map_binding.get("mode") or "")
+        if (anno_store is not None
+                and _sanitize_map_id(map_id) != anno_store.map_id
+                and anno_store.has_saved(map_id)):
+            # The store never loaded this map's annotation file (it is bound
+            # to another partition — typically the live session). Carrying
+            # the live partition over the file would silently destroy
+            # previously saved rooms; a startup binding that happens to name
+            # this map (lifecycle broadcast / env) is NOT a load.
+            return _anno_error(409, (
+                f"map {map_id} already has saved room annotations; load it "
+                "first (or delete the map) instead of overwriting them with "
+                "this live session"
+            ))
         if spatial_exists:
             if current_bound_id and current_bound_id != map_id:
                 return _anno_error(409, f"spatial map {map_id} already exists; load it before updating scene annotations/objects")
+            if current_mode == "mapping":
+                # The artifact was snapshotted at the original Save while the
+                # live frame kept evolving (loop closures) — writing today's
+                # coordinates against that frozen artifact would mis-anchor
+                # every object/room on the next Load.
+                return _anno_error(409, (
+                    f"map {map_id} was saved from this still-running mapping "
+                    "session; its spatial artifact is immutable and the live "
+                    "frame has kept drifting since. Load it in localization "
+                    "mode to edit rooms/objects, or delete it and save anew."
+                ))
             out = {
                 "ok": True,
                 "map_id": map_id,
@@ -789,16 +893,56 @@ def make_app(*, registry: ObjectRegistry,
         object_count = 0
         object_persist_error = None
         if out.get("ok"):
+            gen, broadcast_mode = _latched_lifecycle(map_id)
             if anno_store is not None:
-                anno_store.rebind(map_id, generation=None, carry_current=True)
-            try:
-                object_count = await _persist_scene_objects(map_id)
-                out["objects"] = object_count
-            except Exception as e:  # noqa: BLE001
-                object_persist_error = str(e)
+                anno_store.rebind(map_id, generation=gen, carry_current=True)
+            # Object snapshot: write into a FRESH partition token, commit the
+            # sidecar only once the write is verifiably complete, and only
+            # then purge the previous snapshot (plus any legacy rows under
+            # the bare map id — they belong to frames that no longer exist).
+            # A failure at any point leaves the sidecar at the previous,
+            # still-consistent snapshot.
+            if map_meta is not None and object_store is not None:
+                prev_meta = map_meta.read(map_id)
+                partition, seq = map_meta.next_partition(map_id)
+                try:
+                    # The token repeats after a FAILED save attempt (the
+                    # sidecar only advances on commit) — clear its debris so
+                    # the snapshot holds exactly this attempt's rows.
+                    await asyncio.to_thread(object_store.delete_map, partition)
+                    written, expected = await _persist_scene_objects(partition)
+                    if written < expected:
+                        raise RuntimeError(
+                            f"snapshot incomplete: {written}/{expected} rows written"
+                        )
+                    object_count = written
+                    map_meta.write(make_meta(
+                        map_id, partition, seq,
+                        generation=gen, mode=broadcast_mode,
+                    ))
+                    out["objects"] = object_count
+                    out["snapshot_partition"] = partition
+                    stale_parts = {_sanitize_map_id(map_id)}
+                    if prev_meta is not None:
+                        stale_parts.add(prev_meta.object_partition)
+                    stale_parts.discard(partition)
+                    for part in stale_parts:
+                        try:
+                            await asyncio.to_thread(object_store.delete_map, part)
+                        except Exception as e:  # noqa: BLE001
+                            # Orphan rows cost disk, not correctness — the
+                            # sidecar no longer points at them.
+                            out["stale_partition_cleanup_error"] = str(e)
+                except Exception as e:  # noqa: BLE001
+                    object_persist_error = str(e)
+                    out["object_persist_error"] = object_persist_error
+            elif object_store is not None:
+                object_persist_error = (
+                    "map_meta sidecar unavailable — objects not snapshotted"
+                )
                 out["object_persist_error"] = object_persist_error
             mode_after_save = current_mode if spatial_exists and current_bound_id == map_id and current_mode else "mapping"
-            _set_map_binding(map_id, mode_after_save, "ui_save")
+            _set_map_binding(map_id, mode_after_save, "ui_save", generation=gen)
 
         annotations = anno_store.list_json() if anno_store is not None else []
         out.setdefault("annotations", len(annotations))
@@ -842,6 +986,11 @@ def make_app(*, registry: ObjectRegistry,
         map_id = str(body.get("map_id") or "").strip()
         if not map_id:
             return _anno_error(400, "map_id is required")
+        async with ops_lock:
+            return await _maps_load_locked(map_id, body)
+
+    async def _maps_load_locked(map_id: str, body: dict) -> JSONResponse:
+        """Load body — runs under `ops_lock` (see maps_save)."""
         mode = str(body.get("mode") or "localization")
         load_timeout_s = float(os.environ.get("SCENE_MAP_LOAD_TIMEOUT_S", "240"))
         before_stamp = 0.0
@@ -893,13 +1042,69 @@ def make_app(*, registry: ObjectRegistry,
                     ),
                 }
                 return JSONResponse(out, status_code=502)
-            if anno_store is not None:
-                anno_store.rebind(map_id, generation=None, carry_current=False)
+            # The loaded artifact defines a NEW frame: everything observed
+            # before this load is anchored to the dead pre-load frame — and
+            # the watcher will not catch it (a facade load is deliberately
+            # not drift). Flush first, so the registry ends up holding the
+            # restored snapshot plus post-load observations only.
             try:
-                out["objects_restored"] = await _restore_scene_objects(map_id)
+                async with registry.lock():
+                    flushed = registry.clear_objects()
+                if flushed:
+                    out["objects_flushed"] = flushed
             except Exception as e:  # noqa: BLE001
-                out["object_restore_error"] = str(e)
-            _set_map_binding(map_id, "localization", "ui_load")
+                out["object_flush_error"] = str(e)
+            gen, _broadcast_mode = _latched_lifecycle(map_id)
+            meta = map_meta.read(map_id) if map_meta is not None else None
+            if anno_store is not None:
+                # Localization load keeps the saved map's frame epoch, so the
+                # live broadcast (when present) carries the generation the
+                # rooms were saved under; the sidecar's recorded value is the
+                # fallback. Either lets rebind() re-judge staleness.
+                anno_gen = gen if gen is not None else (
+                    meta.mapping_generation if meta is not None else None
+                )
+                anno_store.rebind(map_id, generation=anno_gen, carry_current=False)
+            if meta is None:
+                # No sidecar → no snapshot known to match this artifact's
+                # frame (pre-epoch save or foreign DB). Restoring the bare
+                # partition would bring back rows from ANY earlier build of
+                # this map — the off-map mis-anchored objects bug.
+                out["objects_restored"] = 0
+                out["semantic_snapshot"] = (
+                    "absent — objects not restored (no epoch sidecar for "
+                    "this map; re-save it to create one)"
+                )
+                # Surface it where the operator is looking (the map dialog
+                # renders `detail`), not only in the log.
+                out["detail"] = (
+                    f"{out.get('detail') or 'loaded'}; no semantic snapshot "
+                    "for this map — objects not restored (rooms still load; "
+                    "re-save the map to snapshot objects)"
+                )
+                log.warning(
+                    "[scene-maps] load %s: no semantic sidecar — restoring "
+                    "no objects (rooms still load; re-save the map to "
+                    "snapshot current objects)", map_id,
+                )
+            else:
+                try:
+                    out["objects_restored"] = await _restore_scene_objects(
+                        meta.object_partition
+                    )
+                    out["snapshot_partition"] = meta.object_partition
+                except Exception as e:  # noqa: BLE001
+                    # Distinguish "could not read the snapshot" from a
+                    # genuinely empty one, in the operator-visible detail —
+                    # saving on top of an unnoticed failed restore would
+                    # commit an empty snapshot.
+                    out["object_restore_error"] = str(e)
+                    out["detail"] = (
+                        f"{out.get('detail') or 'loaded'}; RESTORE FAILED: "
+                        f"{e} — saved objects were NOT loaded; retry the "
+                        "load before saving this map"
+                    )
+            _set_map_binding(map_id, "localization", "ui_load", generation=gen)
         return JSONResponse(out, status_code=200 if out.get("ok") else 502)
 
     async def maps_delete(request) -> JSONResponse:
@@ -909,6 +1114,11 @@ def make_app(*, registry: ObjectRegistry,
         map_id = str(body.get("map_id") or "").strip()
         if not map_id:
             return _anno_error(400, "map_id is required")
+        async with ops_lock:
+            return await _maps_delete_locked(map_id)
+
+    async def _maps_delete_locked(map_id: str) -> JSONResponse:
+        """Delete body — runs under `ops_lock` (see maps_save)."""
         out = await asyncio.to_thread(_map_rpc, "delete_map", {"map_id": map_id})
         if out.get("ok"):
             annotations_deleted = False
@@ -919,11 +1129,36 @@ def make_app(*, registry: ObjectRegistry,
                     annotations_deleted = bool(anno_store.delete_map(map_id))
                 except Exception as e:  # noqa: BLE001
                     cleanup_errors.append(f"annotations: {e}")
+            meta = map_meta.read(map_id) if map_meta is not None else None
+            snapshot_rows_orphaned = False
             if object_store is not None:
-                try:
-                    objects_deleted = int(await asyncio.to_thread(object_store.delete_map, map_id))
-                except Exception as e:  # noqa: BLE001
-                    cleanup_errors.append(f"objects: {e}")
+                # Both the sidecar-pointed snapshot partition and any legacy
+                # rows under the bare map id belong to this map — remove all.
+                parts = {_sanitize_map_id(map_id)}
+                if meta is not None:
+                    parts.add(meta.object_partition)
+                for part in parts:
+                    try:
+                        objects_deleted += int(
+                            await asyncio.to_thread(object_store.delete_map, part)
+                        )
+                    except Exception as e:  # noqa: BLE001
+                        cleanup_errors.append(f"objects[{part}]: {e}")
+                        if meta is not None and part == meta.object_partition:
+                            snapshot_rows_orphaned = True
+            if map_meta is not None:
+                if snapshot_rows_orphaned:
+                    # The sidecar is the only pointer to the rows that just
+                    # failed to delete — keep it so a retried Delete still
+                    # finds them (boot purge only matches `.live*`).
+                    cleanup_errors.append(
+                        "sidecar kept: snapshot rows not deleted — retry delete"
+                    )
+                else:
+                    try:
+                        map_meta.delete(map_id)
+                    except Exception as e:  # noqa: BLE001
+                        cleanup_errors.append(f"sidecar: {e}")
             out["scene_cleanup"] = {
                 "annotations_deleted": annotations_deleted,
                 "objects_deleted": objects_deleted,

--- a/system/scene/tests/test_annotations.py
+++ b/system/scene/tests/test_annotations.py
@@ -235,6 +235,22 @@ def test_corrupt_file_set_aside_not_destroyed():
     print("  [PASS] test_corrupt_file_set_aside_not_destroyed")
 
 
+def test_has_saved_reflects_persisted_partitions_only():
+    """has_saved sees other partitions' files without binding to them —
+    the web Save guard uses it to refuse overwriting never-loaded rooms."""
+    with tempfile.TemporaryDirectory() as base:
+        saved = AnnotationStore(base, map_id="labx")
+        assert not saved.has_saved("labx")          # nothing written yet
+        saved.create(kind="room", name="kitchen", points=ROOM_PTS)
+
+        live = AnnotationStore(base, map_id=".live")
+        assert live.has_saved("labx")               # other partition, saved
+        assert not live.has_saved(".live")          # own partition, unwritten
+        assert not live.has_saved("nowhere")
+        assert live.map_id == ".live"               # probing never rebinds
+    print("  [PASS] test_has_saved_reflects_persisted_partitions_only")
+
+
 def test_from_json_drops_unknown_keys():
     from scene_service.annotations import Annotation
     a = Annotation.from_json({
@@ -501,6 +517,7 @@ if __name__ == "__main__":
     test_reconcile_generation_learns_and_flags()
     test_redraw_clears_stale_and_mark_all_stale_counts()
     test_corrupt_file_set_aside_not_destroyed()
+    test_has_saved_reflects_persisted_partitions_only()
     test_from_json_drops_unknown_keys()
     test_rest_crud_roundtrip()
     test_rest_validation_and_errors()

--- a/system/scene/tests/test_lifecycle_flush.py
+++ b/system/scene/tests/test_lifecycle_flush.py
@@ -1,0 +1,249 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+"""State-machine tests for the lifecycle watcher's epoch response
+(service._lifecycle_watch): confirm → generation bump → cross-map drift.
+
+Drives the watcher with a fake hub and a tiny poll interval on a private
+event loop. Importing scene_service.service needs the full runtime import
+chain (robonix_api, uvicorn, ...) — skips loudly on a bare checkout.
+"""
+import asyncio
+import os
+import sys
+import tempfile
+import time
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from scene_service.annotations import AnnotationStore  # noqa: E402
+from scene_service.map_binding import MapBinding  # noqa: E402
+
+try:  # the state package needs scipy — absent on a bare mac checkout
+    from scene_service.state.object_registry import (
+        BBox3D,
+        Pose3D,
+        SceneObject,
+        ObjectRegistry,
+    )
+    _IMPORT_ERR = None
+except ImportError as e:  # pragma: no cover - environment-dependent
+    _IMPORT_ERR = e
+    BBox3D = Pose3D = SceneObject = ObjectRegistry = None
+
+ROOM_PTS = [[0.0, 0.0], [2.0, 0.0], [2.0, 1.5], [0.0, 1.5]]
+
+
+def _service_mod():
+    err = _IMPORT_ERR
+    if err is None:
+        try:
+            from scene_service import service as service_mod
+            return service_mod
+        except ImportError as e:
+            err = e
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        import pytest
+        pytest.skip(f"service import chain unavailable: {err}")
+    print(f"  [SKIP] lifecycle flush tests unavailable: {err}")
+    return None
+
+
+def _obj(oid: str) -> SceneObject:
+    return SceneObject(
+        object_id=oid, cls="cup",
+        pose=Pose3D(x=1.0, y=2.0, z=0.0, yaw=0.0, frame_id="map"),
+        bbox=BBox3D(size_x=0.1, size_y=0.1, size_z=0.1, yaw=0.0, frame_id="map"),
+        confidence=0.9, first_seen=1.0, last_seen=2.0,
+        observation_count=3, missing=False, attributes={},
+    )
+
+
+class FakeHub:
+    """Mutable latched lifecycle sample; .set() swaps what the watcher sees."""
+
+    def __init__(self):
+        self._sample = None
+        self._count = 0
+
+    def set(self, map_id, generation, mode="mapping"):
+        self._sample = SimpleNamespace(
+            map_id=map_id, generation=generation, mode=mode
+        )
+        self._count += 1
+
+    def has(self, key):
+        return key == "map_lifecycle" and self._sample is not None
+
+    def latest(self, _key):
+        return self._sample, time.time(), self._count
+
+
+async def _settle(ticks: float = 8.0, interval: float = 0.01):
+    """Give the watcher a few poll cycles."""
+    await asyncio.sleep(ticks * interval)
+
+
+def test_confirm_bump_and_cross_map_drift():
+    service_mod = _service_mod()
+    if service_mod is None:
+        return
+
+    async def scenario(tmp):
+        registry = ObjectRegistry()
+        async with registry.lock():
+            registry._objects.update({"o1": _obj("o1"), "o2": _obj("o2")})
+        anno = AnnotationStore(os.path.join(tmp, "anno"), map_id="m1")
+        anno.create(kind="room", name="kitchen", points=ROOM_PTS)
+        hub = FakeHub()
+        binding = MapBinding(map_id="m1", source="env")
+        live = {"map_id": "m1", "mode": "", "generation": None, "source": "env"}
+        task = asyncio.create_task(service_mod._lifecycle_watch(
+            hub, binding, anno,
+            registry=registry, live_binding=live, interval_s=0.01,
+        ))
+        try:
+            # 1) Confirm: matching broadcast → epoch learned, nothing flushed.
+            hub.set("m1", 1)
+            await _settle()
+            assert live["generation"] == 1, live
+            assert set(registry._objects) == {"o1", "o2"}
+            assert not anno.list()[0].stale
+
+            # 2) Generation bump (reset under scene): objects flushed,
+            #    room flagged stale (kept), epoch advanced — exactly once.
+            hub.set("m1", 2)
+            await _settle()
+            assert live["generation"] == 2, live
+            assert registry._objects == {}, registry._objects
+            room = anno.list()[0]
+            assert room.stale and "1" in room.stale_reason and "2" in room.stale_reason
+
+            # 3) New observations arrive in the new frame and STAY (the
+            #    response fired once; an unchanged broadcast never re-flushes).
+            async with registry.lock():
+                registry._objects["o3"] = _obj("o3")
+            await _settle()
+            assert set(registry._objects) == {"o3"}
+
+            # 4) Cross-map drift (mapping loaded another map outside the
+            #    facade): objects flushed, but scene does NOT adopt the id.
+            hub.set("m9", 1)
+            await _settle()
+            assert registry._objects == {}, registry._objects
+            assert live["map_id"] == "m1", live
+        finally:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+    with tempfile.TemporaryDirectory() as tmp:
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(scenario(tmp))
+        finally:
+            loop.close()
+    print("  [PASS] test_confirm_bump_and_cross_map_drift")
+
+
+def test_facade_load_is_not_drift():
+    """A Load through the web facade updates the SAME live-binding dict the
+    watcher polls — the watcher must treat it as the new expectation, not
+    as drift (no flush of the freshly restored objects)."""
+    service_mod = _service_mod()
+    if service_mod is None:
+        return
+
+    async def scenario(tmp):
+        registry = ObjectRegistry()
+        hub = FakeHub()
+        binding = MapBinding(map_id="default", source="default")
+        live = {"map_id": "default", "mode": "", "generation": None,
+                "source": "default"}
+        task = asyncio.create_task(service_mod._lifecycle_watch(
+            hub, binding, None,
+            registry=registry, live_binding=live, interval_s=0.01,
+        ))
+        try:
+            # Facade Load: binding dict updated first, then mapping's latched
+            # broadcast reflects the loaded map.
+            live.update({"map_id": "labx", "mode": "localization",
+                         "generation": 7, "source": "ui_load"})
+            async with registry.lock():
+                registry._objects["restored"] = _obj("restored")
+            hub.set("labx", 7, mode="localization")
+            await _settle()
+            assert set(registry._objects) == {"restored"}, registry._objects
+            assert live["generation"] == 7
+        finally:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+    with tempfile.TemporaryDirectory() as tmp:
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(scenario(tmp))
+        finally:
+            loop.close()
+    print("  [PASS] test_facade_load_is_not_drift")
+
+
+def test_watcher_survives_none_stores_and_malformed_samples():
+    """The watcher is the session's only runtime epoch guard: it must keep
+    running with anno_store/registry absent (their init can fail) and past
+    malformed broadcast samples (int() raising must not end the task)."""
+    service_mod = _service_mod()
+    if service_mod is None:
+        return
+
+    async def scenario():
+        hub = FakeHub()
+        binding = MapBinding(map_id="m1", source="env")
+        live = {"map_id": "m1", "mode": "", "generation": None, "source": "env"}
+        task = asyncio.create_task(service_mod._lifecycle_watch(
+            hub, binding, None,
+            registry=None, live_binding=live, interval_s=0.01,
+        ))
+        try:
+            hub.set("m1", 1)
+            await _settle()
+            assert live["generation"] == 1
+
+            # Malformed sample: generation isn't int()-able.
+            hub._sample = SimpleNamespace(map_id="m1", generation="junk",
+                                          mode="mapping")
+            hub._count += 1
+            await _settle()
+            assert not task.done()          # tick failed, watch continues
+
+            # Bump with no registry and no anno_store: reaction still
+            # advances the epoch instead of dying on the missing pieces.
+            hub.set("m1", 2)
+            await _settle()
+            assert not task.done()
+            assert live["generation"] == 2
+        finally:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(scenario())
+    finally:
+        loop.close()
+    print("  [PASS] test_watcher_survives_none_stores_and_malformed_samples")
+
+
+if __name__ == "__main__":
+    print("Running lifecycle flush tests...\n")
+    test_confirm_bump_and_cross_map_drift()
+    test_facade_load_is_not_drift()
+    test_watcher_survives_none_stores_and_malformed_samples()
+    print("\nAll tests passed!")

--- a/system/scene/tests/test_map_epoch.py
+++ b/system/scene/tests/test_map_epoch.py
@@ -1,0 +1,631 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+"""Epoch-safety tests for the web map facade (Save/Load/Delete).
+
+Drives scene_service.web's /api/maps routes through a hand-rolled ASGI call
+with mapping RPCs monkeypatched and a fake (in-memory) object store, so the
+commit-ordering rules are testable without milvus or ROS:
+
+- Save writes the object snapshot into a FRESH partition token, commits the
+  sidecar only after a complete write, then purges the previous snapshot.
+- Save refuses: mapping-mode semantic-only re-save (frame drift), and
+  overwriting a map's saved annotations from a session that never loaded
+  them (bound-is-not-loaded).
+- Load restores exactly the sidecar's partition; no sidecar → restores
+  NOTHING (the legacy mixed-epoch partition stays dead).
+- Delete removes the sidecar and both partitions.
+
+Skips loudly when the web import chain is unavailable (bare mac checkout).
+"""
+import asyncio
+import json
+import os
+import sys
+import tempfile
+import time
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from scene_service.annotations import AnnotationStore  # noqa: E402
+from scene_service.map_meta import MapMetaStore, make_meta  # noqa: E402
+
+try:  # the state package needs scipy — absent on a bare mac checkout
+    from scene_service.state.object_registry import (
+        BBox3D,
+        ObjectRegistry,
+        Pose3D,
+        SceneObject,
+    )
+    _IMPORT_ERR = None
+except ImportError as e:  # pragma: no cover - environment-dependent
+    _IMPORT_ERR = e
+    BBox3D = ObjectRegistry = Pose3D = SceneObject = None
+
+ROOM_PTS = [[0.0, 0.0], [2.0, 0.0], [2.0, 1.5], [0.0, 1.5]]
+
+
+
+def _unavailable() -> bool:
+    """Skip guard shared by every test — the fakes construct real
+    SceneObjects, so the state import must exist before any argument
+    expression runs."""
+    err = _IMPORT_ERR
+    if err is None:
+        try:
+            import scene_service.web  # noqa: F401
+            return False
+        except ImportError as e:
+            err = e
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        import pytest
+        pytest.skip(f"map facade deps unavailable: {err}")
+    print(f"  [SKIP] map facade tests unavailable: {err}")
+    return True
+
+def _obj(oid: str, cls: str = "cup", *, missing: bool = False,
+         attributes: "dict | None" = None) -> SceneObject:
+    return SceneObject(
+        object_id=oid, cls=cls,
+        pose=Pose3D(x=1.0, y=2.0, z=0.0, yaw=0.0, frame_id="map"),
+        bbox=BBox3D(size_x=0.1, size_y=0.1, size_z=0.1, yaw=0.0, frame_id="map"),
+        confidence=0.9, first_seen=1.0, last_seen=2.0,
+        observation_count=3, missing=missing, attributes=attributes or {},
+    )
+
+
+class FakeObjectStore:
+    """Partition-faithful in-memory stand-in for persistence.ObjectStore."""
+
+    def __init__(self):
+        self.rows: dict[str, dict[str, SceneObject]] = {}
+
+    def persist(self, pairs, *, partition=None):
+        part = self.rows.setdefault(partition, {})
+        for obj, _cap in pairs:
+            part[obj.object_id] = obj
+        return len(pairs)
+
+    def load_all(self, *, partition=None, limit=16384, strict=False):
+        return list(self.rows.get(partition, {}).values())
+
+    def delete_map(self, map_id):
+        return len(self.rows.pop(map_id, {}))
+
+
+class FakeHub:
+    """Serves a fresh occupancy grid (Load's readiness gate) and, when set,
+    a latched lifecycle sample."""
+
+    def __init__(self, lifecycle=None):
+        self._count = 0
+        self.lifecycle = lifecycle
+
+    def has(self, key):
+        if key == "occupancy_grid":
+            return True
+        return key == "map_lifecycle" and self.lifecycle is not None
+
+    def latest(self, key):
+        if key == "map_lifecycle":
+            return self.lifecycle, time.time(), 1
+        self._count += 1
+        grid = SimpleNamespace(info=SimpleNamespace(width=10, height=8))
+        return grid, time.time(), self._count
+
+
+def _registry_with(objs) -> ObjectRegistry:
+    reg = ObjectRegistry()
+    reg._objects.update({o.object_id: o for o in objs})
+    return reg
+
+
+_KEEP = object()  # sentinel: "build the real MapMetaStore"
+
+
+def _make_env(tmp, *, binding, objs=(), anno_map_id=".live",
+              lifecycle=None, map_meta=_KEEP):
+    """(web_mod, app, pieces) or (None, None, None) when deps can't import."""
+    err = _IMPORT_ERR
+    web_mod = None
+    if err is None:
+        try:
+            from scene_service import web as web_mod
+        except ImportError as e:
+            err = e
+    if err is not None:
+        if os.environ.get("PYTEST_CURRENT_TEST"):
+            import pytest
+            pytest.skip(f"map facade deps unavailable: {err}")
+        print(f"  [SKIP] map facade tests unavailable: {err}")
+        return None, None, None
+
+    registry = _registry_with(objs)
+    anno = AnnotationStore(os.path.join(tmp, "anno"), map_id=anno_map_id)
+    meta = MapMetaStore(os.path.join(tmp, "maps")) if map_meta is _KEEP else map_meta
+    store = FakeObjectStore()
+    hub = FakeHub(lifecycle=lifecycle)
+    bind = dict(binding)
+    app = web_mod.make_app(
+        registry=registry, hub=hub, anno_store=anno,
+        object_store=store, map_meta=meta, map_binding=bind,
+    )
+    return web_mod, app, SimpleNamespace(
+        registry=registry, anno=anno, meta=meta, store=store, hub=hub,
+        binding=bind,
+    )
+
+
+def _call(app, method, path, body=None):
+    """One JSON request straight into the ASGI app on a private loop."""
+    raw = json.dumps(body).encode() if body is not None else b""
+    scope = {
+        "type": "http", "http_version": "1.1", "method": method,
+        "scheme": "http", "path": path, "raw_path": path.encode(),
+        "root_path": "", "query_string": b"", "client": ("test", 0),
+        "server": ("test", 80),
+        "headers": [(b"content-type", b"application/json"),
+                    (b"content-length", str(len(raw)).encode())],
+    }
+    sent, done = [], {"body": False}
+
+    async def receive():
+        if done["body"]:
+            return {"type": "http.disconnect"}
+        done["body"] = True
+        return {"type": "http.request", "body": raw, "more_body": False}
+
+    async def send(message):
+        sent.append(message)
+
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(app(scope, receive, send))
+    finally:
+        loop.close()
+    status = next(m["status"] for m in sent if m["type"] == "http.response.start")
+    payload = b"".join(m.get("body", b"") for m in sent if m["type"] == "http.response.body")
+    return status, json.loads(payload or b"{}")
+
+
+class _patched:
+    """Temporarily replace module-level mapping RPC helpers on web."""
+
+    def __init__(self, web_mod, *, rpc=None, maps=None):
+        self._mod, self._rpc, self._maps = web_mod, rpc, maps
+
+    def __enter__(self):
+        self._old = (self._mod._map_rpc, self._mod._maps_payload)
+        if self._rpc is not None:
+            self._mod._map_rpc = self._rpc
+        if self._maps is not None:
+            self._mod._maps_payload = self._maps
+        return self
+
+    def __exit__(self, *exc):
+        self._mod._map_rpc, self._mod._maps_payload = self._old
+        return False
+
+
+def _spatial(*ids):
+    return lambda: {"ok": True, "detail": "", "maps": [
+        {"map_id": i, "has_spatial_artifact": True, "spatial_ok": True}
+        for i in ids
+    ]}
+
+
+def _rpc_ok(op, payload=None, timeout_s=None):
+    return {"ok": True, "map_id": (payload or {}).get("map_id", ""), "detail": "ok"}
+
+
+# ── Save ────────────────────────────────────────────────────────────────────
+
+def test_save_commits_fresh_partition_sidecar_then_purges():
+    if _unavailable():
+        return
+    with tempfile.TemporaryDirectory() as tmp:
+        web_mod, app, env = _make_env(
+            tmp, binding={"map_id": "default", "mode": "", "generation": None,
+                          "source": "default"},
+            objs=[_obj("o1"), _obj("o2"), _obj("gone", missing=True)],
+        )
+        if app is None:
+            return
+        # Legacy rows under the bare id must be gone after the save.
+        env.store.rows["labx"] = {"legacy": _obj("legacy")}
+        with _patched(web_mod, rpc=_rpc_ok, maps=_spatial()):
+            status, body = _call(app, "POST", "/api/maps/save", {"map_id": "labx"})
+        assert status == 200 and body["ok"], body
+        assert body["snapshot_partition"] == "labx__s1"
+        # `missing` objects (known, not currently seen — e.g. everything
+        # right after a Load) are part of the snapshot: filtering them out
+        # would let a Load→Save round-trip commit an empty snapshot.
+        assert body["objects"] == 3
+        assert set(env.store.rows.get("labx__s1", {})) == {"o1", "o2", "gone"}
+        assert "labx" not in env.store.rows              # legacy purged
+        meta = env.meta.read("labx")
+        assert meta and meta.object_partition == "labx__s1"
+    print("  [PASS] test_save_commits_fresh_partition_sidecar_then_purges")
+
+
+def test_resave_rotates_partition_and_purges_previous():
+    if _unavailable():
+        return
+    with tempfile.TemporaryDirectory() as tmp:
+        web_mod, app, env = _make_env(
+            tmp, binding={"map_id": "labx", "mode": "localization",
+                          "generation": 5, "source": "ui_load"},
+            objs=[_obj("o3")], anno_map_id="labx",
+        )
+        if app is None:
+            return
+        env.meta.write(make_meta("labx", "labx__s1", 1))
+        env.store.rows["labx__s1"] = {"old": _obj("old")}
+        with _patched(web_mod, rpc=_rpc_ok, maps=_spatial("labx")):
+            status, body = _call(app, "POST", "/api/maps/save", {"map_id": "labx"})
+        assert status == 200 and body["ok"], body
+        assert body["snapshot_partition"] == "labx__s2"
+        assert body.get("spatial_unchanged") is True
+        assert set(env.store.rows.get("labx__s2", {})) == {"o3"}
+        assert "labx__s1" not in env.store.rows          # previous snapshot purged
+        assert env.meta.read("labx").object_partition == "labx__s2"
+    print("  [PASS] test_resave_rotates_partition_and_purges_previous")
+
+
+def test_mapping_mode_resave_refused():
+    """The artifact froze at the original Save while the live frame kept
+    drifting — a semantic-only re-save would mis-anchor everything."""
+    if _unavailable():
+        return
+    with tempfile.TemporaryDirectory() as tmp:
+        web_mod, app, env = _make_env(
+            tmp, binding={"map_id": "labx", "mode": "mapping",
+                          "generation": 5, "source": "ui_save"},
+            objs=[_obj("o1")], anno_map_id="labx",
+        )
+        if app is None:
+            return
+        with _patched(web_mod, rpc=_rpc_ok, maps=_spatial("labx")):
+            status, body = _call(app, "POST", "/api/maps/save", {"map_id": "labx"})
+        assert status == 409, (status, body)
+        assert env.meta.read("labx") is None             # nothing committed
+    print("  [PASS] test_mapping_mode_resave_refused")
+
+
+def test_save_refuses_overwriting_unloaded_annotations():
+    """Bound-is-not-loaded: a live session must not carry its (possibly
+    empty) annotation partition over a map's previously saved rooms."""
+    if _unavailable():
+        return
+    with tempfile.TemporaryDirectory() as tmp:
+        # Pre-save rooms under labx from an earlier "session".
+        earlier = AnnotationStore(os.path.join(tmp, "anno"), map_id="labx")
+        earlier.create(kind="room", name="kitchen", points=ROOM_PTS)
+        web_mod, app, env = _make_env(
+            tmp, binding={"map_id": "labx", "mode": "", "generation": None,
+                          "source": "lifecycle"},
+            objs=[_obj("o1")], anno_map_id=".live",
+        )
+        if app is None:
+            return
+        with _patched(web_mod, rpc=_rpc_ok, maps=_spatial("labx")):
+            status, body = _call(app, "POST", "/api/maps/save", {"map_id": "labx"})
+        assert status == 409, (status, body)
+        # The saved rooms survived untouched.
+        kept = AnnotationStore(os.path.join(tmp, "anno"), map_id="labx")
+        assert [a.name for a in kept.list()] == ["kitchen"]
+    print("  [PASS] test_save_refuses_overwriting_unloaded_annotations")
+
+
+def test_save_excludes_self_robot_object():
+    """The self-object must stay out of snapshots: the pose tracker
+    re-creates it from the live pose stream every session, so restoring a
+    saved copy would leave a second, frozen robot marker after a Load."""
+    if _unavailable():
+        return
+    with tempfile.TemporaryDirectory() as tmp:
+        web_mod, app, env = _make_env(
+            tmp, binding={"map_id": "default", "mode": "", "generation": None,
+                          "source": "default"},
+            objs=[_obj("o1"),
+                  _obj("selfbot", cls="robot", attributes={"is_robot": True})],
+        )
+        if app is None:
+            return
+        with _patched(web_mod, rpc=_rpc_ok, maps=_spatial()):
+            status, body = _call(app, "POST", "/api/maps/save", {"map_id": "labx"})
+        assert status == 200 and body["ok"], body
+        assert body["objects"] == 1, body
+        assert set(env.store.rows.get("labx__s1", {})) == {"o1"}
+    print("  [PASS] test_save_excludes_self_robot_object")
+
+
+def test_failed_snapshot_keeps_previous_sidecar():
+    """An incomplete object write must leave the sidecar at the previous,
+    still-consistent snapshot (and not purge it)."""
+    if _unavailable():
+        return
+    with tempfile.TemporaryDirectory() as tmp:
+        web_mod, app, env = _make_env(
+            tmp, binding={"map_id": "labx", "mode": "localization",
+                          "generation": None, "source": "ui_load"},
+            objs=[_obj("o1")], anno_map_id="labx",
+        )
+        if app is None:
+            return
+        env.meta.write(make_meta("labx", "labx__s1", 1))
+        env.store.rows["labx__s1"] = {"old": _obj("old")}
+
+        def broken_persist(pairs, *, partition=None):
+            return 0  # milvus upsert failed (persist swallows + returns 0)
+
+        env.store.persist = broken_persist
+        with _patched(web_mod, rpc=_rpc_ok, maps=_spatial("labx")):
+            status, body = _call(app, "POST", "/api/maps/save", {"map_id": "labx"})
+        assert status == 200 and body["ok"], body        # annotations still saved
+        assert "object_persist_error" in body, body
+        assert env.meta.read("labx").object_partition == "labx__s1"
+        assert "old" in env.store.rows.get("labx__s1", {})
+    print("  [PASS] test_failed_snapshot_keeps_previous_sidecar")
+
+
+# ── Load ────────────────────────────────────────────────────────────────────
+
+def test_load_without_sidecar_restores_nothing():
+    """The mis-anchored-restore regression: a legacy partition (rows under
+    the bare map id, written across unknown epochs) must NOT be restored."""
+    if _unavailable():
+        return
+    with tempfile.TemporaryDirectory() as tmp:
+        web_mod, app, env = _make_env(
+            tmp, binding={"map_id": "default", "mode": "", "generation": None,
+                          "source": "default"},
+        )
+        if app is None:
+            return
+        env.store.rows["labx"] = {"ghost": _obj("ghost")}   # mixed-epoch legacy
+        with _patched(web_mod, rpc=_rpc_ok):
+            status, body = _call(app, "POST", "/api/maps/load", {"map_id": "labx"})
+        assert status == 200 and body["ok"], body
+        assert body["objects_restored"] == 0
+        assert "semantic_snapshot" in body
+        assert env.registry._objects == {}               # nothing snuck in
+    print("  [PASS] test_load_without_sidecar_restores_nothing")
+
+
+def test_load_restores_exactly_the_sidecar_partition():
+    if _unavailable():
+        return
+    with tempfile.TemporaryDirectory() as tmp:
+        web_mod, app, env = _make_env(
+            tmp, binding={"map_id": "default", "mode": "", "generation": None,
+                          "source": "default"},
+        )
+        if app is None:
+            return
+        env.meta.write(make_meta("labx", "labx__s2", 2))
+        env.store.rows["labx__s2"] = {"o1": _obj("o1"), "o2": _obj("o2")}
+        env.store.rows["labx"] = {"ghost": _obj("ghost")}   # must stay dead
+        with _patched(web_mod, rpc=_rpc_ok):
+            status, body = _call(app, "POST", "/api/maps/load", {"map_id": "labx"})
+        assert status == 200 and body["ok"], body
+        assert body["objects_restored"] == 2
+        assert body["snapshot_partition"] == "labx__s2"
+        assert set(env.registry._objects) == {"o1", "o2"}
+    print("  [PASS] test_load_restores_exactly_the_sidecar_partition")
+
+
+# ── Delete ──────────────────────────────────────────────────────────────────
+
+def test_delete_removes_sidecar_and_both_partitions():
+    if _unavailable():
+        return
+    with tempfile.TemporaryDirectory() as tmp:
+        web_mod, app, env = _make_env(
+            tmp, binding={"map_id": "default", "mode": "", "generation": None,
+                          "source": "default"},
+        )
+        if app is None:
+            return
+        env.meta.write(make_meta("labx", "labx__s3", 3))
+        env.store.rows["labx__s3"] = {"o1": _obj("o1")}
+        env.store.rows["labx"] = {"legacy": _obj("legacy")}
+        with _patched(web_mod, rpc=_rpc_ok):
+            status, body = _call(app, "POST", "/api/maps/delete", {"map_id": "labx"})
+        assert status == 200 and body["ok"], body
+        assert body["scene_cleanup"]["objects_deleted"] == 2
+        assert "labx__s3" not in env.store.rows and "labx" not in env.store.rows
+        assert env.meta.read("labx") is None
+    print("  [PASS] test_delete_removes_sidecar_and_both_partitions")
+
+
+def test_reserved_map_ids_rejected():
+    """`.live*` (purged at boot) and `*__s<N>` (aliases another map's
+    snapshot partition) are scene-internal namespaces — Save must 400."""
+    if _unavailable():
+        return
+    with tempfile.TemporaryDirectory() as tmp:
+        web_mod, app, env = _make_env(
+            tmp, binding={"map_id": "default", "mode": "", "generation": None,
+                          "source": "default"},
+        )
+        if app is None:
+            return
+        with _patched(web_mod, rpc=_rpc_ok, maps=_spatial()):
+            for bad in (".livelab", ".live", "foo__s1", "labx__s12"):
+                status, body = _call(app, "POST", "/api/maps/save",
+                                     {"map_id": bad})
+                assert status == 400, (bad, status, body)
+            status, _body = _call(app, "POST", "/api/maps/save",
+                                  {"map_id": "fine__sx"})  # not the reserved shape
+            assert status == 200
+    print("  [PASS] test_reserved_map_ids_rejected")
+
+
+def test_generation_threading_from_latched_broadcast():
+    """A latched sample naming the SAME map feeds its generation into the
+    sidecar and live binding; a stale sample naming another map — or a
+    malformed one — degrades to None instead of poisoning the epoch."""
+    if _unavailable():
+        return
+    with tempfile.TemporaryDirectory() as tmp:
+        sample = SimpleNamespace(map_id="labx", generation=4, mode="mapping")
+        web_mod, app, env = _make_env(
+            tmp, binding={"map_id": "default", "mode": "", "generation": None,
+                          "source": "default"},
+            objs=[_obj("o1")], lifecycle=sample,
+        )
+        if app is None:
+            return
+        with _patched(web_mod, rpc=_rpc_ok, maps=_spatial()):
+            status, body = _call(app, "POST", "/api/maps/save", {"map_id": "labx"})
+        assert status == 200 and body["ok"], body
+        assert env.meta.read("labx").mapping_generation == 4
+        assert env.binding["generation"] == 4
+
+        # Stale latch: names a different map than the one being saved.
+        env2_sample = SimpleNamespace(map_id="other", generation=9, mode="mapping")
+        web_mod, app, env = _make_env(
+            tmp + "/b", binding={"map_id": "default", "mode": "",
+                                 "generation": None, "source": "default"},
+            objs=[_obj("o1")], lifecycle=env2_sample,
+        )
+        with _patched(web_mod, rpc=_rpc_ok, maps=_spatial()):
+            status, body = _call(app, "POST", "/api/maps/save", {"map_id": "labx"})
+        assert status == 200 and body["ok"], body
+        assert env.meta.read("labx").mapping_generation is None
+        assert env.binding["generation"] is None
+
+        # Malformed sample: generation isn't an int.
+        junk = SimpleNamespace(map_id="labx", generation="junk", mode="mapping")
+        web_mod, app, env = _make_env(
+            tmp + "/c", binding={"map_id": "default", "mode": "",
+                                 "generation": None, "source": "default"},
+            objs=[_obj("o1")], lifecycle=junk,
+        )
+        with _patched(web_mod, rpc=_rpc_ok, maps=_spatial()):
+            status, body = _call(app, "POST", "/api/maps/save", {"map_id": "labx"})
+        assert status == 200 and body["ok"], body
+        assert env.meta.read("labx").mapping_generation is None
+    print("  [PASS] test_generation_threading_from_latched_broadcast")
+
+
+def test_save_without_sidecar_store_degrades_loudly():
+    """map_meta init failure (None): Save still succeeds for annotations but
+    reports the objects were NOT snapshotted, and writes no orphan rows."""
+    if _unavailable():
+        return
+    with tempfile.TemporaryDirectory() as tmp:
+        web_mod, app, env = _make_env(
+            tmp, binding={"map_id": "default", "mode": "", "generation": None,
+                          "source": "default"},
+            objs=[_obj("o1")], map_meta=None,
+        )
+        if app is None:
+            return
+        with _patched(web_mod, rpc=_rpc_ok, maps=_spatial()):
+            status, body = _call(app, "POST", "/api/maps/save", {"map_id": "labx"})
+        assert status == 200 and body["ok"], body
+        assert "object_persist_error" in body, body
+        assert env.store.rows == {}                      # no orphan write
+    print("  [PASS] test_save_without_sidecar_store_degrades_loudly")
+
+
+def test_load_flushes_preload_live_objects():
+    """Objects observed before a Load are anchored to the dead pre-load
+    frame — the registry must hold only the restored snapshot afterwards."""
+    if _unavailable():
+        return
+    with tempfile.TemporaryDirectory() as tmp:
+        web_mod, app, env = _make_env(
+            tmp, binding={"map_id": "default", "mode": "", "generation": None,
+                          "source": "default"},
+            objs=[_obj("preload1"), _obj("preload2")],
+        )
+        if app is None:
+            return
+        env.meta.write(make_meta("labx", "labx__s1", 1))
+        env.store.rows["labx__s1"] = {"saved": _obj("saved")}
+        with _patched(web_mod, rpc=_rpc_ok):
+            status, body = _call(app, "POST", "/api/maps/load", {"map_id": "labx"})
+        assert status == 200 and body["ok"], body
+        assert body["objects_flushed"] == 2
+        assert body["objects_restored"] == 1
+        assert set(env.registry._objects) == {"saved"}
+    print("  [PASS] test_load_flushes_preload_live_objects")
+
+
+def test_load_restore_failure_is_visible():
+    """A DB read error during restore must be distinguishable from an empty
+    snapshot — in the response error key AND the operator-visible detail."""
+    if _unavailable():
+        return
+    with tempfile.TemporaryDirectory() as tmp:
+        web_mod, app, env = _make_env(
+            tmp, binding={"map_id": "default", "mode": "", "generation": None,
+                          "source": "default"},
+        )
+        if app is None:
+            return
+        env.meta.write(make_meta("labx", "labx__s1", 1))
+
+        def broken_load_all(*, partition=None, limit=16384, strict=False):
+            raise RuntimeError("milvus went away")
+
+        env.store.load_all = broken_load_all
+        with _patched(web_mod, rpc=_rpc_ok):
+            status, body = _call(app, "POST", "/api/maps/load", {"map_id": "labx"})
+        assert status == 200 and body["ok"], body
+        assert "milvus went away" in body.get("object_restore_error", ""), body
+        assert "RESTORE FAILED" in body.get("detail", ""), body
+    print("  [PASS] test_load_restore_failure_is_visible")
+
+
+def test_delete_keeps_sidecar_when_snapshot_delete_fails():
+    """The sidecar is the only pointer to the snapshot rows; deleting it
+    while the rows survived would orphan them beyond any retry."""
+    if _unavailable():
+        return
+    with tempfile.TemporaryDirectory() as tmp:
+        web_mod, app, env = _make_env(
+            tmp, binding={"map_id": "default", "mode": "", "generation": None,
+                          "source": "default"},
+        )
+        if app is None:
+            return
+        env.meta.write(make_meta("labx", "labx__s1", 1))
+        env.store.rows["labx__s1"] = {"o1": _obj("o1")}
+        real_delete = env.store.delete_map
+
+        def failing_delete(map_id):
+            if map_id == "labx__s1":
+                raise RuntimeError("db locked")
+            return real_delete(map_id)
+
+        env.store.delete_map = failing_delete
+        with _patched(web_mod, rpc=_rpc_ok):
+            status, body = _call(app, "POST", "/api/maps/delete", {"map_id": "labx"})
+        assert status == 200 and body["ok"], body
+        assert "sidecar kept" in body.get("scene_cleanup_error", ""), body
+        assert env.meta.read("labx") is not None         # pointer preserved
+        assert "labx__s1" in env.store.rows              # rows still reachable
+    print("  [PASS] test_delete_keeps_sidecar_when_snapshot_delete_fails")
+
+
+if __name__ == "__main__":
+    print("Running map facade epoch tests...\n")
+    test_save_commits_fresh_partition_sidecar_then_purges()
+    test_resave_rotates_partition_and_purges_previous()
+    test_mapping_mode_resave_refused()
+    test_save_refuses_overwriting_unloaded_annotations()
+    test_save_excludes_self_robot_object()
+    test_failed_snapshot_keeps_previous_sidecar()
+    test_load_without_sidecar_restores_nothing()
+    test_load_restores_exactly_the_sidecar_partition()
+    test_delete_removes_sidecar_and_both_partitions()
+    test_reserved_map_ids_rejected()
+    test_generation_threading_from_latched_broadcast()
+    test_save_without_sidecar_store_degrades_loudly()
+    test_load_flushes_preload_live_objects()
+    test_load_restore_failure_is_visible()
+    test_delete_keeps_sidecar_when_snapshot_delete_fails()
+    print("\nAll tests passed!")

--- a/system/scene/tests/test_map_meta.py
+++ b/system/scene/tests/test_map_meta.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+"""Unit tests for the epoch sidecar (scene_service.map_meta).
+
+Pure Python + tmp dirs — always runs, no ROS / milvus needed.
+"""
+import json
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from scene_service.map_meta import (  # noqa: E402
+    MapMetaStore,
+    MapSemanticMeta,
+    make_meta,
+)
+
+
+def test_roundtrip_and_seq_progression():
+    """write → read preserves fields; next_partition advances only after a
+    commit, and hands the SAME token out again after a failed attempt."""
+    with tempfile.TemporaryDirectory() as d:
+        store = MapMetaStore(d)
+        assert store.read("labx") is None
+
+        part1, seq1 = store.next_partition("labx")
+        assert (part1, seq1) == ("labx__s1", 1)
+        # A failed save never called write() → token is reused, not burned.
+        assert store.next_partition("labx") == ("labx__s1", 1)
+
+        store.write(make_meta("labx", part1, seq1, generation=3, mode="mapping"))
+        meta = store.read("labx")
+        assert meta is not None
+        assert meta.object_partition == "labx__s1"
+        assert meta.save_seq == 1
+        assert meta.mapping_generation == 3
+        assert meta.mapping_mode == "mapping"
+        assert meta.saved_at_unix > 0
+
+        part2, seq2 = store.next_partition("labx")
+        assert (part2, seq2) == ("labx__s2", 2)
+        # Maps do not share sequences.
+        assert store.next_partition("other") == ("other__s1", 1)
+    print("  [PASS] test_roundtrip_and_seq_progression")
+
+
+def test_corrupt_sidecar_treated_as_absent():
+    """A malformed sidecar degrades to 'no snapshot' (restore nothing) and
+    the sequence restarts — it must never crash a Load."""
+    with tempfile.TemporaryDirectory() as d:
+        store = MapMetaStore(d)
+        path = os.path.join(d, "labx.json")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("{not json")
+        assert store.read("labx") is None
+        assert store.next_partition("labx") == ("labx__s1", 1)
+        # Parseable JSON but no usable partition → same treatment.
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump({"map_id": "labx", "object_partition": ""}, f)
+        assert store.read("labx") is None
+    print("  [PASS] test_corrupt_sidecar_treated_as_absent")
+
+
+def test_delete_and_sanitization():
+    with tempfile.TemporaryDirectory() as d:
+        store = MapMetaStore(d)
+        store.write(make_meta("labx", "labx__s1", 1))
+        assert store.delete("labx") is True
+        assert store.read("labx") is None
+        assert store.delete("labx") is False
+
+        # Hostile ids are sanitized the same way everywhere.
+        part, _seq = store.next_partition('a/b "c')
+        assert "/" not in part and '"' not in part
+        store.write(make_meta('a/b "c', part, 1))
+        assert store.read('a/b "c').object_partition == part
+    print("  [PASS] test_delete_and_sanitization")
+
+
+def test_unknown_keys_dropped():
+    """A sidecar written by a NEWER scene still loads (forward-tolerant)."""
+    m = MapSemanticMeta.from_json({
+        "map_id": "m", "object_partition": "m__s1", "save_seq": 1,
+        "saved_at_unix": 1.0, "written_by_future_scene": True,
+    })
+    assert m.object_partition == "m__s1"
+    assert not hasattr(m, "written_by_future_scene")
+    print("  [PASS] test_unknown_keys_dropped")
+
+
+if __name__ == "__main__":
+    print("Running map_meta unit tests...\n")
+    test_roundtrip_and_seq_progression()
+    test_corrupt_sidecar_treated_as_absent()
+    test_delete_and_sanitization()
+    test_unknown_keys_dropped()
+    print("\nAll tests passed!")

--- a/system/scene/tests/test_persistence.py
+++ b/system/scene/tests/test_persistence.py
@@ -344,6 +344,45 @@ def test_map_id_sanitized():
     print("  [PASS] test_map_id_sanitized")
 
 
+def test_partition_scoped_operations():
+    """persist/load_all take an explicit partition without touching the
+    store's own binding (the Save/Load snapshot path), and
+    purge_live_partitions clears only leftover `.live*` rows."""
+    try:
+        import milvus_lite  # noqa: F401
+        import pymilvus  # noqa: F401
+    except Exception:
+        print("  [SKIP] test_partition_scoped_operations (pymilvus/milvus-lite not installed)")
+        return
+
+    from scene_service.persistence import ObjectStore
+
+    with tempfile.TemporaryDirectory() as d:
+        store = ObjectStore(os.path.join(d, "objects.db"), map_id="bound")
+        store.persist([(_make_obj("scene.object.a_001", "a"), None)], partition="labx__s1")
+        store.persist([(_make_obj("scene.object.b_001", "b"), None)], partition="labx__s2")
+        store.persist([(_make_obj("scene.object.c_001", "c"), None)])  # bound partition
+        store.persist([(_make_obj("scene.object.d_001", "d"), None)], partition=".live-1-2")
+        assert store.map_id == "bound"  # explicit partitions never rebind
+        assert {o.object_id for o in store.load_all(partition="labx__s1")} \
+            == {"scene.object.a_001"}
+        assert {o.object_id for o in store.load_all(partition="labx__s2")} \
+            == {"scene.object.b_001"}
+        assert {o.object_id for o in store.load_all()} == {"scene.object.c_001"}
+
+        assert store.purge_live_partitions() == 1
+        assert store.load_all(partition=".live-1-2") == []
+        assert {o.object_id for o in store.load_all(partition="labx__s1")} \
+            == {"scene.object.a_001"}  # named snapshots untouched
+
+        assert store.delete_map("labx__s1") == 1
+        assert store.load_all(partition="labx__s1") == []
+        assert {o.object_id for o in store.load_all(partition="labx__s2")} \
+            == {"scene.object.b_001"}  # sibling snapshot untouched
+        store.close()
+    print("  [PASS] test_partition_scoped_operations")
+
+
 if __name__ == "__main__":
     print("Running persistence unit tests...\n")
     test_restore_object_counter_collision()
@@ -356,4 +395,5 @@ if __name__ == "__main__":
     test_object_store_upsert_latest_wins()
     test_object_store_map_id_isolation()
     test_legacy_schema_recreated()
+    test_partition_scoped_operations()
     print("\nAll tests passed!")


### PR DESCRIPTION
## Problem

Semantic objects persisted by Scene were not epoch-aware. Rows written across different map-frame epochs—reset, re-mapping, or reboot—accumulated under the same partition.

As a result, `Load` could restore objects anchored to a frame that no longer existed, causing the “objects drift outside the map” family of bugs: H1, H2, H3, M1, and M2 from the #137 review, following the agreed split.

## Mechanism

* **Save-token sidecar**

  * Every `Save` writes the object snapshot into a fresh Milvus partition:

    ```text
    <map_id>__s<seq>
    ```
  * A sidecar JSON records the partition containing the map’s semantic snapshot.
  * The sidecar is committed only after the write is verified as complete.
  * The previous snapshot is purged after the sidecar commit succeeds.

* **Strict Load behavior**

  * `Load` restores exactly the partition referenced by the sidecar.
  * Maps containing only legacy data have no sidecar, so `Load` restores no semantic objects and reports this explicitly in the response.

* **Runtime epochs**

  * The lifecycle watcher now acts on generation bumps.
  * It flushes derived objects and marks rooms stale.
  * Derived data remains expendable; user assets remain preserved.
  * Watcher actions and facade operations are serialized under a shared `ops_lock`.

* **Generation independence**

  * Epoch safety does not depend on Mapping’s generation broadcast.
  * The broadcast supports the in-session response only.
  * Related change: `service-map-rbnx#3`, merged.

## Commits

1. `feat(scene)`: Snapshot storage layer

   * `map_meta` sidecar
   * Explicit partitions
   * Strict load behavior

2. `feat(scene)`: Facade `Save` / `Load` / `Delete`

   * Commit ordering
   * `409` guards
   * Reserved namespaces
   * Self-robot exclusion

3. `feat(scene)`: Runtime epoch response

   * Watcher actor
   * `.live` partition
   * Boot sweep
   * Builder gating

4. `test(scene)`: 23 new tests

5. `docs(scene)`: README updates

## Testing

### Container Suite

* **106 passed**
* **1 skipped**
* Baseline: 83 tests
* New: 23 tests

### Webots End-to-End Testing

Validated across 14 boots:

* Full-chain `Save`
* Mapping-mode re-save returns `409`
* Cold-boot `Load` ×3
* No-sidecar `Load` with legacy semantics
* Port `8091` reset triggers:

  * Watcher flush
  * Room stale marking
  * Exactly one epoch bump
* UI `Load` from the `/user` page

### Known Gap

The `load → add room → re-save` path was blocked by an upstream RTAB-Map second-save issue, tracked separately. The behavior is covered by unit tests.

Follows up on #137 and addresses the epoch-related issue family identified in its review, following the agreed split.
