### PR TITLE
fix(scene): keep workstation live views responsive

### DIFF
--- a/system/scene/README.md
+++ b/system/scene/README.md
@@ -274,6 +274,7 @@ Hugging Face mirror endpoint (default `https://hf-mirror.com`); the canonical
 | `SCENE_GRAPH_IMAGE_RELATIONS` | `true` | VLM-primary relations: one image-grounded VLM call (projected numbered boxes) owns relational + semantic edges. `false` forces the legacy text-only per-pair inference (also the automatic fallback when no camera frame bundle is available) |
 | `SCENE_GRAPH_IMAGE_MAX_DIM` | `960` | longest-side pixel cap for the annotated frame sent to the VLM; bounds image token cost |
 | `SCENE_PORT` / `SCENE_WEB_PORT` | `50106` / `50107` | gRPC + web UI ports |
+| `SCENE_WEB_HOST` | `0.0.0.0` | Web UI bind host; set `127.0.0.1` on a robot/control workstation to keep the operator surface local-only. An explicit Scene config file's `web_host` takes precedence when that launch path provides one. |
 | `SCENE_OBJECT_MEMORY_ENABLED` | `true` | persist stable objects + warm-restore the registry on boot |
 | `SCENE_OBJECT_MEMORY_DB` | `/data/robonix/scene_memory/objects.db` | milvus-lite DB path (inside container; host-mounted via `rbnx-build/data/robonix`) |
 | `SCENE_MAP_ID` | `default` | FALLBACK map binding: mapping's latched `robonix/service/map/lifecycle` broadcast wins when present at startup; this env (below manifest `map_id`) applies when mapping isn't up yet (normal full-boot order) or doesn't broadcast |

--- a/system/scene/docker/entrypoint.sh
+++ b/system/scene/docker/entrypoint.sh
@@ -55,9 +55,10 @@ cd /scene
 
 # Scene's launcher regenerates these stubs with this image's own protobuf
 # toolchain and validates every module before the service container starts.
-# Do not fall back to the ambient host-generated proto_gen: it may target a
-# newer protobuf runtime and must fail closed instead of disabling protobuf's
-# compatibility check.
+# It also bind-masks /scene/rbnx-build/codegen/proto_gen with this same output:
+# robonix-api deliberately discovers and prepends that conventional directory
+# at provider construction time.  Without the mask it would supersede this
+# PYTHONPATH entry with host gencode from a potentially newer runtime.
 SCENE_PROTO_GEN=/scene/rbnx-build/codegen/scene_proto_gen
 if [ ! -f "$SCENE_PROTO_GEN/atlas_pb2.py" ] \
    || [ ! -f "$SCENE_PROTO_GEN/robonix_contracts_pb2_grpc.py" ]; then

--- a/system/scene/docker/entrypoint.sh
+++ b/system/scene/docker/entrypoint.sh
@@ -53,9 +53,18 @@ configure_zenoh_session
 
 cd /scene
 
-# Codegen output lives under rbnx-build/codegen/. Build phase produces
-# it on the host before this container runs; we just inject onto path.
-export PYTHONPATH="/scene/rbnx-build/codegen/proto_gen:/scene/rbnx-build/codegen/robonix_mcp_types:${PYTHONPATH:-}"
+# Scene's launcher regenerates these stubs with this image's own protobuf
+# toolchain and validates every module before the service container starts.
+# Do not fall back to the ambient host-generated proto_gen: it may target a
+# newer protobuf runtime and must fail closed instead of disabling protobuf's
+# compatibility check.
+SCENE_PROTO_GEN=/scene/rbnx-build/codegen/scene_proto_gen
+if [ ! -f "$SCENE_PROTO_GEN/atlas_pb2.py" ] \
+   || [ ! -f "$SCENE_PROTO_GEN/robonix_contracts_pb2_grpc.py" ]; then
+    echo "[entrypoint] missing runtime-compatible Scene protobuf stubs" >&2
+    exit 1
+fi
+export PYTHONPATH="$SCENE_PROTO_GEN:/scene/rbnx-build/codegen/robonix_mcp_types:${PYTHONPATH:-}"
 
 # robonix-api lives in the workspace pylib dir, also bind-mounted.
 if [ -d /robonix-api ]; then

--- a/system/scene/scene_service/service.py
+++ b/system/scene/scene_service/service.py
@@ -954,9 +954,12 @@ async def _lifecycle_watch(
             if not warned_ephemeral and binding.source in ("config", "env"):
                 log.warning(
                     "[scene] mapping broadcasts an EPHEMERAL session (empty "
-                    "map_id) while scene is bound to %r (source=%s) — set "
-                    "mapping's config.map_id to match", binding.map_id,
-                    binding.source,
+                    "map_id) while scene is bound to %r (source=%s) — mapping "
+                    "mode is using an unsaved live session; Save the current "
+                    "mapping session as %r first, then Load that saved map or "
+                    "restart in localization mode for a stable cross-boot "
+                    "binding",
+                    binding.map_id, binding.source, binding.map_id,
                 )
                 warned_ephemeral = True
             continue
@@ -1082,13 +1085,15 @@ async def _run() -> None:
     if broadcast is not None and not str(broadcast.get("map_id") or ""):
         # mapping is provably UP but running ephemeral (no map_id) — its
         # frame resets every boot, so the named partition scene just bound
-        # statically will never re-anchor. Likely a manifest misconfig
-        # (SCENE_MAP_ID set, mapping's config.map_id forgotten).
+        # statically will not re-anchor across boots until the operator saves
+        # this live session and later loads it in localization mode.
         log.warning(
             "[scene] mapping broadcasts an EPHEMERAL session (empty map_id) "
             "while scene binds %r from %s — objects stored under this id "
-            "won't re-anchor across boots; set mapping's config.map_id to "
-            "match", binding.map_id, binding.source,
+            "won't re-anchor across boots; Save the current mapping session "
+            "as %r first, then Load that saved map or restart in localization "
+            "mode",
+            binding.map_id, binding.source, binding.map_id,
         )
 
     obj_store = None

--- a/system/scene/scene_service/service.py
+++ b/system/scene/scene_service/service.py
@@ -51,6 +51,7 @@ from .state import (
     Pose3D,
 )
 from .state.object_registry import now_unix
+from .web_binding import resolve_web_host
 
 
 logging.basicConfig(
@@ -62,6 +63,11 @@ log = logging.getLogger("scene-service")
 
 def _load_config() -> dict:
     """Read RBNX_CONFIG_FILE if set; otherwise return an empty config.
+
+    An explicitly requested config is safety-relevant input. Unreadable,
+    malformed, empty, or non-mapping content must stop startup instead of
+    silently widening bind addresses and other settings to legacy defaults.
+
     Empty `observations` triggers auto-discovery against atlas — scene
     asks for every cap with a ROS2 topic_out interface and subscribes
     by contract leaf. The manifest only needs to populate
@@ -72,17 +78,21 @@ def _load_config() -> dict:
         return {}
     try:
         text = Path(path).read_text()
-        try:
-            cfg = json.loads(text)
-        except json.JSONDecodeError:
-            import yaml  # PyYAML is in deps
+    except OSError as exc:
+        raise RuntimeError(f"failed to read explicit Scene config {path}") from exc
+    try:
+        cfg = json.loads(text)
+    except json.JSONDecodeError:
+        import yaml  # PyYAML is in deps
 
-            cfg = yaml.safe_load(text) or {}
-    except Exception as e:  # noqa: BLE001
-        log.warning("failed to read %s: %s; using empty config", path, e)
-        return {}
+        try:
+            cfg = yaml.safe_load(text)
+        except yaml.YAMLError as exc:
+            raise RuntimeError(
+                f"failed to parse explicit Scene config {path}"
+            ) from exc
     if not isinstance(cfg, dict):
-        cfg = {}
+        raise ValueError(f"explicit Scene config root must be a mapping: {path}")
     return cfg
 
 
@@ -1285,8 +1295,9 @@ async def _run() -> None:
     # Web debug UI on a separate port — top-down 2D canvas + objects
     # table + robot pose. Lives in the same asyncio loop as the rest
     # of scene so registry reads are local. Set `web_port: 0` in the
-    # deploy-manifest scene block to disable. SCENE_WEB_PORT env is
-    # the override of last resort.
+    # deploy-manifest scene block to disable. SCENE_WEB_PORT and
+    # SCENE_WEB_HOST are environment fallbacks; an explicit Scene config file
+    # can set web_host: 127.0.0.1 to keep this operator surface local-only.
     web_port = int(
         int(config.get("web_port") or "0")
         if config.get("web_port") is not None and config.get("web_port") != ""
@@ -1295,6 +1306,7 @@ async def _run() -> None:
     web_task = None
     web_server: uvicorn.Server | None = None
     if web_port > 0:
+        web_host = resolve_web_host(config)
         web_app = web_ui.make_app(
             registry=registry,
             hub=hub,
@@ -1311,13 +1323,13 @@ async def _run() -> None:
         )
         web_uv = uvicorn.Config(
             app=web_app,
-            host="0.0.0.0",
+            host=web_host,
             port=web_port,
             log_level="warning",
         )
         web_server = uvicorn.Server(web_uv)
         web_task = asyncio.create_task(web_server.serve(), name="scene-web-http")
-        log.info("web UI on http://0.0.0.0:%d", web_port)
+        log.info("web UI on http://%s:%d", web_host, web_port)
 
     log.info(
         "scene up; cap=%s mcp=%s observations=%d",

--- a/system/scene/scene_service/web.py
+++ b/system/scene/scene_service/web.py
@@ -27,7 +27,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from starlette.applications import Starlette
-from starlette.responses import HTMLResponse, JSONResponse
+from starlette.responses import HTMLResponse, JSONResponse, Response
 from starlette.routing import Mount, Route
 from starlette.staticfiles import StaticFiles
 
@@ -58,20 +58,41 @@ _INDEX_HTML = """<!doctype html>
     canvas { display: block; width: 100%; height: 100%; background: #14171f; }
     .legend { position: absolute; bottom: 8px; left: 12px; font-size: 11px;
       color: var(--muted); background: rgba(20,23,31,.85); padding: 4px 8px; border-radius: 4px; }
+    .scene-status { position: absolute; top: 10px; left: 12px; z-index: 2;
+      color: var(--muted); background: rgba(20,23,31,.92); border: 1px solid #33405a;
+      padding: 5px 9px; border-radius: 5px; font-size: 12px; }
+    .scene-status.error { color: #ff8b82; border-color: #6b3640; }
   </style>
 </head>
-<body>
+<body data-ready="loading">
 <div id="wrap">
   <div id="canvas-wrap">
     <canvas id="c"></canvas>
+    <div class="scene-status" id="scene-status" role="status">loading Scene state…</div>
     <div class="legend">scene · 1 m grid · north = +x · 5 Hz</div>
   </div>
 </div>
 <script>
 const c = document.getElementById('c');
 const ctx = c.getContext('2d');
+const sceneStatus = document.getElementById('scene-status');
+let currentState = null;
 function fit() { c.width = c.clientWidth; c.height = c.clientHeight; }
-window.addEventListener('resize', fit); fit();
+window.addEventListener('resize', () => {
+    fit();
+    if (currentState) draw(currentState);
+});
+document.addEventListener('visibilitychange', () => {
+    if (!document.hidden && currentState) draw(currentState);
+});
+fit();
+
+function setSceneStatus(text, kind = '') {
+    sceneStatus.textContent = text || '';
+    sceneStatus.className = 'scene-status' + (kind ? ' ' + kind : '');
+    sceneStatus.style.display = text ? 'block' : 'none';
+}
+function setSceneReady(value) { document.body.dataset.ready = value; }
 
 // World-to-pixel: center on robot if known, else (0,0). 1m = 40 px.
 let center = [0, 0];
@@ -95,6 +116,12 @@ function classColor(cls) { return CLS_COLORS[cls] || '#9aa0a6'; }
 let occImg = null;
 let occMeta = null;
 let occStamp = 0;
+let occLoading = 0;
+let occLoadToken = 0;
+
+function isCurrentOccupancyLoad(token, stamp) {
+    return token === occLoadToken && stamp === occLoading;
+}
 
 function draw(state) {
     fit();
@@ -105,12 +132,28 @@ function draw(state) {
     if (robot) center = [robot.pose.x, robot.pose.y];
 
     // ── Occupancy map underlay ──────────────────────────────────────
-    if (state.occupancy && state.occupancy.stamp_ms !== occStamp) {
-        occStamp = state.occupancy.stamp_ms;
-        occMeta = state.occupancy;
+    if (state.occupancy && state.occupancy.stamp_ms !== occStamp
+        && state.occupancy.stamp_ms !== occLoading) {
+        occLoading = state.occupancy.stamp_ms;
+        const loadToken = ++occLoadToken;
+        const meta = state.occupancy;
         const im = new Image();
-        im.onload = () => { occImg = im; };
-        im.src = 'data:image/png;base64,' + state.occupancy.png_b64;
+        im.onload = () => {
+            if (!isCurrentOccupancyLoad(loadToken, meta.stamp_ms)) return;
+            occImg = im;
+            occMeta = meta;
+            occStamp = meta.stamp_ms;
+            occLoading = 0;
+            if (currentState) draw(currentState);
+        };
+        im.onerror = () => {
+            if (!isCurrentOccupancyLoad(loadToken, meta.stamp_ms)) return;
+            occLoading = 0;
+            setSceneReady('error');
+            setSceneStatus('Scene map image could not be decoded; retrying…', 'error');
+            console.error('occupancy PNG decode failed');
+        };
+        im.src = 'data:image/png;base64,' + meta.png_b64;
     }
     if (occImg && occMeta) {
         // Map cell [0,0] is at world (origin_x, origin_y). Width/height
@@ -195,6 +238,16 @@ function draw(state) {
         ctx.stroke();
         ctx.lineWidth = 1;
     }
+
+    const canvasVisible = c.clientWidth > 0 && c.clientHeight > 0;
+    if (canvasVisible
+        && (!state.occupancy || (occImg && occStamp === state.occupancy.stamp_ms))) {
+        setSceneReady('true');
+        setSceneStatus('');
+    } else {
+        setSceneReady('loading');
+        setSceneStatus(canvasVisible ? 'loading occupancy map…' : 'waiting for visible canvas…');
+    }
 }
 
 function fmt(n) { return Number(n).toFixed(2); }
@@ -202,12 +255,19 @@ function fmt(n) { return Number(n).toFixed(2); }
 async function tick() {
     try {
         const r = await fetch('/api/state', { cache: 'no-store' });
-        if (!r.ok) return;
-        const state = await r.json();
-        draw(state);
+        if (!r.ok) {
+            setSceneReady('error');
+            setSceneStatus(`Scene state unavailable (HTTP ${r.status}); retrying…`, 'error');
+            return;
+        }
+        currentState = await r.json();
+        draw(currentState);
         // Info panel was moved to a top-level floating overlay in
         // _COMBINED_HTML; this iframe no longer has any DOM for it.
-    } catch (_) { /* swallow; next tick will retry */ }
+    } catch (error) {
+        setSceneReady('error');
+        setSceneStatus(`Scene state unavailable; retrying… (${error})`, 'error');
+    }
 }
 // 2Hz tick. The map updates at 1 Hz from slam_toolbox; the robot
 // pose is interpolated visually so 500ms is smooth enough without
@@ -231,6 +291,17 @@ def _shorten_id(object_id: str) -> str:
 # pure waste. With this cache, re-encode is gated to "once per new
 # message", so steady-state /api/state cost drops to a dict lookup.
 _OCCUPANCY_CACHE: dict[str, Any] = {"count": -1, "payload": None}
+
+# Camera previews are much larger than the occupancy thumbnail (a Go2 RGB
+# frame is commonly 1920x1080), and `/cam` polls several times per second.
+# Keep independent caches because RGB and depth advance at different rates.
+# Cache ``None`` as well: an unsupported frame must not be re-encoded on every
+# GET while its hub message count is unchanged.
+_CAMERA_CACHE: dict[str, dict[str, Any]] = {
+    "rgb": {"hub": None, "count": -1, "payload": None},
+    "depth": {"hub": None, "count": -1, "payload": None},
+}
+_CAMERA_PREVIEW_MIN_INTERVAL_S = 0.4
 
 
 def _occupancy_payload(hub: Any) -> Optional[dict]:
@@ -352,29 +423,53 @@ def _image_to_png_b64(msg: Any, *, kind: str) -> Optional[dict]:
     }
 
 
+def _camera_channel_payload(hub: Any, kind: str) -> Optional[dict]:
+    """Return one cached camera preview for the hub's latest channel message.
+
+    The completed cache entry is replaced atomically so a worker-thread reader
+    can observe either the old or new entry, never a partially updated key and
+    payload. Per-app request single-flight is enforced by ``make_app``.
+    """
+    if not hub.has(kind):
+        return None
+    msg, stamp_unix, count = hub.latest(kind)
+    if msg is None or count == 0:
+        return None
+
+    cache = _CAMERA_CACHE[kind]
+    if cache["hub"] is hub and cache["count"] == count:
+        return cache["payload"]
+
+    payload = _image_to_png_b64(msg, kind=kind)
+    if payload is not None and payload["stamp_ms"] == 0:
+        # Prefer the ROS header stamp; fall back to ingest-time when unset.
+        payload["stamp_ms"] = int(stamp_unix * 1000)
+    _CAMERA_CACHE[kind] = {
+        "hub": hub,
+        "count": count,
+        "payload": payload,
+    }
+    return payload
+
+
 def _camera_payload(hub: Any) -> dict:
-    """JSON for the /cam panel: latest RGB + depth as base64 PNGs."""
+    """JSON for the /cam panel: latest RGB + depth as cached PNGs."""
     out: dict[str, Any] = {"rgb": None, "depth": None}
     if hub is None:
         return out
-    if hub.has("rgb"):
-        msg, stamp_unix, count = hub.latest("rgb")
-        if msg is not None and count > 0:
-            enc = _image_to_png_b64(msg, kind="rgb")
-            if enc is not None:
-                # Prefer rclpy stamp; fall back to ingest-time if header is unset.
-                if enc["stamp_ms"] == 0:
-                    enc["stamp_ms"] = int(stamp_unix * 1000)
-                out["rgb"] = enc
-    if hub.has("depth"):
-        msg, stamp_unix, count = hub.latest("depth")
-        if msg is not None and count > 0:
-            enc = _image_to_png_b64(msg, kind="depth")
-            if enc is not None:
-                if enc["stamp_ms"] == 0:
-                    enc["stamp_ms"] = int(stamp_unix * 1000)
-                out["depth"] = enc
+    out["rgb"] = _camera_channel_payload(hub, "rgb")
+    out["depth"] = _camera_channel_payload(hub, "depth")
     return out
+
+
+def _camera_json_bytes(hub: Any) -> bytes:
+    """Encode one camera response completely inside the preview worker."""
+    return json.dumps(
+        _camera_payload(hub),
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
 
 
 def _state_payload(registry: ObjectRegistry,
@@ -619,6 +714,15 @@ def make_app(*, registry: ObjectRegistry,
     """
     if map_binding is None:
         map_binding = {}
+
+    # Camera PNG encoding is CPU-heavy for 1920x1080 frames. Keep this state
+    # inside one ASGI app so concurrent `/api/camera` requests share a single
+    # worker and a recently completed preview without blocking Scene's event
+    # loop or evicting another app's response cache.
+    camera_preview_lock = asyncio.Lock()
+    camera_preview_hub: Any = None
+    camera_preview_bytes: Optional[bytes] = None
+    camera_preview_completed_s = 0.0
 
     async def _persist_scene_objects(map_id: str) -> int:
         if object_store is None:
@@ -1009,7 +1113,34 @@ def make_app(*, registry: ObjectRegistry,
         return HTMLResponse(_USER_HTML)
 
     async def camera_state(_request) -> JSONResponse:
-        return JSONResponse(_camera_payload(hub))
+        """Return a rate-limited, single-flight preview off the event loop."""
+        nonlocal camera_preview_hub
+        nonlocal camera_preview_bytes
+        nonlocal camera_preview_completed_s
+
+        loop = asyncio.get_running_loop()
+        now = loop.time()
+        if (
+            camera_preview_hub is hub
+            and camera_preview_bytes is not None
+            and now - camera_preview_completed_s < _CAMERA_PREVIEW_MIN_INTERVAL_S
+        ):
+            return Response(camera_preview_bytes, media_type="application/json")
+
+        async with camera_preview_lock:
+            now = loop.time()
+            if (
+                camera_preview_hub is hub
+                and camera_preview_bytes is not None
+                and now - camera_preview_completed_s
+                < _CAMERA_PREVIEW_MIN_INTERVAL_S
+            ):
+                return Response(camera_preview_bytes, media_type="application/json")
+            payload = await asyncio.to_thread(_camera_json_bytes, hub)
+            camera_preview_hub = hub
+            camera_preview_bytes = payload
+            camera_preview_completed_s = loop.time()
+            return Response(payload, media_type="application/json")
 
     # Static asset directory ships with scene_service; holds the
     # tiago URDF mesh assets (STL/DAE files lifted from PAL Robotics's
@@ -1446,7 +1577,7 @@ _INDEX_CAM_HTML = r"""<!doctype html>
     <div class="tile" id="depth">
       <span class="label"><b>depth</b> <span class="meta">—</span> <i style="color:#666">(near=bright)</i></span>
       <img id="depth_img" alt="" />
-      <div class="empty" id="depth_empty">no depth stream connected</div>
+      <div class="empty" id="depth_empty">no depth frame available</div>
     </div>
   </div>
   <script>
@@ -2307,6 +2438,10 @@ _USER_HTML = r"""<!doctype html>
     #toast { position: absolute; bottom: 14px; left: 50%; transform: translateX(-50%);
       background: rgba(20,23,31,.95); border: 1px solid #6b3640; color: var(--danger);
       font-size: 12px; padding: 6px 12px; border-radius: 6px; display: none; }
+    #scene-status { position: absolute; top: 10px; right: 10px;
+      background: rgba(20,23,31,.92); border: 1px solid #33405a; color: var(--muted);
+      font-size: 12px; padding: 6px 10px; border-radius: 6px; }
+    #scene-status.error { border-color: #6b3640; color: var(--danger); }
     .legend { position: absolute; bottom: 8px; left: 12px; font-size: 11px;
       color: var(--muted); background: rgba(20,23,31,.85); padding: 4px 8px;
       border-radius: 4px; }
@@ -2352,7 +2487,7 @@ _USER_HTML = r"""<!doctype html>
       white-space: pre-wrap; max-height: 120px; overflow: auto; display: none; }
   </style>
 </head>
-<body>
+<body data-ready="loading">
 <div id="app">
   <header>
     <h1>Map &amp; rooms</h1>
@@ -2382,6 +2517,7 @@ _USER_HTML = r"""<!doctype html>
       <canvas id="c"></canvas>
       <div id="hint"></div>
       <div id="toast"></div>
+      <div id="scene-status" role="status">loading Scene state…</div>
       <div class="legend">drag to pan · wheel to zoom · hover a dot for its label</div>
     </div>
   </div>
@@ -2429,7 +2565,7 @@ _USER_HTML = r"""<!doctype html>
 const c = document.getElementById('c');
 const ctx = c.getContext('2d');
 function fit() { c.width = c.clientWidth; c.height = c.clientHeight; }
-window.addEventListener('resize', fit); fit();
+fit();
 
 // ── view transform (world meters ↔ canvas px) ────────────────────────────
 // Unlike the debug page (which chases the robot) the editor keeps a STABLE
@@ -2449,6 +2585,7 @@ function p2w(px, py) {
 // ── state ────────────────────────────────────────────────────────────────
 let state = null;          // last /api/state payload
 let occImg = null, occMeta = null, occStamp = 0, occLoading = 0;
+let occLoadToken = 0;
 let drawMode = false;
 let draft = [];            // in-progress polygon vertices (world coords)
 let mouseWorld = null;     // live cursor position for the rubber-band edge
@@ -2462,10 +2599,25 @@ let draftSubmitting = false;
 let mapOperationRetry = null;
 let mapOperationDone = null;
 
+window.addEventListener('resize', () => { fit(); draw(); });
+document.addEventListener('visibilitychange', () => {
+    if (!document.hidden) draw();
+});
+
 const hintEl = document.getElementById('hint');
+const sceneStatusEl = document.getElementById('scene-status');
 function setHint(text) {
     hintEl.style.display = text ? 'block' : 'none';
     hintEl.textContent = text || '';
+}
+function setSceneStatus(text, kind = '') {
+    sceneStatusEl.textContent = text || '';
+    sceneStatusEl.className = kind;
+    sceneStatusEl.style.display = text ? 'block' : 'none';
+}
+function setSceneReady(value) { document.body.dataset.ready = value; }
+function isCurrentOccupancyLoad(token, stamp) {
+    return token === occLoadToken && stamp === occLoading;
 }
 let toastTimer = null;
 function toast(text) {
@@ -2620,10 +2772,24 @@ function draw() {
     if (state.occupancy && state.occupancy.stamp_ms !== occStamp
         && state.occupancy.stamp_ms !== occLoading) {
         occLoading = state.occupancy.stamp_ms;
+        const loadToken = ++occLoadToken;
         const meta = state.occupancy;
         const im = new Image();
-        im.onload = () => { occImg = im; occMeta = meta; occStamp = meta.stamp_ms; };
-        im.onerror = () => { occLoading = 0; console.error('occupancy PNG decode failed'); };
+        im.onload = () => {
+            if (!isCurrentOccupancyLoad(loadToken, meta.stamp_ms)) return;
+            occImg = im;
+            occMeta = meta;
+            occStamp = meta.stamp_ms;
+            occLoading = 0;
+            draw();
+        };
+        im.onerror = () => {
+            if (!isCurrentOccupancyLoad(loadToken, meta.stamp_ms)) return;
+            occLoading = 0;
+            setSceneReady('error');
+            setSceneStatus('Scene map image could not be decoded; retrying…', 'error');
+            console.error('occupancy PNG decode failed');
+        };
         im.src = 'data:image/png;base64,' + meta.png_b64;
     }
     if (occImg && occMeta) {
@@ -2719,6 +2885,16 @@ function draw() {
         for (const [x, y] of pts) {
             ctx.beginPath(); ctx.arc(x, y, 3, 0, Math.PI * 2); ctx.fill();
         }
+    }
+
+    const canvasVisible = c.clientWidth > 0 && c.clientHeight > 0;
+    if (canvasVisible
+        && (!state.occupancy || (occImg && occStamp === state.occupancy.stamp_ms))) {
+        setSceneReady('true');
+        setSceneStatus('');
+    } else {
+        setSceneReady('loading');
+        setSceneStatus(canvasVisible ? 'loading occupancy map…' : 'waiting for visible canvas…');
     }
 }
 
@@ -3187,9 +3363,17 @@ async function refresh() {
     let next = null;
     try {
         const r = await fetch('/api/state', { cache: 'no-store' });
-        if (!r.ok) return;
+        if (!r.ok) {
+            setSceneReady('error');
+            setSceneStatus(`Scene state unavailable (HTTP ${r.status}); retrying…`, 'error');
+            return;
+        }
         next = await r.json();
-    } catch (_) { return; /* transient; next poll retries */ }
+    } catch (error) {
+        setSceneReady('error');
+        setSceneStatus(`Scene state unavailable; retrying… (${error})`, 'error');
+        return;
+    }
     state = next;
     const mb = state.map_binding;
     const unsavedLive = mb && mb.source === 'default' && !mb.mode;

--- a/system/scene/scene_service/web_binding.py
+++ b/system/scene/scene_service/web_binding.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+"""Resolve the Scene debug UI bind address.
+
+The port is already deployment-configurable.  Keep the historical all-interface
+default for existing deployments, while allowing safety-sensitive robot
+profiles to bind the UI to loopback explicitly.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+import re
+from collections.abc import Mapping
+
+
+def resolve_web_host(
+    config: Mapping[str, object],
+    environ: Mapping[str, str] | None = None,
+) -> str:
+    """Return the Uvicorn host from config, environment, or legacy default."""
+
+    env = os.environ if environ is None else environ
+    raw = (
+        config["web_host"]
+        if "web_host" in config
+        else env.get("SCENE_WEB_HOST", "0.0.0.0")
+    )
+    if not isinstance(raw, str):
+        raise ValueError("Scene web_host/SCENE_WEB_HOST must be a string")
+    host = raw.strip()
+    if not host:
+        raise ValueError("Scene web_host/SCENE_WEB_HOST must not be blank")
+    invalid = (
+        "://" in host
+        or "/" in host
+        or any(char.isspace() for char in host)
+    )
+    if re.fullmatch(r"[0-9xX.]+", host):
+        try:
+            ipaddress.ip_address(host)
+        except ValueError:
+            invalid = True
+    if invalid:
+        raise ValueError(f"invalid Scene web bind host: {host!r}")
+    return host

--- a/system/scene/scripts/start.sh
+++ b/system/scene/scripts/start.sh
@@ -175,6 +175,7 @@ exec docker run --rm \
     -e ROBONIX_CAPABILITY_ID="${ROBONIX_CAPABILITY_ID:-com.robonix.system.scene}" \
     -e ROBONIX_PKG_HOST_DIR="$(pwd)" \
     -e SCENE_WEB_PORT="${SCENE_WEB_PORT:-50107}" \
+    -e SCENE_WEB_HOST="${SCENE_WEB_HOST-0.0.0.0}" \
     -e SCENE_LOG_LEVEL="${SCENE_LOG_LEVEL:-INFO}" \
     -e SCENE_CG_FORCE_CPU="${SCENE_CG_FORCE_CPU:-}" \
     -e SCENE_CG_OBJ_MIN_POINTS="${SCENE_CG_OBJ_MIN_POINTS:-}" \

--- a/system/scene/scripts/start.sh
+++ b/system/scene/scripts/start.sh
@@ -212,6 +212,7 @@ exec docker run --rm \
     -e CYCLONEDDS_URI="${CYCLONEDDS_URI:-}" \
     "${ZENOH_ARGS[@]}" \
     -v "$(pwd)":/scene \
+    -v "$PKG/rbnx-build/codegen/scene_proto_gen:/scene/rbnx-build/codegen/proto_gen:ro" \
     -v "$SCENE_HOST_DATA_DIR":/data/robonix \
     -v "$(rbnx path robonix-api)":/robonix-api:ro \
     "${EXTRA_MOUNTS[@]}" \

--- a/system/scene/scripts/start.sh
+++ b/system/scene/scripts/start.sh
@@ -33,14 +33,77 @@ fi
 
 CT="${ROBONIX_SCENE_CONTAINER:-robonix_scene}"
 IMG="${ROBONIX_SCENE_IMAGE:-robonix-scene}"
+RUNTIME_PROTO_TMP=""
 
 cleanup() {
     timeout 15s docker stop "$CT" >/dev/null 2>&1 || true
+    if [[ -n "$RUNTIME_PROTO_TMP" ]]; then
+        rm -rf -- "$RUNTIME_PROTO_TMP"
+    fi
 }
 trap cleanup EXIT INT TERM
 
 # Drop a stopped container from a previous run.
 docker rm -f "$CT" >/dev/null 2>&1 || true
+
+# Python protobuf generated code is only forward-compatible within protobuf's
+# documented runtime window.  `rbnx codegen` intentionally uses the host's
+# active python3, which can be newer than this image (for example gencode
+# 7.35.0 with a 6.33.6 runtime).  Never suppress protobuf's version check and
+# never guess a package pin here.  Instead, regenerate Scene's Python stubs
+# with the exact grpc_tools/protobuf stack that will import them, without
+# network access, then validate every generated module before Scene starts.
+# Keep these stubs separate from the host build output: other packages may
+# legitimately use a different Python runtime.
+prepare_runtime_proto_gen() {
+    local proto_staging="$PKG/rbnx-build/proto-staging"
+    local runtime_proto
+    local runtime_proto_gen="$PKG/rbnx-build/codegen/scene_proto_gen"
+
+    runtime_proto="$(rbnx path runtime-proto)" || {
+        echo "[scene/start] cannot resolve Robonix runtime proto directory" >&2
+        return 1
+    }
+    [[ -d "$runtime_proto" && -f "$runtime_proto/atlas.proto" ]] || {
+        echo "[scene/start] missing runtime atlas.proto: $runtime_proto" >&2
+        return 1
+    }
+    [[ -d "$proto_staging" ]] \
+        && find "$proto_staging" -maxdepth 1 -type f -name '*.proto' -print -quit \
+            | grep -q . || {
+        echo "[scene/start] missing staged package protos; run rbnx build first" >&2
+        return 1
+    }
+
+    mkdir -p "$PKG/rbnx-build/codegen"
+    RUNTIME_PROTO_TMP="$(mktemp -d "${runtime_proto_gen}.tmp.XXXXXX")"
+
+    docker run --rm \
+        --network none \
+        --entrypoint sh \
+        --user "$(id -u):$(id -g)" \
+        -e HOME=/tmp \
+        -v "$runtime_proto:/runtime-proto:ro" \
+        -v "$proto_staging:/proto-staging:ro" \
+        -v "$RUNTIME_PROTO_TMP:/proto-gen" \
+        "$IMG" -ec '
+            python3 -m grpc_tools.protoc \
+                -I/runtime-proto \
+                -I/proto-staging \
+                --python_out=/proto-gen \
+                --grpc_python_out=/proto-gen \
+                /runtime-proto/*.proto \
+                /proto-staging/*.proto
+            PYTHONPATH=/proto-gen python3 -c '\''import importlib, pathlib; p = pathlib.Path("/proto-gen"); modules = sorted({f.stem for f in p.glob("*_pb2.py")} | {f.stem for f in p.glob("*_pb2_grpc.py")}); assert modules; [importlib.import_module(name) for name in modules]'\''
+        '
+
+    rm -rf -- "$runtime_proto_gen"
+    mv -- "$RUNTIME_PROTO_TMP" "$runtime_proto_gen"
+    RUNTIME_PROTO_TMP=""
+    echo "[scene/start] runtime-compatible protobuf stubs ready"
+}
+
+prepare_runtime_proto_gen
 
 mkdir -p rbnx-build/data
 # Host-persisted scene state. Mounted at /data/robonix in the container so the
@@ -102,6 +165,7 @@ fi
 
 exec docker run --rm \
     --name "$CT" \
+    --entrypoint /scene/docker/entrypoint.sh \
     --network host \
     --ipc=host \
     "${GPU_ARGS[@]}" \

--- a/system/scene/scripts/start_native.sh
+++ b/system/scene/scripts/start_native.sh
@@ -66,7 +66,8 @@ mkdir -p "$SCENE_ANNOTATIONS_DIR"
 
 # Service knobs (same defaults the docker run wires via -e).
 export SCENE_WEB_PORT="${SCENE_WEB_PORT:-50107}"
+export SCENE_WEB_HOST="${SCENE_WEB_HOST-0.0.0.0}"
 export SCENE_LOG_LEVEL="${SCENE_LOG_LEVEL:-INFO}"
 
-echo "[scene/native] python=$PY ros=$ROS_DISTRO rmw=${RMW_IMPLEMENTATION:-<default>} web=$SCENE_WEB_PORT"
+echo "[scene/native] python=$PY ros=$ROS_DISTRO rmw=${RMW_IMPLEMENTATION:-<default>} web=$SCENE_WEB_HOST:$SCENE_WEB_PORT"
 exec "$PY" -m scene_service.service

--- a/system/scene/tests/test_map_binding.py
+++ b/system/scene/tests/test_map_binding.py
@@ -7,8 +7,10 @@ rclpy / the generated `map` interface package it must return None (not
 raise); on a full ROS container it still returns None because nothing
 publishes the probe topic within the short timeout.
 """
+import ast
 import os
 import sys
+from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -60,9 +62,35 @@ def test_probe_degrades_to_none_without_publisher():
     print("  [PASS] test_probe_degrades_to_none_without_publisher")
 
 
+def test_ephemeral_mapping_warnings_guide_save_then_localization():
+    """Both empty-map lifecycle warnings must describe the supported UI flow."""
+    service_path = (
+        Path(__file__).resolve().parents[1] / "scene_service" / "service.py"
+    )
+    module = ast.parse(service_path.read_text(encoding="utf-8"))
+    messages = [
+        ast.literal_eval(node.args[0])
+        for node in ast.walk(module)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "warning"
+        and node.args
+        and isinstance(node.args[0], ast.Constant)
+        and isinstance(node.args[0].value, str)
+        and "mapping broadcasts an EPHEMERAL session" in node.args[0].value
+    ]
+    assert len(messages) == 2
+    for message in messages:
+        assert "Save the current mapping session as %r first" in message
+        assert "Load that saved map or restart in localization mode" in message
+        assert "config.map_id" not in message
+    print("  [PASS] test_ephemeral_mapping_warnings_guide_save_then_localization")
+
+
 if __name__ == "__main__":
     test_broadcast_wins_over_config_and_env()
     test_empty_broadcast_map_id_falls_through()
     test_config_beats_env_then_env_then_default()
     test_probe_degrades_to_none_without_publisher()
+    test_ephemeral_mapping_warnings_guide_save_then_localization()
     print("test_map_binding: all tests passed")

--- a/system/scene/tests/test_runtime_protobuf_contract.py
+++ b/system/scene/tests/test_runtime_protobuf_contract.py
@@ -100,6 +100,11 @@ exit 0
             self.assertIn("--entrypoint sh", codegen)
             self.assertIn("grpc_tools.protoc", codegen)
             self.assertIn("--entrypoint /scene/docker/entrypoint.sh", service)
+            self.assertIn(
+                f"{scene / 'rbnx-build' / 'codegen' / 'scene_proto_gen'}:"
+                "/scene/rbnx-build/codegen/proto_gen:ro",
+                service,
+            )
             self.assertEqual(ambient.read_text(encoding="utf-8"), "# incompatible host gencode\n")
             self.assertTrue(
                 (scene / "rbnx-build" / "codegen" / "scene_proto_gen" / "atlas_pb2.py").is_file()

--- a/system/scene/tests/test_runtime_protobuf_contract.py
+++ b/system/scene/tests/test_runtime_protobuf_contract.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+"""Offline contract for Scene's image-matched protobuf generation."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+SCENE_ROOT = Path(__file__).resolve().parents[1]
+
+
+class RuntimeProtobufContractTests(unittest.TestCase):
+    def test_launcher_generates_with_runtime_image_without_network(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            scene = root / "scene"
+            (scene / "scripts").mkdir(parents=True)
+            (scene / "docker").mkdir()
+            (scene / "rbnx-build" / "proto-staging").mkdir(parents=True)
+            (scene / "rbnx-build" / "codegen" / "proto_gen").mkdir(parents=True)
+            runtime_proto = root / "runtime-proto"
+            runtime_proto.mkdir()
+
+            shutil.copy2(SCENE_ROOT / "scripts" / "start.sh", scene / "scripts")
+            shutil.copy2(
+                SCENE_ROOT / "docker" / "entrypoint.sh",
+                scene / "docker" / "entrypoint.sh",
+            )
+            (scene / "rbnx-build" / "proto-staging" / "asr.proto").write_text(
+                'syntax = "proto3";\n', encoding="utf-8"
+            )
+            (runtime_proto / "atlas.proto").write_text(
+                'syntax = "proto3";\n', encoding="utf-8"
+            )
+            # The ambient output is intentionally retained and never imported by Scene.
+            ambient = scene / "rbnx-build" / "codegen" / "proto_gen" / "asr_pb2.py"
+            ambient.write_text("# incompatible host gencode\n", encoding="utf-8")
+
+            fake_bin = root / "fake-bin"
+            fake_bin.mkdir()
+            docker_log = root / "docker.log"
+            (fake_bin / "rbnx").write_text(
+                "#!/usr/bin/env bash\n"
+                "set -eu\n"
+                "[[ \"${1:-}\" == path && \"${2:-}\" == runtime-proto ]]\n"
+                "printf '%s\\n' \"$FAKE_RUNTIME_PROTO\"\n",
+                encoding="utf-8",
+            )
+            (fake_bin / "docker").write_text(
+                """#!/usr/bin/env bash
+set -eu
+printf '%q ' "$@" >> "$FAKE_DOCKER_LOG"
+printf '\n' >> "$FAKE_DOCKER_LOG"
+if [[ " $* " == *" --network none "* ]]; then
+    for argument in "$@"; do
+        case "$argument" in
+            *:/proto-gen) output="${argument%:/proto-gen}" ;;
+        esac
+    done
+    [[ -n "${output:-}" ]]
+    printf '# image-matched\n' > "$output/atlas_pb2.py"
+    printf '# image-matched\n' > "$output/robonix_contracts_pb2_grpc.py"
+fi
+exit 0
+""",
+                encoding="utf-8",
+            )
+            for executable in (fake_bin / "rbnx", fake_bin / "docker"):
+                executable.chmod(0o755)
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "PATH": f"{fake_bin}{os.pathsep}{env['PATH']}",
+                    "RBNX_PACKAGE_ROOT": str(scene),
+                    "ROBONIX_SCENE_IMAGE": "scene-runtime:test",
+                    "SCENE_DATA_DIR": str(root / "scene-data"),
+                    "FAKE_RUNTIME_PROTO": str(runtime_proto),
+                    "FAKE_DOCKER_LOG": str(docker_log),
+                }
+            )
+            subprocess.run(
+                ["bash", "scripts/start.sh"],
+                cwd=scene,
+                env=env,
+                check=True,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+            lines = docker_log.read_text(encoding="utf-8").splitlines()
+            codegen = next(line for line in lines if "--network none" in line)
+            service = next(line for line in lines if "--network host" in line)
+            self.assertIn("--entrypoint sh", codegen)
+            self.assertIn("grpc_tools.protoc", codegen)
+            self.assertIn("--entrypoint /scene/docker/entrypoint.sh", service)
+            self.assertEqual(ambient.read_text(encoding="utf-8"), "# incompatible host gencode\n")
+            self.assertTrue(
+                (scene / "rbnx-build" / "codegen" / "scene_proto_gen" / "atlas_pb2.py").is_file()
+            )
+
+    def test_entrypoint_has_no_ambient_codegen_fallback(self):
+        entrypoint = (SCENE_ROOT / "docker" / "entrypoint.sh").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("SCENE_PROTO_GEN=/scene/rbnx-build/codegen/scene_proto_gen", entrypoint)
+        export_line = next(
+            line for line in entrypoint.splitlines() if line.startswith("export PYTHONPATH=")
+        )
+        self.assertIn("$SCENE_PROTO_GEN", export_line)
+        self.assertNotIn("/codegen/proto_gen:", export_line)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/system/scene/tests/test_web_binding.py
+++ b/system/scene/tests/test_web_binding.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+"""Scene web UI binding policy tests."""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from scene_service.web_binding import resolve_web_host
+
+
+def test_explicit_config_host_wins_over_environment():
+    assert resolve_web_host(
+        {"web_host": "127.0.0.1"}, {"SCENE_WEB_HOST": "0.0.0.0"}
+    ) == "127.0.0.1"
+
+
+def test_environment_host_is_supported_for_launcher_compatibility():
+    assert resolve_web_host({}, {"SCENE_WEB_HOST": "127.0.0.1"}) == "127.0.0.1"
+
+
+def test_existing_deployments_keep_legacy_default():
+    assert resolve_web_host({}, {}) == "0.0.0.0"
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        " ",
+        "0",
+        "00",
+        "0x0",
+        "0.0",
+        "0.0.0",
+        "000.000.000.000",
+        "0000000000",
+        "http://127.0.0.1",
+        "127.0.0.1/ui",
+        "bad host",
+    ],
+)
+def test_invalid_bind_hosts_fail_closed(bad):
+    with pytest.raises(ValueError):
+        resolve_web_host({"web_host": bad}, {})
+
+
+@pytest.mark.parametrize("bad", [None, 0, False])
+def test_non_string_manifest_hosts_fail_closed(bad):
+    with pytest.raises(ValueError, match="must be a string"):
+        resolve_web_host({"web_host": bad}, {"SCENE_WEB_HOST": "127.0.0.1"})
+
+
+def test_explicit_blank_values_do_not_fall_back_to_all_interfaces():
+    with pytest.raises(ValueError, match="must not be blank"):
+        resolve_web_host({"web_host": ""}, {"SCENE_WEB_HOST": "127.0.0.1"})
+    with pytest.raises(ValueError, match="must not be blank"):
+        resolve_web_host({}, {"SCENE_WEB_HOST": ""})
+
+
+def test_launchers_preserve_blank_values_for_runtime_rejection():
+    root = Path(__file__).resolve().parents[1]
+    docker_launcher = (root / "scripts" / "start.sh").read_text(encoding="utf-8")
+    native_launcher = (root / "scripts" / "start_native.sh").read_text(
+        encoding="utf-8"
+    )
+    expected = "SCENE_WEB_HOST=\"${SCENE_WEB_HOST-0.0.0.0}\""
+    assert expected in docker_launcher
+    assert expected in native_launcher

--- a/system/scene/tests/test_web_live_views.py
+++ b/system/scene/tests/test_web_live_views.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+"""Focused regressions for Scene's passive live-view pages."""
+
+import asyncio
+import os
+import re
+import shutil
+import subprocess
+import sys
+import threading
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def _web_module():
+    """Import production code so its own ImportError can never become a skip."""
+    from scene_service import web
+
+    return web
+
+
+class _FakeHub:
+    def __init__(self, channels):
+        self.channels = channels
+
+    def has(self, kind):
+        return kind in self.channels
+
+    def latest(self, kind):
+        return self.channels[kind]
+
+
+def _empty_camera_cache():
+    """Return isolated mutable cache state for one focused test."""
+    return {
+        "rgb": {"hub": None, "count": -1, "payload": None},
+        "depth": {"hub": None, "count": -1, "payload": None},
+    }
+
+
+def test_camera_preview_is_encoded_once_per_hub_channel_message(monkeypatch):
+    """Reuse completed encodings but never cross hub or message identity."""
+    web = _web_module()
+    monkeypatch.setattr(web, "_CAMERA_CACHE", _empty_camera_cache())
+    calls = []
+
+    def fake_encode(msg, *, kind):
+        """Return a deterministic encoded record while tracking invocations."""
+        calls.append((msg, kind))
+        return {
+            "width": 2,
+            "height": 1,
+            "encoding": "rgb8",
+            "stamp_ms": 0,
+            "png_b64": f"encoded-{msg}",
+        }
+
+    monkeypatch.setattr(web, "_image_to_png_b64", fake_encode)
+    hub = _FakeHub({"rgb": ("frame-1", 12.5, 1)})
+
+    first = web._camera_payload(hub)
+    second = web._camera_payload(hub)
+    assert first == second
+    assert first["rgb"]["stamp_ms"] == 12500
+    assert calls == [("frame-1", "rgb")]
+
+    hub.channels["rgb"] = ("frame-2", 13.0, 2)
+    assert web._camera_payload(hub)["rgb"]["png_b64"] == "encoded-frame-2"
+    assert calls == [("frame-1", "rgb"), ("frame-2", "rgb")]
+
+    # A new app/hub may start its counter at the same value. Hub identity is
+    # therefore part of the cache key, preventing a stale cross-app frame.
+    other_hub = _FakeHub({"rgb": ("other-frame-2", 14.0, 2)})
+    assert web._camera_payload(other_hub)["rgb"]["png_b64"] == "encoded-other-frame-2"
+    assert calls[-1] == ("other-frame-2", "rgb")
+
+
+def test_unsupported_camera_frame_is_cached_until_message_changes(monkeypatch):
+    """Cache an unsupported frame only until that channel count advances."""
+    web = _web_module()
+    monkeypatch.setattr(web, "_CAMERA_CACHE", _empty_camera_cache())
+    calls = []
+
+    def unsupported(msg, *, kind):
+        calls.append((msg, kind))
+        return None
+
+    monkeypatch.setattr(web, "_image_to_png_b64", unsupported)
+    hub = _FakeHub({"depth": ("unsupported-depth", 1.0, 7)})
+    assert web._camera_payload(hub)["depth"] is None
+    assert web._camera_payload(hub)["depth"] is None
+    assert calls == [("unsupported-depth", "depth")]
+
+    hub.channels["depth"] = ("next-depth", 2.0, 8)
+    assert web._camera_payload(hub)["depth"] is None
+    assert calls == [
+        ("unsupported-depth", "depth"),
+        ("next-depth", "depth"),
+    ]
+
+
+def test_camera_requests_are_offloaded_single_flight_and_rate_limited(monkeypatch):
+    """Keep a slow preview worker from blocking or duplicating ASGI requests."""
+    web = _web_module()
+    hub = object()
+    calls = []
+    entered = threading.Event()
+    release = threading.Event()
+
+    def slow_payload(request_hub):
+        """Hold the worker until the test proves the event loop is responsive."""
+        calls.append(request_hub)
+        entered.set()
+        if not release.wait(timeout=2.0):
+            raise AssertionError("camera encoding blocked the ASGI event loop")
+        return {"rgb": {"stamp_ms": 1, "png_b64": "frame"}, "depth": None}
+
+    monkeypatch.setattr(web, "_camera_payload", slow_payload)
+    monkeypatch.setattr(web, "_CAMERA_PREVIEW_MIN_INTERVAL_S", 0.01)
+    app = web.make_app(registry=object(), hub=hub)
+
+    async def scenario():
+        """Issue overlapping requests and one immediate cache-hit request."""
+        import httpx
+
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://scene.test"
+        ) as client:
+            first = asyncio.create_task(client.get("/api/camera"))
+            second = asyncio.create_task(client.get("/api/camera"))
+            deadline = asyncio.get_running_loop().time() + 0.5
+            while not entered.is_set() and asyncio.get_running_loop().time() < deadline:
+                await asyncio.sleep(0.001)
+            assert entered.is_set(), "slow encoder did not start off the event loop"
+            assert not first.done()
+            release.set()
+            responses = await asyncio.gather(first, second)
+            responses.append(await client.get("/api/camera"))
+            await asyncio.sleep(0.02)
+            responses.append(await client.get("/api/camera"))
+            return responses
+
+    responses = asyncio.run(scenario())
+    assert [response.status_code for response in responses] == [200, 200, 200, 200]
+    assert all(
+        response.json()["rgb"]["png_b64"] == "frame" for response in responses
+    )
+    assert calls == [hub, hub]
+
+
+def test_live_map_pages_expose_first_paint_readiness_and_errors():
+    """Expose visible first-paint state and guard both image callbacks."""
+    web = _web_module()
+    for html in (web._INDEX_HTML, web._USER_HTML):
+        assert '<body data-ready="loading">' in html
+        assert 'role="status"' in html
+        assert "document.body.dataset.ready = value" in html
+        assert "c.clientWidth > 0 && c.clientHeight > 0" in html
+        assert "visibilitychange" in html
+        assert "Scene state unavailable" in html
+        assert "Scene map image could not be decoded" in html
+        assert html.count("if (!isCurrentOccupancyLoad(loadToken, meta.stamp_ms)) return;") == 2
+
+    assert "if (currentState) draw(currentState);" in web._INDEX_HTML
+    assert (
+        "occStamp = meta.stamp_ms;\n            occLoading = 0;\n            draw();"
+        in web._USER_HTML
+    )
+    assert "no depth frame available" in web._INDEX_CAM_HTML
+
+
+def test_occupancy_generation_guard_rejects_late_success_and_error_callbacks():
+    """Execute the shared JS guard against stale token and stamp generations."""
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is not installed")
+    web = _web_module()
+    pattern = re.compile(
+        r"function isCurrentOccupancyLoad\(token, stamp\) \{\s*"
+        r"return token === occLoadToken && stamp === occLoading;\s*\}"
+    )
+    for html in (web._INDEX_HTML, web._USER_HTML):
+        match = pattern.search(html)
+        assert match is not None
+        program = "\n".join(
+            (
+                "let occLoadToken = 2;",
+                "let occLoading = 200;",
+                match.group(0),
+                "if (isCurrentOccupancyLoad(1, 100)) process.exit(1);",
+                "if (isCurrentOccupancyLoad(2, 100)) process.exit(2);",
+                "if (!isCurrentOccupancyLoad(2, 200)) process.exit(3);",
+            )
+        )
+        subprocess.run([node], input=program, text=True, check=True)
+
+
+@pytest.mark.parametrize("html_name", ["_INDEX_HTML", "_USER_HTML", "_INDEX_CAM_HTML"])
+def test_live_view_inline_javascript_is_valid(html_name):
+    """Parse each changed inline script with the host JavaScript engine."""
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is not installed")
+    web = _web_module()
+    html = getattr(web, html_name)
+    script = html.rsplit("<script>", 1)[1].split("</script>", 1)[0]
+    subprocess.run([node, "--check"], input=script, text=True, check=True)


### PR DESCRIPTION
> [!NOTE]
> This PR recreates #162 after the repository history cleanup. The implementation is preserved on the main-repository branch `feat/scene-live-views`; the original contributor is @Origamii520. Closing the original PR was an administrative migration, not an acceptance or rejection of the work.

## Summary

- generate Scene protobuf stubs with the runtime image and mask incompatible host stubs
- support an explicit loopback web binding for workstation-local deployments
- clarify that an unnamed mapping session is ephemeral and must be saved before localization
- move live camera encoding off the asyncio event loop with single-flight/result caching
- add visible first-paint/error states and stale image-callback guards for the live pages

## Motivation

The Unitree Go2 workstation profile runs Scene, Mapping, Dashboard and the official Client together on loopback. The Scene live pages must remain responsive while 1080p camera frames and occupancy snapshots update, and they must not imply that an ephemeral mapping session is already a reusable localization map.

## Validation

- dependency-complete Scene test container, source mounted read-only and network disabled: **119 passed, 5 skipped**
- host Node/live-view regression run: **8 passed**
- focused runtime/web/map tests: **30 passed, 4 skipped** in the network-disabled image
- real Go2 no-motion operator stack reached `ROBONIX GO2 OPERATOR UI READY — MOTION DISABLED`
- Scene `/user`, `/2d`, `/3d`, and `/cam` were exercised alongside Mapping and Dashboard; screenshots and bounded HTTP evidence were retained in the downstream Go2 integration workspace
- no task capability, ROS action goal, chassis command, or physical motion was issued

## Scope boundaries

This does not claim a saved/reloaded map, localization acceptance, semantic landmark acceptance, voice availability, or physical navigation. Those remain behind downstream readiness and explicit hardware-motion gates.

Follow-up to #153.

## Migrated review context

- Original PR: #162
- Original contributor: @Origamii520
- The original discussion remains available on #162. Material review points are restated in a comment on this PR so they remain visible during continued review.
- Validation results quoted above are historical. This branch must be rebased or merged with the current `dev` and tested again before merge.