### PR TITLE
ci: run required checks on dev-next

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ name: CI
 
 on:
   push:
-    branches: [main, dev, dev/**]
+    branches: [main, dev, dev-next, dev/**]
   pull_request:
-    branches: [main, dev, dev/**]
+    branches: [main, dev, dev-next, dev/**]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/commit-authorship.yml
+++ b/.github/workflows/commit-authorship.yml
@@ -4,9 +4,9 @@ name: Commit Authorship
 
 on:
   push:
-    branches: [main, dev, dev/**]
+    branches: [main, dev, dev-next, dev/**]
   pull_request:
-    branches: [main, dev, dev/**]
+    branches: [main, dev, dev-next, dev/**]
   merge_group:
 
 permissions:

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -4,9 +4,9 @@ name: Docs Check
 
 on:
   push:
-    branches: [main, dev, dev/**]
+    branches: [main, dev, dev-next, dev/**]
   pull_request:
-    branches: [main, dev, dev/**]
+    branches: [main, dev, dev-next, dev/**]
 
 jobs:
   docs:


### PR DESCRIPTION
## Summary

- run CI on pushes and pull requests targeting `dev-next`
- run commit-authorship checks on `dev-next`
- run docs checks on `dev-next`

This closes the coverage gap exposed by #180, whose merge into `dev-next` received only PR-triage checks because the required workflows excluded that branch.

## Validation

- parsed all three workflow files with PyYAML
- `python3 -m unittest scripts/tests/test_check_commit_authorship.py`
- `git diff --check`

## Follow-up

After this merges into `dev`, sync it into `dev-next`; the resulting push will trigger the complete required check set against the current `dev-next` head.