### PR TITLE
fix(scene): improve RGB-D geometry and spatial admission

### DIFF
--- a/examples/webots/robonix_manifest.yaml
+++ b/examples/webots/robonix_manifest.yaml
@@ -39,6 +39,22 @@ system:
         visible_miss_frames: 3
         visibility_depth_margin_m: 0.20
         object_ttl_s: 30.0
+        geometry:
+          # Reject RGB-D points outside the physical sensor range, remove
+          # one-pixel SAM boundary leakage, denoise each frame, and admit only
+          # point clouds that fit the current map grid.
+          mask_erosion_px: 1
+          min_depth_m: 0.15
+          max_depth_m: 6.0
+          depth_mad_scale: 3.5
+          depth_min_band_m: 0.12
+          frame_dbscan: true
+          require_occupancy_bounds: true
+          map_bounds_margin_m: 0.25
+          map_max_outside_fraction: 0.20
+          bbox_low_percentile: 5.0
+          bbox_high_percentile: 95.0
+          max_bbox_extent_m: 3.0
   # execution layer
   executor:
     # robonix-client polls Executor for authoritative active RTDL plans.

--- a/system/scene/README.md
+++ b/system/scene/README.md
@@ -322,14 +322,49 @@ environment variables.
 | `visibility_depth_margin_m` | float, m | `0.20` | measured depth must be at least this far behind the stored object center to count as clear-space negative evidence |
 | `object_ttl_s` | float, s | `30.0` | time after the last positive observation before a `missing` object is hard-deleted |
 
+`perception.geometry` controls metric RGB-D admission. All distances use SI
+metres; percentages are expressed on a 0–100 scale and fractions on a 0–1
+scale.
+
+| Key | Type / unit | Default | Meaning |
+|---|---|---|---|
+| `mask_erosion_px` | integer, image pixels | `1` | conservative SAM-mask boundary erosion; automatically falls back when erosion would erase a small valid object |
+| `min_depth_m` | float, m | `0.15` | nearest accepted depth sample |
+| `max_depth_m` | float, m | `6.0` | farthest accepted depth sample |
+| `depth_mad_scale` | float, dimensionless | `3.5` | robust median-absolute-deviation multiplier used to reject depth spikes inside each mask |
+| `depth_min_band_m` | float, m | `0.12` | minimum half-width of the accepted per-mask depth band |
+| `frame_dbscan` | boolean | `true` | run ConceptGraphs DBSCAN noise removal on each newly back-projected object cloud |
+| `require_occupancy_bounds` | boolean | `true` | withhold authoritative objects until a same-frame-id occupancy grid exists, then reject off-map clouds |
+| `map_bounds_margin_m` | float, m | `0.25` | tolerance outside the current occupancy-grid rectangle |
+| `map_max_outside_fraction` | float, fraction | `0.20` | maximum fraction of object-cloud points allowed outside that tolerant map rectangle |
+| `bbox_low_percentile` | float, % | `5.0` | lower robust point-cloud quantile used for the yaw-aligned 3D box |
+| `bbox_high_percentile` | float, % | `95.0` | upper robust point-cloud quantile used for the yaw-aligned 3D box |
+| `max_bbox_extent_m` | float, m | `3.0` | reject a per-frame object hypothesis when any robust 3D box dimension exceeds this deployment limit |
+
 ```yaml
 system:
   scene:
-    perception:
-      period_s: 0.6
-      visible_miss_frames: 3
-      visibility_depth_margin_m: 0.20
-      object_ttl_s: 30.0
+    config:
+      # Scene receives only this nested Driver configuration mapping.
+      # Package/runtime selectors remain siblings of `config`.
+      perception:
+        period_s: 0.6
+        visible_miss_frames: 3
+        visibility_depth_margin_m: 0.20
+        object_ttl_s: 30.0
+        geometry:
+          mask_erosion_px: 1
+          min_depth_m: 0.15
+          max_depth_m: 6.0
+          depth_mad_scale: 3.5
+          depth_min_band_m: 0.12
+          frame_dbscan: true
+          require_occupancy_bounds: true
+          map_bounds_margin_m: 0.25
+          map_max_outside_fraction: 0.20
+          bbox_low_percentile: 5.0
+          bbox_high_percentile: 95.0
+          max_bbox_extent_m: 3.0
 ```
 
 ## Legacy environment and model knobs

--- a/system/scene/scene_service/ingest/perception_concept_graphs.py
+++ b/system/scene/scene_service/ingest/perception_concept_graphs.py
@@ -166,6 +166,205 @@ def _visible_missing_uuids(
     return visible_missing
 
 
+def _erode_binary_mask(mask: np.ndarray, radius_px: int) -> np.ndarray:
+    """Square-kernel binary erosion without an OpenCV/SciPy dependency."""
+    radius = max(0, int(radius_px))
+    source = np.asarray(mask, dtype=bool)
+    if radius == 0 or source.ndim != 2:
+        return source.copy()
+    height, width = source.shape
+    padded = np.pad(source, radius, mode="constant", constant_values=False)
+    eroded = np.ones_like(source)
+    window = 2 * radius + 1
+    for dy in range(window):
+        for dx in range(window):
+            eroded &= padded[dy:dy + height, dx:dx + width]
+    return eroded
+
+
+def _refine_masks_with_depth(
+    masks: Any,
+    depth_m: Any,
+    *,
+    erosion_px: int,
+    min_depth_m: float,
+    max_depth_m: float,
+    mad_scale: float,
+    min_band_m: float,
+    min_points: int,
+    min_retained_ratio: float = 0.25,
+) -> np.ndarray:
+    """Suppress mask-edge background and depth spikes before backprojection.
+
+    Each SAM mask is conservatively eroded, range-gated, then clipped around
+    its median depth using a robust MAD band. If either refinement would erase
+    a small valid object, the previous valid stage is retained. This improves
+    geometry without converting a quality filter into a small-object recall
+    regression.
+    """
+    mask_array = np.asarray(masks, dtype=bool)
+    depth = np.asarray(depth_m, dtype=np.float32)
+    if mask_array.ndim != 3 or depth.ndim != 2:
+        return mask_array.copy()
+    if mask_array.shape[1:] != depth.shape:
+        return mask_array.copy()
+
+    minimum = max(1, int(min_points))
+    near = max(0.0, float(min_depth_m))
+    far = max(near, float(max_depth_m))
+    finite_range = np.isfinite(depth) & (depth >= near) & (depth <= far)
+    out = np.zeros_like(mask_array)
+    for index, original in enumerate(mask_array):
+        ranged = original & finite_range
+        if int(ranged.sum()) < minimum:
+            continue
+
+        eroded = _erode_binary_mask(ranged, erosion_px)
+        required_after_erode = max(
+            minimum,
+            int(round(float(ranged.sum()) * max(0.0, min(1.0, min_retained_ratio)))),
+        )
+        working = eroded if int(eroded.sum()) >= required_after_erode else ranged
+
+        values = depth[working]
+        median = float(np.median(values))
+        mad = float(np.median(np.abs(values - median)))
+        robust_sigma = 1.4826 * mad
+        band = max(float(min_band_m), float(mad_scale) * robust_sigma)
+        clipped = working & (np.abs(depth - median) <= band)
+        required_after_clip = max(
+            minimum,
+            int(round(float(working.sum()) * max(0.0, min(1.0, min_retained_ratio)))),
+        )
+        out[index] = clipped if int(clipped.sum()) >= required_after_clip else working
+    return out
+
+
+def _occupancy_contains_points(
+    points_world: Any,
+    occupancy_grid: Any,
+    *,
+    expected_frame: str,
+    margin_m: float = 0.25,
+    max_outside_fraction: float = 0.20,
+) -> bool:
+    """Check a world-frame point cloud against a possibly rotated map grid."""
+    try:
+        points = np.asarray(points_world, dtype=np.float64)
+        points = points[np.all(np.isfinite(points), axis=1)]
+        info = occupancy_grid.info
+        resolution = float(info.resolution)
+        width = int(info.width)
+        height = int(info.height)
+        frame = str(
+            getattr(getattr(occupancy_grid, "header", None), "frame_id", "") or ""
+        ).strip().lstrip("/")
+        if (
+            points.ndim != 2
+            or points.shape[0] == 0
+            or points.shape[1] < 2
+            or resolution <= 0.0
+            or width <= 0
+            or height <= 0
+            or not frame
+            or frame != str(expected_frame or "").strip().lstrip("/")
+        ):
+            return False
+        origin = info.origin
+        q = origin.orientation
+        yaw = math.atan2(
+            2.0 * (float(q.w) * float(q.z) + float(q.x) * float(q.y)),
+            1.0 - 2.0 * (float(q.y) ** 2 + float(q.z) ** 2),
+        )
+        dx = points[:, 0] - float(origin.position.x)
+        dy = points[:, 1] - float(origin.position.y)
+        cos_yaw, sin_yaw = math.cos(yaw), math.sin(yaw)
+        local_x = cos_yaw * dx + sin_yaw * dy
+        local_y = -sin_yaw * dx + cos_yaw * dy
+        map_width_m = width * resolution
+        map_height_m = height * resolution
+        margin = max(0.0, float(margin_m))
+        inside = (
+            (local_x >= -margin)
+            & (local_x <= map_width_m + margin)
+            & (local_y >= -margin)
+            & (local_y <= map_height_m + margin)
+        )
+        outside_fraction = 1.0 - float(np.mean(inside))
+        center_x = float(np.median(local_x))
+        center_y = float(np.median(local_y))
+        center_inside = (
+            -margin <= center_x <= map_width_m + margin
+            and -margin <= center_y <= map_height_m + margin
+        )
+        return center_inside and outside_fraction <= max(
+            0.0,
+            min(1.0, float(max_outside_fraction)),
+        )
+    except (AttributeError, TypeError, ValueError):
+        return False
+
+
+def _robust_yaw_bbox(
+    points_world: Any,
+    *,
+    low_percentile: float = 5.0,
+    high_percentile: float = 95.0,
+) -> tuple[np.ndarray, np.ndarray, float] | None:
+    """Return a robust yaw-only 3D box as ``(center, extent, yaw)``."""
+    points = np.asarray(points_world, dtype=np.float64)
+    points = points[np.all(np.isfinite(points), axis=1)]
+    if points.ndim != 2 or points.shape[0] < 4 or points.shape[1] < 3:
+        return None
+    low = max(0.0, min(100.0, float(low_percentile)))
+    high = max(low, min(100.0, float(high_percentile)))
+    if high <= low:
+        return None
+    # Estimate orientation from a lightly trimmed cloud. A single far depth
+    # spike otherwise dominates the covariance eigenvectors even though the
+    # later extent quantiles would have rejected that point.
+    trim_low = max(0.0, min(low, 2.0))
+    trim_high = min(100.0, max(high, 98.0))
+    xy_low = np.percentile(points[:, :2], trim_low, axis=0)
+    xy_high = np.percentile(points[:, :2], trim_high, axis=0)
+    yaw_points = points[
+        np.all(
+            (points[:, :2] >= xy_low) & (points[:, :2] <= xy_high),
+            axis=1,
+        )
+    ]
+    if yaw_points.shape[0] < 4:
+        yaw_points = points
+    yaw = _yaw_from_pca_xy(yaw_points[:, :2])
+    if not math.isfinite(yaw):
+        return None
+    anchor_xy = np.median(points[:, :2], axis=0)
+    cos_yaw, sin_yaw = float(np.cos(yaw)), float(np.sin(yaw))
+    world_to_local = np.array(
+        [[cos_yaw, sin_yaw], [-sin_yaw, cos_yaw]],
+        dtype=np.float64,
+    )
+    local_xy = (points[:, :2] - anchor_xy) @ world_to_local.T
+    lo_xy = np.percentile(local_xy, low, axis=0)
+    hi_xy = np.percentile(local_xy, high, axis=0)
+    lo_z, hi_z = np.percentile(points[:, 2], [low, high])
+    local_center_xy = (lo_xy + hi_xy) * 0.5
+    center_xy = anchor_xy + local_center_xy @ world_to_local
+    center = np.asarray(
+        [float(center_xy[0]), float(center_xy[1]), float((lo_z + hi_z) * 0.5)]
+    )
+    extent = np.asarray(
+        [
+            float(hi_xy[0] - lo_xy[0]),
+            float(hi_xy[1] - lo_xy[1]),
+            float(hi_z - lo_z),
+        ]
+    )
+    if not np.all(np.isfinite(center)) or not np.all(np.isfinite(extent)):
+        return None
+    return center, np.maximum(extent, 0.0), yaw
+
+
 _DEFAULT_YOLO_WORLD_WEIGHTS = "/opt/models/yolov8l-world.pt"
 _DEFAULT_MOBILE_SAM_WEIGHTS = "/opt/models/mobile_sam.pt"
 _DEFAULT_CLIP_MODEL = "ViT-B-32"
@@ -457,6 +656,18 @@ class ConceptGraphsDetector:
         visible_miss_threshold: int = 3,
         visibility_depth_margin_m: float = 0.20,
         object_ttl_s: float = 30.0,
+        mask_erosion_px: int = 1,
+        min_depth_m: float = 0.15,
+        max_depth_m: float = 6.0,
+        depth_mad_scale: float = 3.5,
+        depth_min_band_m: float = 0.12,
+        frame_dbscan: bool = True,
+        require_occupancy_bounds: bool = True,
+        map_bounds_margin_m: float = 0.25,
+        map_max_outside_fraction: float = 0.20,
+        bbox_low_percentile: float = 5.0,
+        bbox_high_percentile: float = 95.0,
+        max_bbox_extent_m: float = 3.0,
         confidence_threshold: float = 0.30,
         max_detections: int = 30,
         yolo_weights_path: Optional[str] = None,
@@ -497,6 +708,27 @@ class ConceptGraphsDetector:
             float(visibility_depth_margin_m),
         )
         self._object_ttl_s = max(0.0, float(object_ttl_s))
+        self._mask_erosion_px = max(0, int(mask_erosion_px))
+        self._min_depth_m = max(0.0, float(min_depth_m))
+        self._max_depth_m = max(self._min_depth_m, float(max_depth_m))
+        self._depth_mad_scale = max(0.0, float(depth_mad_scale))
+        self._depth_min_band_m = max(0.0, float(depth_min_band_m))
+        self._frame_dbscan = bool(frame_dbscan)
+        self._require_occupancy_bounds = bool(require_occupancy_bounds)
+        self._map_bounds_margin_m = max(0.0, float(map_bounds_margin_m))
+        self._map_max_outside_fraction = max(
+            0.0,
+            min(1.0, float(map_max_outside_fraction)),
+        )
+        self._bbox_low_percentile = max(
+            0.0,
+            min(100.0, float(bbox_low_percentile)),
+        )
+        self._bbox_high_percentile = max(
+            self._bbox_low_percentile,
+            min(100.0, float(bbox_high_percentile)),
+        )
+        self._max_bbox_extent_m = max(0.05, float(max_bbox_extent_m))
 
         self._yolo: Any = None
         self._sam: Any = None
@@ -553,6 +785,15 @@ class ConceptGraphsDetector:
         # Keep the binding for stable re-identification, but suppress these
         # objects from the 3D live view until they are observed again.
         self._missing_uuids: set[str] = set()
+        self._quality_counters: dict[str, int] = {
+            "healthy_frames": 0,
+            "masks_input": 0,
+            "masks_retained": 0,
+            "depth_rejected_masks": 0,
+            "map_bounds_rejected_detections": 0,
+            "oversized_bbox_rejected_detections": 0,
+            "accepted_frame_detections": 0,
+        }
         # How long a soft-evicted (missing) registry record is kept so a
         # re-detection can re-bind it before it is hard-pruned. Decouples
         # observation_count from concept-graphs uuid churn across ticks.
@@ -627,6 +868,8 @@ class ConceptGraphsDetector:
             self._uuid_to_oid.clear()
             self._expired_uuids.clear()
             self._missing_uuids.clear()
+            for key in getattr(self, "_quality_counters", {}):
+                self._quality_counters[key] = 0
             self._tick_idx = 0
             self._last_logged_total = -1
             self._spatial_not_ready_logged = False
@@ -653,6 +896,26 @@ class ConceptGraphsDetector:
         except Exception as e:  # noqa: BLE001
             log.warning("[scene-cg] embed_text failed: %s", e)
             return None
+
+    def quality_metrics(self) -> dict[str, Any]:
+        """Return cumulative admission counters for operator/CI reporting."""
+        return {
+            **dict(getattr(self, "_quality_counters", {})),
+            "require_occupancy_bounds": bool(
+                getattr(self, "_require_occupancy_bounds", False)
+            ),
+            "frame_dbscan": bool(getattr(self, "_frame_dbscan", False)),
+            "depth_range_m": [
+                float(getattr(self, "_min_depth_m", 0.0)),
+                float(getattr(self, "_max_depth_m", 0.0)),
+            ],
+            "max_bbox_extent_m": float(
+                getattr(self, "_max_bbox_extent_m", 0.0)
+            ),
+            "map_bounds_margin_m": float(
+                getattr(self, "_map_bounds_margin_m", 0.0)
+            ),
+        }
 
     # ── External viz access ──────────────────────────────────────────
     # Web UI's `/3d` page calls into here every frame. Held under the
@@ -718,40 +981,29 @@ class ConceptGraphsDetector:
                     pts = pts[idx]
                     if cols is not None and cols.size:
                         cols = cols[idx]
-                # Yaw-only OBB via 2D PCA on the XY footprint. Same
-                # rationale as in `_project_to_registry`: Open3D's
-                # `get_oriented_bounding_box(robust=True)` segfaults
-                # in qhull on certain pcds, so we never call it.
-                yaw = _yaw_from_pca_xy(pts[:, :2])
-                # Rotate the pts into yaw-aligned frame, take axis-
-                # aligned extent there, build 8 corners, rotate back.
-                cos_y = float(np.cos(yaw)); sin_y = float(np.sin(yaw))
+                bbox_result = _robust_yaw_bbox(
+                    pts,
+                    low_percentile=getattr(self, "_bbox_low_percentile", 5.0),
+                    high_percentile=getattr(self, "_bbox_high_percentile", 95.0),
+                )
+                if bbox_result is None:
+                    continue
+                center, extent, yaw = bbox_result
+                cos_y = float(np.cos(yaw))
+                sin_y = float(np.sin(yaw))
                 rot_xy = np.array([[cos_y, sin_y], [-sin_y, cos_y]])
-                pts_xy = pts[:, :2] - pts[:, :2].mean(axis=0)
-                pts_local = pts_xy @ rot_xy.T  # rotate into yaw frame
-                # 5–95 percentile instead of full min/max — robust
-                # against the depth-spike outliers that were inflating
-                # bbox dimensions to 3 m+ on a single chair.
-                lo_x, hi_x = np.percentile(pts_local[:, 0], [5, 95])
-                lo_y, hi_y = np.percentile(pts_local[:, 1], [5, 95])
-                lo_z, hi_z = np.percentile(pts[:, 2], [5, 95])
-                lo_x, hi_x = float(lo_x), float(hi_x)
-                lo_y, hi_y = float(lo_y), float(hi_y)
-                lo_z, hi_z = float(lo_z), float(hi_z)
-                cx, cy = pts[:, :2].mean(axis=0)
-                # 8 corners in robot-frame XY (yaw-rotated) + raw Z.
+                hx, hy, hz = (float(v) * 0.5 for v in extent)
                 local_corners = np.array([
-                    [lo_x, lo_y, lo_z], [hi_x, lo_y, lo_z],
-                    [lo_x, hi_y, lo_z], [lo_x, lo_y, hi_z],
-                    [hi_x, hi_y, hi_z], [lo_x, hi_y, hi_z],
-                    [hi_x, lo_y, hi_z], [hi_x, hi_y, lo_z],
+                    [-hx, -hy, -hz], [hx, -hy, -hz],
+                    [-hx, hy, -hz], [-hx, -hy, hz],
+                    [hx, hy, hz], [-hx, hy, hz],
+                    [hx, -hy, hz], [hx, hy, -hz],
                 ])
                 corners = np.zeros_like(local_corners)
-                # Rotate xy back into world, then translate.
                 world_xy = local_corners[:, :2] @ rot_xy
-                corners[:, 0] = world_xy[:, 0] + cx
-                corners[:, 1] = world_xy[:, 1] + cy
-                corners[:, 2] = local_corners[:, 2]
+                corners[:, 0] = world_xy[:, 0] + center[0]
+                corners[:, 1] = world_xy[:, 1] + center[1]
+                corners[:, 2] = local_corners[:, 2] + center[2]
                 bbox_corners_arr = corners
                 if not np.all(np.isfinite(bbox_corners_arr)):
                     continue
@@ -768,7 +1020,7 @@ class ConceptGraphsDetector:
                     "n_points": int(obj.get("n_points", pts.shape[0])),
                     "conf_mean": (float(np.mean(obj["conf"])) if obj.get("conf") else 0.0),
                     # Center + size for HUD; clients can also derive from corners.
-                    "center": pts.mean(axis=0).tolist(),
+                    "center": center.tolist(),
                     "bbox_corners": bbox_corners,
                     "inst_color": inst_color,
                     "points": pts.tolist(),
@@ -866,6 +1118,16 @@ class ConceptGraphsDetector:
                 self._spatial_not_ready_logged = True
             return
         self._spatial_not_ready_logged = False
+        occupancy_grid = self._current_occupancy_grid(world_frame)
+        if self._require_occupancy_bounds and occupancy_grid is None:
+            if not getattr(self, "_occupancy_not_ready_logged", False):
+                log.warning(
+                    "occupancy grid unavailable or frame-mismatched; "
+                    "withholding navigation-grade object detections"
+                )
+                self._occupancy_not_ready_logged = True
+            return
+        self._occupancy_not_ready_logged = False
         cam_K_mat = np.array(
             [
                 [K.fx, 0, K.cx],
@@ -976,6 +1238,7 @@ class ConceptGraphsDetector:
             cls_idx = cls_idx[:n]
         if masks.shape[0] == 0:
             return
+        self._quality_counters["masks_input"] += int(masks.shape[0])
 
         # Resize masks to depth resolution if needed (MobileSAM masks
         # come back at the input resolution, which matches RGB; depth
@@ -995,6 +1258,28 @@ class ConceptGraphsDetector:
             except Exception as e:  # noqa: BLE001
                 log.warning("mask resize failed: %s — skipping tick", e)
                 return
+        masks = _refine_masks_with_depth(
+            masks,
+            depth,
+            erosion_px=self._mask_erosion_px,
+            min_depth_m=self._min_depth_m,
+            max_depth_m=self._max_depth_m,
+            mad_scale=self._depth_mad_scale,
+            min_band_m=self._depth_min_band_m,
+            min_points=int(self.cfg["min_points_threshold"]),
+        )
+        retained_masks = int(np.count_nonzero(np.any(masks, axis=(1, 2))))
+        self._quality_counters["masks_retained"] += retained_masks
+        self._quality_counters["depth_rejected_masks"] += (
+            int(masks.shape[0]) - retained_masks
+        )
+        if not masks.any():
+            self._finish_healthy_frame(
+                depth=depth,
+                intrinsics=K,
+                camera_to_world=trans_pose,
+            )
+            return
 
         # ── CLIP per-detection feature ──────────────────────────────
         try:
@@ -1045,7 +1330,7 @@ class ConceptGraphsDetector:
                 dbscan_remove_noise=self.cfg["dbscan_remove_noise"],
                 dbscan_eps=self.cfg["dbscan_eps"],
                 dbscan_min_points=self.cfg["dbscan_min_points"],
-                run_dbscan=False,
+                run_dbscan=self._frame_dbscan,
                 device=self._device,
             )
         except Exception as e:  # noqa: BLE001
@@ -1078,6 +1363,41 @@ class ConceptGraphsDetector:
             # Drop them before they reach the merge pipeline.
             try:
                 pts_chk = np.asarray(entry["pcd"].points)
+                if (
+                    occupancy_grid is not None
+                    and not _occupancy_contains_points(
+                        pts_chk,
+                        occupancy_grid,
+                        expected_frame=world_frame,
+                        margin_m=self._map_bounds_margin_m,
+                        max_outside_fraction=self._map_max_outside_fraction,
+                    )
+                ):
+                    log.debug(
+                        "[scene-cg] drop %s detection outside occupancy bounds",
+                        cls_name,
+                    )
+                    self._quality_counters[
+                        "map_bounds_rejected_detections"
+                    ] += 1
+                    continue
+                frame_bbox = _robust_yaw_bbox(
+                    pts_chk,
+                    low_percentile=self._bbox_low_percentile,
+                    high_percentile=self._bbox_high_percentile,
+                )
+                if (
+                    frame_bbox is None
+                    or float(np.max(frame_bbox[1])) > self._max_bbox_extent_m
+                ):
+                    log.debug(
+                        "[scene-cg] drop %s detection with invalid/oversized bbox",
+                        cls_name,
+                    )
+                    self._quality_counters[
+                        "oversized_bbox_rejected_detections"
+                    ] += 1
+                    continue
                 if pts_chk.shape[0] >= 4:
                     z_max = float(pts_chk[:, 2].max())
                     z_p90 = float(np.percentile(pts_chk[:, 2], 90))
@@ -1126,6 +1446,7 @@ class ConceptGraphsDetector:
                 "new_counter": 0,
             }
             det_list.append(d)
+        self._quality_counters["accepted_frame_detections"] += len(det_list)
 
         if len(det_list) == 0:
             self._finish_healthy_frame(
@@ -1292,6 +1613,7 @@ class ConceptGraphsDetector:
         camera_to_world: Any,
     ) -> None:
         """Commit one healthy frame's positive and negative evidence."""
+        self._quality_counters["healthy_frames"] += 1
         frame_seq = self._tick_idx
         self._tick_idx += 1
         self._maybe_periodic_cleanup()
@@ -1789,6 +2111,32 @@ class ConceptGraphsDetector:
             return ""
         return live or configured
 
+    def _current_occupancy_grid(self, expected_world_frame: str):
+        """Return the current map grid only when its frame matches projection."""
+        if self._hub is None or not self._hub.has("occupancy_grid"):
+            return None
+        try:
+            msg, stamp_unix, count = self._hub.latest("occupancy_grid")
+        except Exception:  # noqa: BLE001
+            return None
+        if msg is None or stamp_unix <= 0.0 or count <= 0:
+            return None
+        frame = str(
+            getattr(getattr(msg, "header", None), "frame_id", "") or ""
+        ).strip().lstrip("/")
+        expected = str(expected_world_frame or "").strip().lstrip("/")
+        if not frame or frame != expected:
+            return None
+        info = getattr(msg, "info", None)
+        if (
+            info is None
+            or int(getattr(info, "width", 0) or 0) <= 0
+            or int(getattr(info, "height", 0) or 0) <= 0
+            or float(getattr(info, "resolution", 0.0) or 0.0) <= 0.0
+        ):
+            return None
+        return msg
+
     def _build_camera_to_map_transform(self, *, expected_world_frame: str = ""):
         """Return a validated camera-to-world transform.
 
@@ -2006,32 +2354,14 @@ class ConceptGraphsDetector:
                 if finite_pts.shape[0] < 4:
                     continue
                 pts = finite_pts
-                obb_yaw = _yaw_from_pca_xy(pts[:, :2])
-                cy_, sy_ = float(np.cos(obb_yaw)), float(np.sin(obb_yaw))
-                pts_local_xy = (pts[:, :2] - pts[:, :2].mean(axis=0)) @ np.array([[cy_, sy_], [-sy_, cy_]]).T
-                obb_center = np.array([
-                    float(pts[:, 0].mean()), float(pts[:, 1].mean()), float(pts[:, 2].mean()),
-                ])
-                # Use 5–95 percentile range instead of full min/max:
-                # a single outlier point (depth backprojection
-                # spike, mask leak) along the principal axis was
-                # blowing chair / table extents to 3 m+. Percentile
-                # is robust to a few stragglers and matches what
-                # the user actually expects to see.
-                lo, hi = np.percentile(pts_local_xy[:, 0], [5, 95])
-                ex_x = float(hi - lo)
-                lo, hi = np.percentile(pts_local_xy[:, 1], [5, 95])
-                ex_y = float(hi - lo)
-                lo, hi = np.percentile(pts[:, 2], [5, 95])
-                ex_z = float(hi - lo)
-                obb_extent = np.array([ex_x, ex_y, ex_z])
-                # Final NaN/Inf guard. If any value made it through
-                # (e.g. zero-variance pcd → PCA returns NaN yaw), skip
-                # this object rather than letting JSON reject the
-                # whole snapshot.
-                if not (np.all(np.isfinite(obb_center)) and np.all(np.isfinite(obb_extent))
-                        and math.isfinite(obb_yaw)):
+                bbox_result = _robust_yaw_bbox(
+                    pts,
+                    low_percentile=self._bbox_low_percentile,
+                    high_percentile=self._bbox_high_percentile,
+                )
+                if bbox_result is None:
                     continue
+                obb_center, obb_extent, obb_yaw = bbox_result
 
                 cls = _canon_class(obj.get("class_name", "object"))
                 conf_list = obj.get("conf", [])
@@ -2050,6 +2380,8 @@ class ConceptGraphsDetector:
                     "size_y": float(max(0.05, obb_extent[1])),
                     "size_z": float(max(0.05, obb_extent[2])),
                     "confidence": max(0.0, min(1.0, conf)),
+                    "geometry_point_count": int(pts.shape[0]),
+                    "geometry_view_count": int(obj.get("num_detections", 1) or 1),
                 })
             except Exception:  # noqa: BLE001
                 continue
@@ -2214,6 +2546,17 @@ class ConceptGraphsDetector:
                     existing.bbox = bbox
                     existing.confidence = max(0.0, min(1.0, s["confidence"]))
                     existing.attributes["observation_lifecycle"] = "visibility"
+                    existing.attributes["geometry_source"] = "rgbd_multi_view"
+                    existing.attributes["bbox_method"] = "yaw_pca_quantile"
+                    existing.attributes["geometry_point_count"] = int(
+                        s.get("geometry_point_count", 0)
+                    )
+                    existing.attributes["geometry_view_count"] = int(
+                        s.get("geometry_view_count", 1)
+                    )
+                    existing.attributes["navigation_grade"] = bool(
+                        getattr(self, "_require_occupancy_bounds", False)
+                    )
                     if is_observed:
                         existing.last_seen = now
                         existing.missing = False
@@ -2238,6 +2581,17 @@ class ConceptGraphsDetector:
                         obj.attributes["cg_uuid"] = u
                         self._uuid_to_oid[u] = obj.object_id
                     obj.attributes["observation_lifecycle"] = "visibility"
+                    obj.attributes["geometry_source"] = "rgbd_multi_view"
+                    obj.attributes["bbox_method"] = "yaw_pca_quantile"
+                    obj.attributes["geometry_point_count"] = int(
+                        s.get("geometry_point_count", 0)
+                    )
+                    obj.attributes["geometry_view_count"] = int(
+                        s.get("geometry_view_count", 1)
+                    )
+                    obj.attributes["navigation_grade"] = bool(
+                        getattr(self, "_require_occupancy_bounds", False)
+                    )
                     obj.attributes["last_observed_frame"] = frame_seq
                     obj.attributes["last_observed_unix"] = now
                     obj.attributes["consecutive_visible_misses"] = 0

--- a/system/scene/scene_service/service.py
+++ b/system/scene/scene_service/service.py
@@ -574,6 +574,19 @@ async def _start_ros_ingest(
     perception_cfg = config.get("perception") or {}
     if not isinstance(perception_cfg, dict):
         raise ValueError("perception must be a mapping")
+    geometry_cfg = perception_cfg.get("geometry") or {}
+    if not isinstance(geometry_cfg, dict):
+        raise ValueError("perception.geometry must be a mapping")
+
+    def _geometry_bool(key: str, default: bool) -> bool:
+        value = geometry_cfg.get(key, default)
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str) and value.strip().lower() in {
+            "true", "false", "1", "0", "yes", "no",
+        }:
+            return value.strip().lower() in {"true", "1", "yes"}
+        raise ValueError(f"perception.geometry.{key} must be a boolean")
     detection_period_s = float(
         perception_cfg["period_s"]
         if perception_cfg.get("period_s") is not None
@@ -594,6 +607,20 @@ async def _start_ros_ingest(
         if perception_cfg.get("object_ttl_s") is not None
         else 30.0
     )
+    mask_erosion_px = int(geometry_cfg.get("mask_erosion_px", 1))
+    min_depth_m = float(geometry_cfg.get("min_depth_m", 0.15))
+    max_depth_m = float(geometry_cfg.get("max_depth_m", 6.0))
+    depth_mad_scale = float(geometry_cfg.get("depth_mad_scale", 3.5))
+    depth_min_band_m = float(geometry_cfg.get("depth_min_band_m", 0.12))
+    frame_dbscan = _geometry_bool("frame_dbscan", True)
+    require_occupancy_bounds = _geometry_bool("require_occupancy_bounds", True)
+    map_bounds_margin_m = float(geometry_cfg.get("map_bounds_margin_m", 0.25))
+    map_max_outside_fraction = float(
+        geometry_cfg.get("map_max_outside_fraction", 0.20)
+    )
+    bbox_low_percentile = float(geometry_cfg.get("bbox_low_percentile", 5.0))
+    bbox_high_percentile = float(geometry_cfg.get("bbox_high_percentile", 95.0))
+    max_bbox_extent_m = float(geometry_cfg.get("max_bbox_extent_m", 3.0))
     if detection_period_s <= 0.0:
         raise ValueError("perception.period_s must be greater than zero")
     if visible_miss_frames < 1:
@@ -604,6 +631,34 @@ async def _start_ros_ingest(
         )
     if object_ttl_s < 0.0:
         raise ValueError("perception.object_ttl_s must not be negative")
+    if mask_erosion_px < 0:
+        raise ValueError("perception.geometry.mask_erosion_px must not be negative")
+    if min_depth_m < 0.0 or max_depth_m <= min_depth_m:
+        raise ValueError(
+            "perception.geometry depth range must satisfy "
+            "0 <= min_depth_m < max_depth_m"
+        )
+    if depth_mad_scale < 0.0 or depth_min_band_m < 0.0:
+        raise ValueError(
+            "perception.geometry depth filters must not be negative"
+        )
+    if map_bounds_margin_m < 0.0:
+        raise ValueError(
+            "perception.geometry.map_bounds_margin_m must not be negative"
+        )
+    if not 0.0 <= map_max_outside_fraction <= 1.0:
+        raise ValueError(
+            "perception.geometry.map_max_outside_fraction must be in [0, 1]"
+        )
+    if not 0.0 <= bbox_low_percentile < bbox_high_percentile <= 100.0:
+        raise ValueError(
+            "perception.geometry bbox percentiles must satisfy "
+            "0 <= low < high <= 100"
+        )
+    if max_bbox_extent_m <= 0.0:
+        raise ValueError(
+            "perception.geometry.max_bbox_extent_m must be greater than zero"
+        )
 
     # ── self-pose bridge ───────────────────────────────────────────────────
     # Polls hub.latest("pose") at 5 Hz and feeds the SelfTracker. Pose
@@ -794,6 +849,18 @@ async def _start_ros_ingest(
             visible_miss_threshold=visible_miss_frames,
             visibility_depth_margin_m=visibility_depth_margin_m,
             object_ttl_s=object_ttl_s,
+            mask_erosion_px=mask_erosion_px,
+            min_depth_m=min_depth_m,
+            max_depth_m=max_depth_m,
+            depth_mad_scale=depth_mad_scale,
+            depth_min_band_m=depth_min_band_m,
+            frame_dbscan=frame_dbscan,
+            require_occupancy_bounds=require_occupancy_bounds,
+            map_bounds_margin_m=map_bounds_margin_m,
+            map_max_outside_fraction=map_max_outside_fraction,
+            bbox_low_percentile=bbox_low_percentile,
+            bbox_high_percentile=bbox_high_percentile,
+            max_bbox_extent_m=max_bbox_extent_m,
             camera_frame=camera_frame,
             base_frame=configured_base_frame or None,
         )

--- a/system/scene/scene_service/web.py
+++ b/system/scene/scene_service/web.py
@@ -339,11 +339,24 @@ def _occupancy_payload(hub: Any) -> Optional[dict]:
     buf = io.BytesIO()
     PILImage.fromarray(out, mode="L").save(buf, format="PNG", optimize=False)
     payload = {
+        "frame_id": str(
+            getattr(getattr(msg, "header", None), "frame_id", "") or ""
+        ).strip(),
         "width": w,
         "height": h,
         "resolution": float(info.resolution),
         "origin_x": float(info.origin.position.x),
         "origin_y": float(info.origin.position.y),
+        "origin_yaw": math.atan2(
+            2.0 * (
+                float(info.origin.orientation.w) * float(info.origin.orientation.z)
+                + float(info.origin.orientation.x) * float(info.origin.orientation.y)
+            ),
+            1.0 - 2.0 * (
+                float(info.origin.orientation.y) ** 2
+                + float(info.origin.orientation.z) ** 2
+            ),
+        ),
         "stamp_ms": int(stamp_unix * 1000),
         "png_b64": base64.b64encode(buf.getvalue()).decode("ascii"),
     }
@@ -477,7 +490,8 @@ def _state_payload(registry: ObjectRegistry,
                    hub: Any, sg_store: Any = None,
                    anno_store: Any = None,
                    map_binding: Optional[dict] = None,
-                   robot_geometry: Any = None) -> dict:
+                   robot_geometry: Any = None,
+                   detector: Any = None) -> dict:
     """Serialise the registry + relations + map into the small JSON
     shape the page consumes. Done in one snapshot so the page never
     sees a half-updated registry. The "relations" field shows the fast
@@ -538,6 +552,11 @@ def _state_payload(registry: ObjectRegistry,
         "robot_footprint": (
             robot_geometry.current().to_json()
             if robot_geometry is not None and robot_geometry.current() is not None
+            else None
+        ),
+        "perception_quality": (
+            detector.quality_metrics()
+            if detector is not None and hasattr(detector, "quality_metrics")
             else None
         ),
         "occupancy": _occupancy_payload(hub),
@@ -866,6 +885,7 @@ def make_app(*, registry: ObjectRegistry,
                 anno_store,
                 map_binding,
                 robot_geometry,
+                detector,
             )
         )
 

--- a/system/scene/tests/test_spatial_quality.py
+++ b/system/scene/tests/test_spatial_quality.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+"""Regression tests for Scene RGB-D geometry admission and robust boxes."""
+
+import math
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from scene_service.ingest.perception_concept_graphs import (
+    _occupancy_contains_points,
+    _refine_masks_with_depth,
+    _robust_yaw_bbox,
+)
+
+
+def test_depth_refinement_removes_mask_edge_background() -> None:
+    masks = np.ones((1, 7, 7), dtype=bool)
+    depth = np.full((7, 7), 5.0, dtype=np.float32)
+    depth[1:6, 1:6] = 2.0
+    refined = _refine_masks_with_depth(
+        masks,
+        depth,
+        erosion_px=1,
+        min_depth_m=0.15,
+        max_depth_m=6.0,
+        mad_scale=3.5,
+        min_band_m=0.12,
+        min_points=4,
+    )
+    assert refined.shape == masks.shape
+    assert int(refined.sum()) == 25
+    assert np.all(refined[0, 1:6, 1:6])
+    assert not np.any(refined[0, 0])
+    assert not np.any(refined[0, -1])
+
+
+def test_depth_refinement_preserves_small_valid_mask_when_erosion_erases_it() -> None:
+    masks = np.zeros((1, 6, 6), dtype=bool)
+    masks[0, 2:4, 2:4] = True
+    depth = np.full((6, 6), 2.0, dtype=np.float32)
+    refined = _refine_masks_with_depth(
+        masks,
+        depth,
+        erosion_px=1,
+        min_depth_m=0.15,
+        max_depth_m=6.0,
+        mad_scale=3.5,
+        min_band_m=0.12,
+        min_points=4,
+    )
+    assert np.array_equal(refined, masks)
+
+
+def _grid(*, yaw: float = 0.0):
+    return SimpleNamespace(
+        header=SimpleNamespace(frame_id="map"),
+        info=SimpleNamespace(
+            resolution=0.5,
+            width=20,
+            height=10,
+            origin=SimpleNamespace(
+                position=SimpleNamespace(x=-2.0, y=-1.0),
+                orientation=SimpleNamespace(
+                    x=0.0,
+                    y=0.0,
+                    z=math.sin(yaw / 2.0),
+                    w=math.cos(yaw / 2.0),
+                ),
+            ),
+        ),
+    )
+
+
+def test_occupancy_bounds_reject_far_ghost_and_frame_mismatch() -> None:
+    inside = np.asarray([[0.0, 0.0, 0.5], [0.1, -0.1, 0.6]])
+    far = np.asarray([[100.0, 100.0, 0.5], [101.0, 100.0, 0.6]])
+    assert _occupancy_contains_points(inside, _grid(), expected_frame="map")
+    assert not _occupancy_contains_points(far, _grid(), expected_frame="map")
+    assert not _occupancy_contains_points(inside, _grid(), expected_frame="odom")
+
+
+def test_occupancy_bounds_support_rotated_map_origin() -> None:
+    # Local grid coordinate (2, 1) rotated +90 degrees and translated by
+    # origin (-2, -1) becomes world (-3, 1).
+    inside_rotated = np.asarray([[-3.0, 1.0, 0.5], [-3.1, 1.1, 0.6]])
+    assert _occupancy_contains_points(
+        inside_rotated,
+        _grid(yaw=math.pi / 2.0),
+        expected_frame="map",
+    )
+
+
+def test_robust_bbox_resists_single_depth_spike() -> None:
+    rng = np.random.default_rng(7)
+    points = np.column_stack(
+        (
+            rng.uniform(0.5, 1.5, 500),
+            rng.uniform(1.75, 2.25, 500),
+            rng.uniform(0.2, 0.8, 500),
+        )
+    )
+    points = np.vstack((points, np.asarray([[30.0, -40.0, 20.0]])))
+    result = _robust_yaw_bbox(points)
+    assert result is not None
+    center, extent, yaw = result
+    assert np.linalg.norm(center - np.asarray([1.0, 2.0, 0.5])) < 0.15
+    assert sorted(extent[:2]) == pytest.approx([0.45, 0.90], abs=0.12)
+    assert extent[2] == pytest.approx(0.54, abs=0.08)
+    assert math.isfinite(yaw)

--- a/testing/scenarios/cap/scene_object_quality.yaml
+++ b/testing/scenarios/cap/scene_object_quality.yaml
@@ -1,0 +1,31 @@
+# Gate live Scene objects on map bounds, finite robust boxes, and background labels.
+name: scene_object_quality
+task: "ci-test: verify live scene object spatial quality"
+steps:
+  - time_s: 0.0
+    content: Checking Scene object quality.
+    rtdl_description: validate map bounds, 3D boxes, and admission metrics
+    status: in_progress
+    rtdl:
+      op: sequence
+      id: scene_object_quality_step
+      children:
+        - op: do
+          id: verify_scene_object_quality
+          cap: executor.builtin_run_command
+          args:
+            command: 'python3 "$(rbnx path root)/testing/verify_scene_object_quality.py"'
+          description: check the live Scene registry against the occupancy map
+          expect:
+            contract: robonix/system/executor/builtin/run_command
+            success: true
+            args:
+              command: 'python3 "$(rbnx path root)/testing/verify_scene_object_quality.py"'
+            output:
+              json:
+                ok: true
+                off_map_count: 0
+                invalid_bbox_count: 0
+                background_label_count: 0
+  - content: Scene spatial object quality verified.
+    status: done

--- a/testing/verify_scene_object_quality.py
+++ b/testing/verify_scene_object_quality.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MulanPSL-2.0
+"""Validate live Scene object spatial sanity against its occupancy map."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import sys
+import time
+import urllib.request
+from typing import Any
+
+
+def _state(url: str) -> dict[str, Any]:
+    with urllib.request.urlopen(url, timeout=3) as response:
+        return json.load(response)
+
+
+def _inside_map(obj: dict[str, Any], occupancy: dict[str, Any], margin_m: float) -> bool:
+    pose = obj.get("pose") or {}
+    x, y = float(pose["x"]), float(pose["y"])
+    dx = x - float(occupancy["origin_x"])
+    dy = y - float(occupancy["origin_y"])
+    yaw = float(occupancy.get("origin_yaw") or 0.0)
+    local_x = math.cos(yaw) * dx + math.sin(yaw) * dy
+    local_y = -math.sin(yaw) * dx + math.cos(yaw) * dy
+    width_m = int(occupancy["width"]) * float(occupancy["resolution"])
+    height_m = int(occupancy["height"]) * float(occupancy["resolution"])
+    return (
+        -margin_m <= local_x <= width_m + margin_m
+        and -margin_m <= local_y <= height_m + margin_m
+    )
+
+
+def _finite_bbox(obj: dict[str, Any], max_extent_m: float) -> bool:
+    bbox = obj.get("bbox") or {}
+    values = [
+        float(bbox["size_x"]),
+        float(bbox["size_y"]),
+        float(bbox["size_z"]),
+        float(bbox.get("yaw") or 0.0),
+    ]
+    return (
+        all(math.isfinite(value) for value in values)
+        and all(0.0 < value <= max_extent_m for value in values[:3])
+    )
+
+
+def main() -> int:
+    port = os.environ.get("SCENE_WEB_PORT", "50107")
+    url = f"http://127.0.0.1:{port}/api/state"
+    deadline = time.monotonic() + 30.0
+    state: dict[str, Any] = {}
+    while time.monotonic() < deadline:
+        try:
+            state = _state(url)
+            quality = state.get("perception_quality") or {}
+            visible = [
+                obj
+                for obj in state.get("objects") or []
+                if not obj.get("missing")
+                and str(obj.get("cls") or "").strip().lower() != "robot"
+            ]
+            if (
+                visible
+                and state.get("occupancy")
+                and int(quality.get("healthy_frames") or 0) > 0
+            ):
+                break
+        except Exception:
+            pass
+        time.sleep(1.0)
+
+    quality = state.get("perception_quality") or {}
+    occupancy = state.get("occupancy") or {}
+    visible = [
+        obj
+        for obj in state.get("objects") or []
+        if not obj.get("missing")
+        and str(obj.get("cls") or "").strip().lower() != "robot"
+    ]
+    max_extent_m = float(quality.get("max_bbox_extent_m") or 0.0)
+    margin_m = float(quality.get("map_bounds_margin_m") or 0.0)
+    off_map = [
+        str(obj.get("id") or "")
+        for obj in visible
+        if not occupancy or not _inside_map(obj, occupancy, margin_m)
+    ]
+    invalid_bbox = [
+        str(obj.get("id") or "")
+        for obj in visible
+        if max_extent_m <= 0.0 or not _finite_bbox(obj, max_extent_m)
+    ]
+    background_labels = [
+        str(obj.get("id") or "")
+        for obj in visible
+        if str(obj.get("cls") or "").strip().lower()
+        in {"floor", "wall", "ceiling", "carpet"}
+    ]
+    result = {
+        "ok": bool(
+            visible
+            and occupancy
+            and quality.get("require_occupancy_bounds") is True
+            and quality.get("frame_dbscan") is True
+            and not off_map
+            and not invalid_bbox
+            and not background_labels
+        ),
+        "visible_objects": len(visible),
+        "off_map_count": len(off_map),
+        "invalid_bbox_count": len(invalid_bbox),
+        "background_label_count": len(background_labels),
+        "quality": quality,
+        "off_map_ids": off_map,
+        "invalid_bbox_ids": invalid_bbox,
+        "background_label_ids": background_labels,
+    }
+    print(json.dumps(result, separators=(",", ":")))
+    return 0 if result["ok"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

This is the second incremental #177 change, stacked on #196. It improves metric RGB-D point clouds and 3D boxes without mixing label/association changes into the same review.

- erodes one configurable SAM boundary pixel, while automatically retaining the original mask when erosion would destroy a small valid object;
- applies sensor-range and robust median/MAD depth filtering before backprojection;
- enables the already-configured per-frame ConceptGraphs DBSCAN path;
- withholds authoritative objects until a same-frame occupancy grid exists;
- rejects point clouds outside the current (possibly rotated) occupancy-grid bounds;
- rejects per-frame hypotheses with an invalid or deployment-oversized robust bbox;
- derives object center, yaw, and extents from trimmed PCA plus configurable quantiles instead of a mean shifted by outliers;
- publishes cumulative admission counters through `/api/state.perception_quality`;
- documents every parameter under `system.scene.config.perception.geometry`, with SI units and semantics.

## Configuration contract

All metric distances are metres. `bbox_*_percentile` uses 0–100 percent; `map_max_outside_fraction` uses 0–1. The Webots deployment opts into the documented defaults explicitly so CI exercises the public Driver contract rather than private environment variables.

## Validation

- Scene test suite: `216 passed`;
- new pure regressions cover mask-edge leakage, small-object erosion fallback, rotated occupancy grids, far ghost rejection, frame mismatch, and bbox resistance to a large depth spike;
- all 16 integration scenarios compile and pass offline harness simulation;
- runtime portability audit passed;
- Python compile and `git diff --check` passed.

The new Webots `scene_object_quality` scenario checks every live non-robot object against the real occupancy map, requires finite positive bboxes below the configured maximum, rejects background labels, and records the admission counters. A trusted real Webots run will be attached before review completion.

## Stack

- base: #196 (`agent/scene-object-lifecycle-177`)
- this PR: spatial/point-cloud/bbox quality only
- follow-up: label evidence and association
- follow-up: epoch-checked object CRUD/flush

After #196 is merged/retargeted, this PR should be retargeted accordingly. Do not merge the stack out of order.

Refs #177
