### PR TITLE
fix(liaison): flush progress narration promptly

### DIFF
--- a/system/liaison/src/voice.rs
+++ b/system/liaison/src/voice.rs
@@ -1144,7 +1144,7 @@ fn tts_boundary_text(kind: u32, streamed: String, final_text: &str) -> Option<St
 }
 
 fn is_narration_boundary(kind: u32) -> bool {
-    matches!(kind, 1 | 2 | 3 | 4)
+    matches!(kind, 1..=4)
 }
 
 fn event_status(kind: u32, session_id: &str, message: &str) -> VoiceEvent {

--- a/system/liaison/src/voice.rs
+++ b/system/liaison/src/voice.rs
@@ -471,7 +471,11 @@ async fn run_session(
                         if kind == 0 {
                             seg.push_str(&ev.text_chunk);
                         }
-                        let is_boundary = matches!(kind, 1 | 2 | 4);
+                        // Status (3) is also a narration boundary. Pilot uses
+                        // it after an in-progress no-call round so TTS can play
+                        // the complete progress update without mislabelling it
+                        // as FinalText and closing the interaction stream.
+                        let is_boundary = is_narration_boundary(kind);
                         let say = if is_boundary {
                             let streamed = std::mem::take(&mut seg);
                             if req.tts_enabled {
@@ -1139,6 +1143,10 @@ fn tts_boundary_text(kind: u32, streamed: String, final_text: &str) -> Option<St
     (!streamed.trim().is_empty()).then_some(streamed)
 }
 
+fn is_narration_boundary(kind: u32) -> bool {
+    matches!(kind, 1 | 2 | 3 | 4)
+}
+
 fn event_status(kind: u32, session_id: &str, message: &str) -> VoiceEvent {
     VoiceEvent {
         event_kind: kind,
@@ -1366,6 +1374,15 @@ mod tests {
         assert_eq!(
             tts_boundary_text(4, String::new(), "final answer"),
             Some("final answer".to_string())
+        );
+    }
+
+    #[test]
+    fn status_flushes_progress_without_requiring_final_text() {
+        assert!(is_narration_boundary(3));
+        assert_eq!(
+            tts_boundary_text(3, "still navigating".to_string(), ""),
+            Some("still navigating".to_string())
         );
     }
 


### PR DESCRIPTION
## What changed

Backport the isolated Liaison narration-boundary fixes from `dev-next` to `dev`:

- treat Pilot status events as narration boundaries so a completed progress update is spoken immediately
- keep the voice event boundary set explicit as the supported range `1..=4`
- preserve the interaction stream instead of mislabelling a progress update as final text

This PR only changes `system/liaison/src/voice.rs`; it does not include the Pilot/Executor lifecycle work from #140.

## Why

Pilot can complete an in-progress no-call round with a status event. Liaison previously buffered that narration until a later final event, which caused delayed or bursty speech feedback.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p robonix-liaison` — 15 passed
- `git diff --check`

The initial build attempt stopped before Liaison compilation because the fresh worktree had not initialized the IDL submodules. After `git submodule update --init --recursive`, the exact test command passed.