### PR TITLE
fix(speech): install sherpa wheels from PyPI mirror

### DIFF
--- a/services/speech/scripts/build.sh
+++ b/services/speech/scripts/build.sh
@@ -102,11 +102,15 @@ fi
 VIRTUAL_ENV="$PKG/$VENV" uv sync "${SYNC_ARGS[@]}"
 
 # Wake-word detection is a core Speech capability, independent of whether ASR
-# and TTS use local models or Tencent. The runtime libraries are published on
-# sherpa-onnx's wheel index rather than PyPI.
-uv pip install --python "$VENV/bin/python" --no-index \
-    --find-links "${SHERPA_ONNX_WHEEL_INDEX:-https://k2-fsa.github.io/sherpa/onnx/cpu-cn.html}" \
-    sherpa-onnx-bin==1.13.4 sherpa-onnx-core==1.13.4
+# and TTS use local models or Tencent. Install the complete, version-matched
+# sherpa-onnx wheel set from the configured Python package index. PyPI and the
+# default TUNA mirror publish Linux x86_64/aarch64 wheels for all three
+# packages, so the build does not need to scrape k2-fsa.github.io (which is not
+# reliably reachable from mainland China).
+SHERPA_ONNX_INDEX_URL="${SHERPA_ONNX_INDEX_URL:-$UV_INDEX_URL}"
+uv pip install --python "$VENV/bin/python" \
+    --index-url "$SHERPA_ONNX_INDEX_URL" \
+    sherpa-onnx==1.13.4 sherpa-onnx-bin==1.13.4 sherpa-onnx-core==1.13.4
 
 # ── 2b. Jetson: use the host's JetPack CUDA torch, not PyPI's ──────────────
 # On Jetson (aarch64), PyPI ships a torch built against a CUDA version that


### PR DESCRIPTION
## What changed

Backport the isolated Speech dependency fix from `dev-next` to `dev`:

- install the complete, version-matched `sherpa-onnx`, `sherpa-onnx-bin`, and `sherpa-onnx-core` wheel set from a configurable Python package index
- default to the existing `UV_INDEX_URL` (TUNA in the Speech build) instead of scraping `k2-fsa.github.io`
- retain `SHERPA_ONNX_INDEX_URL` as an explicit override

## Why

The former build depended on a k2-fsa wheel-index page that is unreliable from mainland China. The same published wheels are available from PyPI mirrors for supported x86_64/aarch64 targets.

## Validation

- `bash -n services/speech/scripts/build.sh`
- real Tencent-backend Speech build completed using the TUNA mirror
- downloaded and loaded the bundled 31.3 MiB KWS model
- created the real `sherpa_onnx.KeywordSpotter` and decoded all bundled WAV fixtures
- detected both English fixtures and four Chinese keyword fixtures (`文森特卡索`, `蒋友伯`, `周望军`, `朱丽楠`)
- `git diff --check`

This is functional inference validation, not import-only validation.
