### PR TITLE
feat(capabilities): add quadruped primitive contracts

### DIFF
--- a/capabilities/lib/quadruped/srv/SetPosture.srv
+++ b/capabilities/lib/quadruped/srv/SetPosture.srv
@@ -1,0 +1,5 @@
+# Set a quadruped to a named body posture, such as stand, sit, or crouch.
+string posture_name
+---
+bool success
+string message

--- a/capabilities/primitive/quadruped/driver.v1.toml
+++ b/capabilities/primitive/quadruped/driver.v1.toml
@@ -1,0 +1,12 @@
+# Lifecycle interface every quadruped primitive implementation MUST declare.
+# `rbnx boot` calls Driver(CMD_INIT, config_json) against this interface
+# right after RegisterCapability and waits for ok=true before moving on.
+[contract]
+id      = "robonix/primitive/quadruped/driver"
+version = "1"
+kind    = "primitive"
+idl     = "lifecycle/srv/Driver.srv"
+description = "Lifecycle control interface for quadruped primitive providers."
+
+[mode]
+type = "rpc"

--- a/capabilities/primitive/quadruped/move.v1.toml
+++ b/capabilities/primitive/quadruped/move.v1.toml
@@ -1,0 +1,12 @@
+# Single-shot motion command. The driver executes a bounded translation,
+# rotation, or velocity command and then stops. This is not a continuous
+# command stream; use twist_in for continuous velocity control.
+[contract]
+id      = "robonix/primitive/quadruped/move"
+version = "1"
+kind    = "primitive"
+idl     = "chassis/srv/ExecuteMoveCommand.srv"
+description = "Low-level bounded quadruped motion command without global path planning."
+
+[mode]
+type = "rpc"

--- a/capabilities/primitive/quadruped/odom.v1.toml
+++ b/capabilities/primitive/quadruped/odom.v1.toml
@@ -1,0 +1,10 @@
+# nav_msgs/Odometry stream; gRPC `Stream(Empty) returns (stream Odometry)`.
+[contract]
+id      = "robonix/primitive/quadruped/odom"
+version = "1"
+kind    = "primitive"
+idl     = "common_interfaces/nav_msgs/msg/Odometry.msg"
+description = "Raw quadruped odometry in the local odom frame."
+
+[mode]
+type = "topic_out"

--- a/capabilities/primitive/quadruped/posture.v1.toml
+++ b/capabilities/primitive/quadruped/posture.v1.toml
@@ -1,0 +1,11 @@
+# Select a driver-defined quadruped body posture. Implementations document the
+# supported posture names and reject names unsupported by their hardware.
+[contract]
+id      = "robonix/primitive/quadruped/posture"
+version = "1"
+kind    = "primitive"
+idl     = "quadruped/srv/SetPosture.srv"
+description = "Set a quadruped to a named body posture."
+
+[mode]
+type = "rpc"

--- a/capabilities/primitive/quadruped/twist_in.v1.toml
+++ b/capabilities/primitive/quadruped/twist_in.v1.toml
@@ -1,0 +1,9 @@
+[contract]
+id      = "robonix/primitive/quadruped/twist_in"
+version = "1"
+kind    = "primitive"
+idl     = "common_interfaces/geometry_msgs/msg/Twist.msg"
+description = "Velocity command input consumed by a quadruped controller."
+
+[mode]
+type = "topic_in"


### PR DESCRIPTION
## Summary

Introduce `robonix/primitive/quadruped/*` as a standard primitive kind for quadruped robots.

## New capability contracts (5)

| contract_id | mode | description |
|-------------|------|-------------|
| `robonix/primitive/quadruped/driver` | rpc | lifecycle entry point for quadruped primitive providers |
| `robonix/primitive/quadruped/move` | rpc | execute a bounded translation, rotation, or velocity command |
| `robonix/primitive/quadruped/twist_in` | topic_in | consume continuous velocity commands |
| `robonix/primitive/quadruped/odom` | topic_out | publish raw quadruped odometry |
| `robonix/primitive/quadruped/posture` | rpc | switch to a driver-supported named body posture |

## New IDL (1)

Under `capabilities/lib/quadruped/`:

- `srv/SetPosture.srv` — accepts a named posture and returns whether the command was accepted, together with a human-readable message.
