### PR TITLE
fix(runtime): bind startup to manifest instance identities

### DIFF
--- a/pylib/robonix-api/robonix_api/capability.py
+++ b/pylib/robonix-api/robonix_api/capability.py
@@ -59,6 +59,8 @@ from .tool import mcp_contract
 
 log = logging.getLogger("robonix_api.capability")
 
+_INSTANCE_NAME_ENV = "RBNX_INSTANCE_NAME"
+
 
 # Transport-ENUM <-> contract.mode compatibility matrix (best-effort
 # check at declare_capability time).
@@ -94,6 +96,24 @@ def _provider_bind_host(value: str | None = None) -> str:
     return str(address)
 
 
+def _resolve_provider_id(default_id: str) -> str:
+    """Resolve a package default id to its deploy-time instance identity."""
+    instance_id = os.environ.get(_INSTANCE_NAME_ENV, "").strip()
+    if not instance_id:
+        if os.environ.get("RBNX_DEPLOY_MANAGED", "").strip():
+            raise RuntimeError(
+                "RBNX_INSTANCE_NAME must be non-empty for a deploy-managed package"
+            )
+        return default_id
+    if instance_id != default_id:
+        log.info(
+            "deployment instance id overrides package default: %r -> %r",
+            default_id,
+            instance_id,
+        )
+    return instance_id
+
+
 # ── _ProviderBase ───────────────────────────────────────────────────────────
 
 
@@ -124,7 +144,8 @@ class _ProviderBase:
         pkg_root: Path | None = None,
         md_path: str | None = None,
     ) -> None:
-        self.id = id
+        self.default_id = id
+        self.id = _resolve_provider_id(id)
         self.namespace = namespace.strip("/")
         if not self.namespace:
             raise ValueError("namespace must be non-empty")

--- a/pylib/robonix-api/tests/test_instance_identity.py
+++ b/pylib/robonix-api/tests/test_instance_identity.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+from unittest.mock import patch
+
+import pytest
+
+from robonix_api.capability import Primitive, _resolve_provider_id
+
+
+def test_package_id_is_the_standalone_default():
+    with patch.dict("os.environ", {}, clear=True):
+        assert _resolve_provider_id("orbbec_camera") == "orbbec_camera"
+
+
+def test_manifest_instance_name_overrides_package_default():
+    with patch.dict(
+        "os.environ",
+        {"RBNX_INSTANCE_NAME": "orbbec_wrist_camera"},
+        clear=True,
+    ):
+        assert _resolve_provider_id("orbbec_camera") == "orbbec_wrist_camera"
+
+
+def test_provider_uses_manifest_instance_for_runtime_identity(tmp_path):
+    with patch.dict(
+        "os.environ",
+        {"RBNX_INSTANCE_NAME": "orbbec_wrist_camera"},
+        clear=True,
+    ):
+        provider = Primitive(
+            "orbbec_camera",
+            "robonix/primitive/camera",
+            pkg_root=tmp_path,
+        )
+    assert provider.default_id == "orbbec_camera"
+    assert provider.id == "orbbec_wrist_camera"
+
+
+def test_blank_instance_name_does_not_erase_package_default():
+    with patch.dict("os.environ", {"RBNX_INSTANCE_NAME": "  "}, clear=True):
+        assert _resolve_provider_id("orbbec_camera") == "orbbec_camera"
+
+
+@pytest.mark.parametrize("instance_name", [None, "", "  "])
+def test_deploy_managed_provider_requires_instance_name(instance_name):
+    env = {"RBNX_DEPLOY_MANAGED": "1"}
+    if instance_name is not None:
+        env["RBNX_INSTANCE_NAME"] = instance_name
+    with (
+        patch.dict("os.environ", env, clear=True),
+        pytest.raises(RuntimeError, match="RBNX_INSTANCE_NAME must be non-empty"),
+    ):
+        _resolve_provider_id("orbbec_camera")

--- a/system/soma/README.md
+++ b/system/soma/README.md
@@ -55,6 +55,11 @@ serves gRPC on `listen`. Skill packages are held until `rbnx boot` writes
 `stage2\n` into the pipe on `$ROBONIX_SOMA_STAGE_FD` (stage 2). Soma stops
 every package it launched on SIGINT/SIGTERM.
 
+For every package, Soma passes the deployment entry's `name` through
+`RBNX_INSTANCE_NAME` and waits only for that exact Atlas provider id. Package
+instance names must be non-empty, whitespace-normalized, unique, and not
+already live before spawn.
+
 `--log` sets Soma's scribe file level (`debug`, `info`, `warn`, or `error`);
 package stdout/stderr is written through scribe under `$SCRIBE_LOG_DIR` or
 `./logs`.

--- a/system/soma/src/deployment.rs
+++ b/system/soma/src/deployment.rs
@@ -125,6 +125,8 @@ impl Deployment {
             .with_context(|| format!("parse '{}'", manifest_path.display()))?;
         let prepared = prepare_deployment_manifest(raw, None)
             .with_context(|| format!("prepare '{}'", manifest_path.display()))?;
+        robonix_cli::manifest::validate_deployment_instance_names(&prepared)
+            .with_context(|| format!("validate identities in '{}'", manifest_path.display()))?;
         let manifest: DeployManifest = serde_yaml::from_value(prepared)
             .with_context(|| format!("decode '{}'", manifest_path.display()))?;
         let cache_root = deployment_path.join("rbnx-boot").join("cache");

--- a/system/soma/src/launcher.rs
+++ b/system/soma/src/launcher.rs
@@ -208,7 +208,7 @@ impl PackageLauncher {
         // early-exit detection rbnx uses for soma itself (deploy.rs).
         let who = format!("{}/{}", target.kind, target.name);
         let outcome = tokio::select! {
-            result = wait_for_registration_core(atlas, &before, &who) => match result {
+            result = wait_for_registration_core(atlas, &before, &target.name, &who) => match result {
                 Ok(o) => o,
                 Err(e) => {
                     self.reap(pid).await;
@@ -250,7 +250,19 @@ impl PackageLauncher {
             return PackageStartupStatus::Spawned { command };
         };
 
-        let config_json = serde_json::to_string(&target.config).unwrap_or_else(|_| "{}".into());
+        let config_json = match serde_json::to_string(&target.config) {
+            Ok(value) => value,
+            Err(error) => {
+                self.reap(pid).await;
+                return PackageStartupStatus::SpawnFailed {
+                    command,
+                    error: format!(
+                        "{who}: serialize config for deployment instance '{}': {error}",
+                        target.name
+                    ),
+                };
+            }
+        };
         self.note_lifecycle(
             pid,
             outcome.provider_id.clone(),

--- a/tools/rbnx/README.md
+++ b/tools/rbnx/README.md
@@ -52,6 +52,13 @@ Run `rbnx <cmd> --help` for full flags.
 - `RBNX_CONFIG_FILE` — explicit path to a config file (overrides
   `~/.robonix/config.yaml`).
 
+Each primitive, service, and skill entry's `name` is its deploy-time Atlas
+provider id. `rbnx boot` passes it as `RBNX_INSTANCE_NAME`; the SDK uses that
+identity for registration, capability declaration, heartbeat, and lifecycle
+state. Package source keeps its own default id for standalone `rbnx start`.
+Startup waits only for the exact expected id, so an unrelated concurrent
+registration cannot receive another instance's lifecycle config.
+
 ## How it finds the source tree
 
 Many subcommands (codegen, build, boot) need to resolve paths inside

--- a/tools/rbnx/src/cmd/deploy.rs
+++ b/tools/rbnx/src/cmd/deploy.rs
@@ -362,7 +362,9 @@ pub(super) fn prepare_manifest(
     root: serde_yaml::Value,
     robonix_source_path: Option<&Path>,
 ) -> Result<serde_yaml::Value> {
-    robonix_cli::manifest::prepare_deployment_manifest(root, robonix_source_path)
+    let prepared = robonix_cli::manifest::prepare_deployment_manifest(root, robonix_source_path)?;
+    robonix_cli::manifest::validate_deployment_instance_names(&prepared)?;
+    Ok(prepared)
 }
 
 /// Make sure `system.soma` exists in the manifest map as a mapping,
@@ -1823,15 +1825,22 @@ async fn spawn_and_init(
         );
     };
 
-    let (provider_id, driver_contract) =
-        match wait_for_registration(atlas, &before, &pkg_label, component, spawn_env.log_dir).await
-        {
-            Ok(v) => v,
-            Err(e) => {
-                reap();
-                return Err(e);
-            }
-        };
+    let (provider_id, driver_contract) = match wait_for_registration(
+        atlas,
+        &before,
+        &entry.name,
+        &pkg_label,
+        component,
+        spawn_env.log_dir,
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(e) => {
+            reap();
+            return Err(e);
+        }
+    };
 
     // Spec: the provider_id this process registers (Python's
     // `Capability(id=...)`) MUST equal robonix_manifest.yaml's `name:`
@@ -1843,8 +1852,8 @@ async fn spawn_and_init(
         output::boot_fail(
             short_label(&pkg_label, component),
             &format!(
-                "provider_id mismatch: manifest says name='{}' but Capability(id='{}') registered. \
-                 Fix python source to match manifest. Log: {}",
+                "deployment instance propagation failed: expected manifest name='{}', \
+                 observed Capability(id='{}'). Log: {}",
                 entry.name,
                 provider_id,
                 log_file.display()
@@ -1867,7 +1876,18 @@ async fn spawn_and_init(
         return Ok(sp);
     };
 
-    let config_json = serde_json::to_string(&entry.config).unwrap_or_else(|_| "{}".into());
+    let config_json = match serde_json::to_string(&entry.config).with_context(|| {
+        format!(
+            "[{component}/{pkg_label}] serialize config for deployment instance '{}'",
+            entry.name
+        )
+    }) {
+        Ok(value) => value,
+        Err(error) => {
+            reap();
+            return Err(error);
+        }
+    };
     sp.provider_id = Some(provider_id.clone());
     sp.driver_contract = Some(driver_contract.clone());
     sp.config_json = Some(config_json.clone());
@@ -2270,14 +2290,20 @@ fn short_label<'a>(pkg_label: &'a str, component: &str) -> &'a str {
 async fn wait_for_registration(
     atlas: &mut AtlasClient,
     before: &HashSet<String>,
+    expected_provider_id: &str,
     pkg_label: &str,
     component: &str,
     log_dir: &Path,
 ) -> Result<(String, Option<String>)> {
-    // One package = one provider. Find the provider that wasn't in `before`.
-    // Multiple new providers = deploy bug, fail loud. No heartbeat-based
-    // freshness fallback — every existing ACTIVE provider heartbeats
-    // periodically and would falsely match.
+    if before.contains(expected_provider_id) {
+        anyhow::bail!(
+            "[{component}/{pkg_label}] deployment instance '{expected_provider_id}' \
+             was already registered before spawn"
+        );
+    }
+
+    // Wait only for this manifest entry's exact provider id. Other packages
+    // may register concurrently and must not receive this instance's config.
     const SPINNER_TICK: Duration = Duration::from_millis(100);
     const POLLS_PER_TICK: u32 = 2; // poll atlas every 200 ms
     let started = Instant::now();
@@ -2302,30 +2328,14 @@ async fn wait_for_registration(
                 .query_capabilities("", "", atlas_pb::Transport::Unspecified)
                 .await
                 .with_context(|| format!("[{component}/{pkg_label}] poll atlas"))?;
-            let matches: Vec<&atlas_pb::CapabilityProvider> = providers
-                .iter()
-                .filter(|provider| !before.contains(&provider.id))
-                .collect();
-            if matches.len() > 1 {
-                let log_file = log_path(log_dir, pkg_label);
-                let cap_ids: Vec<&str> = matches.iter().map(|r| r.id.as_str()).collect();
-                output::boot_fail(
-                    display_label,
-                    &format!(
-                        "multiple new providers appeared from one spawn ({}) — \
-                         package start must register exactly one Capability. Log: {}",
-                        cap_ids.join(", "),
-                        log_file.display()
-                    ),
-                );
-                anyhow::bail!(
-                    "[{component}/{pkg_label}] multiple new providers from one spawn: {} \
-                     — spec is one package start = one Capability(id=...). Log: {}",
-                    cap_ids.join(", "),
-                    log_file.display()
-                );
-            }
-            if let Some(first) = matches.first() {
+            let matched = providers.iter().find(|provider| {
+                robonix_cli::launch::is_expected_provider_registration(
+                    provider,
+                    before,
+                    expected_provider_id,
+                )
+            });
+            if let Some(first) = matched {
                 let provider_id = first.id.clone();
                 // RegisterPrimitive/Service/Skill and DeclareCapability are
                 // two separate RPCs from the package side — Register lands

--- a/tools/rbnx/src/launch.rs
+++ b/tools/rbnx/src/launch.rs
@@ -302,6 +302,15 @@ pub async fn snapshot_provider_ids(atlas: &mut AtlasClient) -> Result<HashSet<St
         .collect())
 }
 
+/// Match only a newly appearing registration for the requested manifest id.
+pub fn is_expected_provider_registration(
+    provider: &atlas_pb::CapabilityProvider,
+    before: &HashSet<String>,
+    expected_provider_id: &str,
+) -> bool {
+    provider.id == expected_provider_id && !before.contains(expected_provider_id)
+}
+
 /// Outcome of `wait_for_registration_core`:
 ///   * `provider_id` — the new provider that appeared after `before`.
 ///   * `driver_contract` — if the new provider also declared a
@@ -332,8 +341,15 @@ pub struct RegistrationOutcome {
 pub async fn wait_for_registration_core(
     atlas: &mut AtlasClient,
     before: &HashSet<String>,
+    expected_provider_id: &str,
     who: &str,
 ) -> Result<RegistrationOutcome> {
+    if before.contains(expected_provider_id) {
+        anyhow::bail!(
+            "[{who}] deployment instance '{expected_provider_id}' was already registered before spawn"
+        );
+    }
+
     // Poll cadence is decoupled from any spinner refresh: we just sleep
     // 200ms between Atlas queries. That's the same cadence the CLI used
     // (one query per 2 spinner ticks at 100ms/tick).
@@ -345,19 +361,10 @@ pub async fn wait_for_registration_core(
             .query_capabilities("", "", atlas_pb::Transport::Unspecified)
             .await
             .with_context(|| format!("[{who}] poll atlas"))?;
-        let matches: Vec<&atlas_pb::CapabilityProvider> = providers
-            .iter()
-            .filter(|provider| !before.contains(&provider.id))
-            .collect();
-        if matches.len() > 1 {
-            let cap_ids: Vec<&str> = matches.iter().map(|r| r.id.as_str()).collect();
-            anyhow::bail!(
-                "[{who}] multiple new providers appeared from one spawn: {} \
-                 — spec is one package start = one Capability(id=...)",
-                cap_ids.join(", ")
-            );
-        }
-        if let Some(first) = matches.first() {
+        let matched = providers.iter().find(|provider| {
+            is_expected_provider_registration(provider, before, expected_provider_id)
+        });
+        if let Some(first) = matched {
             let provider_id = first.id.clone();
             // RegisterPrimitive/Service/Skill and DeclareCapability are
             // two separate RPCs from the package side — Register lands
@@ -501,4 +508,42 @@ pub async fn call_driver_cmd(
         );
     }
     Ok(r.state)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{atlas_pb, is_expected_provider_registration};
+    use std::collections::HashSet;
+
+    #[test]
+    fn expected_registration_ignores_unrelated_provider() {
+        let before = HashSet::from(["existing_camera".to_string()]);
+        let provider = |id: &str| atlas_pb::CapabilityProvider {
+            id: id.to_string(),
+            ..Default::default()
+        };
+
+        assert!(!is_expected_provider_registration(
+            &provider("unrelated_lidar"),
+            &before,
+            "camera",
+        ));
+        assert!(is_expected_provider_registration(
+            &provider("camera"),
+            &before,
+            "camera",
+        ));
+    }
+
+    #[test]
+    fn expected_registration_rejects_an_already_live_id() {
+        let before = HashSet::from(["camera".to_string()]);
+        let provider = atlas_pb::CapabilityProvider {
+            id: "camera".to_string(),
+            ..Default::default()
+        };
+        assert!(!is_expected_provider_registration(
+            &provider, &before, "camera",
+        ));
+    }
 }

--- a/tools/rbnx/src/manifest.rs
+++ b/tools/rbnx/src/manifest.rs
@@ -20,7 +20,7 @@
 use anyhow::{Context, Result};
 use robonix_scribe::warn;
 use serde::Deserialize;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 /// Preferred per-package manifest filename. Legacy `robonix_manifest.yaml`
@@ -72,6 +72,44 @@ pub fn prepare_deployment_manifest(
     }
     expand_deployment_yaml(&mut root);
     Ok(root)
+}
+
+/// Validate Atlas provider identities owned by deployment package entries.
+pub fn validate_deployment_instance_names(root: &serde_yaml::Value) -> Result<()> {
+    let mut seen = HashSet::new();
+    let mut record = |name: &str, location: &str| -> Result<()> {
+        let trimmed = name.trim();
+        if trimmed.is_empty() {
+            anyhow::bail!("{location} must declare a non-empty `name`");
+        }
+        if name != trimmed {
+            anyhow::bail!("{location} `name` must not contain leading or trailing whitespace");
+        }
+        if !seen.insert(name.to_string()) {
+            anyhow::bail!(
+                "duplicate deployment instance name '{name}' at {location}; \
+                 every primitive, service, and skill instance must be unique"
+            );
+        }
+        Ok(())
+    };
+
+    for section in ["primitive", "service", "skill"] {
+        let Some(entries) = root.get(section) else {
+            continue;
+        };
+        let entries = entries
+            .as_sequence()
+            .ok_or_else(|| anyhow::anyhow!("deployment `{section}` must be a list"))?;
+        for (index, entry) in entries.iter().enumerate() {
+            let name = entry
+                .get("name")
+                .and_then(serde_yaml::Value::as_str)
+                .unwrap_or("");
+            record(name, &format!("{section}[{index}]"))?;
+        }
+    }
+    Ok(())
 }
 
 pub fn expand_deployment_env(s: &str) -> String {
@@ -453,5 +491,44 @@ capabilities: []
         manifest
             .validate_and_summarize()
             .expect("package.vendor must not invalidate an otherwise valid manifest");
+    }
+
+    #[test]
+    fn deployment_instance_names_are_unique_across_sections() {
+        let valid: serde_yaml::Value =
+            serde_yaml::from_str("primitive:\n  - name: camera\nservice:\n  - name: navigation\n")
+                .unwrap();
+        validate_deployment_instance_names(&valid).unwrap();
+
+        let duplicate: serde_yaml::Value =
+            serde_yaml::from_str("primitive:\n  - name: camera\nskill:\n  - name: camera\n")
+                .unwrap();
+        assert!(
+            validate_deployment_instance_names(&duplicate)
+                .unwrap_err()
+                .to_string()
+                .contains("duplicate deployment instance name 'camera'")
+        );
+    }
+
+    #[test]
+    fn deployment_instance_name_is_required_and_normalized() {
+        let missing: serde_yaml::Value =
+            serde_yaml::from_str("primitive:\n  - path: camera\n").unwrap();
+        assert!(
+            validate_deployment_instance_names(&missing)
+                .unwrap_err()
+                .to_string()
+                .contains("must declare a non-empty `name`")
+        );
+
+        let padded: serde_yaml::Value =
+            serde_yaml::from_str("primitive:\n  - name: ' camera '\n").unwrap();
+        assert!(
+            validate_deployment_instance_names(&padded)
+                .unwrap_err()
+                .to_string()
+                .contains("must not contain leading or trailing whitespace")
+        );
     }
 }


### PR DESCRIPTION
## Summary

Make a deployment entry's `name` the authoritative runtime instance identity across robonix-api, rbnx boot, and Soma. This closes the provider-registration race described in #170 without importing the experimental shared-Driver work from `dev-next`.

## Problem

Boot and Soma previously diffed Atlas before/after spawn and selected the first newly registered provider. If another provider (for example Executor) registered concurrently, lifecycle configuration could be sent to that unrelated provider and the intended primitive would then be reaped.

## Changes

- resolve `RBNX_INSTANCE_NAME` in robonix-api while retaining the source-level package ID as the standalone default
- require deploy-managed packages to receive a non-empty instance ID
- validate primitive/service/skill names as non-empty, whitespace-normalized, and globally unique within a deployment
- fail if the expected instance ID is already live before spawn
- wait only for the exact manifest instance ID in rbnx and Soma
- fail and reap on configuration serialization errors instead of silently substituting `{}`
- document the package-default versus deployment-instance identity split

## Validation

- `make check`
- `cargo build --workspace`
- `cargo test --workspace --all-targets`
- `PYTHONPATH=pylib/robonix-api pytest -q pylib/robonix-api/tests/test_instance_identity.py` (7 passed)

Closes #170