### PR TITLE
fix(scene): stabilize object labels and association

### DIFF
--- a/examples/webots/robonix_manifest.yaml
+++ b/examples/webots/robonix_manifest.yaml
@@ -39,6 +39,19 @@ system:
         visible_miss_frames: 3
         visibility_depth_margin_m: 0.20
         object_ttl_s: 30.0
+        label:
+          # Require repeated, confidence-weighted evidence before a label is
+          # navigation-grade or allowed to replace a stable track label.
+          history_size: 20
+          min_switch_observations: 3
+          min_winner_share: 0.65
+          switch_margin: 0.20
+        association:
+          # Co-location is not proof of identity (for example, a cup on a
+          # table). Webots uses exact-label tracks and disables the legacy
+          # class-agnostic geometric collapse.
+          confusable_class_groups: []
+          allow_cross_class_merge: false
         geometry:
           # Reject RGB-D points outside the physical sensor range, remove
           # one-pixel SAM boundary leakage, denoise each frame, and admit only

--- a/system/scene/README.md
+++ b/system/scene/README.md
@@ -341,6 +341,35 @@ scale.
 | `bbox_high_percentile` | float, % | `95.0` | upper robust point-cloud quantile used for the yaw-aligned 3D box |
 | `max_bbox_extent_m` | float, m | `3.0` | reject a per-frame object hypothesis when any robust 3D box dimension exceeds this deployment limit |
 
+`perception.vocabulary` owns the YOLO-World prompt vocabulary. Labels are
+case-normalized and de-duplicated while preserving order.
+
+| Key | Type / unit | Default | Meaning |
+|---|---|---|---|
+| `classes` | list of strings | built-in indoor vocabulary | optional full replacement of the detector vocabulary; an explicitly empty list is invalid |
+| `additional_classes` | list of strings | `[]` | deployment-specific labels appended to `classes` or the built-in vocabulary |
+
+`perception.label` converts per-frame classifications into track-level label
+evidence. Observation confidence is the weight; a track's public label changes
+only after the challenger clears every configured gate.
+
+| Key | Type / unit | Default | Meaning |
+|---|---|---|---|
+| `history_size` | integer, observations | `20` | maximum recent class observations retained in the label vote |
+| `min_switch_observations` | integer, observations | `3` | minimum observations supporting a label before it is non-provisional or may replace the current label |
+| `min_winner_share` | float, fraction | `0.65` | minimum share of total confidence-weighted evidence required by the winner |
+| `switch_margin` | float, fraction | `0.20` | winner must exceed the current label by at least this fraction of total weighted evidence |
+
+`perception.association` controls when differently labelled detections may
+share one physical-object track. The safe default is exact-label association.
+Nearby geometry alone is insufficient because distinct objects are often
+co-located (for example, a cup on a table).
+
+| Key | Type / unit | Default | Meaning |
+|---|---|---|---|
+| `confusable_class_groups` | list of string lists | `[]` | reviewed synonym/equivalence groups whose members may associate, such as `["sofa", "couch"]`; every member must exist in the resolved vocabulary |
+| `allow_cross_class_merge` | boolean | `false` | legacy emergency escape hatch that permits unrestricted cross-class association and geometric collapse; not recommended for normal deployments |
+
 ```yaml
 system:
   scene:
@@ -352,6 +381,18 @@ system:
         visible_miss_frames: 3
         visibility_depth_margin_m: 0.20
         object_ttl_s: 30.0
+        vocabulary:
+          # Omit `classes` to retain the built-in indoor vocabulary.
+          additional_classes: []
+        label:
+          history_size: 20
+          min_switch_observations: 3
+          min_winner_share: 0.65
+          switch_margin: 0.20
+        association:
+          confusable_class_groups:
+            - [sofa, couch]
+          allow_cross_class_merge: false
         geometry:
           mask_erosion_px: 1
           min_depth_m: 0.15
@@ -378,11 +419,12 @@ system:
 | `SCENE_YOLO_WORLD_WEIGHTS` | `/opt/models/yolov8l-world.pt` | path inside container |
 | `SCENE_MOBILE_SAM_WEIGHTS` | `/opt/models/mobile_sam.pt` | |
 | `SCENE_CLIP_MODEL` / `SCENE_CLIP_PRETRAINED` | `ViT-B-32` / staged `open_clip_pytorch_model.bin` | Local checkpoint; build.sh downloads it before Docker/native build. |
-| `SCENE_CG_MERGE_THRESHOLD` | `0.55` | per-tick merge threshold |
+| `SCENE_CG_MERGE_THRESHOLD` | `0.85` | per-tick merge threshold |
 | `SCENE_CG_MAX_MERGE_DIST_M` | `1.5` | hard distance gate |
 | `SCENE_CG_OBJ_MIN_POINTS` | `20` | periodic-cleanup cull gate; raise to drop sparse/thin objects, lower to keep them (thin objects like keyboards backproject to sparse clouds) |
-| `SCENE_CG_CROSS_CLASS_CENTROID_MAX_M` | `0.5` | per-tick class-gate bypass radius: a detection within this of an existing object may merge despite a different class label (handles YOLO label flicker on one fixture) |
-| `SCENE_CG_CROSS_CLASS_IOU_THRESH` / `SCENE_CG_CROSS_CLASS_OVERLAP_THRESH` | `0.30` / `0.50` | periodic class-agnostic collapse: fold two records when AABB IoU ≥ first **or** one-inside-other overlap ≥ second, regardless of class/visual sim. Lower to be more aggressive on a flickering desk (`chair` vs `table` split) |
+| `SCENE_CG_ALLOW_CROSS_CLASS_MERGE` | `false` | compatibility switch for unrestricted cross-class association/collapse; Driver `perception.association.allow_cross_class_merge` takes precedence |
+| `SCENE_CG_CROSS_CLASS_CENTROID_MAX_M` | `0.5` | legacy proximity threshold, effective only when unrestricted cross-class merging is explicitly enabled |
+| `SCENE_CG_CROSS_CLASS_IOU_THRESH` / `SCENE_CG_CROSS_CLASS_OVERLAP_THRESH` | `0.30` / `0.50` | legacy class-agnostic collapse thresholds, effective only when unrestricted cross-class merging is explicitly enabled |
 | `SCENE_CG_MERGE_OVERLAP_THRESH` / `SCENE_CG_MERGE_VISUAL_SIM_THRESH` | `0.50` / `0.65` | periodic `merge_overlap` pass: fold pairs with pcd-overlap ≥ first **and** CLIP cosine ≥ second |
 | `SCENE_CG_SAME_CLASS_MERGE_DIST_M` | `0.4` | lenient dedup: fold two SAME-class (or same `SCENE_CG_MERGE_CLASS_GROUPS` bucket) records whose centroids are within this distance, regardless of visual sim (kills "one keyboard → three"). `0` disables |
 | `SCENE_CG_MERGE_CLASS_GROUPS` | `` | opt-in confusable-class reconciliation, e.g. `chair,table,desk;sofa,couch` — listed classes share one merge bucket so label flicker across the group collapses while distinct, distant objects stay separate. Empty = off (never relabels) |

--- a/system/scene/scene_service/ingest/perception_concept_graphs.py
+++ b/system/scene/scene_service/ingest/perception_concept_graphs.py
@@ -70,11 +70,116 @@ _BG_CLASSES = frozenset({"floor", "wall", "ceiling", "carpet"})
 _IGNORED_CLASSES = frozenset({"person"})
 
 
-def _resolved_classes() -> list[str]:
-    raw = os.environ.get("SCENE_OPEN_VOCAB_CLASSES", "").strip()
-    if not raw:
-        return list(_DEFAULT_OPEN_VOCAB)
-    return [s.strip() for s in raw.split(",") if s.strip()]
+def _resolved_classes(
+    configured: Optional[list[str]] = None,
+    additional: Optional[list[str]] = None,
+) -> list[str]:
+    """Resolve the open-vocabulary prompt list with stable de-duplication.
+
+    Normal deployments use Driver config. ``SCENE_OPEN_VOCAB_CLASSES`` remains
+    a legacy full override only when no configured base list is supplied.
+    """
+    raw = (
+        os.environ.get("SCENE_OPEN_VOCAB_CLASSES", "").strip()
+        if configured is None and additional is None
+        else ""
+    )
+    if raw:
+        candidates = [s.strip() for s in raw.split(",") if s.strip()]
+    else:
+        candidates = list(configured or _DEFAULT_OPEN_VOCAB)
+        candidates.extend(additional or ())
+    out: list[str] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        label = str(candidate or "").strip().lower()
+        if label and label not in seen:
+            seen.add(label)
+            out.append(label)
+    return out
+
+
+def _label_evidence(
+    obj: Any,
+    classes: list[str],
+    *,
+    current_label: str,
+    history_size: int,
+    min_switch_observations: int,
+    min_winner_share: float,
+    switch_margin: float,
+) -> dict[str, Any]:
+    """Aggregate recent confidence-weighted class evidence for one map object."""
+    class_ids = list(obj.get("class_id", ()) or ())
+    confidences = list(obj.get("conf", ()) or ())
+    limit = max(1, int(history_size))
+    class_ids = class_ids[-limit:]
+    confidences = confidences[-limit:]
+    scores: dict[str, float] = {}
+    counts: dict[str, int] = {}
+    for index, raw_class_id in enumerate(class_ids):
+        try:
+            class_id = int(raw_class_id)
+        except (TypeError, ValueError):
+            continue
+        if not 0 <= class_id < len(classes):
+            continue
+        label = str(classes[class_id]).strip().lower()
+        if not label:
+            continue
+        try:
+            confidence = float(confidences[index])
+        except (IndexError, TypeError, ValueError):
+            confidence = 1.0
+        weight = max(0.01, min(1.0, confidence))
+        scores[label] = scores.get(label, 0.0) + weight
+        counts[label] = counts.get(label, 0) + 1
+
+    fallback = str(current_label or obj.get("class_name") or "object").strip().lower()
+    if not scores:
+        return {
+            "label": fallback or "object",
+            "confidence": 0.0,
+            "provisional": True,
+            "evidence_count": 0,
+            "candidates": [],
+        }
+    ranked = sorted(scores, key=lambda label: (-scores[label], label))
+    winner = ranked[0]
+    total = max(1e-9, sum(scores.values()))
+    winner_share = scores[winner] / total
+    current = fallback if fallback in scores else ""
+    selected = current or winner
+    if winner != selected:
+        selected_score = scores.get(selected, 0.0)
+        enough_support = counts[winner] >= max(1, int(min_switch_observations))
+        enough_share = winner_share >= max(0.0, min(1.0, float(min_winner_share)))
+        enough_margin = (
+            scores[winner] - selected_score
+            >= max(0.0, float(switch_margin)) * total
+        )
+        if enough_support and enough_share and enough_margin:
+            selected = winner
+    candidates = [
+        {
+            "label": label,
+            "score": round(scores[label], 6),
+            "share": round(scores[label] / total, 6),
+            "observations": counts[label],
+        }
+        for label in ranked[:5]
+    ]
+    return {
+        "label": selected,
+        "confidence": scores.get(selected, 0.0) / total,
+        "provisional": (
+            counts.get(selected, 0) < max(1, int(min_switch_observations))
+            or scores.get(selected, 0.0) / total
+            < max(0.0, min(1.0, float(min_winner_share)))
+        ),
+        "evidence_count": sum(counts.values()),
+        "candidates": candidates,
+    }
 
 
 def _observed_map_object_uuids(
@@ -522,8 +627,33 @@ def _parse_merge_class_groups(raw: str) -> dict[str, str]:
     return out
 
 
+def _merge_class_groups_from_lists(groups: list[list[str]]) -> dict[str, str]:
+    """Build the same bucket map from validated Driver configuration."""
+    out: dict[str, str] = {}
+    for group in groups:
+        members = sorted(
+            {
+                str(member or "").strip().lower()
+                for member in group
+                if str(member or "").strip()
+            }
+        )
+        if len(members) < 2:
+            continue
+        key = "|".join(members)
+        for member in members:
+            out[member] = key
+    return out
+
+
 # ── Model loading ────────────────────────────────────────────────────────
-def _try_load_models(yolo_path, sam_path, clip_model_name, clip_pretrained):
+def _try_load_models(
+    yolo_path,
+    sam_path,
+    clip_model_name,
+    clip_pretrained,
+    classes,
+):
     """Load YOLO-World, MobileSAM, and open_clip in one shot. Returns
     `(yolo, sam, clip_model, clip_preprocess, clip_tokenizer, device)`
     or `(None, ...)` if any piece is unavailable."""
@@ -566,7 +696,6 @@ def _try_load_models(yolo_path, sam_path, clip_model_name, clip_pretrained):
 
     try:
         yolo = YOLO(yw)
-        classes = _resolved_classes()
         yolo.set_classes(classes)
         log.info("[scene-cg] YOLO-World loaded: %d open-vocab classes", len(classes))
     except Exception as e:  # noqa: BLE001
@@ -668,6 +797,14 @@ class ConceptGraphsDetector:
         bbox_low_percentile: float = 5.0,
         bbox_high_percentile: float = 95.0,
         max_bbox_extent_m: float = 3.0,
+        classes: Optional[list[str]] = None,
+        additional_classes: Optional[list[str]] = None,
+        label_history_size: int = 20,
+        label_min_switch_observations: int = 3,
+        label_min_winner_share: float = 0.65,
+        label_switch_margin: float = 0.20,
+        allow_cross_class_merge: Optional[bool] = None,
+        confusable_class_groups: Optional[list[list[str]]] = None,
         confidence_threshold: float = 0.30,
         max_detections: int = 30,
         yolo_weights_path: Optional[str] = None,
@@ -729,6 +866,19 @@ class ConceptGraphsDetector:
             min(100.0, float(bbox_high_percentile)),
         )
         self._max_bbox_extent_m = max(0.05, float(max_bbox_extent_m))
+        self._label_history_size = max(1, int(label_history_size))
+        self._label_min_switch_observations = max(
+            1,
+            int(label_min_switch_observations),
+        )
+        self._label_min_winner_share = max(
+            0.0,
+            min(1.0, float(label_min_winner_share)),
+        )
+        self._label_switch_margin = max(
+            0.0,
+            min(1.0, float(label_switch_margin)),
+        )
 
         self._yolo: Any = None
         self._sam: Any = None
@@ -741,7 +891,9 @@ class ConceptGraphsDetector:
         self._task: Optional[asyncio.Task[None]] = None
         self._stop = asyncio.Event()
         self._inference_lock = threading.Lock()
-        self._classes = _resolved_classes()
+        self._classes = _resolved_classes(classes, additional_classes)
+        if not self._classes:
+            raise ValueError("open-vocabulary class list must not be empty")
         self._tick_idx = 0
         # Set in start() so worker-thread `_project_to_registry` can
         # schedule the actual mutation on the asyncio loop (the registry
@@ -808,9 +960,31 @@ class ConceptGraphsDetector:
         # label flicker across the group merges instead of splitting into
         # separate records. Applied only inside the same-class merge gate and
         # the same-class proximity collapse — both still distance-gated.
-        self._merge_class_group = _parse_merge_class_groups(
-            os.environ.get("SCENE_CG_MERGE_CLASS_GROUPS", "")
-        )
+        if confusable_class_groups is None:
+            self._merge_class_group = _parse_merge_class_groups(
+                os.environ.get("SCENE_CG_MERGE_CLASS_GROUPS", "")
+            )
+        else:
+            self._merge_class_group = _merge_class_groups_from_lists(
+                confusable_class_groups
+            )
+            unknown_group_labels = (
+                set(self._merge_class_group) - set(self._classes)
+            )
+            if unknown_group_labels:
+                raise ValueError(
+                    "confusable class groups reference labels outside the "
+                    "resolved vocabulary: "
+                    + ", ".join(sorted(unknown_group_labels))
+                )
+        if allow_cross_class_merge is None:
+            allow_cross_class_merge = (
+                os.environ.get("SCENE_CG_ALLOW_CROSS_CLASS_MERGE", "")
+                .strip()
+                .lower()
+                in {"1", "true", "yes"}
+            )
+        self._allow_cross_class_merge = bool(allow_cross_class_merge)
 
     async def start(self) -> None:
         if self._task is not None:
@@ -825,6 +999,7 @@ class ConceptGraphsDetector:
             None, _try_load_models,
             self._yolo_weights, self._sam_weights,
             self._clip_model_name, self._clip_pretrained,
+            self._classes,
         )
         if self._yolo is None:
             log.warning("ConceptGraphsDetector skipped — models unavailable")
@@ -899,6 +1074,12 @@ class ConceptGraphsDetector:
 
     def quality_metrics(self) -> dict[str, Any]:
         """Return cumulative admission counters for operator/CI reporting."""
+        provisional_count = 0
+        if self._map_objects is not None:
+            provisional_count = sum(
+                bool(obj.get("label_provisional", True))
+                for obj in self._map_objects
+            )
         return {
             **dict(getattr(self, "_quality_counters", {})),
             "require_occupancy_bounds": bool(
@@ -914,6 +1095,13 @@ class ConceptGraphsDetector:
             ),
             "map_bounds_margin_m": float(
                 getattr(self, "_map_bounds_margin_m", 0.0)
+            ),
+            "label_provisional_objects": provisional_count,
+            "label_history_size": int(
+                getattr(self, "_label_history_size", 0)
+            ),
+            "allow_cross_class_merge": bool(
+                getattr(self, "_allow_cross_class_merge", False)
             ),
         }
 
@@ -1016,6 +1204,18 @@ class ConceptGraphsDetector:
                 out.append({
                     "id": str(obj.get("id", f"obj_{obj_idx}")),
                     "cls": obj.get("class_name", "object"),
+                    "label_confidence": float(
+                        obj.get("label_confidence", 0.0) or 0.0
+                    ),
+                    "label_provisional": bool(
+                        obj.get("label_provisional", True)
+                    ),
+                    "label_evidence_count": int(
+                        obj.get("label_evidence_count", 0) or 0
+                    ),
+                    "label_candidates": list(
+                        obj.get("label_candidates", ()) or ()
+                    ),
                     "num_detections": int(obj.get("num_detections", 1)),
                     "n_points": int(obj.get("n_points", pts.shape[0])),
                     "conf_mean": (float(np.mean(obj["conf"])) if obj.get("conf") else 0.0),
@@ -1075,6 +1275,36 @@ class ConceptGraphsDetector:
     def _tick_once(self) -> None:
         with self._inference_lock:
             self._tick_locked()
+
+    def _association_group(self, label: str) -> str:
+        normalized = str(label or "").strip().lower()
+        return self._merge_class_group.get(normalized, normalized)
+
+    def _association_compatible(self, left: str, right: str) -> bool:
+        """Return whether two labels may share one physical-object track."""
+        if self._allow_cross_class_merge:
+            return True
+        left_group = self._association_group(left)
+        right_group = self._association_group(right)
+        return bool(left_group and left_group == right_group)
+
+    def _stabilize_map_labels(self) -> None:
+        """Resolve each persistent object's label from recent observations."""
+        for obj in self._map_objects or ():
+            evidence = _label_evidence(
+                obj,
+                self._classes,
+                current_label=str(obj.get("class_name", "") or ""),
+                history_size=self._label_history_size,
+                min_switch_observations=self._label_min_switch_observations,
+                min_winner_share=self._label_min_winner_share,
+                switch_margin=self._label_switch_margin,
+            )
+            obj["class_name"] = evidence["label"]
+            obj["label_confidence"] = evidence["confidence"]
+            obj["label_provisional"] = evidence["provisional"]
+            obj["label_evidence_count"] = evidence["evidence_count"]
+            obj["label_candidates"] = evidence["candidates"]
 
     def _tick_locked(self) -> None:
         self._purge_expired_map_objects_locked()
@@ -1524,29 +1754,16 @@ class ConceptGraphsDetector:
                         dist_mask = torch.from_numpy(dist > max_d).to(agg_sim.device)
                         agg_sim[dist_mask] = float("-inf")
 
-                        # Same-class gate. Only enforced when both
-                        # sides have a real class label — empty
-                        # strings (rare) get a free pass.
-                        # **Centroid-proximity bypass**: when the two
-                        # are physically co-located (< cross_class_
-                        # centroid_max_m) we drop the class gate, so
-                        # YOLO label flicker (picture_frame /
-                        # shelf / cabinet on the same wall fixture)
-                        # collapses into one record instead of three
-                        # overlapping bboxes.
-                        prox_m = float(self.cfg["cross_class_centroid_max_m"])
-                        proximate = dist <= prox_m                  # (M, N) bool
-                        # Confusable-class buckets (SCENE_CG_MERGE_CLASS_GROUPS)
-                        # collapse e.g. chair/table/desk to one key so a desk's
-                        # YOLO label flicker is NOT treated as a class mismatch.
-                        # Empty map → identity, i.e. plain class comparison.
-                        grp = self._merge_class_group
+                        # Cross-class association is unsafe by default:
+                        # co-location is common for distinct objects (cup on
+                        # table, plant on cabinet). Only exact classes or a
+                        # deployment-reviewed confusable group may share a
+                        # track. The legacy class-agnostic behaviour requires
+                        # the explicit allow_cross_class_merge escape hatch.
                         cls_mismatch = np.zeros((len(det_classes), len(obj_classes)), dtype=bool)
                         for i, dc in enumerate(det_classes):
-                            dcg = grp.get(dc, dc)
                             for j, oc in enumerate(obj_classes):
-                                ocg = grp.get(oc, oc)
-                                if dcg and ocg and dcg != ocg and not proximate[i, j]:
+                                if not self._association_compatible(dc, oc):
                                     cls_mismatch[i, j] = True
                         cls_mask = torch.from_numpy(cls_mismatch).to(agg_sim.device)
                         agg_sim[cls_mask] = float("-inf")
@@ -1616,7 +1833,9 @@ class ConceptGraphsDetector:
         self._quality_counters["healthy_frames"] += 1
         frame_seq = self._tick_idx
         self._tick_idx += 1
+        self._stabilize_map_labels()
         self._maybe_periodic_cleanup()
+        self._stabilize_map_labels()
         observed_uuids = _observed_map_object_uuids(
             self._map_objects,
             frame_seq=frame_seq,
@@ -1766,6 +1985,19 @@ class ConceptGraphsDetector:
                     objects_b=None,
                     voxel_size=self.cfg["downsample_voxel_size"],
                 )
+                # ConceptGraphs's canonical pass is class-agnostic. Mask
+                # incompatible labels before handing it the overlap matrix so
+                # a nearby tabletop object cannot be absorbed into furniture.
+                if not self._allow_cross_class_merge:
+                    for i, left in enumerate(self._map_objects):
+                        for j in range(i + 1, len(self._map_objects)):
+                            right = self._map_objects[j]
+                            if not self._association_compatible(
+                                left.get("class_name", ""),
+                                right.get("class_name", ""),
+                            ):
+                                overlap_mat[i, j] = 0.0
+                                overlap_mat[j, i] = 0.0
                 # concept-graphs `merge_overlap_objects` returns
                 # `(MapObjectList, index_updates)` — assigning the
                 # tuple directly into self._map_objects silently broke
@@ -1792,7 +2024,10 @@ class ConceptGraphsDetector:
                 ran_any = True
             except Exception as e:  # noqa: BLE001
                 log.warning("merge_overlap_objects failed: %s", e)
-        if self._tick_idx % self.cfg["cross_class_merge_interval_ticks"] == 0:
+        if (
+            self._allow_cross_class_merge
+            and self._tick_idx % self.cfg["cross_class_merge_interval_ticks"] == 0
+        ):
             try:
                 pre = len(self._map_objects)
                 self._map_objects = self._cross_class_geometric_collapse(self._map_objects)
@@ -2380,6 +2615,19 @@ class ConceptGraphsDetector:
                     "size_y": float(max(0.05, obb_extent[1])),
                     "size_z": float(max(0.05, obb_extent[2])),
                     "confidence": max(0.0, min(1.0, conf)),
+                    "label_confidence": max(
+                        0.0,
+                        min(1.0, float(obj.get("label_confidence", 0.0) or 0.0)),
+                    ),
+                    "label_provisional": bool(
+                        obj.get("label_provisional", True)
+                    ),
+                    "label_evidence_count": int(
+                        obj.get("label_evidence_count", 0) or 0
+                    ),
+                    "label_candidates": list(
+                        obj.get("label_candidates", ()) or ()
+                    ),
                     "geometry_point_count": int(pts.shape[0]),
                     "geometry_view_count": int(obj.get("num_detections", 1) or 1),
                 })
@@ -2544,6 +2792,7 @@ class ConceptGraphsDetector:
                     # evidence.
                     existing.pose = pose
                     existing.bbox = bbox
+                    existing.cls = s["cls"]
                     existing.confidence = max(0.0, min(1.0, s["confidence"]))
                     existing.attributes["observation_lifecycle"] = "visibility"
                     existing.attributes["geometry_source"] = "rgbd_multi_view"
@@ -2554,8 +2803,21 @@ class ConceptGraphsDetector:
                     existing.attributes["geometry_view_count"] = int(
                         s.get("geometry_view_count", 1)
                     )
+                    existing.attributes["label_confidence"] = float(
+                        s.get("label_confidence", 0.0)
+                    )
+                    existing.attributes["label_provisional"] = bool(
+                        s.get("label_provisional", True)
+                    )
+                    existing.attributes["label_evidence_count"] = int(
+                        s.get("label_evidence_count", 0)
+                    )
+                    existing.attributes["label_candidates"] = list(
+                        s.get("label_candidates", ()) or ()
+                    )
                     existing.attributes["navigation_grade"] = bool(
                         getattr(self, "_require_occupancy_bounds", False)
+                        and not s.get("label_provisional", True)
                     )
                     if is_observed:
                         existing.last_seen = now
@@ -2589,8 +2851,21 @@ class ConceptGraphsDetector:
                     obj.attributes["geometry_view_count"] = int(
                         s.get("geometry_view_count", 1)
                     )
+                    obj.attributes["label_confidence"] = float(
+                        s.get("label_confidence", 0.0)
+                    )
+                    obj.attributes["label_provisional"] = bool(
+                        s.get("label_provisional", True)
+                    )
+                    obj.attributes["label_evidence_count"] = int(
+                        s.get("label_evidence_count", 0)
+                    )
+                    obj.attributes["label_candidates"] = list(
+                        s.get("label_candidates", ()) or ()
+                    )
                     obj.attributes["navigation_grade"] = bool(
                         getattr(self, "_require_occupancy_bounds", False)
+                        and not s.get("label_provisional", True)
                     )
                     obj.attributes["last_observed_frame"] = frame_seq
                     obj.attributes["last_observed_unix"] = now

--- a/system/scene/scene_service/service.py
+++ b/system/scene/scene_service/service.py
@@ -577,16 +577,112 @@ async def _start_ros_ingest(
     geometry_cfg = perception_cfg.get("geometry") or {}
     if not isinstance(geometry_cfg, dict):
         raise ValueError("perception.geometry must be a mapping")
+    vocabulary_cfg = perception_cfg.get("vocabulary") or {}
+    if not isinstance(vocabulary_cfg, dict):
+        raise ValueError("perception.vocabulary must be a mapping")
+    label_cfg = perception_cfg.get("label") or {}
+    if not isinstance(label_cfg, dict):
+        raise ValueError("perception.label must be a mapping")
+    association_cfg = perception_cfg.get("association") or {}
+    if not isinstance(association_cfg, dict):
+        raise ValueError("perception.association must be a mapping")
 
-    def _geometry_bool(key: str, default: bool) -> bool:
-        value = geometry_cfg.get(key, default)
+    def _config_bool(
+        mapping: dict,
+        prefix: str,
+        key: str,
+        default: Optional[bool],
+    ) -> Optional[bool]:
+        value = mapping.get(key, default)
+        if value is None:
+            return None
         if isinstance(value, bool):
             return value
         if isinstance(value, str) and value.strip().lower() in {
             "true", "false", "1", "0", "yes", "no",
         }:
             return value.strip().lower() in {"true", "1", "yes"}
-        raise ValueError(f"perception.geometry.{key} must be a boolean")
+        raise ValueError(f"{prefix}.{key} must be a boolean")
+
+    def _string_list(
+        mapping: dict,
+        prefix: str,
+        key: str,
+        *,
+        allow_empty: bool,
+    ) -> Optional[list[str]]:
+        if key not in mapping:
+            return None
+        value = mapping[key]
+        if not isinstance(value, list) or any(
+            not isinstance(item, str) for item in value
+        ):
+            raise ValueError(f"{prefix}.{key} must be a list of strings")
+        normalized = [
+            item.strip().lower()
+            for item in value
+            if item.strip()
+        ]
+        if not normalized and not allow_empty:
+            raise ValueError(f"{prefix}.{key} must not be empty")
+        return normalized
+
+    classes = _string_list(
+        vocabulary_cfg,
+        "perception.vocabulary",
+        "classes",
+        allow_empty=False,
+    )
+    additional_classes = _string_list(
+        vocabulary_cfg,
+        "perception.vocabulary",
+        "additional_classes",
+        allow_empty=True,
+    )
+    label_history_size = int(label_cfg.get("history_size", 20))
+    label_min_switch_observations = int(
+        label_cfg.get("min_switch_observations", 3)
+    )
+    label_min_winner_share = float(label_cfg.get("min_winner_share", 0.65))
+    label_switch_margin = float(label_cfg.get("switch_margin", 0.20))
+    allow_cross_class_merge = _config_bool(
+        association_cfg,
+        "perception.association",
+        "allow_cross_class_merge",
+        None,
+    )
+    confusable_class_groups: Optional[list[list[str]]] = None
+    if "confusable_class_groups" in association_cfg:
+        raw_groups = association_cfg["confusable_class_groups"]
+        if not isinstance(raw_groups, list) or any(
+            not isinstance(group, list)
+            or len(group) < 2
+            or any(not isinstance(item, str) for item in group)
+            for group in raw_groups
+        ):
+            raise ValueError(
+                "perception.association.confusable_class_groups must be "
+                "a list of string lists with at least two members"
+            )
+        confusable_class_groups = [
+            [item.strip().lower() for item in group if item.strip()]
+            for group in raw_groups
+        ]
+        if any(len(set(group)) < 2 for group in confusable_class_groups):
+            raise ValueError(
+                "each perception.association.confusable_class_groups entry "
+                "must contain at least two distinct non-empty labels"
+            )
+
+    def _geometry_bool(key: str, default: bool) -> bool:
+        return bool(
+            _config_bool(
+                geometry_cfg,
+                "perception.geometry",
+                key,
+                default,
+            )
+        )
     detection_period_s = float(
         perception_cfg["period_s"]
         if perception_cfg.get("period_s") is not None
@@ -659,6 +755,18 @@ async def _start_ros_ingest(
         raise ValueError(
             "perception.geometry.max_bbox_extent_m must be greater than zero"
         )
+    if label_history_size < 1:
+        raise ValueError("perception.label.history_size must be at least one")
+    if label_min_switch_observations < 1:
+        raise ValueError(
+            "perception.label.min_switch_observations must be at least one"
+        )
+    if not 0.0 <= label_min_winner_share <= 1.0:
+        raise ValueError(
+            "perception.label.min_winner_share must be in [0, 1]"
+        )
+    if not 0.0 <= label_switch_margin <= 1.0:
+        raise ValueError("perception.label.switch_margin must be in [0, 1]")
 
     # ── self-pose bridge ───────────────────────────────────────────────────
     # Polls hub.latest("pose") at 5 Hz and feeds the SelfTracker. Pose
@@ -861,6 +969,14 @@ async def _start_ros_ingest(
             bbox_low_percentile=bbox_low_percentile,
             bbox_high_percentile=bbox_high_percentile,
             max_bbox_extent_m=max_bbox_extent_m,
+            classes=classes,
+            additional_classes=additional_classes,
+            label_history_size=label_history_size,
+            label_min_switch_observations=label_min_switch_observations,
+            label_min_winner_share=label_min_winner_share,
+            label_switch_margin=label_switch_margin,
+            allow_cross_class_merge=allow_cross_class_merge,
+            confusable_class_groups=confusable_class_groups,
             camera_frame=camera_frame,
             base_frame=configured_base_frame or None,
         )

--- a/system/scene/scene_service/state/object_registry.py
+++ b/system/scene/scene_service/state/object_registry.py
@@ -33,6 +33,11 @@ OBJECT_ATTRIBUTE_KEYS = (
     "restored",      # bool — restored from persistence (map Load / legacy
                      #        boot restore) and not yet re-observed;
                      #        perception re-binds it by class+pose, then clears
+    "label_confidence",       # float — confidence-weighted winning label share
+    "label_provisional",      # bool — label has not met the stability gate
+    "label_evidence_count",   # int — recent observations used for the label
+    "label_candidates",       # list — ranked label evidence for diagnostics
+    "navigation_grade",       # bool — geometry and label passed nav admission
 )
 
 # Per-class defaults. Hardcoded for v1; intent is to drive these from a

--- a/system/scene/scene_service/web.py
+++ b/system/scene/scene_service/web.py
@@ -516,6 +516,21 @@ def _state_payload(registry: ObjectRegistry,
                 "yaw": o.bbox.yaw,
             },
             "confidence": o.confidence,
+            "label_confidence": float(
+                o.attributes.get("label_confidence", 0.0) or 0.0
+            ),
+            "label_provisional": bool(
+                o.attributes.get("label_provisional", False)
+            ),
+            "label_evidence_count": int(
+                o.attributes.get("label_evidence_count", 0) or 0
+            ),
+            "label_candidates": list(
+                o.attributes.get("label_candidates", ()) or ()
+            ),
+            "navigation_grade": bool(
+                o.attributes.get("navigation_grade", False)
+            ),
             "observation_count": o.observation_count,
             "missing": o.missing,
         })

--- a/system/scene/tests/test_label_association.py
+++ b/system/scene/tests/test_label_association.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+"""Regression tests for Scene label evidence and class-safe association."""
+
+import asyncio
+
+import pytest
+
+from scene_service.ingest.perception_concept_graphs import (
+    ConceptGraphsDetector,
+    _label_evidence,
+    _resolved_classes,
+)
+from scene_service.state.object_registry import ObjectRegistry
+
+
+def _evidence(class_ids, confidences, *, current="chair"):
+    return _label_evidence(
+        {"class_id": class_ids, "conf": confidences, "class_name": current},
+        ["chair", "table"],
+        current_label=current,
+        history_size=20,
+        min_switch_observations=3,
+        min_winner_share=0.65,
+        switch_margin=0.20,
+    )
+
+
+def test_label_stays_provisional_until_repeated_evidence() -> None:
+    first = _evidence([0], [0.90])
+    assert first["label"] == "chair"
+    assert first["provisional"] is True
+    assert first["evidence_count"] == 1
+
+    stable = _evidence([0, 0, 0], [0.80, 0.90, 0.85])
+    assert stable["label"] == "chair"
+    assert stable["provisional"] is False
+    assert stable["confidence"] == pytest.approx(1.0)
+
+
+def test_label_switch_requires_support_share_and_margin() -> None:
+    weak_challenger = _evidence(
+        [0, 0, 0, 1, 1],
+        [0.90, 0.90, 0.90, 0.95, 0.95],
+    )
+    assert weak_challenger["label"] == "chair"
+
+    strong_challenger = _evidence(
+        [0, 0, 0, 1, 1, 1, 1, 1, 1, 1],
+        [0.90, 0.90, 0.90] + [0.95] * 7,
+    )
+    assert strong_challenger["label"] == "table"
+    assert strong_challenger["provisional"] is False
+    assert strong_challenger["candidates"][0]["label"] == "table"
+
+
+def test_configured_vocabulary_precedes_legacy_env(monkeypatch) -> None:
+    monkeypatch.setenv("SCENE_OPEN_VOCAB_CLASSES", "legacy,override")
+    assert _resolved_classes() == ["legacy", "override"]
+    assert _resolved_classes(
+        ["Chair", "chair", "Desk"],
+        ["Mug", "desk"],
+    ) == ["chair", "desk", "mug"]
+    configured_addition = _resolved_classes(None, ["Mug"])
+    assert "legacy" not in configured_addition
+    assert "mug" in configured_addition
+
+
+def _detector(**kwargs) -> ConceptGraphsDetector:
+    async def _noop(_):
+        return None
+
+    kwargs.setdefault("allow_cross_class_merge", False)
+    return ConceptGraphsDetector(
+        rgb_fetcher_msg=lambda: None,
+        depth_fetcher_msg=lambda: None,
+        camera_info_fetcher=lambda: None,
+        on_detections=_noop,
+        registry=ObjectRegistry(),
+        world_frame_fn=lambda: "map",
+        classes=["chair", "table", "sofa", "couch"],
+        **kwargs,
+    )
+
+
+def test_cross_class_association_is_opt_in() -> None:
+    strict = _detector()
+    assert strict._association_compatible("chair", "chair")
+    assert not strict._association_compatible("chair", "table")
+
+    grouped = _detector(confusable_class_groups=[["sofa", "couch"]])
+    assert grouped._association_compatible("sofa", "couch")
+    assert not grouped._association_compatible("chair", "table")
+
+    legacy = _detector(allow_cross_class_merge=True)
+    assert legacy._association_compatible("chair", "table")
+
+
+def test_confusable_groups_must_reference_resolved_vocabulary() -> None:
+    with pytest.raises(ValueError, match="outside the resolved vocabulary"):
+        _detector(confusable_class_groups=[["sofa", "loveseat"]])
+
+
+def test_snapshot_exposes_stable_label_evidence() -> None:
+    detector = _detector()
+    snapshot = {
+        "uuid": "u1",
+        "cls": "chair",
+        "x": 1.0,
+        "y": 2.0,
+        "z": 0.5,
+        "yaw": 0.0,
+        "size_x": 0.5,
+        "size_y": 0.5,
+        "size_z": 1.0,
+        "confidence": 0.9,
+        "label_confidence": 0.8,
+        "label_provisional": False,
+        "label_evidence_count": 4,
+        "label_candidates": [{"label": "chair", "share": 0.8}],
+    }
+    asyncio.run(
+        detector._apply_snapshot(
+            [snapshot],
+            observed_uuids={"u1"},
+            frame_seq=4,
+        )
+    )
+    obj = next(iter(detector._registry.all_objects()))
+    assert obj.cls == "chair"
+    assert obj.attributes["label_confidence"] == pytest.approx(0.8)
+    assert obj.attributes["label_provisional"] is False
+    assert obj.attributes["label_evidence_count"] == 4
+    assert obj.attributes["navigation_grade"] is True

--- a/testing/scenarios/cap/scene_label_stability.yaml
+++ b/testing/scenarios/cap/scene_label_stability.yaml
@@ -1,0 +1,30 @@
+# Gate confidence-weighted label convergence on a live static Webots scene.
+name: scene_label_stability
+task: "ci-test: verify live scene label stability"
+steps:
+  - time_s: 0.0
+    content: Checking Scene label evidence and association safety.
+    rtdl_description: validate converged object labels across repeated frames
+    status: in_progress
+    rtdl:
+      op: sequence
+      id: scene_label_stability_step
+      children:
+        - op: do
+          id: verify_scene_label_stability
+          cap: executor.builtin_run_command
+          args:
+            command: 'python3 "$(rbnx path root)/testing/verify_scene_label_stability.py"'
+          description: sample stable live object IDs and detect label changes
+          expect:
+            contract: robonix/system/executor/builtin/run_command
+            success: true
+            args:
+              command: 'python3 "$(rbnx path root)/testing/verify_scene_label_stability.py"'
+            output:
+              json:
+                ok: true
+                label_switch_count: 0
+                allow_cross_class_merge: false
+  - content: Scene label stability verified.
+    status: done

--- a/testing/verify_scene_label_stability.py
+++ b/testing/verify_scene_label_stability.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MulanPSL-2.0
+"""Verify live Scene labels converge and remain stable on static Webots objects."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import urllib.request
+from typing import Any
+
+
+def _state(url: str) -> dict[str, Any]:
+    with urllib.request.urlopen(url, timeout=3) as response:
+        return json.load(response)
+
+
+def _visible_metric_objects(state: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        obj
+        for obj in state.get("objects") or []
+        if not obj.get("missing")
+        and str(obj.get("cls") or "").strip().lower() != "robot"
+        and int(obj.get("label_evidence_count") or 0) > 0
+    ]
+
+
+def main() -> int:
+    port = os.environ.get("SCENE_WEB_PORT", "50107")
+    url = f"http://127.0.0.1:{port}/api/state"
+    deadline = time.monotonic() + 45.0
+    state: dict[str, Any] = {}
+    stable: list[dict[str, Any]] = []
+    while time.monotonic() < deadline:
+        try:
+            state = _state(url)
+            stable = [
+                obj
+                for obj in _visible_metric_objects(state)
+                if not obj.get("label_provisional")
+                and obj.get("navigation_grade") is True
+            ]
+            if stable:
+                break
+        except Exception:
+            pass
+        time.sleep(1.0)
+
+    initial_labels = {
+        str(obj["id"]): str(obj.get("cls") or "")
+        for obj in stable
+        if obj.get("id")
+    }
+    label_switches: list[dict[str, str]] = []
+    samples = 0
+    for _ in range(8):
+        if not initial_labels:
+            break
+        time.sleep(1.0)
+        try:
+            latest = _state(url)
+        except Exception:
+            continue
+        samples += 1
+        current = {
+            str(obj["id"]): str(obj.get("cls") or "")
+            for obj in _visible_metric_objects(latest)
+            if obj.get("id")
+        }
+        for object_id, initial_label in initial_labels.items():
+            current_label = current.get(object_id)
+            if current_label is not None and current_label != initial_label:
+                label_switches.append(
+                    {
+                        "id": object_id,
+                        "from": initial_label,
+                        "to": current_label,
+                    }
+                )
+
+    quality = state.get("perception_quality") or {}
+    result = {
+        "ok": bool(
+            initial_labels
+            and samples >= 6
+            and quality.get("allow_cross_class_merge") is False
+            and not label_switches
+        ),
+        "stable_object_count": len(initial_labels),
+        "samples": samples,
+        "label_switch_count": len(label_switches),
+        "allow_cross_class_merge": quality.get("allow_cross_class_merge"),
+        "labels": initial_labels,
+        "label_switches": label_switches,
+    }
+    print(json.dumps(result, separators=(",", ":")))
+    return 0 if result["ok"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- make the YOLO-World vocabulary deployment-configurable through `system.scene.config.perception.vocabulary`
- accumulate confidence-weighted label evidence per physical-object track and expose provisional/confidence/candidate diagnostics
- require repeated support, winner share, and switch margin before changing a stable label
- keep provisional labels out of `navigation_grade` object use
- disable unsafe cross-class proximity and geometric merging by default
- allow only deployment-reviewed `confusable_class_groups`, with the legacy unrestricted mode behind an explicit compatibility switch
- add a live Webots label-stability gate and document every parameter and unit

## Root cause

Scene previously treated one frame's YOLO-World class as the object label. It also bypassed the class gate for nearby centroids and periodically force-merged overlapping geometry regardless of class. That made transient classification errors persistent and could merge distinct co-located objects such as an item on furniture. There was no track-level evidence, convergence state, or deployment vocabulary contract.

## Validation

- `222 passed` — complete `system/scene/tests`
- `17 passed` — Webots manifest configuration tests
- `17 scenario(s)` — offline scenario simulation
- runtime portability audit passed
- Python compile and `git diff --check` passed
- live Webots ChatOps requested after this draft is opened

This is phase 3 of #177 and is intentionally stacked on #197 (`agent/scene-spatial-quality-177`). It should be retargeted to `dev-next` after the preceding PRs land. Do not merge before the live Webots label-stability result is reviewed.