### PR TITLE
feat(scene): expose stable room region queries

### DIFF
--- a/capabilities/lib/semantic_map/msg/Region.msg
+++ b/capabilities/lib/semantic_map/msg/Region.msg
@@ -1,0 +1,11 @@
+# User-authored room region anchored to the active SLAM map.
+# `id` is the stable Scene identifier accepted directly by goal_room.
+
+string id
+string kind
+string name
+float64[] points_xy
+float64 theta
+bool stale
+string stale_reason
+float64 updated_at_unix

--- a/capabilities/lib/semantic_map/srv/ListObjects.srv
+++ b/capabilities/lib/semantic_map/srv/ListObjects.srv
@@ -1,8 +1,6 @@
 # robonix/system/scene/list_objects — return every object the scene
-# registry currently believes exists. No filters, no scoping; the LLM
-# calls this every round to ground its world model and filters
-# client-side by label / distance / etc. (cheaper than baking those
-# knobs into the schema).
+# registry currently believes exists. Room entries remain for v1
+# compatibility; new callers should use ListRegions for full room geometry.
 ---
 Object[] objects
 float64 stamp_unix

--- a/capabilities/lib/semantic_map/srv/ListRegions.srv
+++ b/capabilities/lib/semantic_map/srv/ListRegions.srv
@@ -1,0 +1,6 @@
+# robonix/system/scene/list_regions — return user-authored room regions.
+# Physical objects are deliberately excluded; use list_objects for them.
+---
+Region[] regions
+string map_id
+float64 stamp_unix

--- a/capabilities/system/scene/list_objects.v1.toml
+++ b/capabilities/system/scene/list_objects.v1.toml
@@ -1,12 +1,11 @@
-# Return every object the scene registry currently believes exists.
-# No filters, no scoping; the LLM filters client-side. Pilot calls
-# this every round to ground its world model.
+# Return every object the scene registry currently believes exists. Room
+# entries remain for v1 compatibility; list_regions exposes full geometry.
 [contract]
 id      = "robonix/system/scene/list_objects"
 version = "1"
 kind    = "service"
 idl     = "semantic_map/srv/ListObjects.srv"
-description = "List all objects currently known to the scene registry."
+description = "List objects currently known to Scene, including compatibility room entries. Use list_regions for room geometry and staleness."
 
 [mode]
 type = "rpc"

--- a/capabilities/system/scene/list_regions.v1.toml
+++ b/capabilities/system/scene/list_regions.v1.toml
@@ -1,0 +1,10 @@
+# Return user-authored room regions without mixing them with perceived objects.
+[contract]
+id      = "robonix/system/scene/list_regions"
+version = "1"
+kind    = "service"
+idl     = "semantic_map/srv/ListRegions.srv"
+description = "List all registered room regions with stable IDs and polygon metadata. Use this before goal_room; use list_objects only for perceived physical objects."
+
+[mode]
+type = "rpc"

--- a/system/scene/README.md
+++ b/system/scene/README.md
@@ -413,6 +413,7 @@ file, the sidecar, and every object partition of the map.
 | Contract                                       | Tool name        | What it does                                                        |
 |------------------------------------------------|------------------|---------------------------------------------------------------------|
 | `robonix/system/scene/list_objects`            | `list_objects`   | Flat list of every currently-tracked object (id, label, x,y,z, last_seen). LLM filters client-side. |
+| `robonix/system/scene/list_regions`            | `list_regions`   | Room regions only, with stable IDs accepted by `goal_room`, polygon geometry, and staleness metadata. |
 | `robonix/system/scene/get_robot_context`       | `get_robot_context` | One coherent robot pose, room/area containment, and nearby-object snapshot. |
 | `robonix/system/scene/goal_near`               | `goal_near`      | Footprint-safe approach pose near a registered object. Pass to `navigation/navigate`. |
 | `robonix/system/scene/goal_room`               | `goal_room`      | Footprint-safe pose inside a room annotation. |

--- a/system/scene/package_manifest.jetson-docker.yaml
+++ b/system/scene/package_manifest.jetson-docker.yaml
@@ -23,6 +23,7 @@ start: ROBONIX_SCENE_FORCE=docker bash scripts/start.sh
 capabilities:
   - name: robonix/system/scene/list_objects
   - name: robonix/system/scene/get_robot_context
+  - name: robonix/system/scene/list_regions
   - name: robonix/system/scene/goal_near
   - name: robonix/system/scene/goal_room
   - name: robonix/system/scene/get_scene_graph

--- a/system/scene/package_manifest.jetson-native.yaml
+++ b/system/scene/package_manifest.jetson-native.yaml
@@ -27,6 +27,7 @@ start: ROBONIX_SCENE_FORCE=native bash scripts/start.sh
 capabilities:
   - name: robonix/system/scene/list_objects
   - name: robonix/system/scene/get_robot_context
+  - name: robonix/system/scene/list_regions
   - name: robonix/system/scene/goal_near
   - name: robonix/system/scene/goal_room
   - name: robonix/system/scene/get_scene_graph

--- a/system/scene/package_manifest.yaml
+++ b/system/scene/package_manifest.yaml
@@ -1,5 +1,5 @@
 # Scene MCP server — current-state semantic + geometric map of the
-# robot's environment. Exposes 6 read-only MCP tools for Pilot.
+# robot's environment. Exposes read-only MCP tools for Pilot.
 #
 # Deployment shape: scene runs in its OWN docker container (image
 # `robonix-scene`, built by scripts/build.sh). Joins host network so:
@@ -33,6 +33,7 @@ stop: docker rm -f "${ROBONIX_SCENE_CONTAINER:-robonix_scene}"
 capabilities:
   - name: robonix/system/scene/list_objects
   - name: robonix/system/scene/get_robot_context
+  - name: robonix/system/scene/list_regions
   - name: robonix/system/scene/goal_near
   - name: robonix/system/scene/goal_room
   - name: robonix/system/scene/get_scene_graph

--- a/system/scene/scene_service/mcp_tools.py
+++ b/system/scene/scene_service/mcp_tools.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: MulanPSL-2.0
-"""FastMCP tool definitions — two read-only handlers, that's it.
+"""FastMCP tool definitions for read-only Scene queries.
 
-  list_objects()           → flat list of every object in the registry
+  list_objects()           → perceived physical objects in the registry
+  list_regions()           → user-authored room regions with stable IDs
   goal_near(object_id)     → reachable approach pose for a physical object
   goal_room(room_id)       → reachable pose inside a room polygon
 
@@ -46,9 +47,12 @@ from semantic_map_mcp import (  # type: ignore
     GetSceneGraph_Response,
     ListObjects_Request,
     ListObjects_Response,
+    ListRegions_Request,
+    ListRegions_Response,
     ListRelations_Request,
     ListRelations_Response,
     Object,
+    Region,
     SceneAnnotation as SceneAnnotationIDL,
     SceneGraphEdge as SceneGraphEdgeIDL,
     SceneGraphNode as SceneGraphNodeIDL,
@@ -261,12 +265,12 @@ def _to_idl(o: SceneObject) -> Object:
     )
 
 
-def _annotation_centroid(a: "Annotation") -> tuple[float, float]:
-    return polygon_centroid(getattr(a, "points", []) or [])
-
-
 def _annotation_object_id(a: "Annotation") -> str:
     return f"scene.{a.kind}.{a.annotation_id}"
+
+
+def _annotation_centroid(a: "Annotation") -> tuple[float, float]:
+    return polygon_centroid(getattr(a, "points", []) or [])
 
 
 def _annotation_to_object(a: "Annotation") -> Object:
@@ -366,10 +370,10 @@ mcp = FastMCP("scene_provider")
 
 @mcp_contract(mcp, contract_id="robonix/system/scene/list_objects")
 async def list_objects(_req: ListObjects_Request) -> ListObjects_Response:
-    """Return every object the scene registry currently believes
-    exists, plus room annotations, as a flat list. Use this tool to discover
-    stable object/room IDs before goal_near or goal_room. Use get_scene_graph
-    only when object relationships are needed.
+    """Return perceived objects plus compatibility room entries.
+
+    New callers should call list_regions for full room geometry and staleness.
+    Use get_scene_graph only when object relationships are needed.
     Contract: robonix/system/scene/list_objects."""
     if _REGISTRY is None:
         raise RuntimeError("scene mcp_tools.attach_state was never called")
@@ -377,7 +381,11 @@ async def list_objects(_req: ListObjects_Request) -> ListObjects_Response:
     visible = [o for o in objs.values() if not o.missing]
     objects = [_to_idl(o) for o in visible]
     if _ANNO_STORE is not None:
-        objects.extend(_annotation_to_object(a) for a in _ANNO_STORE.list() if a.kind == "room")
+        objects.extend(
+            _annotation_to_object(annotation)
+            for annotation in _ANNO_STORE.list()
+            if annotation.kind == "room"
+        )
 
     # Scene Hook: auto-save observation when objects are visible.
     # This is fire-and-forget — list_objects returns immediately
@@ -387,6 +395,45 @@ async def list_objects(_req: ListObjects_Request) -> ListObjects_Response:
 
     return ListObjects_Response(
         objects=objects,
+        stamp_unix=time.time(),
+    )
+
+
+def _annotation_to_region(a: "Annotation") -> Region:
+    points_xy: list[float] = []
+    for point in a.points or []:
+        if len(point) >= 2:
+            points_xy.extend([float(point[0]), float(point[1])])
+    return Region(
+        id=_annotation_object_id(a),
+        kind=a.kind,
+        name=a.name,
+        points_xy=points_xy,
+        theta=float(a.theta) if a.theta is not None else 0.0,
+        stale=bool(a.stale),
+        stale_reason=a.stale_reason or "",
+        updated_at_unix=float(a.updated_at or 0.0),
+    )
+
+
+@mcp_contract(mcp, contract_id="robonix/system/scene/list_regions")
+async def list_regions(_req: ListRegions_Request) -> ListRegions_Response:
+    """Return every registered room region with its stable goal_room ID.
+
+    Perceived physical objects are intentionally excluded. Stale annotations
+    remain visible and are marked explicitly so callers never infer absence
+    from a hidden or incomplete room list.
+    Contract: robonix/system/scene/list_regions.
+    """
+    if _ANNO_STORE is None:
+        raise RuntimeError("scene annotation store is unavailable")
+    return ListRegions_Response(
+        regions=[
+            _annotation_to_region(annotation)
+            for annotation in _ANNO_STORE.list()
+            if annotation.kind == "room"
+        ],
+        map_id=_ANNO_STORE.map_id,
         stamp_unix=time.time(),
     )
 
@@ -598,15 +645,6 @@ async def goal_room(req: GoalRoom_Request) -> GoalRoom_Response:
     The result never falls outside the room polygon.
     Contract: robonix/system/scene/goal_room.
     """
-    footprint = _ROBOT_GEOMETRY.current() if _ROBOT_GEOMETRY is not None else None
-    if footprint is None:
-        return GoalRoom_Response(
-            reachable=False,
-            x=0.0,
-            y=0.0,
-            yaw=0.0,
-            reason="Soma footprint unavailable — robot geometry is not ready",
-        )
     room, ambiguous = _resolve_room_target(req.room_id)
     if ambiguous:
         candidates = ", ".join(
@@ -625,10 +663,27 @@ async def goal_room(req: GoalRoom_Request) -> GoalRoom_Response:
             reachable=False, x=0.0, y=0.0, yaw=0.0,
             reason=(
                 f"unknown room reference '{req.room_id}'; pass a stable ID or "
-                f"unique room name returned by list_objects; {_room_id_hint()}"
+                f"unique room name returned by list_regions; {_room_id_hint()}"
             ),
         )
     stable_room_id = _annotation_object_id(room)
+    if room.stale:
+        return GoalRoom_Response(
+            reachable=False, x=0.0, y=0.0, yaw=0.0,
+            reason=(
+                f"room '{room.name}' ({stable_room_id}) is stale: "
+                f"{room.stale_reason or 'geometry may not match the active map'}"
+            ),
+        )
+    footprint = _ROBOT_GEOMETRY.current() if _ROBOT_GEOMETRY is not None else None
+    if footprint is None:
+        return GoalRoom_Response(
+            reachable=False,
+            x=0.0,
+            y=0.0,
+            yaw=0.0,
+            reason="Soma footprint unavailable — robot geometry is not ready",
+        )
     if _HUB is None or not _HUB.has("occupancy_grid"):
         return GoalRoom_Response(
             reachable=False, x=0.0, y=0.0, yaw=0.0,
@@ -830,6 +885,7 @@ __all__ = [
     "attach_annotation_store",
     "get_robot_context",
     "list_objects",
+    "list_regions",
     "goal_near",
     "goal_room",
     "get_scene_graph",

--- a/system/scene/scene_service/service.py
+++ b/system/scene/scene_service/service.py
@@ -1532,6 +1532,7 @@ async def _run() -> None:
     # description / JSON schema stay in sync with the codegen types.
     for fn in (
         mcp_tools.list_objects,
+        mcp_tools.list_regions,
         mcp_tools.get_robot_context,
         mcp_tools.goal_near,
         mcp_tools.goal_room,
@@ -1553,7 +1554,7 @@ async def _run() -> None:
             description=(fn.__doc__ or "").strip(),
             input_schema_json=schema,
         )
-    log.info("scene declared 7 MCP tools at %s", scene.mcp_endpoint)
+    log.info("scene declared 8 MCP tools at %s", scene.mcp_endpoint)
 
     # ROS2 ingest hub + downstream consumers (self-pose, perception).
     # _start_ros_ingest still wants a raw atlas stub for QueryCapabilities;

--- a/system/scene/tests/test_regions.py
+++ b/system/scene/tests/test_regions.py
@@ -1,0 +1,84 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from scene_service import mcp_tools
+
+
+class _Store:
+    map_id = "3f_demo"
+
+    def list(self):
+        return [
+            SimpleNamespace(
+                annotation_id="anno.315",
+                kind="room",
+                name="room 315",
+                points=[(0.0, 0.0), (2.0, 0.0), (2.0, 3.0), (0.0, 3.0)],
+                theta=0.5,
+                stale=False,
+                stale_reason="",
+                updated_at=123.0,
+            ),
+            SimpleNamespace(
+                annotation_id="anno.poi",
+                kind="poi",
+                name="charging spot",
+                points=[(1.0, 1.0)],
+                theta=None,
+                stale=False,
+                stale_reason="",
+                updated_at=124.0,
+            ),
+        ]
+
+
+def test_list_regions_returns_rooms_with_goal_room_ids_and_full_geometry():
+    mcp_tools.attach_annotation_store(_Store())
+    response = asyncio.run(mcp_tools.list_regions(mcp_tools.ListRegions_Request()))
+
+    assert response.map_id == "3f_demo"
+    assert len(response.regions) == 1
+    region = response.regions[0]
+    assert region.id == "scene.room.anno.315"
+    assert region.kind == "room"
+    assert region.name == "room 315"
+    assert region.points_xy == [0.0, 0.0, 2.0, 0.0, 2.0, 3.0, 0.0, 3.0]
+    assert region.stale is False
+
+
+def test_list_regions_reports_annotation_store_unavailable():
+    mcp_tools.attach_annotation_store(None)
+    with pytest.raises(RuntimeError, match="annotation store is unavailable"):
+        asyncio.run(mcp_tools.list_regions(mcp_tools.ListRegions_Request()))
+
+
+class _Registry:
+    async def snapshot(self):
+        return {}, {}
+
+
+def test_list_objects_keeps_room_entries_for_v1_compatibility():
+    mcp_tools.attach_state(registry=_Registry())
+    mcp_tools.attach_annotation_store(_Store())
+    response = asyncio.run(mcp_tools.list_objects(mcp_tools.ListObjects_Request()))
+    assert [obj.id for obj in response.objects] == ["scene.room.anno.315"]
+
+
+class _StaleStore(_Store):
+    def list(self):
+        rooms = super().list()
+        rooms[0].stale = True
+        rooms[0].stale_reason = "map epoch changed"
+        return rooms
+
+
+def test_goal_room_rejects_stale_geometry_before_navigation():
+    mcp_tools.attach_annotation_store(_StaleStore())
+    response = asyncio.run(
+        mcp_tools.goal_room(mcp_tools.GoalRoom_Request(room_id="scene.room.anno.315"))
+    )
+    assert response.reachable is False
+    assert "is stale" in response.reason
+    assert "map epoch changed" in response.reason


### PR DESCRIPTION
## Summary

Add a focused `list_regions` Scene contract for room discovery and make `goal_room` fail closed when room geometry is stale. This is intentionally separate from the broader Scene object-world-model reliability work tracked in #177.

## Changes

- add `Region.msg`, `ListRegions.srv`, and `robonix/system/scene/list_regions`
- return stable `scene.room.<annotation_id>` identifiers, full polygon geometry, map ID, update time, and explicit staleness
- preserve room entries in `list_objects.v1` for backward compatibility while directing new callers to `list_regions`
- reject stale room geometry before checking live navigation geometry or returning a goal
- report an unavailable annotation store as an error instead of an ambiguous empty map
- register the new contract in native, Jetson Docker, and Jetson native Scene manifests

## Stacked review order

This PR is temporarily based on #194 (`agent/soma-footprint-scene`) so its diff contains only the room/region increment and uses the Soma-backed footprint planner. After #194 enters `dev`, retarget this PR to `dev`; do not merge this PR first.

## Validation

- real clean codegen from this branch: 42 packages, 205 messages, 111 services; all 82 generated Python modules imported successfully
- complete Scene suite: 174 passed (excluding the known macOS Bash 3 fake-Docker launcher case that runs on Linux CI)
- runtime portability audit and `git diff --check`: passed
- commit authorship: passed

The object label, point-cloud, 3D-box, association, and dropout experiments remain isolated under #177.