### PR TITLE
fix(rbnx): allow offline deployment builds

### DIFF
--- a/tools/rbnx/src/cmd/mod.rs
+++ b/tools/rbnx/src/cmd/mod.rs
@@ -51,6 +51,10 @@ pub enum Commands {
         /// Clean build (remove rbnx-build before building). Default: incremental.
         #[arg(long)]
         clean: bool,
+        /// Skip the remote-provider freshness check before building cached packages.
+        /// Useful when offline or when the deployment cache is intentionally pinned.
+        #[arg(long)]
+        no_update_check: bool,
     },
     /// Start one package (runs its `start` block; blocks until it exits)
     ///
@@ -397,7 +401,8 @@ pub async fn execute(command: Commands, config: Config) -> Result<()> {
             path,
             global,
             clean,
-        } => run_package::execute_build(config, file, path, global, clean).await,
+            no_update_check,
+        } => run_package::execute_build(config, file, path, global, clean, no_update_check).await,
         Commands::Start {
             package,
             endpoint,

--- a/tools/rbnx/src/cmd/run_package.rs
+++ b/tools/rbnx/src/cmd/run_package.rs
@@ -141,13 +141,14 @@ pub async fn execute_build(
     path: Option<PathBuf>,
     global: Option<String>,
     clean: bool,
+    no_update_check: bool,
 ) -> Result<()> {
     if let Some(file) = file {
         let manifest_path = resolve_local_path_for_filesystem(&file)?;
         if !manifest_path.is_file() {
             anyhow::bail!("deployment manifest not found: {}", manifest_path.display());
         }
-        return build_deploy_manifest(&manifest_path, &config, clean);
+        return build_deploy_manifest(&manifest_path, &config, clean, no_update_check);
     }
 
     // Deploy-manifest mode: if `path` (or cwd, when -p is omitted)
@@ -165,7 +166,7 @@ pub async fn execute_build(
     if let Some(dir) = candidate_dir {
         let deploy_manifest = dir.join("robonix_manifest.yaml");
         if deploy_manifest.is_file() {
-            return build_deploy_manifest(&deploy_manifest, &config, clean);
+            return build_deploy_manifest(&deploy_manifest, &config, clean, no_update_check);
         }
     }
     let package_root = resolve_package_path(&config, path, global)?;
@@ -184,7 +185,12 @@ pub async fn execute_build(
 /// "fetch → build" be a controlled offline step the user can run
 /// when they have network / time, then `rbnx boot` is a fast,
 /// online-optional bring-up.
-fn build_deploy_manifest(manifest_path: &Path, config: &Config, clean: bool) -> Result<()> {
+fn build_deploy_manifest(
+    manifest_path: &Path,
+    config: &Config,
+    clean: bool,
+    no_update_check: bool,
+) -> Result<()> {
     use serde_yaml::Value;
     let manifest_dir = manifest_path
         .parent()
@@ -203,7 +209,9 @@ fn build_deploy_manifest(manifest_path: &Path, config: &Config, clean: bool) -> 
         &format!("packages declared in {}", manifest_path.display()),
     );
     // Notice (non-fatal) if any cloned remote provider is behind upstream.
-    super::check_remotes::report_outdated(manifest_path);
+    if !no_update_check {
+        super::check_remotes::report_outdated(manifest_path);
+    }
 
     // Collect (section, name, pkg_dir, url_to_clone) for every entry.
     struct Resolved {

--- a/tools/rbnx/src/main.rs
+++ b/tools/rbnx/src/main.rs
@@ -166,6 +166,25 @@ mod tests {
     }
 
     #[test]
+    fn build_accepts_no_update_check() {
+        let cli = Cli::try_parse_from([
+            "rbnx",
+            "build",
+            "-f",
+            "robot/robonix_manifest.yaml",
+            "--no-update-check",
+        ])
+        .expect("build --no-update-check should parse");
+        assert!(matches!(
+            cli.command,
+            cmd::Commands::Build {
+                no_update_check: true,
+                ..
+            }
+        ));
+    }
+
+    #[test]
     fn boot_accepts_verbose_mode() {
         let cli = Cli::try_parse_from(["rbnx", "boot", "-v"]).expect("boot -v should parse");
         assert!(matches!(


### PR DESCRIPTION
## What changed

Backport the isolated `rbnx` offline-build behavior from `dev-next` to `dev`:

- allow deployment and package builds to skip the update check explicitly
- preserve offline operation when the package source is already available locally
- expose the same switch through the CLI entry points used by deployment builds

This PR intentionally contains only the standalone offline-build commit. It does not include the planning/runtime changes from #140 or the shared lifecycle Driver migration.

## Why

A robot deployment may need to rebuild from its local cache while GitHub or a proxy is unavailable. Update discovery must not make an otherwise reproducible local build fail.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p robonix-cli` — 11 passed
- `git diff --check`

The first local test attempt correctly exposed uninitialized IDL submodules; after `git submodule update --init --recursive`, the exact repository build completed successfully.
