### PR TITLE
ci(webots): preserve spatial state across lifecycle reboot

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1043,15 +1043,20 @@ jobs:
         # state under <manifest-dir>/rbnx-boot/ (not ~/.robonix/), that
         # Soma package children are stopped cleanly, and that the stack
         # can come back up after a clean teardown (the issue #128
-        # regression). The second boot reuses the per-run sim container;
-        # the validator does NOT start a new webots instance. CI leaves
-        # the second boot running so the next step can exercise scenarios
-        # against the restarted stack; the final cleanup step shuts it down.
+        # regression). The second boot reuses both the per-run sim container
+        # and the persistent mapping/scene state: a process restart must not
+        # silently turn into a new-map session while the physical robot stays
+        # at its post-scenario pose. CI leaves the second boot running so the
+        # next step can exercise scenarios against the restarted stack; the
+        # final cleanup step shuts it down.
         working-directory: examples/webots
         run: |
           set -euo pipefail
           milvus_lock="$(dirname "$AGENT_MILVUS_URI")/.$(basename "$AGENT_MILVUS_URI").lock"
-          export ROBONIX_LIFECYCLE_RESET_PATHS="${MAPPING_MAPS_DIR}:${SCENE_DATA_DIR}:${AGENT_MEMORY_DIR}:${AGENT_MILVUS_URI}:${milvus_lock}"
+          # Scenario memory uses fixed fixture keys and must be isolated between
+          # passes. Mapping and scene data are deliberately preserved because
+          # they are runtime state whose reboot recovery this test exercises.
+          export ROBONIX_LIFECYCLE_RESET_PATHS="${AGENT_MEMORY_DIR}:${AGENT_MILVUS_URI}:${milvus_lock}"
           python3 "$GITHUB_WORKSPACE/testing/validate_lifecycle.py" \
             --rbnx rbnx \
             --manifest robonix_manifest.ci.generated.yaml \


### PR DESCRIPTION
## What changed

- preserve mapping and scene persistence across the Webots boot → shutdown → boot lifecycle pass
- reset only fixed-key agent-memory fixtures between scenario passes
- document that the second boot intentionally reuses both the running simulator and its persistent spatial state

## Why

The previous lifecycle setup kept the physical simulator at its post-scenario pose but deleted the mapping database and scene state before restarting Robonix. That mixed a moved robot with a fresh map session. In run `30148154807` attempt 2, the first 17/17 scenarios, scene-map persistence, and boot/shutdown/reboot checks passed, but the second `object_navigation` pass failed while RTAB-Map was continuously rebuilding/resizing the map and Nav2 treated the robot start as occupied.

A normal process reboot must preserve persistent spatial state. The scenario's immutable `ci_test_map` fixture is still removed explicitly before the second pass, so fixture isolation remains intact.

## Validation

- `git diff --check`
- workflow YAML parsed successfully
- lifecycle reset contract assertion confirms mapping/scene paths are preserved and agent memory is reset
- `python testing/simulate_ci.py`: 17 scenarios passed
- full Webots lifecycle and post-restart scenario suite will run in CI

Assisted-by: Codex:gpt-5.6
