### PR TITLE
test(scene): measure Webots object ground truth

### DIFF
--- a/testing/README.md
+++ b/testing/README.md
@@ -25,10 +25,12 @@ job). You can also run it by hand against any booted deploy.
 | Scene perception | Real scene service over Webots RGB-D, camera intrinsics, and ConceptGraphs | Scenarios require non-robot objects from the live scene registry and use one as the navigation target. |
 | Speech/audio hardware | Real speech service plus audio driver using ALSA `null` devices | The runner has no physical speaker/mic. CI checks TTS-to-speaker and mic/speaker driver wiring through normal ALSA devices, not acoustic output. |
 
-This workflow is therefore not a perception-quality or physical-audio quality
-test. It is a build/boot/dispatch/runtime integration test for the
-Webots-backed robot stack, with deterministic substitution only at the VLM
-planning boundary.
+This workflow is primarily a build/boot/dispatch/runtime integration test for
+the Webots-backed robot stack, with deterministic substitution only at the VLM
+planning boundary. It also contains one bounded Scene perception-quality gate
+against checked-in Webots ground truth. That gate does not replace physical
+robot evaluation. Audio remains a wiring check rather than an acoustic-quality
+test.
 
 ## Pieces
 
@@ -56,6 +58,32 @@ Execution order after boot:
    `scenarios/flow/`.
 3. The workflow uploads per-scenario JSONL event streams, boot logs, provider
    logs, sim stdout, ROS logs, final `rbnx caps`, and a summary JSON.
+
+## Scene object ground-truth gate
+
+`scene_object_quality` checks more than API success. Its fixture description is
+stored in `testing/fixtures/webots_office_scene_quality.json`; positions are
+resolved from the named nodes in the checked-in `office.wbt` at test time, so
+the verifier does not duplicate simulator coordinates or add runtime
+robot/environment constants.
+
+The target is the named `PottedTree` nearest TIAGo's initial view. Its
+0.3 × 0.3 × 1.3 m dimensions come from the pinned Cyberbotics R2025a proto and
+are recorded with their source URL. Across eight live samples the verifier
+reports and gates:
+
+- target recall and label accuracy;
+- stable Scene ID count;
+- median center XY/Z error and maximum XY drift;
+- yaw-oriented 3D bbox IoU;
+- exported point-cloud inlier fraction and point count;
+- navigation-grade status;
+- the existing occupancy-bound, bbox-sanity, and background-label checks.
+
+Thresholds are SI-valued and live beside the fixture metadata. They form a
+regression floor for this specific simulator scene, not a claim about physical
+robot accuracy. Physical RGB-D and per-environment metrics required by issue
+#177 remain a separate release gate.
 
 ## Reports and sharing
 

--- a/testing/fixtures/webots_office_scene_quality.json
+++ b/testing/fixtures/webots_office_scene_quality.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "world": "examples/webots/sim/ros_ws/src/eaios_webots/worlds/office.wbt",
+  "map_ground_z_world_m": 0.0,
+  "robot": {
+    "node_type": "TiagoLite",
+    "name": "my_robot"
+  },
+  "target": {
+    "node_type": "PottedTree",
+    "name": "potted tree(2)",
+    "label": "potted_plant",
+    "bbox_size_m": [0.3, 0.3, 1.3],
+    "association_radius_m": 0.75,
+    "dimension_source": "https://github.com/cyberbotics/webots/blob/R2025a/projects/objects/plants/protos/PottedTree.proto"
+  },
+  "sampling": {
+    "sample_count": 8,
+    "interval_s": 1.0
+  },
+  "thresholds": {
+    "min_target_recall": 0.875,
+    "min_label_accuracy": 1.0,
+    "max_stable_ids": 1,
+    "max_median_center_xy_error_m": 0.2,
+    "max_center_xy_drift_m": 0.15,
+    "max_median_center_z_error_m": 0.45,
+    "min_median_bbox_iou_3d": 0.15,
+    "point_margin_m": 0.1,
+    "min_median_point_inlier_fraction": 0.65,
+    "min_median_point_count": 20,
+    "min_navigation_grade_fraction": 1.0
+  }
+}

--- a/testing/scenarios/cap/scene_object_quality.yaml
+++ b/testing/scenarios/cap/scene_object_quality.yaml
@@ -1,10 +1,10 @@
-# Gate live Scene objects on map bounds, finite robust boxes, and background labels.
+# Gate live Scene objects on map bounds and checked-in Webots ground truth.
 name: scene_object_quality
 task: "ci-test: verify live scene object spatial quality"
 steps:
   - time_s: 0.0
     content: Checking Scene object quality.
-    rtdl_description: validate map bounds, 3D boxes, and admission metrics
+    rtdl_description: validate label, center, 3D box, cloud, stability, and admission
     status: in_progress
     rtdl:
       op: sequence
@@ -27,5 +27,9 @@ steps:
                 off_map_count: 0
                 invalid_bbox_count: 0
                 background_label_count: 0
+                ground_truth_metrics:
+                  ok: true
+                  label_accuracy: 1.0
+                  stable_id_count: 1
   - content: Scene spatial object quality verified.
     status: done

--- a/testing/scene_quality_ground_truth.py
+++ b/testing/scene_quality_ground_truth.py
@@ -1,0 +1,478 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MulanPSL-2.0
+"""Ground-truth helpers for the Webots Scene object-quality acceptance gate.
+
+Runtime Scene code must remain deployment-neutral.  The simulator, however,
+has an authoritative world file.  This module resolves a named robot and a
+named fixture from that file, converts the fixture into the initial map frame,
+and computes label/center/box/point-cloud metrics without copying world
+coordinates into the verifier.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+import statistics
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+_FLOAT = r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?"
+
+
+@dataclass(frozen=True)
+class ObjectGroundTruth:
+    """One simulator fixture expressed in Scene's initial map frame."""
+
+    label: str
+    center_m: tuple[float, float, float]
+    size_m: tuple[float, float, float]
+    yaw_rad: float
+    association_radius_m: float
+
+
+def _node_blocks(world_text: str, node_type: str) -> Iterable[str]:
+    """Yield balanced ``NodeType { ... }`` blocks from a Webots world."""
+
+    pattern = re.compile(rf"(?m)^\s*{re.escape(node_type)}\s*\{{")
+    for match in pattern.finditer(world_text):
+        brace = world_text.find("{", match.start())
+        depth = 0
+        quoted = False
+        escaped = False
+        for index in range(brace, len(world_text)):
+            char = world_text[index]
+            if quoted:
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == '"':
+                    quoted = False
+                continue
+            if char == '"':
+                quoted = True
+            elif char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+                if depth == 0:
+                    yield world_text[match.start() : index + 1]
+                    break
+
+
+def _named_node(world_text: str, node_type: str, name: str) -> str:
+    name_pattern = re.compile(rf'(?m)^\s*name\s+"{re.escape(name)}"\s*$')
+    matches = [
+        block
+        for block in _node_blocks(world_text, node_type)
+        if name_pattern.search(block)
+    ]
+    if len(matches) != 1:
+        raise ValueError(
+            f"expected one {node_type} named {name!r}, found {len(matches)}"
+        )
+    return matches[0]
+
+
+def _vector_field(block: str, field: str, length: int) -> tuple[float, ...]:
+    values = r"\s+".join(f"({_FLOAT})" for _ in range(length))
+    match = re.search(rf"(?m)^\s*{re.escape(field)}\s+{values}\s*$", block)
+    if match is None:
+        raise ValueError(f"node is missing {field}")
+    parsed = tuple(float(value) for value in match.groups())
+    if not all(math.isfinite(value) for value in parsed):
+        raise ValueError(f"{field} contains a non-finite value")
+    return parsed
+
+
+def _planar_yaw(rotation: Sequence[float]) -> float:
+    axis_x, axis_y, axis_z, angle = rotation
+    norm = math.sqrt(axis_x * axis_x + axis_y * axis_y + axis_z * axis_z)
+    if norm <= 1e-12:
+        return 0.0
+    axis_x /= norm
+    axis_y /= norm
+    axis_z /= norm
+    if math.hypot(axis_x, axis_y) > 0.05 or abs(axis_z) < 0.95:
+        raise ValueError("quality fixture rotation is not planar")
+    return axis_z * angle
+
+
+def _normalise_angle(angle: float) -> float:
+    return math.atan2(math.sin(angle), math.cos(angle))
+
+
+def load_ground_truth(
+    config_path: Path,
+    *,
+    repository_root: Path,
+) -> tuple[ObjectGroundTruth, dict[str, Any]]:
+    """Load a fixture description and resolve its live coordinates from WBT."""
+
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    world_path = repository_root / str(config["world"])
+    world_text = world_path.read_text(encoding="utf-8")
+    robot_spec = config["robot"]
+    target_spec = config["target"]
+    robot = _named_node(
+        world_text,
+        str(robot_spec["node_type"]),
+        str(robot_spec["name"]),
+    )
+    target = _named_node(
+        world_text,
+        str(target_spec["node_type"]),
+        str(target_spec["name"]),
+    )
+
+    robot_xyz = _vector_field(robot, "translation", 3)
+    target_xyz = _vector_field(target, "translation", 3)
+    robot_yaw = _planar_yaw(_vector_field(robot, "rotation", 4))
+    target_yaw = _planar_yaw(_vector_field(target, "rotation", 4))
+    size_m = tuple(float(value) for value in target_spec["bbox_size_m"])
+    if len(size_m) != 3 or any(
+        not math.isfinite(value) or value <= 0.0 for value in size_m
+    ):
+        raise ValueError("target.bbox_size_m must contain three positive SI values")
+
+    # Webots x/y are the ground plane and z is vertical.  The mapping stack
+    # anchors map XY to the robot's initial pose, so rotate the world-space
+    # displacement by the inverse initial robot yaw.
+    dx = target_xyz[0] - robot_xyz[0]
+    dy = target_xyz[1] - robot_xyz[1]
+    cosine = math.cos(-robot_yaw)
+    sine = math.sin(-robot_yaw)
+    center_x = cosine * dx - sine * dy
+    center_y = sine * dx + cosine * dy
+    ground_z = float(config.get("map_ground_z_world_m", 0.0))
+    center_z = target_xyz[2] - ground_z + size_m[2] * 0.5
+    truth = ObjectGroundTruth(
+        label=str(target_spec["label"]).strip().lower(),
+        center_m=(center_x, center_y, center_z),
+        size_m=(size_m[0], size_m[1], size_m[2]),
+        yaw_rad=_normalise_angle(target_yaw - robot_yaw),
+        association_radius_m=float(target_spec["association_radius_m"]),
+    )
+    return truth, config
+
+
+def nearest_object(
+    objects: Sequence[dict[str, Any]],
+    truth: ObjectGroundTruth,
+    *,
+    center_key: str = "pose",
+) -> dict[str, Any] | None:
+    """Associate by metric position so an incorrect label remains measurable."""
+
+    candidates: list[tuple[float, dict[str, Any]]] = []
+    for obj in objects:
+        if bool(obj.get("missing")):
+            continue
+        if str(obj.get("cls") or "").strip().lower() == "robot":
+            continue
+        center = obj.get(center_key) or {}
+        if isinstance(center, (list, tuple)):
+            if len(center) < 2:
+                continue
+            x, y = float(center[0]), float(center[1])
+        else:
+            try:
+                x, y = float(center["x"]), float(center["y"])
+            except (KeyError, TypeError, ValueError):
+                continue
+        distance = math.hypot(x - truth.center_m[0], y - truth.center_m[1])
+        candidates.append((distance, obj))
+    if not candidates:
+        return None
+    distance, obj = min(candidates, key=lambda item: item[0])
+    return obj if distance <= truth.association_radius_m else None
+
+
+def _rectangle(
+    center_x: float,
+    center_y: float,
+    size_x: float,
+    size_y: float,
+    yaw: float,
+) -> list[tuple[float, float]]:
+    cosine = math.cos(yaw)
+    sine = math.sin(yaw)
+    half_x, half_y = size_x * 0.5, size_y * 0.5
+    return [
+        (
+            center_x + cosine * x - sine * y,
+            center_y + sine * x + cosine * y,
+        )
+        for x, y in (
+            (-half_x, -half_y),
+            (half_x, -half_y),
+            (half_x, half_y),
+            (-half_x, half_y),
+        )
+    ]
+
+
+def _polygon_area(polygon: Sequence[tuple[float, float]]) -> float:
+    if len(polygon) < 3:
+        return 0.0
+    return (
+        abs(
+            sum(
+                x0 * y1 - x1 * y0
+                for (x0, y0), (x1, y1) in zip(
+                    polygon,
+                    [*polygon[1:], polygon[0]],
+                )
+            )
+        )
+        * 0.5
+    )
+
+
+def _clip_polygon(
+    subject: Sequence[tuple[float, float]],
+    clip: Sequence[tuple[float, float]],
+) -> list[tuple[float, float]]:
+    """Sutherland-Hodgman clipping for two counter-clockwise rectangles."""
+
+    output = list(subject)
+    for edge_start, edge_end in zip(clip, [*clip[1:], clip[0]]):
+        input_points = output
+        output = []
+        if not input_points:
+            break
+
+        def inside(point: tuple[float, float]) -> bool:
+            return (edge_end[0] - edge_start[0]) * (point[1] - edge_start[1]) - (
+                edge_end[1] - edge_start[1]
+            ) * (point[0] - edge_start[0]) >= -1e-12
+
+        def intersection(
+            first: tuple[float, float],
+            second: tuple[float, float],
+        ) -> tuple[float, float]:
+            dx1, dy1 = second[0] - first[0], second[1] - first[1]
+            dx2, dy2 = edge_end[0] - edge_start[0], edge_end[1] - edge_start[1]
+            denominator = dx1 * dy2 - dy1 * dx2
+            if abs(denominator) <= 1e-12:
+                return second
+            t = (
+                (edge_start[0] - first[0]) * dy2 - (edge_start[1] - first[1]) * dx2
+            ) / denominator
+            return first[0] + t * dx1, first[1] + t * dy1
+
+        previous = input_points[-1]
+        previous_inside = inside(previous)
+        for current in input_points:
+            current_inside = inside(current)
+            if current_inside:
+                if not previous_inside:
+                    output.append(intersection(previous, current))
+                output.append(current)
+            elif previous_inside:
+                output.append(intersection(previous, current))
+            previous = current
+            previous_inside = current_inside
+    return output
+
+
+def bbox_iou_3d(obj: dict[str, Any], truth: ObjectGroundTruth) -> float:
+    """Return yaw-oriented 3D IoU between a Scene box and simulator truth."""
+
+    pose = obj.get("pose") or {}
+    bbox = obj.get("bbox") or {}
+    try:
+        center = (float(pose["x"]), float(pose["y"]), float(pose["z"]))
+        size = (
+            float(bbox["size_x"]),
+            float(bbox["size_y"]),
+            float(bbox["size_z"]),
+        )
+        yaw = float(bbox.get("yaw") or pose.get("yaw") or 0.0)
+    except (KeyError, TypeError, ValueError):
+        return 0.0
+    if any(not math.isfinite(value) or value <= 0.0 for value in size):
+        return 0.0
+    predicted_xy = _rectangle(center[0], center[1], size[0], size[1], yaw)
+    truth_xy = _rectangle(
+        truth.center_m[0],
+        truth.center_m[1],
+        truth.size_m[0],
+        truth.size_m[1],
+        truth.yaw_rad,
+    )
+    area = _polygon_area(_clip_polygon(predicted_xy, truth_xy))
+    predicted_low = center[2] - size[2] * 0.5
+    predicted_high = center[2] + size[2] * 0.5
+    truth_low = truth.center_m[2] - truth.size_m[2] * 0.5
+    truth_high = truth.center_m[2] + truth.size_m[2] * 0.5
+    overlap_z = max(
+        0.0, min(predicted_high, truth_high) - max(predicted_low, truth_low)
+    )
+    intersection = area * overlap_z
+    predicted_volume = size[0] * size[1] * size[2]
+    truth_volume = truth.size_m[0] * truth.size_m[1] * truth.size_m[2]
+    union = predicted_volume + truth_volume - intersection
+    return intersection / union if union > 0.0 else 0.0
+
+
+def point_inlier_fraction(
+    points: Sequence[Sequence[float]],
+    truth: ObjectGroundTruth,
+    *,
+    margin_m: float,
+) -> float | None:
+    """Fraction of exported points inside the fixture box plus SI margin."""
+
+    valid = [
+        (float(point[0]), float(point[1]), float(point[2]))
+        for point in points
+        if len(point) >= 3 and all(math.isfinite(float(value)) for value in point[:3])
+    ]
+    if not valid:
+        return None
+    cosine = math.cos(-truth.yaw_rad)
+    sine = math.sin(-truth.yaw_rad)
+    half = tuple(value * 0.5 + margin_m for value in truth.size_m)
+    inliers = 0
+    for x, y, z in valid:
+        dx, dy, dz = (
+            x - truth.center_m[0],
+            y - truth.center_m[1],
+            z - truth.center_m[2],
+        )
+        local_x = cosine * dx - sine * dy
+        local_y = sine * dx + cosine * dy
+        if abs(local_x) <= half[0] and abs(local_y) <= half[1] and abs(dz) <= half[2]:
+            inliers += 1
+    return inliers / len(valid)
+
+
+def _median(values: Sequence[float]) -> float | None:
+    return float(statistics.median(values)) if values else None
+
+
+def _maximum_pairwise_xy(samples: Sequence[dict[str, Any]]) -> float | None:
+    centers = [
+        (float(sample["pose"]["x"]), float(sample["pose"]["y"])) for sample in samples
+    ]
+    if not centers:
+        return None
+    return max(
+        math.hypot(first[0] - second[0], first[1] - second[1])
+        for first in centers
+        for second in centers
+    )
+
+
+def evaluate_ground_truth(
+    samples: Sequence[dict[str, Any]],
+    point_samples: Sequence[dict[str, Any]],
+    truth: ObjectGroundTruth,
+    *,
+    expected_samples: int,
+    thresholds: dict[str, Any],
+) -> dict[str, Any]:
+    """Summarise and gate observations without hiding missing measurements."""
+
+    xy_errors = [
+        math.hypot(
+            float(sample["pose"]["x"]) - truth.center_m[0],
+            float(sample["pose"]["y"]) - truth.center_m[1],
+        )
+        for sample in samples
+    ]
+    z_errors = [
+        abs(float(sample["pose"]["z"]) - truth.center_m[2]) for sample in samples
+    ]
+    ious = [bbox_iou_3d(sample, truth) for sample in samples]
+    labels = [str(sample.get("cls") or "").strip().lower() for sample in samples]
+    ids = {str(sample.get("id") or "") for sample in samples if sample.get("id")}
+    navigation_grade_fraction = (
+        sum(bool(sample.get("navigation_grade")) for sample in samples) / len(samples)
+        if samples
+        else 0.0
+    )
+    inlier_values = [
+        value
+        for sample in point_samples
+        if (
+            value := point_inlier_fraction(
+                sample.get("points") or (),
+                truth,
+                margin_m=float(thresholds["point_margin_m"]),
+            )
+        )
+        is not None
+    ]
+    point_counts = [
+        int(sample.get("n_points") or len(sample.get("points") or ()))
+        for sample in point_samples
+    ]
+    target_recall = len(samples) / max(1, expected_samples)
+    label_accuracy = (
+        sum(label == truth.label for label in labels) / len(labels) if labels else 0.0
+    )
+    metrics = {
+        "sample_count": len(samples),
+        "expected_samples": expected_samples,
+        "target_recall": target_recall,
+        "label_accuracy": label_accuracy,
+        "stable_id_count": len(ids),
+        "median_center_xy_error_m": _median(xy_errors),
+        "max_center_xy_drift_m": _maximum_pairwise_xy(samples),
+        "median_center_z_error_m": _median(z_errors),
+        "median_bbox_iou_3d": _median(ious),
+        "median_point_inlier_fraction": _median(inlier_values),
+        "median_point_count": _median([float(value) for value in point_counts]),
+        "navigation_grade_fraction": navigation_grade_fraction,
+    }
+    failures: list[str] = []
+
+    def require_at_least(metric: str, threshold: str) -> None:
+        value = metrics[metric]
+        if value is None or float(value) < float(thresholds[threshold]):
+            failures.append(f"{metric} below {thresholds[threshold]}")
+
+    def require_at_most(metric: str, threshold: str) -> None:
+        value = metrics[metric]
+        if value is None or float(value) > float(thresholds[threshold]):
+            failures.append(f"{metric} above {thresholds[threshold]}")
+
+    require_at_least("target_recall", "min_target_recall")
+    require_at_least("label_accuracy", "min_label_accuracy")
+    if not ids or len(ids) > int(thresholds["max_stable_ids"]):
+        failures.append(f"stable_id_count above {thresholds['max_stable_ids']}")
+    require_at_most(
+        "median_center_xy_error_m",
+        "max_median_center_xy_error_m",
+    )
+    require_at_most("max_center_xy_drift_m", "max_center_xy_drift_m")
+    require_at_most(
+        "median_center_z_error_m",
+        "max_median_center_z_error_m",
+    )
+    require_at_least("median_bbox_iou_3d", "min_median_bbox_iou_3d")
+    require_at_least(
+        "median_point_inlier_fraction",
+        "min_median_point_inlier_fraction",
+    )
+    require_at_least("median_point_count", "min_median_point_count")
+    require_at_least(
+        "navigation_grade_fraction",
+        "min_navigation_grade_fraction",
+    )
+    return {
+        "ok": not failures,
+        "failures": failures,
+        "ground_truth": {
+            "label": truth.label,
+            "center_m": list(truth.center_m),
+            "bbox_size_m": list(truth.size_m),
+            "yaw_rad": truth.yaw_rad,
+        },
+        **metrics,
+    }

--- a/testing/test_scene_quality_ground_truth.py
+++ b/testing/test_scene_quality_ground_truth.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+from __future__ import annotations
+
+import math
+import unittest
+from pathlib import Path
+
+from scene_quality_ground_truth import (
+    bbox_iou_3d,
+    evaluate_ground_truth,
+    load_ground_truth,
+    nearest_object,
+    point_inlier_fraction,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "testing/fixtures/webots_office_scene_quality.json"
+
+
+class SceneQualityGroundTruthTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.truth, cls.config = load_ground_truth(FIXTURE, repository_root=ROOT)
+
+    def _object(
+        self,
+        *,
+        object_id: str = "scene.object.potted_plant_001",
+        label: str = "potted_plant",
+        dx: float = 0.0,
+        dy: float = 0.0,
+        dz: float = 0.0,
+    ) -> dict:
+        truth = self.truth
+        return {
+            "id": object_id,
+            "cls": label,
+            "pose": {
+                "x": truth.center_m[0] + dx,
+                "y": truth.center_m[1] + dy,
+                "z": truth.center_m[2] + dz,
+                "yaw": truth.yaw_rad,
+            },
+            "bbox": {
+                "size_x": truth.size_m[0],
+                "size_y": truth.size_m[1],
+                "size_z": truth.size_m[2],
+                "yaw": truth.yaw_rad,
+            },
+            "navigation_grade": True,
+            "missing": False,
+        }
+
+    def test_world_file_resolves_expected_initial_map_center(self) -> None:
+        self.assertEqual(self.truth.label, "potted_plant")
+        self.assertAlmostEqual(self.truth.center_m[0], 1.54636, places=4)
+        self.assertAlmostEqual(self.truth.center_m[1], 0.16051, places=4)
+        self.assertAlmostEqual(self.truth.center_m[2], 0.65, places=6)
+
+    def test_nearest_object_associates_before_checking_label(self) -> None:
+        wrong_label = self._object(label="chair", dx=0.05)
+        far_correct_label = self._object(
+            object_id="scene.object.potted_plant_002",
+            dx=1.0,
+        )
+        self.assertIs(
+            nearest_object([far_correct_label, wrong_label], self.truth),
+            wrong_label,
+        )
+
+    def test_oriented_bbox_iou_and_point_inliers(self) -> None:
+        obj = self._object()
+        self.assertAlmostEqual(bbox_iou_3d(obj, self.truth), 1.0, places=9)
+        obj["pose"]["x"] += 2.0
+        self.assertEqual(bbox_iou_3d(obj, self.truth), 0.0)
+
+        center = self.truth.center_m
+        fraction = point_inlier_fraction(
+            [
+                center,
+                (center[0] + 0.05, center[1], center[2] + 0.2),
+                (center[0] + 2.0, center[1], center[2]),
+            ],
+            self.truth,
+            margin_m=0.0,
+        )
+        self.assertAlmostEqual(fraction or 0.0, 2.0 / 3.0)
+
+    def test_evaluation_reports_accuracy_stability_and_cloud_quality(self) -> None:
+        samples = [
+            self._object(dx=0.01 * math.sin(index), dy=0.01 * math.cos(index))
+            for index in range(8)
+        ]
+        center = self.truth.center_m
+        points = [
+            [
+                center[0] + (index % 3 - 1) * 0.03,
+                center[1] + (index % 5 - 2) * 0.02,
+                center[2] + (index % 7 - 3) * 0.05,
+            ]
+            for index in range(50)
+        ]
+        point_samples = [
+            {
+                "id": "cg-fixture",
+                "cls": "potted_plant",
+                "center": list(center),
+                "points": points,
+                "n_points": 50,
+            }
+            for _ in range(8)
+        ]
+        result = evaluate_ground_truth(
+            samples,
+            point_samples,
+            self.truth,
+            expected_samples=8,
+            thresholds=self.config["thresholds"],
+        )
+        self.assertTrue(result["ok"], result["failures"])
+        self.assertEqual(result["stable_id_count"], 1)
+        self.assertEqual(result["label_accuracy"], 1.0)
+        self.assertGreater(result["median_point_inlier_fraction"], 0.99)
+
+    def test_evaluation_rejects_contract_success_with_bad_world_state(self) -> None:
+        samples = [
+            self._object(
+                object_id=f"scene.object.bad_{index % 2}",
+                label="chair",
+                dx=0.3 + index * 0.01,
+                dz=0.6,
+            )
+            for index in range(8)
+        ]
+        result = evaluate_ground_truth(
+            samples,
+            [],
+            self.truth,
+            expected_samples=8,
+            thresholds=self.config["thresholds"],
+        )
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["label_accuracy"], 0.0)
+        self.assertEqual(result["stable_id_count"], 2)
+        self.assertIn(
+            "median_point_inlier_fraction below 0.65",
+            result["failures"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/testing/verify_scene_object_quality.py
+++ b/testing/verify_scene_object_quality.py
@@ -1,24 +1,34 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MulanPSL-2.0
-"""Validate live Scene object spatial sanity against its occupancy map."""
+"""Validate live Scene objects against occupancy and Webots ground truth."""
 
 from __future__ import annotations
 
+import argparse
 import json
 import math
 import os
 import sys
 import time
 import urllib.request
+from pathlib import Path
 from typing import Any
 
+from scene_quality_ground_truth import (
+    evaluate_ground_truth,
+    load_ground_truth,
+    nearest_object,
+)
 
-def _state(url: str) -> dict[str, Any]:
+
+def _json(url: str) -> dict[str, Any]:
     with urllib.request.urlopen(url, timeout=3) as response:
         return json.load(response)
 
 
-def _inside_map(obj: dict[str, Any], occupancy: dict[str, Any], margin_m: float) -> bool:
+def _inside_map(
+    obj: dict[str, Any], occupancy: dict[str, Any], margin_m: float
+) -> bool:
     pose = obj.get("pose") or {}
     x, y = float(pose["x"]), float(pose["y"])
     dx = x - float(occupancy["origin_x"])
@@ -42,31 +52,65 @@ def _finite_bbox(obj: dict[str, Any], max_extent_m: float) -> bool:
         float(bbox["size_z"]),
         float(bbox.get("yaw") or 0.0),
     ]
-    return (
-        all(math.isfinite(value) for value in values)
-        and all(0.0 < value <= max_extent_m for value in values[:3])
+    return all(math.isfinite(value) for value in values) and all(
+        0.0 < value <= max_extent_m for value in values[:3]
     )
 
 
+def _visible_objects(state: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        obj
+        for obj in state.get("objects") or []
+        if not obj.get("missing")
+        and str(obj.get("cls") or "").strip().lower() != "robot"
+    ]
+
+
+def _round_floats(value: Any) -> Any:
+    if isinstance(value, float):
+        return round(value, 6)
+    if isinstance(value, list):
+        return [_round_floats(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _round_floats(item) for key, item in value.items()}
+    return value
+
+
 def main() -> int:
-    port = os.environ.get("SCENE_WEB_PORT", "50107")
-    url = f"http://127.0.0.1:{port}/api/state"
-    deadline = time.monotonic() + 30.0
+    repository_root = Path(__file__).resolve().parents[1]
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--scene-url",
+        default=f"http://127.0.0.1:{os.environ.get('SCENE_WEB_PORT', '50107')}",
+    )
+    parser.add_argument(
+        "--ground-truth",
+        type=Path,
+        default=(repository_root / "testing/fixtures/webots_office_scene_quality.json"),
+    )
+    args = parser.parse_args()
+    state_url = f"{args.scene_url.rstrip('/')}/api/state"
+    objects3d_url = f"{args.scene_url.rstrip('/')}/api/objects3d"
+
+    try:
+        truth, fixture = load_ground_truth(
+            args.ground_truth,
+            repository_root=repository_root,
+        )
+    except Exception as exc:
+        print(json.dumps({"ok": False, "error": f"ground truth: {exc}"}))
+        return 1
+
+    deadline = time.monotonic() + 45.0
     state: dict[str, Any] = {}
     while time.monotonic() < deadline:
         try:
-            state = _state(url)
+            state = _json(state_url)
             quality = state.get("perception_quality") or {}
-            visible = [
-                obj
-                for obj in state.get("objects") or []
-                if not obj.get("missing")
-                and str(obj.get("cls") or "").strip().lower() != "robot"
-            ]
             if (
-                visible
-                and state.get("occupancy")
+                state.get("occupancy")
                 and int(quality.get("healthy_frames") or 0) > 0
+                and nearest_object(_visible_objects(state), truth) is not None
             ):
                 break
         except Exception:
@@ -75,12 +119,7 @@ def main() -> int:
 
     quality = state.get("perception_quality") or {}
     occupancy = state.get("occupancy") or {}
-    visible = [
-        obj
-        for obj in state.get("objects") or []
-        if not obj.get("missing")
-        and str(obj.get("cls") or "").strip().lower() != "robot"
-    ]
+    visible = _visible_objects(state)
     max_extent_m = float(quality.get("max_bbox_extent_m") or 0.0)
     margin_m = float(quality.get("map_bounds_margin_m") or 0.0)
     off_map = [
@@ -99,16 +138,49 @@ def main() -> int:
         if str(obj.get("cls") or "").strip().lower()
         in {"floor", "wall", "ceiling", "carpet"}
     ]
+
+    sampling = fixture["sampling"]
+    expected_samples = int(sampling["sample_count"])
+    interval_s = float(sampling["interval_s"])
+    samples: list[dict[str, Any]] = []
+    point_samples: list[dict[str, Any]] = []
+    for index in range(expected_samples):
+        try:
+            state = _json(state_url)
+            target = nearest_object(_visible_objects(state), truth)
+            if target is not None:
+                samples.append(target)
+            snapshot = _json(objects3d_url)
+            point_target = nearest_object(
+                snapshot.get("objects") or [],
+                truth,
+                center_key="center",
+            )
+            if point_target is not None:
+                point_samples.append(point_target)
+        except Exception:
+            pass
+        if index + 1 < expected_samples:
+            time.sleep(interval_s)
+
+    ground_truth = evaluate_ground_truth(
+        samples,
+        point_samples,
+        truth,
+        expected_samples=expected_samples,
+        thresholds=fixture["thresholds"],
+    )
+    spatial_ok = bool(
+        visible
+        and occupancy
+        and quality.get("require_occupancy_bounds") is True
+        and quality.get("frame_dbscan") is True
+        and not off_map
+        and not invalid_bbox
+        and not background_labels
+    )
     result = {
-        "ok": bool(
-            visible
-            and occupancy
-            and quality.get("require_occupancy_bounds") is True
-            and quality.get("frame_dbscan") is True
-            and not off_map
-            and not invalid_bbox
-            and not background_labels
-        ),
+        "ok": bool(spatial_ok and ground_truth["ok"]),
         "visible_objects": len(visible),
         "off_map_count": len(off_map),
         "invalid_bbox_count": len(invalid_bbox),
@@ -117,8 +189,9 @@ def main() -> int:
         "off_map_ids": off_map,
         "invalid_bbox_ids": invalid_bbox,
         "background_label_ids": background_labels,
+        "ground_truth_metrics": ground_truth,
     }
-    print(json.dumps(result, separators=(",", ":")))
+    print(json.dumps(_round_floats(result), separators=(",", ":")))
     return 0 if result["ok"] else 1
 
 


### PR DESCRIPTION
## Summary

This adds a fifth, validation-only layer on top of the #196–#199 Scene stack. The previous `scene_object_quality` scenario checked map bounds, finite box dimensions, and background labels, but it did not prove that a detected object had the correct class, center, 3D box, or point cloud.

The new gate:

- resolves the named TIAGo and `potted tree(2)` directly from the checked-in `office.wbt`, instead of copying simulator coordinates into runtime or verifier code;
- keeps the fixture dimensions and their pinned Cyberbotics R2025a source in a dedicated test metadata file;
- associates by metric position before checking the label, so a wrong class cannot evade measurement;
- samples the live Scene state eight times and reports target recall, label accuracy, stable-ID count, median center XY/Z error, maximum XY drift, yaw-oriented 3D bbox IoU, point-cloud inlier fraction and point count, and navigation-grade fraction;
- retains the existing occupancy-bound, bbox-sanity, DBSCAN, and background-label checks;
- documents that this is a Webots regression floor, not a substitute for physical RGB-D evaluation.

No runtime capability, robot geometry, frame, or environment constant is added by this PR. Simulator-specific truth remains under `testing/`.

## Why

Historical real run 30073019220 passed the former 17/17 suite while admitting a plant before pose/map readiness and allowing the same static object ID to drift 0.205 m in XY and 0.287 m in Z. `goal_near` and Navigation still passed, showing that contract-flow success alone was not an accuracy gate.

## Local validation

- `python3 -m unittest discover -s testing -p 'test_*.py' -v`: 14 passed, including a negative regression proving that wrong labels, unstable IDs, bad geometry, and missing cloud evidence fail the gate;
- `python3 testing/simulate_ci.py`: all 18 scenarios passed offline simulation (run in an isolated temporary venv with PyYAML because the macOS system Python lacks it);
- Black check, Python compile, commit-authorship check, public-file CJK scan, and `git diff --check`: passed;
- `scripts/check-docs.sh` could not run locally because macOS Bash 3 lacks `mapfile`; the equivalent changed-file language scan passed and GitHub Docs Check remains authoritative.

## Real Webots gate

A current-stack GPU-backed run is still required. The self-hosted runner currently has only about 758 MiB free while the workflow requires 4096 MiB, and existing workloads were not stopped. This PR must remain draft and unmerged until the real metrics are captured and any threshold/runtime regressions are resolved.

Stack: #196 → #197 → #198 → #199 → this PR.

Refs #177