### PR TITLE
fix(scene): make object lifecycle observation-aware

### DIFF
--- a/examples/webots/robonix_manifest.yaml
+++ b/examples/webots/robonix_manifest.yaml
@@ -29,7 +29,16 @@ system:
   vitals:
     listen: 0.0.0.0:50093
   # soma+scene layer
-  scene: {}
+  scene:
+    config:
+      perception:
+        # Metric SI units. A removed object must be absent in three healthy,
+        # depth-verified frames before it becomes missing. Sensor/model
+        # outages and occlusion do not count as negative observations.
+        period_s: 0.6
+        visible_miss_frames: 3
+        visibility_depth_margin_m: 0.20
+        object_ttl_s: 30.0
   # execution layer
   executor:
     # robonix-client polls Executor for authoritative active RTDL plans.

--- a/system/scene/README.md
+++ b/system/scene/README.md
@@ -48,7 +48,7 @@ The metric pipeline is ConceptGraphs-style per-frame perception with 4 stages:
    * **Distance gate** — centroid > 1.5 m apart → never merge (kills "9 × 5 m bbox spanning the room" failure).
    * **Same-class gate** — different YOLO class names → never merge (kills "potted_plant on cabinet collapses to one record").
    * **Threshold** — agg_sim < 0.55 → spawn new object instead.
-5. **Project to registry.** A persistent `MapObjectList.uuid → ObjectRegistry.object_id` cache keeps registry IDs stable across ticks. Bounding boxes are yaw-only (numpy 2D PCA on the XY footprint, no Open3D OBB — `get_oriented_bounding_box(robust=True)` segfaults qhull on near-coplanar pcds), with 5–95 percentile extents to ignore depth-spike outliers.
+5. **Project to registry.** A persistent `MapObjectList.uuid → ObjectRegistry.object_id` cache keeps registry IDs stable across ticks, but only UUIDs carrying the current `image_idx` refresh `last_seen` and `observation_count`. An unmatched object becomes `missing` only after repeated healthy frames whose current depth image shows clear space behind its old location; out-of-FOV, occluded, disconnected-sensor, failed-model, and stale-transform cases remain unknown. Bounding boxes are yaw-only (numpy 2D PCA on the XY footprint, no Open3D OBB — `get_oriented_bounding_box(robust=True)` segfaults qhull on near-coplanar pcds), with 5–95 percentile extents to ignore depth-spike outliers.
 
 Periodic cleanup (every 30 ticks) runs concept-graphs's `denoise_objects` + `filter_objects` + `merge_overlap_objects` so duplicates from edge-case detections eventually collapse.
 
@@ -308,7 +308,31 @@ Hugging Face mirror endpoint (default `https://hf-mirror.com`); the canonical
 `https://huggingface.co` file URL is always tried as a fallback. Set
 `RBNX_HF_MIRROR=` to skip the mirror.
 
-## Configuration knobs (env vars)
+## Driver configuration
+
+These values belong under `system.scene.config.perception` in the deployment
+manifest. Durations are seconds, distances are metres, and frame counts are
+dimensionless. Explicit Driver configuration takes precedence over legacy
+environment variables.
+
+| Key | Type / unit | Default | Meaning |
+|---|---|---|---|
+| `period_s` | float, s | `0.6` | minimum interval between metric perception frames |
+| `visible_miss_frames` | integer, frames | `3` | consecutive healthy, depth-verified absences required before marking an object `missing` |
+| `visibility_depth_margin_m` | float, m | `0.20` | measured depth must be at least this far behind the stored object center to count as clear-space negative evidence |
+| `object_ttl_s` | float, s | `30.0` | time after the last positive observation before a `missing` object is hard-deleted |
+
+```yaml
+system:
+  scene:
+    perception:
+      period_s: 0.6
+      visible_miss_frames: 3
+      visibility_depth_margin_m: 0.20
+      object_ttl_s: 30.0
+```
+
+## Legacy environment and model knobs
 
 | Env | Default | Notes |
 |---|---|---|
@@ -327,7 +351,7 @@ Hugging Face mirror endpoint (default `https://hf-mirror.com`); the canonical
 | `SCENE_CG_MERGE_OVERLAP_THRESH` / `SCENE_CG_MERGE_VISUAL_SIM_THRESH` | `0.50` / `0.65` | periodic `merge_overlap` pass: fold pairs with pcd-overlap ≥ first **and** CLIP cosine ≥ second |
 | `SCENE_CG_SAME_CLASS_MERGE_DIST_M` | `0.4` | lenient dedup: fold two SAME-class (or same `SCENE_CG_MERGE_CLASS_GROUPS` bucket) records whose centroids are within this distance, regardless of visual sim (kills "one keyboard → three"). `0` disables |
 | `SCENE_CG_MERGE_CLASS_GROUPS` | `` | opt-in confusable-class reconciliation, e.g. `chair,table,desk;sofa,couch` — listed classes share one merge bucket so label flicker across the group collapses while distinct, distant objects stay separate. Empty = off (never relabels) |
-| `SCENE_OBJECT_TTL_SEC` | `30` | how long a soft-evicted (`missing`) object is kept so a re-detection can re-bind its id + observation_count before it is hard-pruned; decouples object identity from per-tick uuid churn |
+| `SCENE_OBJECT_TTL_SEC` | unset | compatibility override for `perception.object_ttl_s`; new deployments should use Driver configuration |
 | `SCENE_GRAPH_IMAGE_RELATIONS` | `true` | VLM-primary relations: one image-grounded VLM call (projected numbered boxes) owns relational + semantic edges. `false` forces the legacy text-only per-pair inference (also the automatic fallback when no camera frame bundle is available) |
 | `SCENE_GRAPH_IMAGE_MAX_DIM` | `960` | longest-side pixel cap for the annotated frame sent to the VLM; bounds image token cost |
 | `SCENE_PORT` / `SCENE_WEB_PORT` | `50106` / `50107` | gRPC + web UI ports |

--- a/system/scene/scene_service/ingest/perception_concept_graphs.py
+++ b/system/scene/scene_service/ingest/perception_concept_graphs.py
@@ -77,6 +77,95 @@ def _resolved_classes() -> list[str]:
     return [s.strip() for s in raw.split(",") if s.strip()]
 
 
+def _observed_map_object_uuids(
+    map_objects: Any,
+    *,
+    frame_seq: int,
+) -> set[str]:
+    """Return map-object UUIDs that contain evidence from ``frame_seq``.
+
+    ConceptGraphs keeps every contributing frame in ``image_idx`` when it
+    merges a detection into a historical object. This is the positive
+    observation boundary: membership in the persistent ``MapObjectList`` is
+    not evidence that an object was seen in the current frame.
+    """
+    observed: set[str] = set()
+    for obj in map_objects or ():
+        try:
+            indices = obj.get("image_idx", ())
+            if frame_seq not in indices:
+                continue
+            uuid_value = str(obj.get("id", "") or "")
+            if uuid_value:
+                observed.add(uuid_value)
+        except (TypeError, ValueError):
+            continue
+    return observed
+
+
+def _visible_missing_uuids(
+    map_objects: Any,
+    *,
+    observed_uuids: set[str],
+    depth_m: Any,
+    intrinsics: Any,
+    camera_to_world: Any,
+    depth_margin_m: float,
+) -> set[str]:
+    """Return unmatched objects whose old location is visibly empty.
+
+    The historical object center is projected into the current depth image.
+    A miss counts only when the measured surface is materially *behind* the
+    stored object. A closer surface means occlusion; a similar depth means the
+    object may still be present but the detector missed it; invalid/out-of-FOV
+    depth is unknown. Those cases must not delete state.
+    """
+    try:
+        depth = np.asarray(depth_m, dtype=np.float32)
+        transform = np.asarray(camera_to_world, dtype=np.float64)
+        if depth.ndim != 2 or transform.shape != (4, 4):
+            return set()
+        world_to_camera = np.linalg.inv(transform)
+    except (TypeError, ValueError, np.linalg.LinAlgError):
+        return set()
+
+    height, width = depth.shape
+    margin = max(0.0, float(depth_margin_m))
+    visible_missing: set[str] = set()
+    for obj in map_objects or ():
+        try:
+            uuid_value = str(obj.get("id", "") or "")
+            if not uuid_value or uuid_value in observed_uuids:
+                continue
+            points = np.asarray(obj["pcd"].points, dtype=np.float64)
+            points = points[np.all(np.isfinite(points), axis=1)]
+            if points.shape[0] < 1:
+                continue
+            center_world = np.append(np.median(points, axis=0), 1.0)
+            center_camera = world_to_camera @ center_world
+            expected_depth = float(center_camera[2])
+            if not math.isfinite(expected_depth) or expected_depth <= 0.0:
+                continue
+            u = int(round(float(intrinsics.fx) * center_camera[0] / expected_depth
+                          + float(intrinsics.cx)))
+            v = int(round(float(intrinsics.fy) * center_camera[1] / expected_depth
+                          + float(intrinsics.cy)))
+            if not (0 <= u < width and 0 <= v < height):
+                continue
+            u0, u1 = max(0, u - 1), min(width, u + 2)
+            v0, v1 = max(0, v - 1), min(height, v + 2)
+            patch = depth[v0:v1, u0:u1]
+            valid = patch[np.isfinite(patch) & (patch > 0.0)]
+            if valid.size == 0:
+                continue
+            measured_depth = float(np.median(valid))
+            if measured_depth > expected_depth + margin:
+                visible_missing.add(uuid_value)
+        except (KeyError, TypeError, ValueError, np.linalg.LinAlgError):
+            continue
+    return visible_missing
+
+
 _DEFAULT_YOLO_WORLD_WEIGHTS = "/opt/models/yolov8l-world.pt"
 _DEFAULT_MOBILE_SAM_WEIGHTS = "/opt/models/mobile_sam.pt"
 _DEFAULT_CLIP_MODEL = "ViT-B-32"
@@ -365,6 +454,9 @@ class ConceptGraphsDetector:
         robot_base_frame_fn: Optional[Callable[[], str]] = None,
         period_s: float = 0.6,
         pose_max_age_s: float = 2.0,
+        visible_miss_threshold: int = 3,
+        visibility_depth_margin_m: float = 0.20,
+        object_ttl_s: float = 30.0,
         confidence_threshold: float = 0.30,
         max_detections: int = 30,
         yolo_weights_path: Optional[str] = None,
@@ -399,6 +491,12 @@ class ConceptGraphsDetector:
         self._world_frame_fn = world_frame_fn or (lambda: "")
         self._robot_base_frame_fn = robot_base_frame_fn or (lambda: "")
         self._pose_max_age_s = max(0.0, float(pose_max_age_s))
+        self._visible_miss_threshold = max(1, int(visible_miss_threshold))
+        self._visibility_depth_margin_m = max(
+            0.0,
+            float(visibility_depth_margin_m),
+        )
+        self._object_ttl_s = max(0.0, float(object_ttl_s))
 
         self._yolo: Any = None
         self._sam: Any = None
@@ -449,15 +547,21 @@ class ConceptGraphsDetector:
         # here (not lazily) so _apply_snapshot is safe to call before the first
         # _project_to_registry tick — including from unit tests.
         self._uuid_to_oid: dict[str, str] = {}
+        self._expired_uuids: set[str] = set()
+        # UUIDs backed by historical ConceptGraphs geometry but currently
+        # confirmed absent by repeated, unobstructed RGB-D observations.
+        # Keep the binding for stable re-identification, but suppress these
+        # objects from the 3D live view until they are observed again.
+        self._missing_uuids: set[str] = set()
         # How long a soft-evicted (missing) registry record is kept so a
         # re-detection can re-bind it before it is hard-pruned. Decouples
         # observation_count from concept-graphs uuid churn across ticks.
-        try:
-            self._object_ttl_s = float(
-                os.environ.get("SCENE_OBJECT_TTL_SEC", "30.0").strip() or "30.0"
-            )
-        except ValueError:
-            self._object_ttl_s = 30.0
+        legacy_ttl = os.environ.get("SCENE_OBJECT_TTL_SEC", "").strip()
+        if legacy_ttl:
+            try:
+                self._object_ttl_s = max(0.0, float(legacy_ttl))
+            except ValueError:
+                pass
         # Optional confusable-class reconciliation (off by default): maps a
         # group of classes (e.g. chair/table/desk) to one bucket so YOLO-World
         # label flicker across the group merges instead of splitting into
@@ -505,6 +609,27 @@ class ConceptGraphsDetector:
         if self._task is not None:
             await self._task
             self._task = None
+
+    async def reset_derived_state(self) -> None:
+        """Atomically drop detector-owned state after a map epoch change."""
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self._reset_derived_state_locked)
+
+    def _reset_derived_state_locked(self) -> None:
+        with self._inference_lock:
+            if self._cg is not None:
+                self._map_objects = self._cg["MapObjectList"]()
+            elif self._map_objects is not None:
+                try:
+                    self._map_objects = type(self._map_objects)()
+                except TypeError:
+                    self._map_objects = []
+            self._uuid_to_oid.clear()
+            self._expired_uuids.clear()
+            self._missing_uuids.clear()
+            self._tick_idx = 0
+            self._last_logged_total = -1
+            self._spatial_not_ready_logged = False
 
     # ── Text embedding (shared CLIP) ─────────────────────────────────
     def embed_text(self, texts: list[str]) -> Optional[list[list[float]]]:
@@ -559,10 +684,13 @@ class ConceptGraphsDetector:
         # projected, or ones that periodic cleanup is about to evict),
         # which never matches the 2D view's count.
         live_uuids = getattr(self, "_uuid_to_oid", None)
+        missing_uuids = getattr(self, "_missing_uuids", set())
         for obj_idx, obj in enumerate(map_objs):
             if live_uuids is not None and live_uuids:
                 u = str(obj.get("id", ""))
                 if u and u not in live_uuids:
+                    continue
+                if u and u in missing_uuids:
                     continue
             try:
                 pcd = obj.get("pcd")
@@ -697,6 +825,7 @@ class ConceptGraphsDetector:
             self._tick_locked()
 
     def _tick_locked(self) -> None:
+        self._purge_expired_map_objects_locked()
         rgb_msg = self._rgb_msg()
         depth_msg = self._depth_msg()
         if rgb_msg is None or depth_msg is None:
@@ -724,6 +853,27 @@ class ConceptGraphsDetector:
         depth = _depth_msg_to_metres(depth_msg)
         if rgb is None or depth is None:
             return
+        world_frame = str(self._world_frame_fn() or "").strip()
+        trans_pose = self._build_camera_to_map_transform(
+            expected_world_frame=world_frame,
+        )
+        if trans_pose is None or not world_frame:
+            if not getattr(self, "_spatial_not_ready_logged", False):
+                log.warning(
+                    "camera pose/extrinsics unavailable; withholding spatial "
+                    "detections until contracts or header-derived TF are ready"
+                )
+                self._spatial_not_ready_logged = True
+            return
+        self._spatial_not_ready_logged = False
+        cam_K_mat = np.array(
+            [
+                [K.fx, 0, K.cx],
+                [0, K.fy, K.cy],
+                [0, 0, 1.0],
+            ],
+            dtype=np.float32,
+        )
         # YOLO-World predict expects RGB in standard channel order.
         # Internal Ultralytics handles BGR-as-input fine but CLIP later
         # needs RGB. Convert once here.
@@ -747,8 +897,11 @@ class ConceptGraphsDetector:
         r0 = yolo_results[0]
         boxes = getattr(r0, "boxes", None)
         if boxes is None or len(boxes) == 0:
-            self._tick_idx += 1
-            self._maybe_periodic_cleanup()
+            self._finish_healthy_frame(
+                depth=depth,
+                intrinsics=K,
+                camera_to_world=trans_pose,
+            )
             return
 
         try:
@@ -758,6 +911,11 @@ class ConceptGraphsDetector:
         except Exception:  # noqa: BLE001
             return
         if xyxy.shape[0] == 0:
+            self._finish_healthy_frame(
+                depth=depth,
+                intrinsics=K,
+                camera_to_world=trans_pose,
+            )
             return
 
         # Cap the count so SAM doesn't get a 200-bbox dump.
@@ -786,8 +944,11 @@ class ConceptGraphsDetector:
             for cidx in cls_idx
         ], dtype=bool)
         if not keep.any():
-            self._tick_idx += 1
-            self._maybe_periodic_cleanup()
+            self._finish_healthy_frame(
+                depth=depth,
+                intrinsics=K,
+                camera_to_world=trans_pose,
+            )
             return
         xyxy = xyxy[keep]
         confs = confs[keep]
@@ -870,24 +1031,6 @@ class ConceptGraphsDetector:
             return
 
         # ── Per-detection PCD + bbox in map frame ────────────────────
-        cam_K_mat = np.array([
-            [K.fx, 0,    K.cx],
-            [0,    K.fy, K.cy],
-            [0,    0,    1.0],
-        ], dtype=np.float32)
-        world_frame = str(self._world_frame_fn() or "").strip()
-        trans_pose = self._build_camera_to_map_transform(
-            expected_world_frame=world_frame,
-        )
-        if trans_pose is None or not world_frame:
-            if not getattr(self, "_spatial_not_ready_logged", False):
-                log.warning(
-                    "camera pose/extrinsics unavailable; withholding spatial "
-                    "detections until contracts or header-derived TF are ready"
-                )
-                self._spatial_not_ready_logged = True
-            return
-        self._spatial_not_ready_logged = False
         try:
             obj_pcds_and_bboxes = self._cg["detections_to_obj_pcd_and_bbox"](
                 depth_array=depth.astype(np.float32),
@@ -985,8 +1128,11 @@ class ConceptGraphsDetector:
             det_list.append(d)
 
         if len(det_list) == 0:
-            self._tick_idx += 1
-            self._maybe_periodic_cleanup()
+            self._finish_healthy_frame(
+                depth=depth,
+                intrinsics=K,
+                camera_to_world=trans_pose,
+            )
             return
 
         # ── Concept-graphs merge ─────────────────────────────────────
@@ -1132,9 +1278,56 @@ class ConceptGraphsDetector:
                     log.warning("concept-graphs merge pipeline failed: %s", e)
                 return
 
+        self._finish_healthy_frame(
+            depth=depth,
+            intrinsics=K,
+            camera_to_world=trans_pose,
+        )
+
+    def _finish_healthy_frame(
+        self,
+        *,
+        depth: Any,
+        intrinsics: Any,
+        camera_to_world: Any,
+    ) -> None:
+        """Commit one healthy frame's positive and negative evidence."""
+        frame_seq = self._tick_idx
         self._tick_idx += 1
         self._maybe_periodic_cleanup()
-        self._project_to_registry()
+        observed_uuids = _observed_map_object_uuids(
+            self._map_objects,
+            frame_seq=frame_seq,
+        )
+        visible_miss_uuids = _visible_missing_uuids(
+            self._map_objects,
+            observed_uuids=observed_uuids,
+            depth_m=depth,
+            intrinsics=intrinsics,
+            camera_to_world=camera_to_world,
+            depth_margin_m=self._visibility_depth_margin_m,
+        )
+        self._project_to_registry(
+            observed_uuids=observed_uuids,
+            visible_miss_uuids=visible_miss_uuids,
+            frame_seq=frame_seq,
+            observed_at=time.time(),
+        )
+
+    def _purge_expired_map_objects_locked(self) -> None:
+        """Remove TTL-expired UUIDs from the persistent ConceptGraphs map."""
+        expired = set(getattr(self, "_expired_uuids", set()))
+        if not expired or self._map_objects is None:
+            return
+        self._expired_uuids.difference_update(expired)
+        if self._cg is not None:
+            retained = self._cg["MapObjectList"]()
+        else:
+            retained = []
+        for obj in self._map_objects:
+            if str(obj.get("id", "") or "") not in expired:
+                retained.append(obj)
+        self._map_objects = retained
 
     # ── Voxel pcd-overlap (replaces concept-graphs `overlap` mode) ──
     @staticmethod
@@ -1755,9 +1948,21 @@ class ConceptGraphsDetector:
         )
 
     # ── Project MapObjectList → ObjectRegistry ──────────────────────
-    def _project_to_registry(self) -> None:
-        """Replace registry's perception-source objects with a snapshot
-        of the current MapObjectList. Robot self-record is preserved.
+    def _project_to_registry(
+        self,
+        *,
+        observed_uuids: Optional[set[str]] = None,
+        visible_miss_uuids: Optional[set[str]] = None,
+        frame_seq: int = 0,
+        observed_at: Optional[float] = None,
+    ) -> None:
+        """Project persistent geometry without replaying positive sightings.
+
+        ``observed_uuids`` contains only objects matched or created by the
+        current healthy frame. ``visible_miss_uuids`` contains unmatched
+        objects whose old location had clear depth evidence of absence.
+        Historical map membership alone updates neither ``last_seen`` nor the
+        observation count.
 
         Runs from the worker thread; the registry uses an asyncio.Lock,
         so we schedule the actual mutation back onto the asyncio loop
@@ -1853,12 +2058,27 @@ class ConceptGraphsDetector:
         # serializes with the snapshot reader (same asyncio.Lock).
         try:
             asyncio.run_coroutine_threadsafe(
-                self._apply_snapshot(snapshots), self._asyncio_loop,
+                self._apply_snapshot(
+                    snapshots,
+                    observed_uuids=observed_uuids,
+                    visible_miss_uuids=visible_miss_uuids,
+                    frame_seq=frame_seq,
+                    observed_at=observed_at,
+                ),
+                self._asyncio_loop,
             )
         except Exception as e:  # noqa: BLE001
             log.debug("schedule registry update failed: %s", e)
 
-    async def _apply_snapshot(self, snapshots: list[dict]) -> None:
+    async def _apply_snapshot(
+        self,
+        snapshots: list[dict],
+        *,
+        observed_uuids: Optional[set[str]] = None,
+        visible_miss_uuids: Optional[set[str]] = None,
+        frame_seq: int = 0,
+        observed_at: Optional[float] = None,
+    ) -> None:
         """Reconcile concept-graphs MapObjectList state into the
         registry **incrementally**. Robot self-record and non-
         perception objects are preserved; for our own objects we:
@@ -1894,7 +2114,22 @@ class ConceptGraphsDetector:
         suffix climbed into the thousands), reset observation_count,
         and broke any consumer that held an oid across ticks.
         """
-        now = time.time()
+        now = time.time() if observed_at is None else float(observed_at)
+        # Compatibility for direct callers predating FrameObservation: an
+        # omitted set means every supplied snapshot is a positive observation.
+        # Production always passes an explicit set, including an empty set.
+        if observed_uuids is None:
+            observed_uuids = {
+                str(s.get("uuid", "") or "")
+                for s in snapshots
+                if str(s.get("uuid", "") or "")
+            }
+        if visible_miss_uuids is None:
+            visible_miss_uuids = set()
+        if not hasattr(self, "_expired_uuids"):
+            self._expired_uuids = set()
+        if not hasattr(self, "_missing_uuids"):
+            self._missing_uuids = set()
         live_uuids = {s["uuid"] for s in snapshots if s.get("uuid")}
         async with self._registry.lock():
             wf = self._world_frame_fn()
@@ -1914,6 +2149,7 @@ class ConceptGraphsDetector:
             # exist while this loop runs.
             for s in snapshots:
                 u = s.get("uuid", "")
+                is_observed = bool(u and u in observed_uuids)
                 pose = Pose3D(
                     x=s["x"], y=s["y"], z=s["z"],
                     yaw=s.get("yaw", 0.0), frame_id=wf,
@@ -1924,7 +2160,7 @@ class ConceptGraphsDetector:
                 )
                 oid = self._uuid_to_oid.get(u) if u else None
                 existing = self._registry._objects.get(oid) if oid else None
-                if existing is None:
+                if existing is None and is_observed:
                     # No uuid binding yet (first sighting of this uuid). Before
                     # minting a new id, try to re-adopt a stable record so the
                     # object keeps its id (and accumulated count) across a uuid
@@ -1970,17 +2206,24 @@ class ConceptGraphsDetector:
                             existing.attributes["cg_uuid"] = u
                             self._uuid_to_oid[u] = existing.object_id
                 if existing is not None:
-                    # Update in place. Preserve oid + first_seen. The count is
-                    # registry-owned (one per tick seen) so it survives a uuid
-                    # swap instead of resetting to the CG object's num_detections.
+                    # Geometry is the persistent fused MapObject snapshot and
+                    # may be projected every tick. Positive-observation state
+                    # changes only when this UUID received current-frame
+                    # evidence.
                     existing.pose = pose
                     existing.bbox = bbox
                     existing.confidence = max(0.0, min(1.0, s["confidence"]))
-                    existing.last_seen = now
-                    existing.missing = False
-                    existing.observation_count += 1
+                    existing.attributes["observation_lifecycle"] = "visibility"
+                    if is_observed:
+                        existing.last_seen = now
+                        existing.missing = False
+                        self._missing_uuids.discard(u)
+                        existing.observation_count += 1
+                        existing.attributes["last_observed_frame"] = frame_seq
+                        existing.attributes["last_observed_unix"] = now
+                        existing.attributes["consecutive_visible_misses"] = 0
                     adopted_oids.add(existing.object_id)
-                else:
+                elif is_observed:
                     obj = self._registry.insert_object(
                         cls=s["cls"],
                         pose=pose,
@@ -1994,7 +2237,27 @@ class ConceptGraphsDetector:
                     if u:
                         obj.attributes["cg_uuid"] = u
                         self._uuid_to_oid[u] = obj.object_id
+                    obj.attributes["observation_lifecycle"] = "visibility"
+                    obj.attributes["last_observed_frame"] = frame_seq
+                    obj.attributes["last_observed_unix"] = now
+                    obj.attributes["consecutive_visible_misses"] = 0
+                    self._missing_uuids.discard(u)
                     adopted_oids.add(obj.object_id)
+
+            # Negative evidence is also frame-scoped. A missing vote is
+            # accepted only when the current RGB-D/model pass was healthy and
+            # depth showed clear space behind the object's old location.
+            for u in visible_miss_uuids:
+                oid = self._uuid_to_oid.get(u)
+                obj = self._registry._objects.get(oid) if oid else None
+                if obj is None or obj.attributes.get("is_robot"):
+                    continue
+                misses = int(obj.attributes.get("consecutive_visible_misses", 0)) + 1
+                obj.attributes["consecutive_visible_misses"] = misses
+                obj.attributes["last_visible_miss_frame"] = frame_seq
+                if misses >= self._visible_miss_threshold:
+                    obj.missing = True
+                    self._missing_uuids.add(u)
 
             # Evict registry records whose source uuid is gone. Runs AFTER
             # bind/adopt so a record adopted above (cg_uuid rebound to a live
@@ -2030,7 +2293,20 @@ class ConceptGraphsDetector:
             # stale one, so soft eviction does not resurrect duplicates.
             for obj in doomed:
                 self._registry.soft_evict(obj)
-            self._registry.prune_expired(now, self._object_ttl_s)
+            uuid_by_oid = {
+                oid: uuid_value
+                for uuid_value, oid in self._uuid_to_oid.items()
+            }
+            pruned_oids = self._registry.prune_expired(
+                now,
+                self._object_ttl_s,
+            )
+            for oid in pruned_oids:
+                uuid_value = uuid_by_oid.get(oid)
+                if uuid_value:
+                    self._uuid_to_oid.pop(uuid_value, None)
+                    self._expired_uuids.add(uuid_value)
+                    self._missing_uuids.discard(uuid_value)
 
     def _rebind_restored(self, cls: str, pose: Pose3D) -> Optional[SceneObject]:
         """Nearest warm-restored, not-yet-rebound object of class `cls` whose

--- a/system/scene/scene_service/scene_graph/store.py
+++ b/system/scene/scene_service/scene_graph/store.py
@@ -122,6 +122,17 @@ class SceneGraphStore:
             updated_at=max(self._geometric_updated_at, self._semantic_updated_at),
         )
 
+    def clear_derived_state(self) -> None:
+        """Clear every object-derived live slice and persistent cache."""
+        self._nodes.clear()
+        self._geometric_edges.clear()
+        self._semantic_edges.clear()
+        self._geometric_updated_at = 0.0
+        self._semantic_updated_at = 0.0
+        self._caption_cache.clear()
+        self._relation_cache.clear()
+        self.flush_caches()
+
     # ── caption cache ────────────────────────────────────────────────────
 
     @staticmethod

--- a/system/scene/scene_service/service.py
+++ b/system/scene/scene_service/service.py
@@ -19,7 +19,7 @@ import os
 import signal
 import time
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Awaitable, Callable, Optional
 
 import uvicorn  # used for the web debug UI; cap owns the MCP HTTP server
 
@@ -571,6 +571,39 @@ async def _start_ros_ingest(
     )
     if pose_max_age_s <= 0.0:
         raise ValueError("pose_max_age_s must be greater than zero")
+    perception_cfg = config.get("perception") or {}
+    if not isinstance(perception_cfg, dict):
+        raise ValueError("perception must be a mapping")
+    detection_period_s = float(
+        perception_cfg["period_s"]
+        if perception_cfg.get("period_s") is not None
+        else (os.environ.get("SCENE_DETECT_PERIOD_S") or 0.6)
+    )
+    visible_miss_frames = int(
+        perception_cfg.get("visible_miss_frames")
+        if perception_cfg.get("visible_miss_frames") is not None
+        else 3
+    )
+    visibility_depth_margin_m = float(
+        perception_cfg.get("visibility_depth_margin_m")
+        if perception_cfg.get("visibility_depth_margin_m") is not None
+        else 0.20
+    )
+    object_ttl_s = float(
+        perception_cfg.get("object_ttl_s")
+        if perception_cfg.get("object_ttl_s") is not None
+        else 30.0
+    )
+    if detection_period_s <= 0.0:
+        raise ValueError("perception.period_s must be greater than zero")
+    if visible_miss_frames < 1:
+        raise ValueError("perception.visible_miss_frames must be at least one")
+    if visibility_depth_margin_m < 0.0:
+        raise ValueError(
+            "perception.visibility_depth_margin_m must not be negative"
+        )
+    if object_ttl_s < 0.0:
+        raise ValueError("perception.object_ttl_s must not be negative")
 
     # ── self-pose bridge ───────────────────────────────────────────────────
     # Polls hub.latest("pose") at 5 Hz and feeds the SelfTracker. Pose
@@ -756,8 +789,11 @@ async def _start_ros_ingest(
             # starves co-located GPU work (e.g. FunASR ASR), making voice slow.
             # Raise SCENE_DETECT_PERIOD_S (e.g. 2.0) to free the GPU when running
             # speech + perception together.
-            period_s=float(os.environ.get("SCENE_DETECT_PERIOD_S", "") or 0.6),
+            period_s=detection_period_s,
             pose_max_age_s=pose_max_age_s,
+            visible_miss_threshold=visible_miss_frames,
+            visibility_depth_margin_m=visibility_depth_margin_m,
+            object_ttl_s=object_ttl_s,
             camera_frame=camera_frame,
             base_frame=configured_base_frame or None,
         )
@@ -1216,6 +1252,7 @@ async def _lifecycle_watch(
     live_binding: Optional[dict] = None,
     ops_lock: Optional[asyncio.Lock] = None,
     semantic_hold: Optional[dict] = None,
+    derived_state_reset: Optional[Callable[[], Awaitable[None]]] = None,
     interval_s: float = 5.0,
 ) -> None:
     """React to map-frame epoch changes and external map switches."""
@@ -1233,11 +1270,13 @@ async def _lifecycle_watch(
     last_warned: Optional[tuple] = None
 
     async def _flush_registry(why: str) -> bool:
-        if registry is None:
-            return True
         try:
-            async with registry.lock():
-                dropped = registry.clear_objects()
+            if derived_state_reset is not None:
+                await derived_state_reset()
+            dropped = 0
+            if registry is not None:
+                async with registry.lock():
+                    dropped = registry.clear_objects()
             log.warning(
                 "[scene] flushed %d mis-anchored object(s) %s", dropped, why
             )
@@ -1589,18 +1628,6 @@ async def _run_active(config: dict) -> None:
     bg_tasks = [
         geometry_task,
         asyncio.create_task(_stale_tick(registry), name="scene-stale-tick"),
-        asyncio.create_task(
-            _lifecycle_watch(
-                hub,
-                binding,
-                anno_store,
-                registry=registry,
-                live_binding=live_binding,
-                ops_lock=map_ops_lock,
-                semantic_hold=semantic_hold,
-            ),
-            name="scene-lifecycle-watch",
-        ),
         # Background reconciler: keeps scene's hub adding subscriptions
         # for new ROS2 topic_outs that appear on atlas after start
         # (mapping comes up after scene; same pattern for any future
@@ -1617,11 +1644,6 @@ async def _run_active(config: dict) -> None:
         ),
         *ingest_bg,
     ]
-    # These tasks are fire-and-forget: nothing awaits them, so an uncaught
-    # exception would otherwise vanish until shutdown (the failure mode of
-    # the failure-detectors themselves). Surface any death immediately.
-    for _t in bg_tasks:
-        _t.add_done_callback(_log_bg_task_exit)
 
     # ── Relation layer ───────────────────────────────────────────────
     # Fast geometric relations (contact/containment + reachable_by) are
@@ -1646,6 +1668,33 @@ async def _run_active(config: dict) -> None:
     mcp_tools.attach_scene_graph_store(sg_store)
     geo_loop = GeometricRelationLoop(registry, sg_store)
     await geo_loop.start()
+
+    async def _reset_derived_state() -> None:
+        reset = getattr(perception, "reset_derived_state", None)
+        if reset is not None:
+            await reset()
+        sg_store.clear_derived_state()
+
+    bg_tasks.append(
+        asyncio.create_task(
+            _lifecycle_watch(
+                hub,
+                binding,
+                anno_store,
+                registry=registry,
+                live_binding=live_binding,
+                ops_lock=map_ops_lock,
+                semantic_hold=semantic_hold,
+                derived_state_reset=_reset_derived_state,
+            ),
+            name="scene-lifecycle-watch",
+        )
+    )
+    # These tasks are fire-and-forget: nothing awaits them, so an uncaught
+    # exception would otherwise vanish until shutdown (the failure mode of
+    # the failure-detectors themselves). Surface any death immediately.
+    for _t in bg_tasks:
+        _t.add_done_callback(_log_bg_task_exit)
 
     # ── Scene Graph (optional LLM enrichment of the residual) ────────
     sg_stop: asyncio.Event | None = None
@@ -1715,6 +1764,7 @@ async def _run_active(config: dict) -> None:
             ops_lock=map_ops_lock,
             semantic_hold=semantic_hold,
             robot_geometry=robot_geometry,
+            derived_state_reset=_reset_derived_state,
         )
         web_uv = uvicorn.Config(
             app=web_app,

--- a/system/scene/scene_service/state/object_registry.py
+++ b/system/scene/scene_service/state/object_registry.py
@@ -285,6 +285,12 @@ class ObjectRegistry:
         for obj in self._objects.values():
             if obj.missing or obj.attributes.get("is_robot"):
                 continue
+            # RGB-D tracks own staleness through healthy, visibility-checked
+            # negative observations. Wall-clock silence can mean an occlusion,
+            # out-of-FOV object, disconnected sensor, or failed model and must
+            # not be converted into evidence that the object disappeared.
+            if obj.attributes.get("observation_lifecycle") == "visibility":
+                continue
             if (now - obj.last_seen) > self.grace_period_s:
                 obj.missing = True
                 flipped += 1

--- a/system/scene/scene_service/web.py
+++ b/system/scene/scene_service/web.py
@@ -675,7 +675,8 @@ def make_app(*, registry: ObjectRegistry,
              map_binding: Optional[dict] = None,
              ops_lock: Optional[asyncio.Lock] = None,
              semantic_hold: Optional[dict] = None,
-             robot_geometry: Any = None) -> Starlette:
+             robot_geometry: Any = None,
+             derived_state_reset: Any = None) -> Starlette:
     """Build the Starlette ASGI app the entrypoint mounts on its own
     uvicorn server.
 
@@ -711,6 +712,8 @@ def make_app(*, registry: ObjectRegistry,
     watcher's epoch response (service.py shares the same lock): the handlers
     suspend at RPC awaits mid-critical-section, and an interleaved flush or
     second Save would mix sessions/epochs in one snapshot.
+    `derived_state_reset` clears detector maps, UUID bindings, and scene-graph
+    state before a successful map Load restores the new epoch.
 
     Annotation API contract (STABLE once shipped — any frontend builds on
     it; see system/scene/README.md):
@@ -1221,6 +1224,8 @@ def make_app(*, registry: ObjectRegistry,
             # recreate the mixed-epoch state this ordering exists to
             # prevent.
             try:
+                if derived_state_reset is not None:
+                    await derived_state_reset()
                 registry_lock = getattr(registry, "lock", None)
                 if callable(registry_lock):
                     async with registry_lock():

--- a/system/scene/tests/test_lifecycle_flush.py
+++ b/system/scene/tests/test_lifecycle_flush.py
@@ -97,9 +97,15 @@ def test_confirm_bump_and_cross_map_drift():
         hub = FakeHub()
         binding = MapBinding(map_id="m1", source="env")
         live = {"map_id": "m1", "mode": "", "generation": None, "source": "env"}
+        derived_resets = []
+
+        async def reset_derived():
+            derived_resets.append(time.time())
+
         task = asyncio.create_task(service_mod._lifecycle_watch(
             hub, binding, anno,
-            registry=registry, live_binding=live, interval_s=0.01,
+            registry=registry, live_binding=live,
+            derived_state_reset=reset_derived, interval_s=0.01,
         ))
         try:
             # 1) Confirm: matching broadcast → epoch learned, nothing flushed.
@@ -108,6 +114,7 @@ def test_confirm_bump_and_cross_map_drift():
             assert live["generation"] == 1, live
             assert set(registry._objects) == {"o1", "o2"}
             assert not anno.list()[0].stale
+            assert derived_resets == []
 
             # 2) Generation bump (reset under scene): objects flushed,
             #    room flagged stale (kept), epoch advanced — exactly once.
@@ -115,6 +122,7 @@ def test_confirm_bump_and_cross_map_drift():
             await _settle()
             assert live["generation"] == 2, live
             assert registry._objects == {}, registry._objects
+            assert len(derived_resets) == 1
             room = anno.list()[0]
             assert room.stale and "1" in room.stale_reason and "2" in room.stale_reason
 
@@ -131,6 +139,7 @@ def test_confirm_bump_and_cross_map_drift():
             await _settle()
             assert registry._objects == {}, registry._objects
             assert live["map_id"] == "m1", live
+            assert len(derived_resets) == 2
         finally:
             task.cancel()
             try:

--- a/system/scene/tests/test_map_epoch.py
+++ b/system/scene/tests/test_map_epoch.py
@@ -123,7 +123,7 @@ _KEEP = object()  # sentinel: "build the real MapMetaStore"
 
 
 def _make_env(tmp, *, binding, objs=(), anno_map_id=".live",
-              lifecycle=None, map_meta=_KEEP):
+              lifecycle=None, map_meta=_KEEP, derived_state_reset=None):
     """(web_mod, app, pieces) or (None, None, None) when deps can't import."""
     err = _IMPORT_ERR
     web_mod = None
@@ -148,6 +148,7 @@ def _make_env(tmp, *, binding, objs=(), anno_map_id=".live",
     app = web_mod.make_app(
         registry=registry, hub=hub, anno_store=anno,
         object_store=store, map_meta=meta, map_binding=bind,
+        derived_state_reset=derived_state_reset,
     )
     return web_mod, app, SimpleNamespace(
         registry=registry, anno=anno, meta=meta, store=store, hub=hub,
@@ -548,10 +549,16 @@ def test_load_flushes_preload_live_objects():
     if _unavailable():
         return
     with tempfile.TemporaryDirectory() as tmp:
+        resets = []
+
+        async def reset_derived_state():
+            resets.append("reset")
+
         web_mod, app, env = _make_env(
             tmp, binding={"map_id": "default", "mode": "", "generation": None,
                           "source": "default"},
             objs=[_obj("preload1"), _obj("preload2")],
+            derived_state_reset=reset_derived_state,
         )
         if app is None:
             return
@@ -563,6 +570,7 @@ def test_load_flushes_preload_live_objects():
         assert body["objects_flushed"] == 2
         assert body["objects_restored"] == 1
         assert set(env.registry._objects) == {"saved"}
+        assert resets == ["reset"]
     print("  [PASS] test_load_flushes_preload_live_objects")
 
 

--- a/system/scene/tests/test_observation_lifecycle.py
+++ b/system/scene/tests/test_observation_lifecycle.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+"""Observation-aware Scene object lifecycle regression tests."""
+
+import asyncio
+import threading
+from types import SimpleNamespace
+
+import numpy as np
+
+from scene_service.ingest.perception_concept_graphs import (
+    ConceptGraphsDetector,
+    _observed_map_object_uuids,
+    _visible_missing_uuids,
+)
+from scene_service.state import ObjectRegistry
+
+
+def _snapshot(uuid: str = "cg-1") -> dict:
+    return {
+        "uuid": uuid,
+        "cls": "cup",
+        "x": 1.0,
+        "y": 2.0,
+        "z": 0.8,
+        "yaw": 0.0,
+        "size_x": 0.1,
+        "size_y": 0.1,
+        "size_z": 0.2,
+        "confidence": 0.9,
+    }
+
+
+def _detector(registry: ObjectRegistry) -> ConceptGraphsDetector:
+    detector = ConceptGraphsDetector.__new__(ConceptGraphsDetector)
+    detector._registry = registry
+    detector._uuid_to_oid = {}
+    detector._expired_uuids = set()
+    detector._missing_uuids = set()
+    detector._world_frame_fn = lambda: "map"
+    detector._object_ttl_s = 30.0
+    detector._visible_miss_threshold = 3
+    detector._inference_lock = threading.Lock()
+    detector._cg = None
+    detector._map_objects = []
+    detector.cfg = {"max_merge_dist_m": 1.5}
+    return detector
+
+
+def test_historical_projection_does_not_refresh_positive_observation() -> None:
+    async def scenario() -> None:
+        registry = ObjectRegistry(grace_period_s=0.1)
+        detector = _detector(registry)
+
+        await detector._apply_snapshot(
+            [_snapshot()],
+            observed_uuids={"cg-1"},
+            visible_miss_uuids=set(),
+            frame_seq=1,
+            observed_at=100.0,
+        )
+        obj = next(iter(registry._objects.values()))
+        oid = obj.object_id
+        assert obj.last_seen == 100.0
+        assert obj.observation_count == 1
+
+        await detector._apply_snapshot(
+            [_snapshot()],
+            observed_uuids=set(),
+            visible_miss_uuids=set(),
+            frame_seq=2,
+            observed_at=101.0,
+        )
+        obj = registry._objects[oid]
+        assert obj.last_seen == 100.0
+        assert obj.observation_count == 1
+        assert not obj.missing
+
+        # Observation-aware objects do not become missing merely because the
+        # sensor/model stopped producing healthy frames.
+        async with registry.lock():
+            assert registry.mark_stale(200.0) == 0
+        assert not registry._objects[oid].missing
+
+    asyncio.run(scenario())
+
+
+def test_only_repeated_healthy_visible_misses_mark_missing() -> None:
+    async def scenario() -> None:
+        registry = ObjectRegistry()
+        detector = _detector(registry)
+        await detector._apply_snapshot(
+            [_snapshot()],
+            observed_uuids={"cg-1"},
+            visible_miss_uuids=set(),
+            frame_seq=1,
+            observed_at=100.0,
+        )
+        oid = next(iter(registry._objects))
+
+        for frame_seq in (2, 3):
+            await detector._apply_snapshot(
+                [_snapshot()],
+                observed_uuids=set(),
+                visible_miss_uuids={"cg-1"},
+                frame_seq=frame_seq,
+                observed_at=100.0 + frame_seq,
+            )
+            assert not registry._objects[oid].missing
+
+        await detector._apply_snapshot(
+            [_snapshot()],
+            observed_uuids=set(),
+            visible_miss_uuids={"cg-1"},
+            frame_seq=4,
+            observed_at=104.0,
+        )
+        obj = registry._objects[oid]
+        assert obj.missing
+        assert detector._missing_uuids == {"cg-1"}
+        assert obj.attributes["consecutive_visible_misses"] == 3
+        assert obj.last_seen == 100.0
+
+        await detector._apply_snapshot(
+            [_snapshot()],
+            observed_uuids={"cg-1"},
+            visible_miss_uuids=set(),
+            frame_seq=5,
+            observed_at=105.0,
+        )
+        obj = registry._objects[oid]
+        assert not obj.missing
+        assert detector._missing_uuids == set()
+        assert obj.object_id == oid
+        assert obj.observation_count == 2
+        assert obj.last_seen == 105.0
+        assert obj.attributes["consecutive_visible_misses"] == 0
+
+    asyncio.run(scenario())
+
+
+def test_current_frame_membership_is_distinct_from_historical_map_membership() -> None:
+    objects = [
+        {"id": "old", "image_idx": [1, 2]},
+        {"id": "matched", "image_idx": [1, 7]},
+        {"id": "new", "image_idx": [7]},
+        {"id": "", "image_idx": [7]},
+    ]
+    assert _observed_map_object_uuids(objects, frame_seq=7) == {"matched", "new"}
+
+
+def test_depth_visibility_requires_clear_line_of_sight() -> None:
+    obj = {
+        "id": "cg-1",
+        "pcd": SimpleNamespace(
+            points=np.asarray(
+                [
+                    [-0.05, -0.05, 2.0],
+                    [0.05, -0.05, 2.0],
+                    [-0.05, 0.05, 2.0],
+                    [0.05, 0.05, 2.0],
+                ],
+                dtype=np.float32,
+            )
+        ),
+    }
+    intrinsics = SimpleNamespace(fx=100.0, fy=100.0, cx=2.0, cy=2.0)
+    camera_to_world = np.eye(4, dtype=np.float32)
+
+    removed_depth = np.full((5, 5), 4.0, dtype=np.float32)
+    assert _visible_missing_uuids(
+        [obj],
+        observed_uuids=set(),
+        depth_m=removed_depth,
+        intrinsics=intrinsics,
+        camera_to_world=camera_to_world,
+        depth_margin_m=0.2,
+    ) == {"cg-1"}
+
+    occluded_depth = np.full((5, 5), 1.0, dtype=np.float32)
+    assert not _visible_missing_uuids(
+        [obj],
+        observed_uuids=set(),
+        depth_m=occluded_depth,
+        intrinsics=intrinsics,
+        camera_to_world=camera_to_world,
+        depth_margin_m=0.2,
+    )
+
+    present_depth = np.full((5, 5), 2.05, dtype=np.float32)
+    assert not _visible_missing_uuids(
+        [obj],
+        observed_uuids=set(),
+        depth_m=present_depth,
+        intrinsics=intrinsics,
+        camera_to_world=camera_to_world,
+        depth_margin_m=0.2,
+    )
+
+
+def test_epoch_reset_drops_map_objects_and_uuid_bindings() -> None:
+    async def scenario() -> None:
+        detector = _detector(ObjectRegistry())
+        detector._map_objects = [{"id": "cg-1"}]
+        detector._uuid_to_oid["cg-1"] = "scene.object.cup_001"
+        detector._tick_idx = 9
+        await detector.reset_derived_state()
+        assert detector._map_objects == []
+        assert detector._uuid_to_oid == {}
+        assert detector._tick_idx == 0
+
+    asyncio.run(scenario())
+
+
+def test_ttl_prunes_registry_binding_and_historical_map_object() -> None:
+    async def scenario() -> None:
+        registry = ObjectRegistry()
+        detector = _detector(registry)
+        detector._visible_miss_threshold = 1
+        await detector._apply_snapshot(
+            [_snapshot()],
+            observed_uuids={"cg-1"},
+            visible_miss_uuids=set(),
+            frame_seq=1,
+            observed_at=100.0,
+        )
+        await detector._apply_snapshot(
+            [_snapshot()],
+            observed_uuids=set(),
+            visible_miss_uuids={"cg-1"},
+            frame_seq=2,
+            observed_at=101.0,
+        )
+        detector._map_objects = [{"id": "cg-1"}]
+        await detector._apply_snapshot(
+            [_snapshot()],
+            observed_uuids=set(),
+            visible_miss_uuids=set(),
+            frame_seq=3,
+            observed_at=131.0,
+        )
+        assert registry._objects == {}
+        assert detector._uuid_to_oid == {}
+        assert detector._expired_uuids == {"cg-1"}
+        detector._purge_expired_map_objects_locked()
+        assert detector._map_objects == []
+
+    asyncio.run(scenario())

--- a/system/scene/tests/test_scene_graph.py
+++ b/system/scene/tests/test_scene_graph.py
@@ -228,6 +228,17 @@ def test_store_cache():
         cached2 = store2.get_cached_relation(node, node2, hint)
         assert cached2 is not None
         assert cached2.relation == "on_top_of"
+
+        # A map-epoch reset clears both live slices and persisted derived
+        # caches, so old object ids and edges cannot reappear.
+        store2.set_geometric([node], [edge])
+        store2.clear_derived_state()
+        assert store2.get_snapshot() is None
+        assert store2.get_cached_caption(node) is None
+        assert store2.get_cached_relation(node, node2, hint) is None
+        store3 = SceneGraphStore(cache_dir=tmpdir)
+        assert store3.get_cached_caption(node) is None
+        assert store3.get_cached_relation(node, node2, hint) is None
     print("  [PASS] test_store_cache")
 
 

--- a/testing/scenarios/cap/scene_object_dropout.yaml
+++ b/testing/scenarios/cap/scene_object_dropout.yaml
@@ -1,0 +1,29 @@
+# Verify Scene object dropout against a real, removable Webots fixture.
+name: scene_object_dropout
+task: "ci-test: verify scene object dropout and stable re-identification"
+steps:
+  - time_s: 0.0
+    content: Verifying a removable Webots object.
+    rtdl_description: spawn, remove, re-observe, and expire a Webots fixture
+    status: in_progress
+    rtdl:
+      op: sequence
+      id: scene_object_dropout_step
+      children:
+        - op: do
+          id: verify_scene_object_dropout
+          cap: executor.builtin_run_command
+          args:
+            command: 'python3 "$(rbnx path root)/testing/verify_scene_object_dropout.py"'
+          description: run the live Webots Scene object lifecycle verifier
+          expect:
+            contract: robonix/system/executor/builtin/run_command
+            success: true
+            args:
+              command: 'python3 "$(rbnx path root)/testing/verify_scene_object_dropout.py"'
+            output:
+              json:
+                ok: true
+                reappeared_same_id: true
+  - content: Scene dropout and stable re-identification verified.
+    status: done

--- a/testing/verify_scene_object_dropout.py
+++ b/testing/verify_scene_object_dropout.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MulanPSL-2.0
+"""Live Webots acceptance check for Scene object dropout and re-identification.
+
+The Webots ROS 2 supervisor imports a chair into the robot's initial camera
+view, Scene observes it, the supervisor removes it, and this verifier checks:
+
+* repeated healthy RGB-D misses hide the object promptly;
+* respawning at the same pose reuses the stable Scene object id; and
+* the final removal is hard-pruned after the configured TTL.
+
+This script is intentionally stdlib-only. It runs through Executor's
+``run_command`` capability in the integration scenario so the same current PR
+checkout that boots Webots also supplies the verifier.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.request
+from typing import Any, Callable
+
+
+FIXTURE_NAME = "scene_dropout_fixture"
+FIXTURE_NODE = (
+    'OfficeChair { translation 0.0 -4.0 0 '
+    'rotation 0 0 1 0 name "scene_dropout_fixture" }'
+)
+
+
+def _run_ros(container: str, command: str, request: str) -> str:
+    """Run one ROS 2 CLI operation in the simulator container.
+
+    The request is passed as positional ``$1`` rather than interpolated into
+    the shell program, so the VRML/YAML quoting is preserved exactly.
+    """
+    proc = subprocess.run(
+        [
+            "docker",
+            "exec",
+            container,
+            "bash",
+            "-lc",
+            (
+                "set -e; source /opt/ros/humble/setup.bash; "
+                f"{command} \"$1\""
+            ),
+            "scene-dropout-verifier",
+            request,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"ROS command failed ({proc.returncode}): "
+            f"{proc.stdout.strip()} {proc.stderr.strip()}"
+        )
+    return f"{proc.stdout}\n{proc.stderr}"
+
+
+def _spawn(container: str) -> None:
+    request = json.dumps({"data": FIXTURE_NODE})
+    output = _run_ros(
+        container,
+        (
+            "ros2 service call /spawn_node_from_string "
+            "webots_ros2_msgs/srv/SpawnNodeFromString"
+        ),
+        request,
+    )
+    if "success=true" not in output.lower() and "success: true" not in output.lower():
+        raise RuntimeError(f"Webots supervisor rejected fixture: {output.strip()}")
+
+
+def _remove(container: str) -> None:
+    request = json.dumps({"data": FIXTURE_NAME})
+    _run_ros(
+        container,
+        "ros2 topic pub --once /remove_node std_msgs/msg/String",
+        request,
+    )
+
+
+def _state(url: str) -> dict[str, Any]:
+    with urllib.request.urlopen(url, timeout=3) as response:
+        return json.load(response)
+
+
+def _objects(url: str) -> list[dict[str, Any]]:
+    return list(_state(url).get("objects") or [])
+
+
+def _wait(
+    description: str,
+    timeout_s: float,
+    predicate: Callable[[list[dict[str, Any]]], Any],
+    scene_url: str,
+) -> tuple[Any, float]:
+    start = time.monotonic()
+    last: list[dict[str, Any]] = []
+    while time.monotonic() - start < timeout_s:
+        try:
+            last = _objects(scene_url)
+            value = predicate(last)
+            if value:
+                return value, time.monotonic() - start
+        except Exception:
+            pass
+        time.sleep(0.5)
+    compact = [
+        {
+            "id": obj.get("id"),
+            "cls": obj.get("cls"),
+            "missing": obj.get("missing"),
+            "observation_count": obj.get("observation_count"),
+        }
+        for obj in last
+        if str(obj.get("cls") or "").lower() != "robot"
+    ]
+    raise TimeoutError(f"{description} timed out after {timeout_s}s; objects={compact}")
+
+
+def _visible_chair_not_in(
+    baseline_ids: set[str],
+) -> Callable[[list[dict[str, Any]]], str | None]:
+    def predicate(objects: list[dict[str, Any]]) -> str | None:
+        for obj in objects:
+            oid = str(obj.get("id") or "")
+            label = str(obj.get("cls") or "").lower()
+            if (
+                oid
+                and oid not in baseline_ids
+                and "chair" in label
+                and not bool(obj.get("missing"))
+            ):
+                return oid
+        return None
+
+    return predicate
+
+
+def _object_missing(oid: str) -> Callable[[list[dict[str, Any]]], bool]:
+    return lambda objects: any(
+        str(obj.get("id") or "") == oid and bool(obj.get("missing"))
+        for obj in objects
+    )
+
+
+def _object_visible(oid: str) -> Callable[[list[dict[str, Any]]], bool]:
+    return lambda objects: any(
+        str(obj.get("id") or "") == oid and not bool(obj.get("missing"))
+        for obj in objects
+    )
+
+
+def _object_absent(oid: str) -> Callable[[list[dict[str, Any]]], bool]:
+    return lambda objects: all(str(obj.get("id") or "") != oid for obj in objects)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--scene-url",
+        default=f"http://127.0.0.1:{os.environ.get('SCENE_WEB_PORT', '50107')}/api/state",
+    )
+    parser.add_argument(
+        "--container",
+        default=os.environ.get("ROBONIX_SIM_CONTAINER", "robonix_tiago_sim"),
+    )
+    args = parser.parse_args()
+
+    spawned = False
+    result: dict[str, Any] = {"ok": False}
+    try:
+        baseline_ids = {
+            str(obj.get("id") or "")
+            for obj in _objects(args.scene_url)
+            if str(obj.get("id") or "")
+        }
+        # A previous interrupted verifier may have left the fixture imported.
+        # remove_node is idempotent from this script's perspective.
+        with __import__("contextlib").suppress(Exception):
+            _remove(args.container)
+
+        _spawn(args.container)
+        spawned = True
+        oid, appear_latency = _wait(
+            "fixture appearance",
+            20.0,
+            _visible_chair_not_in(baseline_ids),
+            args.scene_url,
+        )
+
+        _remove(args.container)
+        spawned = False
+        _, missing_latency = _wait(
+            "visibility-verified missing transition",
+            10.0,
+            _object_missing(oid),
+            args.scene_url,
+        )
+
+        _spawn(args.container)
+        spawned = True
+        _, reappear_latency = _wait(
+            "stable-id reappearance",
+            20.0,
+            _object_visible(oid),
+            args.scene_url,
+        )
+
+        _remove(args.container)
+        spawned = False
+        _, final_missing_latency = _wait(
+            "second missing transition",
+            10.0,
+            _object_missing(oid),
+            args.scene_url,
+        )
+        _, delete_latency = _wait(
+            "TTL hard deletion",
+            36.0,
+            _object_absent(oid),
+            args.scene_url,
+        )
+
+        result = {
+            "ok": True,
+            "object_id": oid,
+            "appearance_latency_s": round(appear_latency, 3),
+            "missing_latency_s": round(missing_latency, 3),
+            "reappeared_same_id": True,
+            "reappearance_latency_s": round(reappear_latency, 3),
+            "final_missing_latency_s": round(final_missing_latency, 3),
+            "delete_latency_s": round(delete_latency, 3),
+        }
+        print(json.dumps(result, separators=(",", ":")))
+        return 0
+    except Exception as exc:
+        result["error"] = str(exc)
+        print(json.dumps(result, separators=(",", ":")))
+        return 1
+    finally:
+        if spawned:
+            with __import__("contextlib").suppress(Exception):
+                _remove(args.container)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

This is the first incremental fix for #177. It separates current-frame observations from the persistent ConceptGraphs map so historical objects can no longer refresh themselves forever.

- refreshes `last_seen` and `observation_count` only for UUIDs carrying current-frame evidence;
- treats absence as negative evidence only on a healthy RGB-D frame when the old location is in view and depth shows clear space behind it;
- marks objects missing after a configurable number of visible misses, then prunes them after a configurable TTL;
- preserves stable IDs when objects reappear before the TTL;
- clears the ConceptGraphs map, UUID bindings, registry objects, and Scene Graph caches together on map epoch changes and map loads;
- moves lifecycle thresholds to `system.scene.config.perception` with SI units and documents their semantics;
- adds a live Webots Supervisor fixture that spawns, removes, respawns, and finally expires a real chair through the complete Scene pipeline.

This PR is intentionally stacked on #195 (`agent/dev-next-portability`) because #177 work targets the experimental `dev-next` Scene pipeline. After #195 is reviewed/merged, this PR should be retargeted to `dev-next`.

## Why

The previous projection path serialized the entire historical `MapObjectList` after every tick and treated every retained entry as a fresh positive observation. Consequently `last_seen` advanced forever, `missing` was cleared forever, and dropout/TTL could never remove a moved object.

The new lifecycle distinguishes:

1. a positive current-frame match;
2. a visibility-verified miss;
3. unknown state caused by occlusion, out-of-FOV, sensor/model failure, or unavailable spatial transform.

Only (1) refreshes an object, and only repeated (2) can mark it missing.

## Validation

- `211 passed` across `system/scene/tests` using clean generated Scene protobuf/MCP modules from the #195 base;
- focused lifecycle/map/identity/persistence suite: `45 passed, 23 skipped` (Milvus-Lite skips on macOS are expected);
- all 15 integration scenarios compile and pass the offline harness simulation;
- Python compile check passed for every modified Scene module and the live verifier;
- `git diff --check` passed.

The latest-head Webots integration run exercises the new `scene_object_dropout` scenario through the trusted Robonix CI path. It must report fixture appearance, visible-miss transition, same-ID reappearance, and TTL hard deletion before this PR is considered verified.

## Scope left for follow-up PRs

This PR repairs readiness/epoch reset and dropout state semantics. It does not claim to finish #177. Spatial admission/plane filtering, multi-view geometry and bbox uncertainty, label posterior/association, and supported CRUD/flush contracts remain separate, measured follow-ups.

Refs #177
