### PR TITLE
ci: require human authorship for commits

### DIFF
--- a/.github/workflows/commit-authorship.yml
+++ b/.github/workflows/commit-authorship.yml
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+
+name: Commit Authorship
+
+on:
+  push:
+    branches: [main, dev, dev/**]
+  pull_request:
+    branches: [main, dev, dev/**]
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  authorship:
+    name: Human authorship policy
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Test commit authorship checker
+        run: python3 -m unittest scripts/tests/test_check_commit_authorship.py
+
+      - name: Check commits introduced by this change
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PUSH_BASE_SHA: ${{ github.event.before }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          MERGE_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MERGE_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
+          WORKFLOW_HEAD_SHA: ${{ github.sha }}
+        run: |
+          case "$EVENT_NAME" in
+            pull_request)
+              base="$PR_BASE_SHA"
+              head="$PR_HEAD_SHA"
+              ;;
+            merge_group)
+              base="$MERGE_BASE_SHA"
+              head="$MERGE_HEAD_SHA"
+              ;;
+            *)
+              base="$PUSH_BASE_SHA"
+              head="$WORKFLOW_HEAD_SHA"
+              ;;
+          esac
+
+          python3 scripts/check_commit_authorship.py \
+            --base "$base" \
+            --head "$head"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,11 @@ available to them.
 
 - Don't commit unless the user explicitly says to. Multiple smaller reviewable
   commits beat one mega-commit.
+- A commit's Git author must be a human contributor. Never use an AI agent in
+  the author or committer fields, or in authorship, sign-off, review, or test
+  trailers. When AI materially assists a change, the human author may disclose
+  it only as `Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL ...]` and remains
+  fully responsible for the contribution. See `CONTRIBUTING.md`.
 - Don't force-push to `main` ever. Force-push to `dev` / `dev-wheatfox` only
   when the user explicitly authorizes it.
 - Always create new commits rather than amending pushed commits, unless the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,200 @@
+# Contributing to Robonix
+
+Robonix accepts contributions from people who can review, explain, license,
+validate, and maintain the changes they submit. This guide applies to code,
+capability contracts, system components, examples, and repository
+documentation in `syswonder/robonix`.
+
+## Prepare a focused change
+
+Base normal development work on the latest `dev` branch and create a focused
+topic branch:
+
+```bash
+git switch dev
+git pull --ff-only origin dev
+git switch -c fix/short-description
+```
+
+Read the repository-root `AGENTS.md` and the README for every component you
+change. Keep each commit limited to one independently reviewable problem. Do
+not rename public concepts, change capability contracts, or reorganize
+unrelated code as part of an incidental fix.
+
+## License and SPDX identifiers
+
+Original Robonix source code is licensed under MulanPSL-2.0. Add the matching
+SPDX identifier at the beginning of every new original source file:
+
+```rust
+// SPDX-License-Identifier: MulanPSL-2.0
+```
+
+```python
+# SPDX-License-Identifier: MulanPSL-2.0
+```
+
+Keep a shell script's shebang on the first line and put the SPDX identifier on
+the second line:
+
+```bash
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MulanPSL-2.0
+```
+
+Preserve the existing license, copyright notice, and SPDX identifier of code
+imported from another project. Do not relabel third-party code as
+MulanPSL-2.0. Contributors are responsible for confirming provenance and
+license compatibility before submission.
+
+## Code style and repository layout
+
+- Rust uses edition 2024 and standard `rustfmt`. Use `snake_case` for modules
+  and functions, `CamelCase` for types, and `robonix-*` crate names.
+- Python targets Python 3.10 or newer, uses four-space indentation, and uses
+  `snake_case` for modules and functions. Run the checks supplied by the
+  package being changed; the repository does not define one global Python
+  formatter command.
+- Capability contracts live under the appropriate `capabilities/` category
+  and use `<interface>.v1.toml` filenames. Shared IDL lives under
+  `capabilities/lib/`.
+- Put Rust unit tests next to the code behind `#[cfg(test)]` and integration
+  tests in the crate's `tests/` directory. Add package-local tests or smoke
+  tests for Python runtime changes.
+- When functionality changes in a Rust component under `system/*` or
+  `tools/*`, update that component's README in the same contribution.
+- Do not hand-edit generated documentation under `docs/src/reference/`.
+  Change the contracts, IDL, or generator inputs and regenerate it.
+
+The repository requires a comment for a function or method body longer than
+five lines. Describe at least its behavior and document side effects or
+constraints that are not evident from the signature.
+
+## Build and validation
+
+Run Rust commands from the repository root. Before submitting a Rust change,
+run:
+
+```bash
+make fmt
+make check
+cargo build --workspace
+cargo test --workspace --all-targets
+```
+
+`make fmt` runs `cargo fmt --all`. `make check` verifies formatting and runs
+workspace clippy with warnings denied. GitHub Actions additionally builds the
+workspace and runs all workspace targets.
+
+Run the package-specific tests, build scripts, and smoke tests for Python,
+contracts, code generation, Webots, or hardware-facing changes. Changes that
+cross an Atlas wire protocol, Driver lifecycle, or Python API singleton
+boundary require an end-to-end run; compilation alone is not sufficient.
+
+## Commit messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/):
+
+```text
+<type>(optional scope): <imperative description>
+```
+
+Recommended types are `feat`, `fix`, `docs`, `refactor`, `test`, `perf`, `ci`,
+`build`, and `chore`. Examples:
+
+```text
+feat(atlas): expose provider health query
+fix(pilot): preserve active plan on steer
+docs: explain package configuration
+ci: check commit authorship
+```
+
+Use `!` before the colon and a `BREAKING CHANGE:` footer for an incompatible
+change. Avoid vague subjects such as `update`, `changes`, or `fix stuff`.
+
+## Human authorship and AI assistance
+
+This policy applies to commits submitted on or after July 20, 2026.
+
+- A commit's Git author and committer must be human contributors. An AI coding
+  agent must not be named in either field.
+- Do not attribute authorship or responsibility to an AI agent through
+  `Co-authored-by`, `Co-developed-by`, `Signed-off-by`, `Reviewed-by`,
+  `Tested-by`, `Acked-by`, or `Suggested-by` trailers.
+- The human author must review and understand the complete change, confirm its
+  provenance and license compatibility, run appropriate validation, and accept
+  full responsibility for its correctness, security, and maintenance.
+- AI assistance is permitted. When an AI tool materially assists a change,
+  disclose it in the commit message with the Robonix `Assisted-by` format:
+
+  ```text
+  Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL ...]
+  ```
+
+  For example:
+
+  ```text
+  Assisted-by: Codex:gpt-5.6 clang-tidy
+  ```
+
+  `AGENT_NAME` identifies the tool or agent, `MODEL_VERSION` identifies the
+  model, and optional trailing names identify specialized analysis tools. Do
+  not put an email address in `Assisted-by`, and do not list ordinary tools
+  such as Git, compilers, build systems, editors, or shells.
+
+Robonix defines this as its own contribution policy. Its `Assisted-by` syntax
+adopts a documented convention from the Linux kernel community, whose public
+guidance also distinguishes human DCO certification and responsibility from
+tool attribution. These documents are references for the trailer format, not
+the governance policy of this project:
+
+- <https://docs.kernel.org/process/coding-assistants.html>
+- <https://docs.kernel.org/process/submitting-patches.html#using-assisted-by>
+
+CI checks every commit introduced by a pull request or protected-branch push.
+It rejects known AI identities in Git authorship fields and responsibility or
+authorship trailers, while allowing a correctly formatted `Assisted-by`
+trailer. The check cannot determine whether undisclosed AI assistance occurred;
+accurate disclosure remains the human contributor's responsibility.
+
+Run the same check locally against a proposed range:
+
+```bash
+python3 scripts/check_commit_authorship.py --base origin/dev --head HEAD
+```
+
+## Commit trailers
+
+Trailers record specific human actions and must not be added without the named
+person's knowledge:
+
+- `Signed-off-by: Name <email>` certifies the
+  [Developer Certificate of Origin 1.1](https://developercertificate.org/).
+  Robonix does not currently require a sign-off on every commit. When a human
+  can make that certification and chooses or is asked to sign, use
+  `git commit -s`.
+- `Co-authored-by: Name <email>` identifies another human who wrote the
+  change.
+- `Co-developed-by: Name <email>` identifies a human co-developer and is
+  immediately followed by that person's own `Signed-off-by`.
+- `Reviewed-by`, `Tested-by`, and `Acked-by` record actions explicitly
+  performed and approved for attribution by the named human.
+- `Fixes: <commit> ("<subject>")` identifies the commit that introduced a
+  regression. Use at least 12 hexadecimal characters and include its subject.
+- `Assisted-by` is the only trailer for AI assistance and does not assign
+  authorship, review, testing, or legal certification.
+
+## Pull requests
+
+Push the topic branch and open a pull request against `dev`. The pull request
+must:
+
+1. explain the problem, user-visible impact, and implementation;
+2. list the validation commands actually run and their results;
+3. identify capability-contract, generated-code, configuration, or migration
+   effects;
+4. link related issues, for example with `Closes #123`; and
+5. include screenshots or terminal output for CLI, TUI, or web UI changes.
+
+Do not commit credentials, model keys, generated secrets, build artifacts, or
+unrelated local changes. All required checks must pass before merge.

--- a/README.md
+++ b/README.md
@@ -379,6 +379,12 @@ environment. See the
 and the [robot integration guide](https://robonix.syswonder.org/integration-guide/vendor-onboarding.html)
 for topology and deployment details.
 
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the repository's license headers,
+code style, validation commands, commit format, human-authorship policy, and AI
+assistance disclosure rules.
+
 ## Contributors
 
 [![All Contributors](https://img.shields.io/github/all-contributors/syswonder/robonix?color=ee8449&style=flat-square)](#contributors)

--- a/scripts/check_commit_authorship.py
+++ b/scripts/check_commit_authorship.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MulanPSL-2.0
+"""Reject commits that attribute authorship or responsibility to an AI agent."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ZERO_SHA_RE = re.compile(r"^0+$")
+TRAILER_RE = re.compile(r"^([A-Za-z][A-Za-z0-9-]*):\s*(.*?)\s*$")
+IDENTITY_RE = re.compile(r"^(.*?)\s*<([^<>]+)>\s*$")
+
+# These patterns identify coding agents, not ordinary repository automation.
+# GitHub's merge and Actions bots remain valid committers.
+AI_NAME_RE = re.compile(
+    r"(?:^|[\s._+-])(?:"
+    r"chatgpt|openai[\s._+-]*codex|codex|github[\s._+-]*copilot|copilot|"
+    r"claude(?:[\s._+-]+code)?|anthropic[\s._+-]*claude|"
+    r"gemini(?:[\s._+-]+cli)?|cursor(?:[\s._+-]+agent)?|"
+    r"aider|devin|openhands|swe[\s._+-]*agent"
+    r")(?:$|[\s._+-])",
+    re.IGNORECASE,
+)
+AI_EMAIL_RE = re.compile(
+    r"(?:"
+    r"noreply@anthropic\.com|"
+    r"(?:copilot|codex|chatgpt|claude|gemini|cursor|aider|devin|"
+    r"openhands|swe-agent)(?:[^@]*)@"
+    r")",
+    re.IGNORECASE,
+)
+
+AUTHORSHIP_TRAILERS = {
+    "co-authored-by",
+    "co-developed-by",
+    "signed-off-by",
+    "reviewed-by",
+    "tested-by",
+    "acked-by",
+    "suggested-by",
+}
+
+
+@dataclass(frozen=True)
+class CommitRecord:
+    sha: str
+    author_name: str
+    author_email: str
+    committer_name: str
+    committer_email: str
+    message: str
+
+
+def is_ai_identity(name: str, email: str) -> bool:
+    """Return whether a Git identity represents a known AI coding agent."""
+
+    return bool(AI_NAME_RE.search(name.strip()) or AI_EMAIL_RE.search(email.strip()))
+
+
+def validate_assisted_by(value: str) -> str | None:
+    """Validate Robonix ``Assisted-by: AGENT:MODEL [TOOLS...]`` syntax."""
+
+    if "<" in value or ">" in value:
+        return "Assisted-by identifies a tool, so it must not use a person/email form"
+
+    agent_model, _separator, _tools = value.partition(" ")
+    agent, colon, model = agent_model.partition(":")
+    if not colon or not agent.strip() or not model.strip():
+        return "expected Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL ...]"
+    return None
+
+
+def inspect_record(record: CommitRecord) -> list[str]:
+    """Return policy violations for one parsed commit."""
+
+    violations: list[str] = []
+    if is_ai_identity(record.author_name, record.author_email):
+        violations.append(
+            f"Git author is an AI identity: {record.author_name} <{record.author_email}>"
+        )
+    if is_ai_identity(record.committer_name, record.committer_email):
+        violations.append(
+            "Git committer is an AI identity: "
+            f"{record.committer_name} <{record.committer_email}>"
+        )
+
+    for line_number, line in enumerate(record.message.splitlines(), 1):
+        match = TRAILER_RE.match(line)
+        if not match:
+            continue
+        key, value = match.group(1).lower(), match.group(2)
+        if key == "assisted-by":
+            error = validate_assisted_by(value)
+            if error:
+                violations.append(
+                    "invalid Assisted-by trailer on message line "
+                    f"{line_number}: {error}"
+                )
+            continue
+        if key not in AUTHORSHIP_TRAILERS:
+            continue
+        identity = IDENTITY_RE.match(value)
+        if identity and is_ai_identity(identity.group(1), identity.group(2)):
+            violations.append(
+                f"AI identity used in {match.group(1)} trailer on message line "
+                f"{line_number}; use Assisted-by instead"
+            )
+
+    return violations
+
+
+def git(*args: str) -> str:
+    """Run Git from the repository root and return UTF-8 output."""
+
+    result = subprocess.run(
+        ["git", *args],
+        cwd=Path(__file__).resolve().parents[1],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return result.stdout
+
+
+def introduced_commits(base: str, head: str) -> list[str]:
+    """List commits introduced between event base and head."""
+
+    if not head:
+        raise ValueError("head commit is empty")
+    if not base or ZERO_SHA_RE.fullmatch(base):
+        return [head]
+    return git("rev-list", "--reverse", f"{base}..{head}").splitlines()
+
+
+def load_record(sha: str) -> CommitRecord:
+    """Load one commit using NUL separators so message text is lossless."""
+
+    fields = git("show", "-s", "--format=%H%x00%an%x00%ae%x00%cn%x00%ce%x00%B", sha).split(
+        "\0", 5
+    )
+    if len(fields) != 6:
+        raise ValueError(f"could not parse commit {sha}")
+    return CommitRecord(*fields)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default="", help="exclusive base commit")
+    parser.add_argument("--head", default="HEAD", help="inclusive head commit")
+    args = parser.parse_args()
+
+    try:
+        commits = introduced_commits(args.base.strip(), args.head.strip())
+    except (ValueError, subprocess.CalledProcessError) as error:
+        print(f"error: cannot determine commit range: {error}", file=sys.stderr)
+        return 2
+
+    if not commits:
+        print("Commit authorship check: no introduced commits.")
+        return 0
+
+    failed = False
+    for sha in commits:
+        try:
+            record = load_record(sha)
+        except (ValueError, subprocess.CalledProcessError) as error:
+            print(f"error: cannot read commit {sha}: {error}", file=sys.stderr)
+            return 2
+        violations = inspect_record(record)
+        if not violations:
+            continue
+        failed = True
+        print(f"::error title=Commit authorship policy::{record.sha}")
+        print(f"commit {record.sha}")
+        for violation in violations:
+            print(f"  - {violation}")
+
+    if failed:
+        print()
+        print("Robonix commits must retain a human author and accountable submitter.")
+        print("Disclose AI assistance only with: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL ...]")
+        print("See CONTRIBUTING.md for the policy and examples.")
+        return 1
+
+    print(f"Commit authorship check: {len(commits)} commit(s) passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_check_commit_authorship.py
+++ b/scripts/tests/test_check_commit_authorship.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "check_commit_authorship.py"
+SPEC = importlib.util.spec_from_file_location("check_commit_authorship", SCRIPT)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def record(
+    *,
+    author_name="Human Developer",
+    author_email="human@example.com",
+    committer_name="GitHub",
+    committer_email="noreply@github.com",
+    message="fix: keep responsibility human",
+):
+    """Build a deterministic commit record for checker unit tests."""
+
+    return MODULE.CommitRecord(
+        "a" * 40,
+        author_name,
+        author_email,
+        committer_name,
+        committer_email,
+        message,
+    )
+
+
+class CommitAuthorshipTests(unittest.TestCase):
+    def test_human_author_and_github_committer_are_allowed(self):
+        self.assertEqual(MODULE.inspect_record(record()), [])
+
+    def test_ai_git_author_is_rejected(self):
+        violations = MODULE.inspect_record(
+            record(author_name="OpenAI Codex", author_email="human@example.com")
+        )
+        self.assertTrue(any("Git author is an AI identity" in item for item in violations))
+
+    def test_ai_git_committer_is_rejected(self):
+        violations = MODULE.inspect_record(
+            record(committer_name="Claude Code", committer_email="noreply@anthropic.com")
+        )
+        self.assertTrue(any("Git committer is an AI identity" in item for item in violations))
+
+    def test_ai_coauthor_trailer_is_rejected(self):
+        violations = MODULE.inspect_record(
+            record(
+                message=(
+                    "fix: keep responsibility human\n\n"
+                    "Co-authored-by: Claude Fable 5 <noreply@anthropic.com>"
+                )
+            )
+        )
+        self.assertTrue(any("use Assisted-by instead" in item for item in violations))
+
+    def test_robonix_assisted_by_is_allowed(self):
+        violations = MODULE.inspect_record(
+            record(message="fix: disclose assistance\n\nAssisted-by: Codex:gpt-5.6 clang-tidy")
+        )
+        self.assertEqual(violations, [])
+
+    def test_email_style_assisted_by_is_rejected(self):
+        violations = MODULE.inspect_record(
+            record(message="fix: disclose assistance\n\nAssisted-by: Codex <bot@example.com>")
+        )
+        self.assertTrue(any("must not use a person/email form" in item for item in violations))
+
+    def test_unrelated_message_text_is_not_treated_as_attribution(self):
+        violations = MODULE.inspect_record(
+            record(message="docs: explain how Codex assistance is disclosed")
+        )
+        self.assertEqual(violations, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add the repository's first complete contribution guide, covering MulanPSL-2.0 SPDX headers, Rust and Python conventions, validation commands, commit titles, trailers, and pull request evidence
- require human Git authors and committers for commits submitted from July 20, 2026 onward
- reserve authorship, review, test, and DCO trailers for people; disclose material AI assistance only with `Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL ...]`
- add a focused CI check for commits introduced by each pull request, merge queue entry, or protected-branch push

This is a Robonix project policy. The `Assisted-by` syntax adopts a public convention from the Linux kernel community as a trailer-format reference; it does not import Linux project governance into Robonix.

## Responsibility model

The human contributor must review and understand the complete change, verify provenance and license compatibility, run the relevant validation, and accept responsibility for correctness, security, and maintenance. The checker is intentionally best-effort: it can reject prohibited identities and trailers in Git metadata, but it cannot infer undisclosed tool use.

`Signed-off-by` remains an optional human DCO certification. This PR does not make sign-off mandatory.

## Validation

- `python3 -m unittest scripts/tests/test_check_commit_authorship.py` — 7/7 passed
- checker accepted a recent 51-commit range from `dev`
- checker rejected the known historical Claude co-author attribution
- end-to-end temporary Git repositories accepted a human author with `Assisted-by` and rejected an AI author
- all GitHub workflow YAML files parsed successfully
- `git diff --check`

## Documentation

A companion Robonix Book PR documents the same policy and the complete contribution workflow in Chinese.

Companion documentation: [syswonder/robonix-book#15](https://github.com/syswonder/robonix-book/pull/15).