### PR TITLE
fix(rbnx): generate catalog-ready manifests

### DIFF
--- a/tools/rbnx/src/cmd/init.rs
+++ b/tools/rbnx/src/cmd/init.rs
@@ -21,30 +21,15 @@ fn robot_catalog_name(name: &str) -> String {
     format!("robonix.robot.{}", suffix.replace('-', "."))
 }
 
-pub async fn execute(name: &str, path: Option<&Path>) -> Result<()> {
-    validate_name(name)?;
-
-    let base = match path {
-        Some(p) => p.to_path_buf(),
-        None => std::env::current_dir()?,
-    };
-    let project_dir = base.join(name);
-
-    if project_dir.exists() {
-        anyhow::bail!("directory '{}' already exists", project_dir.display());
-    }
-
-    output::action("Init", &format!("creating robot deployment '{name}'"));
-
-    std::fs::create_dir_all(&project_dir).context("failed to create deployment directory")?;
-
-    // robonix_manifest.yaml (deployment manifest).
+fn deployment_manifest(name: &str) -> String {
     let catalog_name = robot_catalog_name(name);
-    let manifest = format!(
-        r#"catalog:
+    format!(
+        r#"manifestVersion: 1
+catalog:
   name: {catalog_name}
   version: 0.1.0
-  description: TODO: describe this robot deployment.
+  description: "TODO: describe this robot deployment."
+  license: Apache-2.0
   tags:
     - robot
     - deploy
@@ -75,7 +60,6 @@ system:
   liaison:
     listen: 0.0.0.0:50081
     log: info
-  memory: []
 
 primitive: []
 
@@ -83,7 +67,28 @@ service: []
 
 skill: []
 "#
-    );
+    )
+}
+
+pub async fn execute(name: &str, path: Option<&Path>) -> Result<()> {
+    validate_name(name)?;
+
+    let base = match path {
+        Some(p) => p.to_path_buf(),
+        None => std::env::current_dir()?,
+    };
+    let project_dir = base.join(name);
+
+    if project_dir.exists() {
+        anyhow::bail!("directory '{}' already exists", project_dir.display());
+    }
+
+    output::action("Init", &format!("creating robot deployment '{name}'"));
+
+    std::fs::create_dir_all(&project_dir).context("failed to create deployment directory")?;
+
+    // robonix_manifest.yaml (deployment manifest).
+    let manifest = deployment_manifest(name);
     std::fs::write(project_dir.join("robonix_manifest.yaml"), manifest)
         .context("failed to write robonix_manifest.yaml")?;
 
@@ -106,4 +111,37 @@ __pycache__/
     output::sub_step(".gitignore");
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_manifest_has_complete_robot_catalog_metadata() {
+        let root: serde_yaml::Value =
+            serde_yaml::from_str(&deployment_manifest("robot-example-mobile")).unwrap();
+        let catalog = root
+            .get("catalog")
+            .and_then(|value| value.as_mapping())
+            .unwrap();
+
+        assert_eq!(
+            root.get("manifestVersion").and_then(|value| value.as_u64()),
+            Some(1)
+        );
+        for key in [
+            "name",
+            "version",
+            "description",
+            "license",
+            "tags",
+            "maintainers",
+        ] {
+            assert!(
+                catalog.contains_key(serde_yaml::Value::String(key.into())),
+                "missing catalog.{key}"
+            );
+        }
+    }
 }

--- a/tools/rbnx/src/cmd/package_new.rs
+++ b/tools/rbnx/src/cmd/package_new.rs
@@ -32,6 +32,32 @@ fn python_module_name(name: &str) -> String {
     name.replace('-', "_")
 }
 
+fn package_manifest(package_name: &str, ns_kind: &str) -> String {
+    format!(
+        r#"manifestVersion: 1
+
+build: bash scripts/build.sh
+
+start: bash scripts/start.sh
+
+package:
+  name: "{package_name}"
+  version: 0.0.1
+  description: "TODO: describe what this {ns_kind} package provides."
+  tags:
+    - {ns_kind}
+    - robonix
+  maintainers:
+    - Your Name <you@example.com>
+  license: Apache-2.0
+
+capabilities: []
+
+depends: []
+"#
+    )
+}
+
 pub async fn execute(name: &str, pkg_type: &str, path: Option<&Path>) -> Result<()> {
     validate_name(name)?;
 
@@ -82,29 +108,7 @@ pub async fn execute(name: &str, pkg_type: &str, path: Option<&Path>) -> Result<
     }
 
     // package_manifest.yaml — capabilities default to empty.
-    let manifest = format!(
-        r#"manifestVersion: 1
-
-build: bash scripts/build.sh
-
-start: bash scripts/start.sh
-
-package:
-  name: "{package_name}"
-  version: 0.0.1
-  description: TODO: describe what this {ns_kind} package provides.
-  tags:
-    - {ns_kind}
-    - robonix
-  maintainers:
-    - Your Name <you@example.com>
-  license: Apache-2.0
-
-capabilities: []
-
-depends: []
-"#
-    );
+    let manifest = package_manifest(&package_name, ns_kind);
     std::fs::write(pkg_dir.join("package_manifest.yaml"), manifest)
         .context("failed to write package_manifest.yaml")?;
 
@@ -212,4 +216,48 @@ if __name__ == "__main__":
     output::sub_step(".gitignore");
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_manifest_has_complete_package_metadata() {
+        let root: serde_yaml::Value =
+            serde_yaml::from_str(&package_manifest("robonix.service.example", "service")).unwrap();
+        let package = root
+            .get("package")
+            .and_then(|value| value.as_mapping())
+            .unwrap();
+
+        assert_eq!(
+            root.get("manifestVersion").and_then(|value| value.as_u64()),
+            Some(1)
+        );
+        for key in [
+            "name",
+            "version",
+            "description",
+            "license",
+            "tags",
+            "maintainers",
+        ] {
+            assert!(
+                package.contains_key(serde_yaml::Value::String(key.into())),
+                "missing package.{key}"
+            );
+        }
+        assert!(root.get("start").and_then(|value| value.as_str()).is_some());
+        assert!(
+            root.get("capabilities")
+                .and_then(|value| value.as_sequence())
+                .is_some()
+        );
+        assert!(
+            root.get("depends")
+                .and_then(|value| value.as_sequence())
+                .is_some()
+        );
+    }
 }

--- a/tools/rbnx/src/manifest.rs
+++ b/tools/rbnx/src/manifest.rs
@@ -161,8 +161,11 @@ pub struct Package {
     pub id: Option<String>,
     #[serde(default)]
     pub version: String,
-    /// Deprecated package metadata accepted for old manifests. New package
-    /// manifests should use maintainers/tags for catalog metadata.
+    /// Legacy publisher label retained for manifest compatibility. It is not
+    /// used as package identity or Catalog metadata; new manifests should use
+    /// `name`, `tags`, and `maintainers` instead.
+    #[serde(default)]
+    pub vendor: String,
     #[serde(default)]
     pub description: String,
     #[serde(default)]
@@ -420,5 +423,35 @@ impl Manifest {
             capabilities: self.capabilities.iter().map(|c| c.name.clone()).collect(),
             depends: self.depends.iter().map(|d| d.name.clone()).collect(),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn package_vendor_is_backward_compatible() {
+        let raw: RawManifest = serde_yaml::from_str(
+            r#"
+manifestVersion: 1
+package:
+  name: com.robonix.system.scene
+  version: 0.1.0
+  vendor: robonix
+  description: Legacy package metadata example.
+  license: MulanPSL-2.0
+start: bash scripts/start.sh
+capabilities: []
+"#,
+        )
+        .expect("legacy package.vendor must parse");
+
+        let manifest = normalize(raw, Path::new("package_manifest.yaml"));
+
+        assert_eq!(manifest.package.vendor, "robonix");
+        manifest
+            .validate_and_summarize()
+            .expect("package.vendor must not invalidate an otherwise valid manifest");
     }
 }


### PR DESCRIPTION
## What changed

Backport the isolated manifest-generation alignment from `dev-next` to `dev`:

- generate robot deployment manifests with `manifestVersion: 1` and complete Catalog metadata
- generate package manifests with quoted descriptions, license, tags, and maintainers
- keep legacy `package.vendor` readable for backward compatibility without treating it as package identity
- add parser and template regression tests

This PR changes only `rbnx init`, `rbnx package-new`, and manifest parsing. It does not include lifecycle Driver migration or target-manifest selection.

## Why

Newly generated repositories should be publishable to the Package Catalog without developers having to discover missing metadata fields after generation. Existing manifests using `vendor` must continue to parse while projects migrate.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p robonix-cli` — 13 passed
- `git diff --check`

The generated YAML is parsed in tests and checked for the required robot/package metadata fields.