### PR TITLE
ci: enable and repair required dev-next checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ name: CI
 
 on:
   push:
-    branches: [main, dev, dev/**]
+    branches: [main, dev, dev-next, dev/**]
   pull_request:
-    branches: [main, dev, dev/**]
+    branches: [main, dev, dev-next, dev/**]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/commit-authorship.yml
+++ b/.github/workflows/commit-authorship.yml
@@ -4,9 +4,9 @@ name: Commit Authorship
 
 on:
   push:
-    branches: [main, dev, dev/**]
+    branches: [main, dev, dev-next, dev/**]
   pull_request:
-    branches: [main, dev, dev/**]
+    branches: [main, dev, dev-next, dev/**]
   merge_group:
 
 permissions:

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -4,9 +4,9 @@ name: Docs Check
 
 on:
   push:
-    branches: [main, dev, dev/**]
+    branches: [main, dev, dev-next, dev/**]
   pull_request:
-    branches: [main, dev, dev/**]
+    branches: [main, dev, dev-next, dev/**]
 
 jobs:
   docs:

--- a/services/speech/config.spec
+++ b/services/speech/config.spec
@@ -18,9 +18,9 @@ config:
   # FunASR and TTS can remain available.
   disable_whisper: false
 
-  # list of non-empty strings, default: ["罗伯特"].
+  # list of non-empty strings; defaults to the Mandarin wake phrase below.
   # Wake phrases compiled into the runtime keyword file.
-  wake_words: ["罗伯特"]
+  wake_words: ["罗伯特"]  # i18n-ok: Mandarin runtime default
 
   # string path or null, default: bundled build artifact.
   # Directory containing the sherpa-onnx keyword-spotting model.
@@ -42,9 +42,9 @@ config:
   # CPU threads used by the wake-word backend.
   wake_word_num_threads: 2
 
-  # list of non-empty strings, default: ["我在"].
+  # list of non-empty strings; defaults to the Mandarin warm-up phrase below.
   # Short phrases synthesized during initialization to warm the TTS backend.
-  tts_warm_phrases: ["我在"]
+  tts_warm_phrases: ["我在"]  # i18n-ok: Mandarin runtime default
 
   # Local backend ----------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Apply the stable CI coverage already merged into `dev` by #181 directly on top of `dev-next`, and fix the pre-existing Speech documentation violation that the newly enabled checks exposed.

## Changes

- run Rust CI and Webots smoke checks for `dev-next`
- run commit-authorship checks for `dev-next`
- run docs checks for `dev-next`
- preserve the real Mandarin wake-word/TTS defaults while tagging them as intentional `i18n-ok` fixtures

## Validation

- workflow YAML parsed successfully
- 13 commit-authorship unit tests passed
- Speech config parsed as YAML
- no untagged CJK remains in `services/speech/config.spec`
- `git diff --check`
- predecessor #182 exposed the Speech docs failure; this branch is based directly on current `dev-next` to avoid the divergent-history/add-add conflict in that PR

## Scope

CI routing and its directly exposed documentation fix only. No Pilot experiment code is merged.