### PR TITLE
feat(api): allow providers to bind loopback

### DIFF
--- a/pylib/robonix-api/README.md
+++ b/pylib/robonix-api/README.md
@@ -67,6 +67,23 @@ current form as a compatibility path.
 
 The Atlas wire protocol (atlas_pb2 / atlas_pb2_grpc) is pre-generated and bundled in the wheel. Per-contract stubs (`robonix_contracts_pb2`, MCP typed dataclasses) are generated **per deployment** by `rbnx codegen` against your contract TOMLs — `robonix-api` automatically picks them up from `<pkg>/rbnx-build/codegen/` at runtime.
 
+## Provider network binding
+
+Provider lifecycle gRPC, user gRPC, and MCP servers keep the compatible
+all-interface default (`0.0.0.0`). A deployment that must make every provider
+local-only sets this before provider construction:
+
+```bash
+export ROBONIX_PROVIDER_BIND_HOST=127.0.0.1
+export ROBONIX_ADVERTISE_HOST=127.0.0.1
+```
+
+`ROBONIX_PROVIDER_BIND_HOST` must be an IPv4 address literal and controls every
+server socket owned by `robonix-api`. When it is a non-wildcard address and no
+advertise override is set, that same address is advertised to Atlas
+automatically. Cross-host deployments should retain `0.0.0.0` and set
+`ROBONIX_ADVERTISE_HOST` to the provider address reachable by consumers.
+
 ## Versioning
 
 `robonix-api` tracks the Robonix v0.1.x series. Wire format and public API are frozen within v0.1.x. Pre-release builds (`0.1.0rc*`) are published to Test PyPI first; stable releases to PyPI.

--- a/pylib/robonix-api/robonix_api/capability.py
+++ b/pylib/robonix-api/robonix_api/capability.py
@@ -23,6 +23,7 @@ Layered API:
 from __future__ import annotations
 
 import inspect
+import ipaddress
 import json
 import logging
 import os
@@ -68,6 +69,31 @@ _MODE_TRANSPORT_OK = {
 }
 
 
+def _provider_bind_host(value: str | None = None) -> str:
+    """Return the provider server bind host as a normalized IPv4 literal.
+
+    The default preserves existing cross-host behavior. Deployments that must
+    keep capability servers local can set ``ROBONIX_PROVIDER_BIND_HOST`` to
+    ``127.0.0.1`` before constructing a provider.
+    """
+
+    raw = (
+        os.environ.get("ROBONIX_PROVIDER_BIND_HOST", "0.0.0.0")
+        if value is None
+        else value
+    )
+    host = str(raw).strip()
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError as exc:
+        raise ValueError(
+            "ROBONIX_PROVIDER_BIND_HOST must be an IPv4 address literal"
+        ) from exc
+    if not isinstance(address, ipaddress.IPv4Address):
+        raise ValueError("ROBONIX_PROVIDER_BIND_HOST must be an IPv4 address literal")
+    return str(address)
+
+
 # ── _ProviderBase ───────────────────────────────────────────────────────────
 
 
@@ -102,6 +128,7 @@ class _ProviderBase:
         self.namespace = namespace.strip("/")
         if not self.namespace:
             raise ValueError("namespace must be non-empty")
+        self._bind_host = _provider_bind_host()
 
         # Locate pkg_root from the caller's frame if not given.
         if pkg_root is None:
@@ -407,14 +434,16 @@ class _ProviderBase:
         would hand the consumer "127.0.0.1:<port>" and it would dial its
         own loopback instead of this host.
 
-        Resolution order: ROBONIX_ADVERTISE_HOST (explicit override) ->
-        the local source IP that routes toward the atlas host (this is the
-        interface a remote consumer reaches us on, since the atlas is the
-        rendezvous both sides already share) -> 127.0.0.1 (same-host only,
-        when route resolution fails)."""
-        explicit = os.environ.get("ROBONIX_ADVERTISE_HOST")
+        Resolution order: ROBONIX_ADVERTISE_HOST (explicit override) -> an
+        explicit non-wildcard provider bind host -> the local source IP that
+        routes toward the atlas host -> 127.0.0.1 when route resolution fails.
+        A loopback bind therefore advertises loopback automatically instead of
+        publishing an endpoint that the server does not accept."""
+        explicit = os.environ.get("ROBONIX_ADVERTISE_HOST", "").strip()
         if explicit:
             return explicit
+        if not ipaddress.ip_address(self._bind_host).is_unspecified:
+            return self._bind_host
         atlas = os.environ.get("ROBONIX_ATLAS", "127.0.0.1:50051")
         atlas_host = atlas.rsplit(":", 1)[0] if ":" in atlas else atlas
         return self.resolve_host_ip(atlas_host) or "127.0.0.1"
@@ -528,23 +557,15 @@ class _ProviderBase:
         from mcp.server.fastmcp import FastMCP
         from mcp.server.transport_security import TransportSecuritySettings
 
-        # Cross-host reachability. The MCP SDK auto-enables DNS-rebinding
-        # protection whenever the bound host is a loopback name
-        # (127.0.0.1 / localhost / ::1), pinning allowed_hosts to localhost.
-        # A consumer on another machine dialing this provider by LAN IP is
-        # then rejected with HTTP 421 "Misdirected Request" (Invalid Host
-        # header). Binding host="0.0.0.0" happens to sidestep that on the
-        # current SDK, but that is incidental — a newer SDK could enable the
-        # check for 0.0.0.0 too, and any provider that legitimately binds a
-        # loopback host would still 421. So disable the Host-header check
-        # explicitly: providers are reached through atlas-issued endpoints,
-        # not untrusted browser origins, so DNS-rebinding protection buys
-        # nothing here and only breaks cross-host dialing.
+        # Preserve cross-host compatibility for wildcard/LAN binds. A
+        # loopback-only deployment is also reachable from a local browser, so
+        # keep the MCP SDK's Host-header/DNS-rebinding guard enabled there.
+        protect_loopback = ipaddress.ip_address(self._bind_host).is_loopback
         self._mcp_app = FastMCP(
             self.id,
-            host="0.0.0.0",
+            host=self._bind_host,
             transport_security=TransportSecuritySettings(
-                enable_dns_rebinding_protection=False
+                enable_dns_rebinding_protection=protect_loopback
             ),
         )
 
@@ -713,10 +734,16 @@ class _ProviderBase:
                      contract_id, base, method_name)
 
         # 2c. bind on port 0 -- OS picks free port.
-        self._driver_port = server.add_insecure_port("[::]:0")
+        self._driver_port = server.add_insecure_port(f"{self._bind_host}:0")
+        if self._driver_port == 0:
+            raise RuntimeError(
+                f"cannot bind lifecycle gRPC server on {self._bind_host}"
+            )
         server.start()
         self._driver_server = server
-        log.info("Lifecycle gRPC serving on 0.0.0.0:%d", self._driver_port)
+        log.info(
+            "Lifecycle gRPC serving on %s:%d", self._bind_host, self._driver_port
+        )
 
         # 3. atlas-declare every gRPC capability
         endpoint = f"{self._advertise_host()}:{self._driver_port}"
@@ -773,12 +800,12 @@ class _ProviderBase:
         import uvicorn
 
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.bind(("0.0.0.0", 0))
+        s.bind((self._bind_host, 0))
         self._mcp_port = s.getsockname()[1]
         s.close()
         cfg = uvicorn.Config(
             self._mcp_app.streamable_http_app(),  # pyright: ignore[reportOptionalMemberAccess]
-            host="0.0.0.0",
+            host=self._bind_host,
             port=self._mcp_port,
             log_level="warning",
         )
@@ -786,7 +813,7 @@ class _ProviderBase:
         thread = threading.Thread(target=server.run, name="robonix-mcp", daemon=True)
         thread.start()
         self._mcp_server_thread = thread
-        log.info("MCP HTTP serving on 0.0.0.0:%d", self._mcp_port)
+        log.info("MCP HTTP serving on %s:%d", self._bind_host, self._mcp_port)
 
     def _declare_mcp_handlers(self) -> None:
         endpoint = f"http://{self._advertise_host()}:{self._mcp_port}/mcp/"

--- a/pylib/robonix-api/tests/test_provider_bind_host.py
+++ b/pylib/robonix-api/tests/test_provider_bind_host.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+from robonix_api.capability import Service, _provider_bind_host
+
+
+class ProviderBindHostTest(unittest.TestCase):
+    def test_default_and_loopback_values_are_normalized(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(_provider_bind_host(), "0.0.0.0")
+        self.assertEqual(_provider_bind_host(" 127.0.0.1 "), "127.0.0.1")
+
+    def test_hostname_ipv6_and_empty_values_are_rejected(self) -> None:
+        for value in ("", "localhost", "::1", "not-an-address"):
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                _provider_bind_host(value)
+
+    def test_loopback_bind_is_advertised_without_route_probe(self) -> None:
+        with tempfile.TemporaryDirectory() as directory, mock.patch.dict(
+            os.environ,
+            {"ROBONIX_PROVIDER_BIND_HOST": "127.0.0.1"},
+            clear=True,
+        ):
+            provider = Service(
+                id="test_provider",
+                namespace="robonix/service/test",
+                pkg_root=Path(directory),
+            )
+            with mock.patch.object(provider, "resolve_host_ip") as resolve:
+                self.assertEqual(provider._advertise_host(), "127.0.0.1")
+                resolve.assert_not_called()
+
+    def test_explicit_advertise_host_remains_authoritative(self) -> None:
+        with tempfile.TemporaryDirectory() as directory, mock.patch.dict(
+            os.environ,
+            {
+                "ROBONIX_PROVIDER_BIND_HOST": "127.0.0.1",
+                "ROBONIX_ADVERTISE_HOST": "10.20.30.40",
+            },
+            clear=True,
+        ):
+            provider = Service(
+                id="test_provider",
+                namespace="robonix/service/test",
+                pkg_root=Path(directory),
+            )
+            self.assertEqual(provider._advertise_host(), "10.20.30.40")
+
+    def test_all_provider_server_paths_use_one_bind_host(self) -> None:
+        source = Path(__file__).parents[1] / "robonix_api" / "capability.py"
+        text = source.read_text(encoding="utf-8")
+        self.assertIn('FastMCP(\n            self.id,\n            host=self._bind_host,', text)
+        self.assertIn("enable_dns_rebinding_protection=protect_loopback", text)
+        self.assertIn('add_insecure_port(f"{self._bind_host}:0")', text)
+        self.assertIn('s.bind((self._bind_host, 0))', text)
+        self.assertIn('host=self._bind_host,\n            port=self._mcp_port', text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add `ROBONIX_PROVIDER_BIND_HOST` with backward-compatible `0.0.0.0` default
- validate the value as an IPv4 literal
- apply the selected host consistently to lifecycle gRPC, MCP HTTP and driver servers
- advertise the explicit non-wildcard bind host when no advertise override is set

## Motivation

Robot deployments need a source-level way to keep capability servers on
loopback. The Go2 deployment sets both bind and advertise hosts to
`127.0.0.1`; remote access is handled through authenticated SSH tunnels.

## Validation

- `PYTHONPATH=pylib/robonix-api python3 -m unittest pylib/robonix-api/tests/test_provider_bind_host.py` — 5 tests passed

No ROS graph, robot hardware or motion command was used during validation.

Related deployment: https://github.com/syswonder/robot-unitree-go2
