### PR TITLE
fix(api): allow loopback MCP host headers

### DIFF
--- a/pylib/robonix-api/robonix_api/capability.py
+++ b/pylib/robonix-api/robonix_api/capability.py
@@ -114,6 +114,17 @@ def _resolve_provider_id(default_id: str) -> str:
     return instance_id
 
 
+def _mcp_loopback_allowed_hosts(bind_host: str) -> list[str]:
+    """Return exact/wildcard Host values accepted by a loopback MCP server."""
+
+    if not ipaddress.ip_address(bind_host).is_loopback:
+        return []
+    hosts = [bind_host, f"{bind_host}:*"]
+    if bind_host == "127.0.0.1":
+        hosts.extend(["localhost", "localhost:*"])
+    return hosts
+
+
 # ── _ProviderBase ───────────────────────────────────────────────────────────
 
 
@@ -581,12 +592,17 @@ class _ProviderBase:
         # Preserve cross-host compatibility for wildcard/LAN binds. A
         # loopback-only deployment is also reachable from a local browser, so
         # keep the MCP SDK's Host-header/DNS-rebinding guard enabled there.
+        # The SDK defaults allowed_hosts to an empty list when callers provide
+        # explicit transport settings, which otherwise rejects every Atlas MCP
+        # request with HTTP 421. Allow only this loopback endpoint (with its
+        # dynamically allocated port) and the equivalent localhost spelling.
         protect_loopback = ipaddress.ip_address(self._bind_host).is_loopback
         self._mcp_app = FastMCP(
             self.id,
             host=self._bind_host,
             transport_security=TransportSecuritySettings(
-                enable_dns_rebinding_protection=protect_loopback
+                enable_dns_rebinding_protection=protect_loopback,
+                allowed_hosts=_mcp_loopback_allowed_hosts(self._bind_host),
             ),
         )
 

--- a/pylib/robonix-api/tests/test_provider_bind_host.py
+++ b/pylib/robonix-api/tests/test_provider_bind_host.py
@@ -7,7 +7,11 @@ import tempfile
 import unittest
 from unittest import mock
 
-from robonix_api.capability import Service, _provider_bind_host
+from robonix_api.capability import (
+    Service,
+    _mcp_loopback_allowed_hosts,
+    _provider_bind_host,
+)
 
 
 class ProviderBindHostTest(unittest.TestCase):
@@ -52,11 +56,19 @@ class ProviderBindHostTest(unittest.TestCase):
             )
             self.assertEqual(provider._advertise_host(), "10.20.30.40")
 
+    def test_loopback_mcp_host_allowlist_covers_dynamic_port(self) -> None:
+        self.assertEqual(
+            _mcp_loopback_allowed_hosts("127.0.0.1"),
+            ["127.0.0.1", "127.0.0.1:*", "localhost", "localhost:*"],
+        )
+        self.assertEqual(_mcp_loopback_allowed_hosts("0.0.0.0"), [])
+
     def test_all_provider_server_paths_use_one_bind_host(self) -> None:
         source = Path(__file__).parents[1] / "robonix_api" / "capability.py"
         text = source.read_text(encoding="utf-8")
         self.assertIn('FastMCP(\n            self.id,\n            host=self._bind_host,', text)
         self.assertIn("enable_dns_rebinding_protection=protect_loopback", text)
+        self.assertIn("allowed_hosts=_mcp_loopback_allowed_hosts(self._bind_host)", text)
         self.assertIn('add_insecure_port(f"{self._bind_host}:0")', text)
         self.assertIn('s.bind((self._bind_host, 0))', text)
         self.assertIn('host=self._bind_host,\n            port=self._mcp_port', text)


### PR DESCRIPTION
## Summary
- keep DNS rebinding protection enabled for loopback-bound MCP providers
- allow only the exact loopback host, its dynamic port, and the equivalent localhost spelling
- preserve wildcard/LAN behavior without adding an allowlist

This fixes local Atlas MCP requests being rejected with HTTP 421 when FastMCP receives explicit transport settings.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=pylib/robonix-api python3 -m pytest -q pylib/robonix-api/tests/test_provider_bind_host.py` (6 passed)
- `python3 scripts/check_commit_authorship.py --base origin/dev --head HEAD` (1 commit passed)
- `git diff --check origin/dev`