### PR TITLE
fix(speech): make playback and provider selection reliable

### DIFF
--- a/services/speech/README.md
+++ b/services/speech/README.md
@@ -29,7 +29,7 @@ service:
     config:
       speech_backend: tencent
       tencent_asr_appid: "1234567890"
-      tencent_asr_engine: 16k_zh_en
+      tencent_asr_engine: 16k_zh
       tencent_tts_voice_type: 502003
       tencent_tts_region: ap-guangzhou
 ```
@@ -44,7 +44,7 @@ export TENCENTCLOUD_SECRET_KEY=...
 Do not commit Tencent credentials. Put them in the operator shell, a local
 ignored env file, or a machine-local boot wrapper. The AppID and non-secret
 backend settings belong in the deployment manifest. Useful optional knobs:
-`TENCENT_ASR_ENGINE` (default `16k_zh_en`), `TENCENT_TTS_VOICE_TYPE` (default
+`TENCENT_ASR_ENGINE` (default `16k_zh`), `TENCENT_TTS_VOICE_TYPE` (default
 `1001`), and `TENCENT_TTS_REGION` (default `ap-guangzhou`).
 
 With `SPEECH_BACKEND=tencent`, the build installs only the cloud client and

--- a/services/speech/package_manifest.yaml
+++ b/services/speech/package_manifest.yaml
@@ -18,7 +18,7 @@
 #   default_speaker_provider_id: str — provider id used by speech/speak when
 #       its request target is empty; explicit request target overrides this
 #   tencent_asr_appid: str   — Tencent Cloud ASR AppID (secret id/key stay in env)
-#   tencent_asr_engine: str  — default 16k_zh_en
+#   tencent_asr_engine: str  — default 16k_zh
 #   tencent_asr_host: str    — default asr.cloud.tencent.com
 #   tencent_tts_voice_type: int — default 1001
 #   tencent_tts_region: str — default ap-guangzhou

--- a/services/speech/speech_service/service.py
+++ b/services/speech/speech_service/service.py
@@ -1187,6 +1187,14 @@ from speech_mcp import (  # noqa: E402
 _SPEAKER_CONTRACT = "robonix/primitive/audio/speaker"
 _speak_tts = None
 _default_speaker_provider_id = ""
+_speaker_locks_guard = threading.Lock()
+_speaker_locks: dict[str, threading.Lock] = {}
+
+
+def _speaker_lock(provider_id: str) -> threading.Lock:
+    """Return the process-wide serialization lock for one speaker provider."""
+    with _speaker_locks_guard:
+        return _speaker_locks.setdefault(provider_id, threading.Lock())
 
 
 @speech.mcp("robonix/service/speech/list_speakers")
@@ -1229,40 +1237,48 @@ def speak(req: Speak_Request) -> Speak_Response:
         raise RuntimeError(f"no speaker provider (target={target!r})")
     cap = caps[0]
 
-    tts_backend = _tts_servicer.tts_backend
-    if tts_backend is None:
-        log.warning("speech/speak called before Driver(INIT) installed a TTS backend; using direct Edge TTS fallback")
-    if tts_backend is None and _speak_tts is None:
-        _speak_tts = EdgeTTSBackend()
-    if tts_backend is None:
-        tts_backend = _speak_tts
-    # MCP handlers run inside FastMCP's event loop, so asyncio.run() here
-    # would error ("loop already running"). Synthesize on a worker thread
-    # that owns its own loop.
-    import asyncio
-    import concurrent.futures
-    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
-        pcm = ex.submit(lambda: asyncio.run(tts_backend.synthesize(text))).result()
-    if not pcm:
-        raise RuntimeError("TTS backend returned no PCM audio")
-    log.info("speech/speak synthesized %d PCM bytes for %d chars", len(pcm), len(text))
+    # Calls targeting the same physical speaker must synthesize and play in
+    # order. Without this lock concurrent RTDL trees race at the primitive;
+    # one stream wins and the other receives RESOURCE_EXHAUSTED. Different
+    # speaker providers retain independent queues.
+    speaker_lock = _speaker_lock(cap.provider_id)
+    if speaker_lock.locked():
+        log.info("speech/speak queued for busy speaker %s", cap.provider_id)
+    with speaker_lock:
+        tts_backend = _tts_servicer.tts_backend
+        if tts_backend is None:
+            log.warning("speech/speak called before Driver(INIT) installed a TTS backend; using direct Edge TTS fallback")
+        if tts_backend is None and _speak_tts is None:
+            _speak_tts = EdgeTTSBackend()
+        if tts_backend is None:
+            tts_backend = _speak_tts
+        # MCP handlers run inside FastMCP's event loop, so asyncio.run() here
+        # would error ("loop already running"). Synthesize on a worker thread
+        # that owns its own loop.
+        import asyncio
+        import concurrent.futures
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+            pcm = ex.submit(lambda: asyncio.run(tts_backend.synthesize(text))).result()
+        if not pcm:
+            raise RuntimeError("TTS backend returned no PCM audio")
+        log.info("speech/speak synthesized %d PCM bytes for %d chars", len(pcm), len(text))
 
-    with speech.connect_capability(cap, _SPEAKER_CONTRACT, Transport.GRPC) as ch:
-        stub = contracts_grpc.RobonixPrimitiveAudioSpeakerStub(
-            grpc.insecure_channel(ch.endpoint)
-        )
+        with speech.connect_capability(cap, _SPEAKER_CONTRACT, Transport.GRPC) as ch:
+            stub = contracts_grpc.RobonixPrimitiveAudioSpeakerStub(
+                grpc.insecure_channel(ch.endpoint)
+            )
 
-        def frames():
-            frame_bytes = 9600 * 2  # 600 ms s16le frames
-            seq = 0
-            for i in range(0, len(pcm), frame_bytes):
-                seq += 1
-                yield audio_pb2.AudioChunk(
-                    data=pcm[i:i + frame_bytes], timestamp_ns=0,
-                    sequence=seq, duration_s=0.0,
-                )
+            def frames():
+                frame_bytes = 9600 * 2  # 600 ms s16le frames
+                seq = 0
+                for i in range(0, len(pcm), frame_bytes):
+                    seq += 1
+                    yield audio_pb2.AudioChunk(
+                        data=pcm[i:i + frame_bytes], timestamp_ns=0,
+                        sequence=seq, duration_s=0.0,
+                    )
 
-        stub.Speaker(frames())
+            stub.Speaker(frames())
 
     return Speak_Response(ok=True, detail=f"spoke {len(text)} chars on {cap.provider_id}")
 

--- a/services/speech/speech_service/service.py
+++ b/services/speech/speech_service/service.py
@@ -1205,6 +1205,7 @@ def list_speakers(req: ListSpeakers_Request) -> ListSpeakers_Response:
     caps = ATLAS.find_capability(
         contract_id=_SPEAKER_CONTRACT,
         namespace_prefix=(req.namespace_prefix or ""),
+        transport=Transport.GRPC,
     )
     seen: dict[str, dict] = {}
     for c in caps:

--- a/services/speech/speech_service/tencent_cloud.py
+++ b/services/speech/speech_service/tencent_cloud.py
@@ -69,7 +69,7 @@ class TencentRealtimeASRBackend:
 
     def __init__(self):
         self.creds = TencentCredentials.from_env()
-        self.engine = os.environ.get("TENCENT_ASR_ENGINE", "16k_zh_en")
+        self.engine = os.environ.get("TENCENT_ASR_ENGINE", "16k_zh")
         self.host = os.environ.get("TENCENT_ASR_HOST", "asr.cloud.tencent.com")
         self.needvad = int(os.environ.get("TENCENT_ASR_NEEDVAD", "1"))
         self.voice_format = int(os.environ.get("TENCENT_ASR_VOICE_FORMAT", "1"))
@@ -161,7 +161,7 @@ class TencentRealtimeASRBackend:
         # snapshot here so a long-lived backend never signs with stale AppID
         # or credentials captured by an earlier initialization attempt.
         self.creds = TencentCredentials.from_env()
-        self.engine = os.environ.get("TENCENT_ASR_ENGINE", "16k_zh_en")
+        self.engine = os.environ.get("TENCENT_ASR_ENGINE", "16k_zh")
         now = int(time.time())
         params = {
             "engine_model_type": self.engine,

--- a/services/speech/tests/test_list_speakers.py
+++ b/services/speech/tests/test_list_speakers.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from speech_service.service import ATLAS, Transport, list_speakers
+
+
+class ListSpeakersTest(unittest.TestCase):
+    def test_queries_only_grpc_speakers_with_requested_namespace_prefix(self):
+        request = SimpleNamespace(namespace_prefix="robot/audio")
+
+        with patch.object(ATLAS, "find_capability", return_value=[]) as find_capability:
+            list_speakers(request)
+
+        find_capability.assert_called_once_with(
+            contract_id="robonix/primitive/audio/speaker",
+            namespace_prefix="robot/audio",
+            transport=Transport.GRPC,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/services/speech/tests/test_speak_queue.py
+++ b/services/speech/tests/test_speak_queue.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+import threading
+import unittest
+
+from speech_service.service import _speaker_lock
+
+
+class SpeakerQueueTest(unittest.TestCase):
+    def test_same_provider_serializes_callers(self):
+        lock = _speaker_lock("robot-speaker")
+        entered = threading.Event()
+
+        def waiter():
+            with _speaker_lock("robot-speaker"):
+                entered.set()
+
+        with lock:
+            thread = threading.Thread(target=waiter)
+            thread.start()
+            self.assertFalse(entered.wait(0.05))
+        self.assertTrue(entered.wait(0.5))
+        thread.join(timeout=0.5)
+        self.assertFalse(thread.is_alive())
+
+    def test_different_providers_do_not_block_each_other(self):
+        first = _speaker_lock("robot-speaker-a")
+        second = _speaker_lock("robot-speaker-b")
+        self.assertIsNot(first, second)
+        with first:
+            self.assertTrue(second.acquire(blocking=False))
+            second.release()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

Backport the remaining isolated Speech runtime fixes from `dev-next` to `dev`:

- serialize concurrent playback requests per speaker provider while allowing different speakers to run independently
- use Tencent's basic `16k_zh` realtime ASR engine by default
- return only gRPC speaker providers that can actually accept playback requests

The revised-ASR transcript deduplication change was audited but is already present in `dev`, so it is intentionally not duplicated here. This PR does not include the Sherpa installation change from #164.

## Why

Concurrent TTS calls could overlap on one physical speaker, the previous Tencent engine default could select a product without the expected free quota, and speaker discovery could report providers that were not playable through the Speech service.

## Validation

- Speech unit tests: 5 passed
  - per-speaker playback serialization
  - speaker discovery filtering
  - Tencent ASR URL/signature behavior
- `python3 -m compileall -q services/speech/speech_service services/speech/tests`
- `git diff --check`

All commits use `wheatfox <wheatfox17@icloud.com>`.