### PR TITLE
ci(webots): isolate pre-checkout failure evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         run: python3 -m pip install "websockets>=14,<17"
       - name: Test custom ports and helper readiness
         run: python3 examples/webots/sim/tests/test_streaming.py
+      - name: Test Webots report infrastructure failures
+        run: python3 -m unittest discover -s testing -p 'test_*.py' -v
 
   check:
     name: Rust (fmt + clippy + build + tests)

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -377,6 +377,59 @@ jobs:
             auth.docker.io:443
             production.cloudflare.docker.com:443
 
+      - name: Initialize current-run diagnostics
+        run: |
+          set -euo pipefail
+          case "${GITHUB_WORKSPACE:-}" in
+            /home/*/*/_work/*/*) ;;
+            *) echo "::error::refusing to sanitize unexpected workspace: ${GITHUB_WORKSPACE:-<unset>}"; exit 1 ;;
+          esac
+
+          # The capacity gate deliberately runs before checkout. Self-hosted
+          # workspaces persist between jobs, so remove only generated evidence
+          # from the previous run before a pre-checkout failure can upload it.
+          for relative in \
+            testing/logs \
+            testing/report \
+            examples/webots/rbnx-boot/logs \
+            examples/webots/rbnx-boot/processes.json \
+            examples/webots/logs \
+            system/scene/logs; do
+            target="$GITHUB_WORKSPACE/$relative"
+            [ -e "$target" ] || continue
+            sudo -n chown -R "$(id -u):$(id -g)" "$target" 2>/dev/null || true
+            rm -rf -- "$target"
+            if [ -e "$target" ]; then
+              echo "::error::could not remove stale generated evidence: $target"
+              exit 1
+            fi
+          done
+
+          for target in \
+            "$RUNNER_TEMP/sim-logs" \
+            "$RUNNER_TEMP/lifecycle-logs" \
+            "$RUNNER_TEMP/report-assets" \
+            "$RUNNER_TEMP/cache-provider-logs" \
+            "$RUNNER_TEMP/report-metadata.json" \
+            "$RUNNER_TEMP/remote-provenance.txt" \
+            "$RUNNER_TEMP/fake_vlm.log" \
+            "$RUNNER_TEMP/rbnx-boot.log" \
+            "$RUNNER_TEMP/lifecycle.out" \
+            "$RUNNER_TEMP/scenarios.out" \
+            "$RUNNER_TEMP/scenarios.restart.out"; do
+            [ -e "$target" ] || continue
+            sudo -n chown -R "$(id -u):$(id -g)" "$target" 2>/dev/null || true
+            rm -rf -- "$target"
+          done
+          mkdir -p "$RUNNER_TEMP/sim-logs"
+          printf 'Webots suite has not started for run %s attempt %s.\n' \
+            "$RUN_ID" "$RUN_ATTEMPT" \
+            >"$RUNNER_TEMP/sim-logs/infrastructure.txt"
+          {
+            echo "ROBONIX_CI_CHECKOUT_READY=false"
+            echo "ROBONIX_CI_ISOLATION_READY=false"
+          } >> "$GITHUB_ENV"
+
       - name: Select runner GPU
         run: |
           set -euo pipefail
@@ -427,6 +480,9 @@ jobs:
           done
           if [ "$free_mib" -lt "$ROBONIX_CI_MIN_GPU_FREE_MIB" ]; then
             echo "::error title=Runner GPU unavailable::GPU ${ROBONIX_CI_GPU_ID} has ${free_mib} MiB free; ${ROBONIX_CI_MIN_GPU_FREE_MIB} MiB is required"
+            printf 'Runner GPU capacity gate failed before checkout: GPU %s has %s MiB free; %s MiB is required.\n' \
+              "$ROBONIX_CI_GPU_ID" "$free_mib" "$ROBONIX_CI_MIN_GPU_FREE_MIB" \
+              >"$RUNNER_TEMP/sim-logs/infrastructure.txt"
             nvidia-smi --query-compute-apps=pid,process_name,used_memory --format=csv,noheader || true
             exit 1
           fi
@@ -466,6 +522,9 @@ jobs:
         with:
           ref: ${{ inputs.pr_number != '' && (inputs.pr_base_ref || github.event.repository.default_branch) || inputs.ref }}
           fetch-depth: ${{ inputs.pr_number != '' && '0' || '1' }}
+
+      - name: Mark checkout ready
+        run: echo "ROBONIX_CI_CHECKOUT_READY=true" >> "$GITHUB_ENV"
 
       - name: Merge PR head into current base
         if: ${{ inputs.pr_number != '' }}
@@ -613,6 +672,7 @@ jobs:
             echo "RBNX_MODEL_DOWNLOAD_MAX_TIME=600"
             echo "RBNX_MODEL_DOWNLOAD_CONNECT_TIMEOUT=20"
             echo "RBNX_MODEL_DOWNLOAD_RETRIES=2"
+            echo "ROBONIX_CI_ISOLATION_READY=true"
           } >> "$GITHUB_ENV"
           mkdir -p "${RUNNER_TOOL_CACHE:-$HOME/.cache}/robonix-models"
 
@@ -1187,6 +1247,10 @@ jobs:
       - name: Capture runtime logs
         if: always()
         run: |
+          if [ "${ROBONIX_CI_ISOLATION_READY:-false}" != "true" ]; then
+            echo "per-run isolation was not initialized; refusing to inspect default or unrelated runtime resources"
+            exit 0
+          fi
           # Capture the sim/webots container stdout and the in-container ROS
           # logs so a failure leaves a full trace alongside the scribe logs.
           mkdir -p "$RUNNER_TEMP/sim-logs"
@@ -1219,9 +1283,21 @@ jobs:
       - name: Stop run resources
         if: always()
         run: |
+          if [ "${ROBONIX_CI_ISOLATION_READY:-false}" != "true" ]; then
+            echo "per-run isolation was not initialized; refusing unscoped shutdown"
+            docker ps -aq --filter "name=ci-${RUN_KEY}-" | while read -r cid; do
+              [ -n "$cid" ] || continue
+              docker rm -f "$cid" >/dev/null 2>&1 || true
+            done
+            docker volume ls -q --filter "name=ci-${RUN_KEY}_" | while read -r vid; do
+              [ -n "$vid" ] || continue
+              docker volume rm -f "$vid" >/dev/null 2>&1 || true
+            done
+            exit 0
+          fi
           # never touch other users' containers/processes; match on the run-id
           # prefix. $RUN_ID is the GitHub-assigned numeric id (job-level env).
-          rbnx shutdown --server "${ROBONIX_CI_ATLAS:-127.0.0.1:50051}" 2>/dev/null || true
+          rbnx shutdown --server "$ROBONIX_CI_ATLAS" 2>/dev/null || true
           [ -n "${RBNX_BOOT_PID:-}" ] && kill "${RBNX_BOOT_PID}" 2>/dev/null || true
           [ -n "${FAKE_VLM_PID:-}" ] && kill "${FAKE_VLM_PID}" 2>/dev/null || true
           for port in "${ATLAS_PORT:-}" "${EXECUTOR_PORT:-}" "${SOMA_PORT:-}" "${PILOT_PORT:-}" "${LIAISON_PORT:-}" "${FAKE_VLM_PORT:-}" "${ROBONIX_SIM_STREAM_PORT:-}" "${ROBONIX_SIM_VIEWER_PORT:-}" "${MAPPING_GRPC_PORT:-}" "${NAV2_DRIVER_PORT:-}" "${SCENE_WEB_PORT:-}"; do
@@ -1279,13 +1355,13 @@ jobs:
           done
 
       - name: Prepare self-contained report viewer assets
-        if: always()
+        if: ${{ always() && env.ROBONIX_CI_CHECKOUT_READY == 'true' }}
         run: |
           set -euo pipefail
           python3 testing/prepare_report_assets.py --asset-dir "$RUNNER_TEMP/report-assets"
 
       - name: Generate test report
-        if: always()
+        if: ${{ always() && env.ROBONIX_CI_CHECKOUT_READY == 'true' }}
         env:
           REPORT_PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number || '' }}
           REPORT_PR_TITLE: ${{ inputs.pr_title || github.event.pull_request.title || '' }}

--- a/testing/build_report_from_artifacts.py
+++ b/testing/build_report_from_artifacts.py
@@ -52,6 +52,24 @@ def _empty_summary(path: Path, reason: str) -> Path:
     return path
 
 
+def _missing_summary_reason(artifact_root: Path) -> str:
+    infrastructure = _find_file(artifact_root, "infrastructure.txt")
+    if infrastructure is not None:
+        try:
+            reason = infrastructure.read_text(
+                encoding="utf-8",
+                errors="replace",
+            ).strip()
+        except OSError:
+            reason = ""
+        if reason:
+            return reason[:2000]
+    return (
+        "No machine-readable scenario summary was produced; "
+        "logs are still embedded below."
+    )
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description="Build Robonix Webots report from artifacts")
     ap.add_argument("--artifact-root", type=Path, required=True)
@@ -73,7 +91,7 @@ def main() -> int:
     if summary_json is None:
         summary_json = _empty_summary(
             args.out_dir / "synthetic-summary.json",
-            "No machine-readable scenario summary was produced; logs are still embedded below.",
+            _missing_summary_reason(artifact_root),
         )
 
     metadata_jsons = list(args.metadata_json)

--- a/testing/report.py
+++ b/testing/report.py
@@ -887,6 +887,13 @@ def write_html(
         score = 0
     verdict = "NO DATA" if total == 0 else ("PASS" if failed == 0 else "FAIL")
     result_class = "pass" if verdict == "PASS" else "fail"
+    infrastructure_note = str(summary.get("infrastructure_note", "") or "").strip()
+    infrastructure_section = (
+        '<div class="infrastructure-note"><strong>Infrastructure:</strong> '
+        f"{html.escape(infrastructure_note)}</div>"
+        if infrastructure_note
+        else ""
+    )
     generated_on = html.escape(_format_beijing_time(metadata.get("generated_on", "")))
     embedded_styles = _inline_styles(inline_styles or [])
     embedded_scripts = _inline_scripts(inline_scripts or [])
@@ -1368,6 +1375,13 @@ def write_html(
       color: var(--muted);
       margin: 6px 0 10px;
     }}
+    .infrastructure-note {{
+      background: #fffbeb;
+      border: 1px solid #fcd34d;
+      color: #92400e;
+      margin: 0 0 16px;
+      padding: 10px 12px;
+    }}
     .coverage-table td:first-child {{
       color: #374151;
       font-family: var(--mono);
@@ -1387,6 +1401,7 @@ def write_html(
     <div class=\"card\"><strong>Failures</strong><span class=\"metric\">{failed}</span></div>
     <div class=\"card\"><strong>Score</strong><span class=\"metric score-metric\">{score}/100</span></div>
   </div>
+  {infrastructure_section}
   {_llm_analysis_section(analysis)}
   <h2>Run Metadata</h2>
   {_metadata_table(metadata)}
@@ -1639,16 +1654,25 @@ def write_markdown(summary: dict, analysis: dict | None, out: Path) -> None:
     passed = int(summary.get("passed", 0) or 0)
     failed = int(summary.get("failed", 0) or 0)
     verdict = "NO DATA" if total == 0 else ("PASS" if failed == 0 else "FAIL")
+    infrastructure_note = " ".join(
+        str(summary.get("infrastructure_note", "") or "").split()
+    ).replace("|", "\\|")
     lines = [
         "## Robonix Webots CI",
         "",
         f"**Result:** `{verdict}`",
         f"**Scenarios:** `{passed}/{total}`",
         f"**Failures:** `{failed}`",
-        "",
-        "| Status | Suite | Scenario | Rounds | Failures |",
-        "| --- | --- | --- | ---: | --- |",
     ]
+    if infrastructure_note:
+        lines.extend([f"**Infrastructure:** {infrastructure_note}"])
+    lines.extend(
+        [
+            "",
+            "| Status | Suite | Scenario | Rounds | Failures |",
+            "| --- | --- | --- | ---: | --- |",
+        ]
+    )
     for sc in summary.get("scenarios", []):
         failures = "<br>".join(str(f).replace("|", "\\|") for f in sc.get("failures", [])) or "-"
         lines.append(

--- a/testing/test_build_report_from_artifacts.py
+++ b/testing/test_build_report_from_artifacts.py
@@ -1,45 +1,63 @@
 # SPDX-License-Identifier: MulanPSL-2.0
+import tempfile
+import unittest
 from pathlib import Path
 
 from build_report_from_artifacts import _missing_summary_reason
 from report import write_html, write_markdown
 
 
-def test_missing_summary_uses_current_infrastructure_reason(tmp_path: Path):
-    log_dir = tmp_path / "_temp" / "sim-logs"
-    log_dir.mkdir(parents=True)
-    (log_dir / "infrastructure.txt").write_text(
-        "Runner GPU capacity gate failed before checkout.\n",
-        encoding="utf-8",
-    )
+class InfrastructureReportTests(unittest.TestCase):
+    def test_missing_summary_uses_current_infrastructure_reason(self):
+        with tempfile.TemporaryDirectory() as raw_dir:
+            root = Path(raw_dir)
+            log_dir = root / "_temp" / "sim-logs"
+            log_dir.mkdir(parents=True)
+            (log_dir / "infrastructure.txt").write_text(
+                "Runner GPU capacity gate failed before checkout.\n",
+                encoding="utf-8",
+            )
 
-    assert (
-        _missing_summary_reason(tmp_path)
-        == "Runner GPU capacity gate failed before checkout."
-    )
+            self.assertEqual(
+                _missing_summary_reason(root),
+                "Runner GPU capacity gate failed before checkout.",
+            )
+
+    def test_missing_summary_falls_back_without_infrastructure_log(self):
+        with tempfile.TemporaryDirectory() as raw_dir:
+            reason = _missing_summary_reason(Path(raw_dir))
+
+        self.assertTrue(
+            reason.startswith("No machine-readable scenario summary was produced")
+        )
+
+    def test_infrastructure_reason_is_visible_in_report_summary(self):
+        summary = {
+            "total": 0,
+            "passed": 0,
+            "failed": 0,
+            "rate": 0,
+            "scenarios": [],
+            "coverage": [],
+            "infrastructure_note": "GPU capacity gate failed before checkout.",
+        }
+        with tempfile.TemporaryDirectory() as raw_dir:
+            root = Path(raw_dir)
+            html_path = root / "index.html"
+            markdown_path = root / "summary.md"
+
+            write_html(summary, [], {}, {}, html_path)
+            write_markdown(summary, {}, markdown_path)
+
+            self.assertIn(
+                "GPU capacity gate failed before checkout.",
+                html_path.read_text(encoding="utf-8"),
+            )
+            self.assertIn(
+                "GPU capacity gate failed before checkout.",
+                markdown_path.read_text(encoding="utf-8"),
+            )
 
 
-def test_missing_summary_falls_back_without_infrastructure_log(tmp_path: Path):
-    reason = _missing_summary_reason(tmp_path)
-
-    assert reason.startswith("No machine-readable scenario summary was produced")
-
-
-def test_infrastructure_reason_is_visible_in_report_summary(tmp_path: Path):
-    summary = {
-        "total": 0,
-        "passed": 0,
-        "failed": 0,
-        "rate": 0,
-        "scenarios": [],
-        "coverage": [],
-        "infrastructure_note": "GPU capacity gate failed before checkout.",
-    }
-    html_path = tmp_path / "index.html"
-    markdown_path = tmp_path / "summary.md"
-
-    write_html(summary, [], {}, {}, html_path)
-    write_markdown(summary, {}, markdown_path)
-
-    assert "GPU capacity gate failed before checkout." in html_path.read_text()
-    assert "GPU capacity gate failed before checkout." in markdown_path.read_text()
+if __name__ == "__main__":
+    unittest.main()

--- a/testing/test_build_report_from_artifacts.py
+++ b/testing/test_build_report_from_artifacts.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+from pathlib import Path
+
+from build_report_from_artifacts import _missing_summary_reason
+from report import write_html, write_markdown
+
+
+def test_missing_summary_uses_current_infrastructure_reason(tmp_path: Path):
+    log_dir = tmp_path / "_temp" / "sim-logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "infrastructure.txt").write_text(
+        "Runner GPU capacity gate failed before checkout.\n",
+        encoding="utf-8",
+    )
+
+    assert (
+        _missing_summary_reason(tmp_path)
+        == "Runner GPU capacity gate failed before checkout."
+    )
+
+
+def test_missing_summary_falls_back_without_infrastructure_log(tmp_path: Path):
+    reason = _missing_summary_reason(tmp_path)
+
+    assert reason.startswith("No machine-readable scenario summary was produced")
+
+
+def test_infrastructure_reason_is_visible_in_report_summary(tmp_path: Path):
+    summary = {
+        "total": 0,
+        "passed": 0,
+        "failed": 0,
+        "rate": 0,
+        "scenarios": [],
+        "coverage": [],
+        "infrastructure_note": "GPU capacity gate failed before checkout.",
+    }
+    html_path = tmp_path / "index.html"
+    markdown_path = tmp_path / "summary.md"
+
+    write_html(summary, [], {}, {}, html_path)
+    write_markdown(summary, {}, markdown_path)
+
+    assert "GPU capacity gate failed before checkout." in html_path.read_text()
+    assert "GPU capacity gate failed before checkout." in markdown_path.read_text()


### PR DESCRIPTION
## Problem

Webots run [30291204773](https://github.com/syswonder/robonix/actions/runs/30291204773) failed at the GPU capacity gate before checkout, build, simulator startup, or scenario execution. The report nevertheless reused a previous workspace's `summary.json` and announced 17/17 scenarios passed.

The same early-failure path could also call `rbnx caps` and `rbnx shutdown` against the default `127.0.0.1:50051`, even though no run-specific Atlas port had been allocated.

Closes #200.

## Implementation

- Remove only generated diagnostic and report paths from the persistent self-hosted workspace before the pre-checkout GPU gate.
- Reset the corresponding runner-temporary outputs and create a current-run infrastructure marker.
- Track checkout and per-run-isolation readiness explicitly.
- Record the GPU capacity failure in the current run's infrastructure log.
- Refuse runtime log inspection and unscoped shutdown until per-run isolation is ready.
- Skip workspace-based report generation before checkout; the trusted report job then creates a zero-scenario synthetic summary from the current infrastructure-only artifact.
- Promote the exact current-run infrastructure reason into the synthetic summary and render it prominently in both the HTML and Markdown reports.
- Run the dependency-free report regression tests in the existing Webots Python smoke job on every PR.
- Keep normal run-scoped diagnostics and cleanup unchanged after isolation succeeds.

## Validation

- `python3 scripts/check_commit_authorship.py --base origin/dev --head HEAD`
  - 1 commit passed.
- `git diff --check origin/dev...HEAD`
  - passed.
- Parsed all 41 workflow `run: |` blocks after replacing GitHub expressions and checked them with `bash -n`
  - passed.
- Static workflow assertions verified phase ordering, early-failure guards, stale-evidence cleanup coverage, and removal of the default Atlas fallback.
- Built an infrastructure-only report artifact with `testing/build_report_from_artifacts.py`
  - produced a synthetic summary with 0 total, 0 passed, and 0 failed scenarios, with the exact GPU-capacity reason visible in HTML and Markdown.
- `python3 -m unittest discover -s testing -v`
  - 3 passed with no third-party test dependency.
- `/opt/miniconda3/bin/python -m pytest -q testing/test_build_report_from_artifacts.py`
  - the same 3 tests also passed under pytest.
- Manual workflow-dispatch run [30292449224](https://github.com/syswonder/robonix/actions/runs/30292449224) exercised the real pre-checkout GPU-capacity failure:
  - initialization, guarded capture, guarded cleanup, report generation, and report publishing completed;
  - checkout, build, boot, and all scenarios were correctly skipped;
  - the raw artifact contained only the current `infrastructure.txt`, with no stale `summary.json`;
  - the generated report showed 0/0 scenarios instead of the previous stale 17/17 result.

## Compatibility

No capability contracts, generated code, package manifests, runtime configuration, or migration behavior changes.
