### PR TITLE
feat(sentinel): add authenticated robot policy enforcement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3217,6 +3217,7 @@ name = "robonix-executor"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "nix 0.31.3",
  "prost",
@@ -3225,6 +3226,7 @@ dependencies = [
  "robonix-atlas",
  "robonix-codegen",
  "robonix-scribe",
+ "robonix-sentinel",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -3325,6 +3327,15 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+]
+
+[[package]]
+name = "robonix-sentinel"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "system/liaison",
     "system/pilot",
     "system/scribe",
+    "system/sentinel",
     "system/soma",
     "system/vitals",
     "tools/rbnx",
@@ -38,6 +39,7 @@ tokio = { version = "1", features = ["full"] }
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 sha2 = "0.10"
 serde_yaml = "0.9"
 toml = "1.1"

--- a/capabilities/lib/liaison/srv/StartVoiceSession.srv
+++ b/capabilities/lib/liaison/srv/StartVoiceSession.srv
@@ -11,6 +11,6 @@ string  voiceprint_node_id      # ""
 string  tts_node_id             # ""
 string  speaker_node_id         # ""
 string  context_json            # extra fields merged into Task.context_json
-string  session_token           # opaque Keystone login session; never forwarded to Pilot
+string  session_token           # opaque Keystone login session; forwarded only on the internal Pilot→Executor path
 ---
 liaison/VoiceEvent event        # streamed

--- a/capabilities/lib/pilot/msg/Plan.msg
+++ b/capabilities/lib/pilot/msg/Plan.msg
@@ -6,3 +6,7 @@ string session_id
 uint32 round
 RtdlNode[] nodes
 uint32 root_index
+# Internal-only credential copied from Task. Pilot clears it from every Plan
+# event sent to clients; Executor consumes it once to obtain canonical identity
+# from Keystone and clears it before running the tree.
+string auth_session_token

--- a/capabilities/lib/pilot/msg/Task.msg
+++ b/capabilities/lib/pilot/msg/Task.msg
@@ -26,3 +26,7 @@ string text
 uint8[] audio_data
 string context_json
 uint64 timestamp_ms
+# Opaque Keystone credential installed by Liaison after authentication. Pilot
+# must never parse or expose it; it is forwarded only to Executor for canonical
+# identity revalidation before capability dispatch.
+string auth_session_token

--- a/capabilities/lib/sentinel/srv/ListRules.srv
+++ b/capabilities/lib/sentinel/srv/ListRules.srv
@@ -1,0 +1,3 @@
+string session_token
+---
+string rules_json

--- a/capabilities/lib/sentinel/srv/ReplaceRules.srv
+++ b/capabilities/lib/sentinel/srv/ReplaceRules.srv
@@ -1,0 +1,4 @@
+string session_token
+string rules_json
+---
+string rules_json

--- a/capabilities/system/sentinel/list_rules.v1.toml
+++ b/capabilities/system/sentinel/list_rules.v1.toml
@@ -1,0 +1,9 @@
+[contract]
+id = "robonix/system/sentinel/list_rules"
+version = "1"
+kind = "service"
+idl = "sentinel/srv/ListRules.srv"
+description = "List the robot-wide Sentinel rules for an authenticated administrator."
+
+[mode]
+type = "rpc"

--- a/capabilities/system/sentinel/replace_rules.v1.toml
+++ b/capabilities/system/sentinel/replace_rules.v1.toml
@@ -1,0 +1,9 @@
+[contract]
+id = "robonix/system/sentinel/replace_rules"
+version = "1"
+kind = "service"
+idl = "sentinel/srv/ReplaceRules.srv"
+description = "Atomically replace robot-wide Sentinel rules as an authenticated administrator."
+
+[mode]
+type = "rpc"

--- a/examples/webots/SENTINEL_DEMO.md
+++ b/examples/webots/SENTINEL_DEMO.md
@@ -1,0 +1,24 @@
+# Webots Sentinel demo policy
+
+Both Webots manifests declare two paths:
+
+- `sentinel_rules` is the robot-local policy managed by Sentinel.
+- `sentinel_rules_seed` is the checked-in `sentinel-rules.v1.json` baseline.
+
+On the first boot, Executor validates the versioned seed and copies it to the
+robot-local path. Later boots never overwrite that file, so rule replacements
+made through the administrator API survive rebuilds and alternate worktrees.
+To reproduce a completely fresh demo, move or back up the existing
+`~/.robonix/data/sentinel-rules.json` and then run:
+
+```bash
+rbnx boot -f examples/webots/robonix_manifest.sentinel-demo.yaml
+```
+
+The v1 seed allows Keystone administrators to invoke `robonix/skill/*` and
+denies that namespace for everyone else. Calls outside that namespace keep
+Sentinel's documented overlay behavior: they are allowed when no rule matches.
+
+The seed intentionally makes no assumptions about a robot's movement state,
+gripper layout, or component IDs. Deployment-specific argument and trusted
+state conditions continue to use typed RFC 6901 JSON Pointer predicates.

--- a/examples/webots/robonix_manifest.sentinel-demo.yaml
+++ b/examples/webots/robonix_manifest.sentinel-demo.yaml
@@ -1,0 +1,31 @@
+manifestVersion: 1
+name: robonix-webots-sentinel-demo
+
+# SENTINEL_DEMO.md documents the versioned first-boot policy and reset path.
+
+system:
+  atlas:
+    listen: 0.0.0.0:50051
+    log: info
+
+  keystone:
+    listen: 0.0.0.0:50095
+    log: info
+    database: ${HOME}/.robonix/data/keystone.db
+    bootstrap_credentials_file: ${HOME}/.robonix/data/keystone-bootstrap-admin.txt
+
+  executor:
+    listen: 127.0.0.1:50061
+    sentinel_listen: 0.0.0.0:50062
+    sentinel_rules: ${HOME}/.robonix/data/sentinel-rules.json
+    sentinel_rules_seed: sentinel-rules.v1.json
+    log: info
+
+# Keeping the simulated camera under primitive preserves the normal package
+# semantics. rbnx therefore injects Soma automatically; Scene/navigation are
+# intentionally absent from this focused Sentinel acceptance deployment.
+primitive:
+  - name: tiago_camera
+    path: ./primitives/tiago_camera
+    config:
+      sentinel_timeout_s: 150

--- a/examples/webots/robonix_manifest.yaml
+++ b/examples/webots/robonix_manifest.yaml
@@ -30,6 +30,14 @@ system:
   # execution layer
   executor:
     listen: 127.0.0.1:50061
+    # Executor execution remains robot-local, while the macOS Client must be
+    # able to reach the admin-only Sentinel management provider through Atlas.
+    sentinel_listen: 0.0.0.0:50062
+    # Rules belong to this robot and survive rebuilds or alternate worktrees.
+    sentinel_rules: ${HOME}/.robonix/data/sentinel-rules.json
+    # Copied only when the robot-local file is absent; later admin edits win.
+    # See SENTINEL_DEMO.md for the baseline policy and fresh-demo procedure.
+    sentinel_rules_seed: sentinel-rules.v1.json
     log: info
   # interaction layer
   pilot:

--- a/examples/webots/sentinel-rules.v1.json
+++ b/examples/webots/sentinel-rules.v1.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "webots-demo-allow-admin-skills-v1",
+    "effect": "allow",
+    "priority": 100,
+    "conditions": {
+      "contract": "robonix/skill/*",
+      "roles": [
+        "admin"
+      ]
+    },
+    "reason": "Webots demo administrators may invoke registered skills"
+  },
+  {
+    "id": "webots-demo-deny-non-admin-skills-v1",
+    "effect": "deny",
+    "priority": 10,
+    "conditions": {
+      "contract": "robonix/skill/*"
+    },
+    "reason": "Webots demo skills require the Keystone admin role"
+  }
+]

--- a/system/executor/Cargo.toml
+++ b/system/executor/Cargo.toml
@@ -20,10 +20,12 @@ clap.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
+chrono.workspace = true
 robonix-scribe.workspace = true
 uuid.workspace = true
 rmcp = { workspace = true, features = ["client", "transport-child-process", "transport-streamable-http-client-reqwest"] }
 robonix-atlas = { path = "../atlas" }
+robonix-sentinel = { path = "../sentinel" }
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", features = ["signal", "process"] }

--- a/system/executor/README.md
+++ b/system/executor/README.md
@@ -20,14 +20,29 @@ by `make build` and `make install` respectively.
 Manual launch:
 
 ```sh
-robonix-executor --atlas 127.0.0.1:50051 --listen 127.0.0.1:50072
+robonix-executor --atlas 127.0.0.1:50051 --listen 127.0.0.1:50061
 ```
 
 Important configuration:
 
 - `--atlas` / `ROBONIX_ATLAS_ENDPOINT`: Atlas endpoint. Defaults to `127.0.0.1:50051`.
-- `--listen` / `ROBONIX_EXECUTOR_LISTEN`: Executor gRPC listen address. Defaults to `127.0.0.1:50072`.
+- `--listen` / `ROBONIX_EXECUTOR_LISTEN`: Executor gRPC listen address. Defaults to `127.0.0.1:50061`.
+- `--sentinel-listen` / `ROBONIX_SENTINEL_LISTEN`: Sentinel management gRPC listen address. Defaults to the Executor address with its port incremented by one (`127.0.0.1:50062` for the defaults). Atlas requires distinct providers to advertise distinct endpoints.
 - `--id` / `ROBONIX_EXECUTOR_PROVIDER_ID`: provider id registered with Atlas. Defaults to `executor`.
+- `--sentinel-rules` / `ROBONIX_SENTINEL_RULES`: robot-local Sentinel rule file. Defaults to `$ROBONIX_DATA_DIR/sentinel-rules.json`, or `rbnx-boot/data/sentinel-rules.json` when the data directory is unset.
+
+For a remote Client, bind only the Sentinel management endpoint externally and
+keep Executor execution robot-local. Like other robot-local providers, Atlas
+records the loopback advertise address; robonix-client rewrites that host to
+the configured remote Atlas host while preserving port `50062`:
+
+```yaml
+system:
+  executor:
+    listen: 127.0.0.1:50061
+    sentinel_listen: 0.0.0.0:50062
+    sentinel_rules: ${HOME}/.robonix/data/sentinel-rules.json
+```
 - `--log`: env_logger filter. Falls back to `RUST_LOG`, then `robonix_executor=info`.
 
 ## RTDL Execution
@@ -50,7 +65,12 @@ skips children that have not started yet, `parallel` shares the cancellation
 state across branches, and the target plan still emits `plan_complete` with
 `any_failed=true`.
 
-Executor declares two gRPC contracts:
+Executor declares its execution/control contracts on the Executor endpoint and
+the admin-only Sentinel rule-management contracts on the separate Sentinel
+endpoint. Both servers live in the same process; capability dispatch is still
+checked in Executor immediately before provider invocation.
+
+The primary Executor contracts include:
 
 - `robonix/system/executor/execute`: Pilot submits one `Plan` and receives an
   `RtdlEvent` stream.

--- a/system/executor/src/config.rs
+++ b/system/executor/src/config.rs
@@ -6,7 +6,9 @@
 
 use anyhow::{Context, Result};
 use clap::Parser;
+use robonix_sentinel::{Rule, Sentinel};
 use serde::Deserialize;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 pub const DEFAULT_EXECUTOR_PROVIDER_ID: &str = "executor";
@@ -18,7 +20,9 @@ pub const DEFAULT_LISTEN: &str = "127.0.0.1:50061";
 pub struct ExecutorConfig {
     pub atlas_endpoint: String,
     pub listen: String,
+    pub sentinel_listen: String,
     pub id: String,
+    pub sentinel_rules: PathBuf,
 }
 
 #[derive(Parser, Debug)]
@@ -36,9 +40,22 @@ pub struct Args {
     #[arg(long, env = "ROBONIX_EXECUTOR_LISTEN")]
     pub listen: Option<String>,
 
+    /// Address the robot-local Sentinel management gRPC service binds to.
+    /// Defaults to the Executor listen address with its port incremented by one.
+    #[arg(long, env = "ROBONIX_SENTINEL_LISTEN")]
+    pub sentinel_listen: Option<String>,
+
     /// Override executor's id (singleton; rarely needed).
     #[arg(long, env = "ROBONIX_EXECUTOR_PROVIDER_ID")]
     pub id: Option<String>,
+
+    /// Robot-local Sentinel rules file.
+    #[arg(long, env = "ROBONIX_SENTINEL_RULES")]
+    pub sentinel_rules: Option<PathBuf>,
+
+    /// Optional versioned seed copied to `sentinel_rules` only on first boot.
+    #[arg(long, env = "ROBONIX_SENTINEL_RULES_SEED")]
+    pub sentinel_rules_seed: Option<PathBuf>,
 
     /// Optional YAML config file (rbnx writes this; CLI/env still override).
     #[arg(long, env = "ROBONIX_CONFIG_PATH")]
@@ -65,7 +82,13 @@ struct FileConfig {
     #[serde(default)]
     listen: Option<String>,
     #[serde(default)]
+    sentinel_listen: Option<String>,
+    #[serde(default)]
     id: Option<String>,
+    #[serde(default)]
+    sentinel_rules: Option<PathBuf>,
+    #[serde(default)]
+    sentinel_rules_seed: Option<PathBuf>,
 }
 
 impl ExecutorConfig {
@@ -74,22 +97,108 @@ impl ExecutorConfig {
             Some(path) => load_yaml(path)?,
             None => FileConfig::default(),
         };
+        let deployment_cfg = args
+            .config_json
+            .as_deref()
+            .map(serde_json::from_str::<FileConfig>)
+            .transpose()
+            .context("parse Executor deployment config")?
+            .unwrap_or_default();
+        let data_dir = std::env::var_os("ROBONIX_DATA_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("rbnx-boot/data"));
+        let listen = args
+            .listen
+            .or(deployment_cfg.listen)
+            .or(file_cfg.listen)
+            .unwrap_or_else(|| DEFAULT_LISTEN.to_string());
+        let sentinel_listen = args
+            .sentinel_listen
+            .or(deployment_cfg.sentinel_listen)
+            .or(file_cfg.sentinel_listen)
+            .map(Ok)
+            .unwrap_or_else(|| adjacent_listen(&listen))?;
+        let sentinel_rules = args
+            .sentinel_rules
+            .or(deployment_cfg.sentinel_rules)
+            .or(file_cfg.sentinel_rules)
+            .unwrap_or_else(|| data_dir.join("sentinel-rules.json"));
+        let sentinel_rules_seed = args
+            .sentinel_rules_seed
+            .or(deployment_cfg.sentinel_rules_seed)
+            .or(file_cfg.sentinel_rules_seed);
+        bootstrap_sentinel_rules(&sentinel_rules, sentinel_rules_seed.as_deref())?;
         Ok(Self {
             atlas_endpoint: args
                 .atlas
                 .or_else(env_atlas)
+                .or(deployment_cfg.atlas_endpoint)
                 .or(file_cfg.atlas_endpoint)
                 .unwrap_or_else(|| DEFAULT_ATLAS_ENDPOINT.to_string()),
-            listen: args
-                .listen
-                .or(file_cfg.listen)
-                .unwrap_or_else(|| DEFAULT_LISTEN.to_string()),
+            listen,
+            sentinel_listen,
             id: args
                 .id
+                .or(deployment_cfg.id)
                 .or(file_cfg.id)
                 .unwrap_or_else(|| DEFAULT_EXECUTOR_PROVIDER_ID.to_string()),
+            sentinel_rules,
         })
     }
+}
+
+fn adjacent_listen(listen: &str) -> Result<String> {
+    let mut address: std::net::SocketAddr = listen
+        .parse()
+        .with_context(|| format!("invalid executor listen address '{listen}'"))?;
+    let port = address
+        .port()
+        .checked_add(1)
+        .context("cannot derive Sentinel listen address from port 65535")?;
+    address.set_port(port);
+    Ok(address.to_string())
+}
+
+/// Initialize a robot-local policy from a checked-in seed without ever
+/// replacing a policy already managed through Sentinel's admin API.
+fn bootstrap_sentinel_rules(path: &Path, seed: Option<&Path>) -> Result<()> {
+    if path.exists() {
+        return Ok(());
+    }
+    let Some(seed) = seed else {
+        return Ok(());
+    };
+    let raw = std::fs::read_to_string(seed)
+        .with_context(|| format!("read Sentinel rules seed '{}'", seed.display()))?;
+    let rules = serde_json::from_str::<Vec<Rule>>(&raw)
+        .with_context(|| format!("parse Sentinel rules seed '{}'", seed.display()))?;
+    Sentinel::new(rules)
+        .with_context(|| format!("validate Sentinel rules seed '{}'", seed.display()))?;
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create Sentinel rules directory '{}'", parent.display()))?;
+    }
+    match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+    {
+        Ok(mut target) => {
+            if let Err(error) = target.write_all(raw.as_bytes()) {
+                drop(target);
+                let _ = std::fs::remove_file(path);
+                return Err(error)
+                    .with_context(|| format!("bootstrap Sentinel rules '{}'", path.display()));
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("bootstrap Sentinel rules '{}'", path.display()));
+        }
+    }
+    Ok(())
 }
 
 /// Read the `ROBONIX_ATLAS` env var as an atlas-endpoint alias.
@@ -114,4 +223,108 @@ fn load_yaml(path: &Path) -> Result<FileConfig> {
         .with_context(|| format!("read executor config '{}'", path.display()))?;
     serde_yaml::from_str(&raw)
         .with_context(|| format!("parse executor config '{}'", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(config_json: Option<&str>) -> Args {
+        Args {
+            atlas: Some("127.0.0.1:50051".to_owned()),
+            listen: None,
+            sentinel_listen: None,
+            id: None,
+            sentinel_rules: None,
+            sentinel_rules_seed: None,
+            config: None,
+            log: None,
+            config_json: config_json.map(str::to_owned),
+        }
+    }
+
+    #[test]
+    fn deployment_config_resolves_remote_sentinel_and_robot_local_rules() {
+        let config = ExecutorConfig::resolve(args(Some(
+            r#"{
+                "listen":"127.0.0.1:50061",
+                "sentinel_listen":"0.0.0.0:50062",
+                "sentinel_rules":"/home/robot/.robonix/data/sentinel-rules.json"
+            }"#,
+        )))
+        .expect("Executor deployment config");
+
+        assert_eq!(config.listen, "127.0.0.1:50061");
+        assert_eq!(config.sentinel_listen, "0.0.0.0:50062");
+        assert_eq!(
+            config.sentinel_rules,
+            PathBuf::from("/home/robot/.robonix/data/sentinel-rules.json")
+        );
+    }
+
+    #[test]
+    fn sentinel_defaults_to_executor_adjacent_port() {
+        let config = ExecutorConfig::resolve(args(None)).expect("default Executor config");
+        assert_eq!(config.listen, DEFAULT_LISTEN);
+        assert_eq!(config.sentinel_listen, "127.0.0.1:50062");
+    }
+
+    #[test]
+    fn sentinel_adjacent_port_overflow_is_rejected() {
+        let error = ExecutorConfig::resolve(args(Some(r#"{"listen":"127.0.0.1:65535"}"#)))
+            .expect_err("adjacent Sentinel port overflow");
+        assert!(error.to_string().contains("port 65535"), "{error:#}");
+    }
+
+    #[test]
+    fn versioned_seed_bootstraps_fresh_rules_without_overwriting_changes() {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock")
+            .as_nanos();
+        let temp = std::env::temp_dir().join(format!(
+            "executor-sentinel-seed-{}-{nonce}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&temp).expect("test directory");
+        let seed = temp.join("sentinel-rules.v1.json");
+        let target = temp.join("data/sentinel-rules.json");
+        let seed_json =
+            r#"[{"id":"demo","effect":"deny","conditions":{"contract":"robonix/demo/*"}}]"#;
+        std::fs::write(&seed, seed_json).expect("versioned seed");
+        let config_json = serde_json::json!({
+            "sentinel_rules": target,
+            "sentinel_rules_seed": seed,
+        })
+        .to_string();
+
+        let config = ExecutorConfig::resolve(args(Some(&config_json))).expect("seeded config");
+        assert_eq!(config.sentinel_rules, target);
+        assert_eq!(
+            std::fs::read_to_string(&target).expect("bootstrapped rules"),
+            seed_json
+        );
+
+        std::fs::write(&target, "[]\n").expect("admin-managed replacement");
+        ExecutorConfig::resolve(args(Some(&config_json))).expect("existing rules config");
+        assert_eq!(
+            std::fs::read_to_string(&target).expect("preserved rules"),
+            "[]\n"
+        );
+        std::fs::remove_dir_all(temp).expect("remove test directory");
+    }
+
+    #[test]
+    fn checked_in_webots_seed_is_nonempty_and_valid() {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../examples/webots/sentinel-rules.v1.json");
+        let raw = std::fs::read_to_string(&path).expect("Webots Sentinel seed");
+        let rules = serde_json::from_str::<Vec<Rule>>(&raw).expect("parse Webots Sentinel seed");
+
+        assert!(
+            !rules.is_empty(),
+            "Webots Sentinel seed must not allow-all by omission"
+        );
+        Sentinel::new(rules).expect("validate Webots Sentinel seed");
+    }
 }

--- a/system/executor/src/main.rs
+++ b/system/executor/src/main.rs
@@ -9,7 +9,10 @@
 //      so pilot's atlas-driven discovery surfaces them to the LLM as plain
 //      capabilities. Calls hitting these contracts short-circuit to in-process
 //      handlers in `dispatch::builtin` — no MCP loopback.
-//   4. Serves Execute on `listen`. Per-call dispatch resolves provider via
+//   4. Serves Executor RPCs on `listen` and Sentinel management RPCs on the
+//      adjacent (or configured) `sentinel_listen` endpoint. Atlas requires
+//      endpoints to be unique across providers.
+//   5. Per-call dispatch resolves provider via
 //      `ConnectCapability(provider_id, contract_id, MCP)` on atlas.
 
 mod config;
@@ -17,6 +20,7 @@ mod dispatch;
 mod pb;
 mod plan_runtime;
 mod rtdl_wire;
+mod sentinel_runtime;
 mod service;
 
 use anyhow::{Context, Result};
@@ -28,9 +32,12 @@ use pb::contracts::robonix_system_executor_control_plan_server::RobonixSystemExe
 use pb::contracts::robonix_system_executor_execute_server::RobonixSystemExecutorExecuteServer;
 use pb::contracts::robonix_system_executor_get_health_server::RobonixSystemExecutorGetHealthServer;
 use pb::contracts::robonix_system_executor_list_active_plans_server::RobonixSystemExecutorListActivePlansServer;
+use pb::contracts::robonix_system_sentinel_list_rules_server::RobonixSystemSentinelListRulesServer;
+use pb::contracts::robonix_system_sentinel_replace_rules_server::RobonixSystemSentinelReplaceRulesServer;
 use robonix_atlas::client::{self as atlas_client, AtlasClient};
 use robonix_atlas::pb as atlas_pb;
 use robonix_scribe::{info, warn};
+use sentinel_runtime::{SENTINEL_NAMESPACE, SENTINEL_PROVIDER_ID, SentinelRuntime};
 use service::ExecutorServiceImpl;
 use std::time::Duration;
 
@@ -54,16 +61,30 @@ async fn main() -> Result<()> {
         .register_service(&cfg.id, EXECUTOR_NAMESPACE, "")
         .await?;
     info!("registered as '{}' under '{EXECUTOR_NAMESPACE}'", cfg.id);
+    atlas
+        .register_service(SENTINEL_PROVIDER_ID, SENTINEL_NAMESPACE, "")
+        .await?;
+    info!("registered as '{SENTINEL_PROVIDER_ID}' under '{SENTINEL_NAMESPACE}'");
 
     let listen_addr: std::net::SocketAddr = cfg
         .listen
         .parse()
         .with_context(|| format!("invalid executor listen address '{}'", cfg.listen))?;
+    let sentinel_listen_addr: std::net::SocketAddr = cfg
+        .sentinel_listen
+        .parse()
+        .with_context(|| format!("invalid Sentinel listen address '{}'", cfg.sentinel_listen))?;
     let advertised = match listen_addr.ip() {
         std::net::IpAddr::V4(ip) if ip.is_unspecified() => {
             format!("127.0.0.1:{}", listen_addr.port())
         }
         _ => listen_addr.to_string(),
+    };
+    let sentinel_advertised = match sentinel_listen_addr.ip() {
+        std::net::IpAddr::V4(ip) if ip.is_unspecified() => {
+            format!("127.0.0.1:{}", sentinel_listen_addr.port())
+        }
+        _ => sentinel_listen_addr.to_string(),
     };
 
     // Execute RPC: pilot → executor for plan dispatch.
@@ -80,6 +101,31 @@ async fn main() -> Result<()> {
             ),
         )
         .await?;
+
+    for (contract_id, contract_path, service_name, method_path) in [
+        (
+            "robonix/system/sentinel/list_rules",
+            "capabilities/system/sentinel/list_rules.v1.toml",
+            "robonix.contracts.RobonixSystemSentinelListRules",
+            "/robonix.contracts.RobonixSystemSentinelListRules/ListRules",
+        ),
+        (
+            "robonix/system/sentinel/replace_rules",
+            "capabilities/system/sentinel/replace_rules.v1.toml",
+            "robonix.contracts.RobonixSystemSentinelReplaceRules",
+            "/robonix.contracts.RobonixSystemSentinelReplaceRules/ReplaceRules",
+        ),
+    ] {
+        atlas
+            .declare_capability(
+                SENTINEL_PROVIDER_ID,
+                contract_id,
+                atlas_pb::Transport::Grpc,
+                &sentinel_advertised,
+                atlas_client::grpc_params(contract_path, service_name, method_path),
+            )
+            .await?;
+    }
 
     // Out-of-band RTDL meta operations. These never enter PlanRuntime as a
     // new plan, so canceling work cannot create a self-referential cancel tree.
@@ -176,37 +222,56 @@ async fn main() -> Result<()> {
     {
         warn!("SetLifecycleState(ACTIVE) failed: {e:#}");
     }
+    if let Err(e) = atlas
+        .set_lifecycle_state(
+            SENTINEL_PROVIDER_ID,
+            atlas_pb::LifecycleState::StateActive,
+            "",
+        )
+        .await
+    {
+        warn!("Sentinel SetLifecycleState(ACTIVE) failed: {e:#}");
+    }
 
     // Atlas evicts providers after ~60s without a heartbeat. Send one every
     // 20s so we stay registered for the lifetime of the process.
     {
         let mut hb = atlas.clone();
-        let provider_id = cfg.id.clone();
+        let provider_ids = [cfg.id.clone(), SENTINEL_PROVIDER_ID.to_owned()];
         tokio::spawn(async move {
             let mut tick = tokio::time::interval(Duration::from_secs(20));
             tick.tick().await;
             loop {
                 tick.tick().await;
-                if let Err(e) = hb.heartbeat(&provider_id).await {
-                    warn!("heartbeat failed: {e:#}");
+                for provider_id in &provider_ids {
+                    if let Err(e) = hb.heartbeat(provider_id).await {
+                        warn!("heartbeat for '{provider_id}' failed: {e:#}");
+                    }
                 }
             }
         });
     }
 
-    let svc = ExecutorServiceImpl::new(atlas, cfg.id.clone());
+    let sentinel = SentinelRuntime::load(cfg.sentinel_rules.clone())
+        .with_context(|| format!("load Sentinel rules '{}'", cfg.sentinel_rules.display()))?;
+    let svc = ExecutorServiceImpl::new(atlas, cfg.id.clone(), sentinel);
     info!("executor gRPC on {listen_addr}");
+    info!("sentinel gRPC on {sentinel_listen_addr}");
     info!("robonix-executor ready on {listen_addr}");
 
-    tonic::transport::Server::builder()
+    let executor_server = tonic::transport::Server::builder()
         .add_service(RobonixSystemExecutorExecuteServer::new(svc.clone()))
         .add_service(RobonixSystemExecutorCancelAllPlansServer::new(svc.clone()))
         .add_service(RobonixSystemExecutorControlPlanServer::new(svc.clone()))
         .add_service(RobonixSystemExecutorListActivePlansServer::new(svc.clone()))
-        .add_service(RobonixSystemExecutorGetHealthServer::new(svc))
-        .serve(listen_addr)
-        .await
-        .context("executor gRPC server failed")?;
+        .add_service(RobonixSystemExecutorGetHealthServer::new(svc.clone()))
+        .serve(listen_addr);
+    let sentinel_server = tonic::transport::Server::builder()
+        .add_service(RobonixSystemSentinelListRulesServer::new(svc.clone()))
+        .add_service(RobonixSystemSentinelReplaceRulesServer::new(svc))
+        .serve(sentinel_listen_addr);
+    tokio::try_join!(executor_server, sentinel_server)
+        .context("Executor or Sentinel gRPC server failed")?;
 
     Ok(())
 }

--- a/system/executor/src/plan_runtime.rs
+++ b/system/executor/src/plan_runtime.rs
@@ -893,6 +893,7 @@ mod tests {
             plan_id: "p".into(),
             session_id: "s".into(),
             round: 0,
+            auth_session_token: String::new(),
             root_index: 0,
             nodes: vec![
                 RtdlNode {
@@ -954,6 +955,7 @@ mod tests {
                 plan_id: "p1".into(),
                 session_id: "s".into(),
                 round: 0,
+                auth_session_token: String::new(),
                 root_index: 0,
                 nodes: vec![RtdlNode {
                     node_kind: 0,

--- a/system/executor/src/sentinel_runtime.rs
+++ b/system/executor/src/sentinel_runtime.rs
@@ -1,0 +1,634 @@
+// SPDX-License-Identifier: MulanPSL-2.0
+
+//! Robot-local Sentinel policy storage, admin management, and dispatch checks.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use chrono::{Datelike, Local, Timelike};
+use robonix_atlas::client::{self as atlas_client, AtlasClient};
+use robonix_sentinel::{EvaluationContext, Rule, Sentinel};
+use tokio::sync::RwLock;
+use tonic::{Request, Response, Status};
+
+use crate::pb::contracts::robonix_system_keystone_get_profile_client::RobonixSystemKeystoneGetProfileClient;
+use crate::pb::contracts::robonix_system_scene_get_robot_context_client::RobonixSystemSceneGetRobotContextClient;
+use crate::pb::contracts::robonix_system_sentinel_list_rules_server::RobonixSystemSentinelListRules;
+use crate::pb::contracts::robonix_system_sentinel_replace_rules_server::RobonixSystemSentinelReplaceRules;
+use crate::pb::contracts::robonix_system_soma_get_health_client::RobonixSystemSomaGetHealthClient;
+use crate::pb::contracts::robonix_system_vitals_get_client::RobonixSystemVitalsGetClient;
+use crate::pb::keystone::GetProfileRequest;
+use crate::pb::semantic_map::GetRobotContextRequest;
+use crate::pb::sentinel::{
+    ListRulesRequest, ListRulesResponse, ReplaceRulesRequest, ReplaceRulesResponse,
+};
+use crate::pb::soma::{GetHealthRequest, Scalar, SomaHealthSnapshot};
+use crate::pb::vitals::{GetVitalsRequest, VitalsSnapshot};
+use crate::service::ExecutorServiceImpl;
+
+const KEYSTONE_GET_PROFILE: &str = "robonix/system/keystone/get_profile";
+const SOMA_GET_HEALTH: &str = "robonix/system/soma/get_health";
+const VITALS_GET: &str = "robonix/system/vitals/get";
+const SCENE_GET_ROBOT_CONTEXT: &str = "robonix/system/scene/get_robot_context";
+const ATLAS_CONTROL_TIMEOUT: Duration = Duration::from_millis(250);
+const SNAPSHOT_TIMEOUT: Duration = Duration::from_millis(750);
+const ADMIN_RPC_TIMEOUT: Duration = Duration::from_secs(2);
+pub const SENTINEL_PROVIDER_ID: &str = "sentinel";
+pub const SENTINEL_NAMESPACE: &str = "robonix/system/sentinel";
+
+/// Canonical identity resolved directly from Keystone by Executor.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SentinelIdentity {
+    pub known: bool,
+    pub user_id: String,
+    pub roles: Vec<String>,
+}
+
+/// Shared policy state. Replacements are validated and persisted before publish.
+#[derive(Clone)]
+pub struct SentinelRuntime {
+    path: Arc<PathBuf>,
+    policy: Arc<RwLock<Sentinel>>,
+}
+
+impl SentinelRuntime {
+    /// Load the robot-local rule file, or start with an empty allow-by-default policy.
+    pub fn load(path: PathBuf) -> Result<Self> {
+        let rules = if path.exists() {
+            let raw = std::fs::read_to_string(&path)
+                .with_context(|| format!("read Sentinel rules '{}'", path.display()))?;
+            serde_json::from_str::<Vec<Rule>>(&raw)
+                .with_context(|| format!("parse Sentinel rules '{}'", path.display()))?
+        } else {
+            Vec::new()
+        };
+        let policy = Sentinel::new(rules).context("validate Sentinel rules")?;
+        Ok(Self {
+            path: Arc::new(path),
+            policy: Arc::new(RwLock::new(policy)),
+        })
+    }
+
+    /// Serialize the active rule set for the admin UI.
+    pub async fn rules_json(&self) -> Result<String> {
+        serde_json::to_string_pretty(self.policy.read().await.list_rules())
+            .context("serialize Sentinel rules")
+    }
+
+    /// Validate and persist a complete replacement before making it active.
+    pub async fn replace_rules(&self, raw: &str) -> Result<String> {
+        let rules = serde_json::from_str::<Vec<Rule>>(raw).context("parse rules_json")?;
+        let replacement = Sentinel::new(rules).context("validate rules_json")?;
+        let normalized = serde_json::to_string_pretty(replacement.list_rules())
+            .context("serialize rules_json")?;
+        persist_atomically(&self.path, &normalized).await?;
+        *self.policy.write().await = replacement;
+        Ok(normalized)
+    }
+
+    /// Evaluate one call using canonical Keystone identity and fresh system snapshots.
+    pub async fn check(
+        &self,
+        atlas: &AtlasClient,
+        consumer_id: &str,
+        contract_id: &str,
+        args_json: &str,
+        identity: &SentinelIdentity,
+    ) -> robonix_sentinel::Decision {
+        let args = match parse_capability_args(args_json) {
+            Ok(args) => args,
+            Err(decision) => return decision,
+        };
+        let policy = self.policy.read().await.clone();
+        let state =
+            collect_trusted_state(atlas, consumer_id, &policy.required_context_roots()).await;
+        let now = Local::now();
+        let context = EvaluationContext {
+            identity_known: identity.known,
+            user_id: (!identity.user_id.is_empty()).then(|| identity.user_id.clone()),
+            roles: identity.roles.clone(),
+            state,
+            weekday: now.weekday().number_from_monday() as u8,
+            minute_of_day: (now.hour() * 60 + now.minute()) as u16,
+        };
+        policy.check(contract_id, &args, &context)
+    }
+}
+
+fn parse_capability_args(args_json: &str) -> Result<serde_json::Value, robonix_sentinel::Decision> {
+    serde_json::from_str(args_json).map_err(|error| robonix_sentinel::Decision {
+        allow: false,
+        indeterminate: true,
+        rule_id: "invalid_args_json".to_owned(),
+        reason: format!("capability args_json is not valid JSON: {error}"),
+    })
+}
+
+/// Write to a sibling temporary file and rename it over the active policy.
+async fn persist_atomically(path: &Path, contents: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .with_context(|| format!("create Sentinel data directory '{}'", parent.display()))?;
+    }
+    let temporary = path.with_extension("json.tmp");
+    tokio::fs::write(&temporary, contents)
+        .await
+        .with_context(|| format!("write temporary Sentinel rules '{}'", temporary.display()))?;
+    tokio::fs::rename(&temporary, path)
+        .await
+        .with_context(|| format!("publish Sentinel rules '{}'", path.display()))?;
+    Ok(())
+}
+
+async fn collect_trusted_state(
+    atlas: &AtlasClient,
+    consumer_id: &str,
+    roots: &BTreeSet<String>,
+) -> serde_json::Value {
+    let (soma, vitals, scene) = tokio::join!(
+        collect_optional_root(roots, "soma", fetch_soma(atlas.clone(), consumer_id)),
+        collect_optional_root(roots, "vitals", fetch_vitals(atlas.clone(), consumer_id)),
+        collect_optional_root(roots, "scene", fetch_scene(atlas.clone(), consumer_id)),
+    );
+    let mut state = serde_json::Map::new();
+    for (name, value) in [("soma", soma), ("vitals", vitals), ("scene", scene)] {
+        if let Some(value) = value {
+            state.insert(name.to_owned(), value);
+        }
+    }
+    serde_json::Value::Object(state)
+}
+
+async fn collect_optional_root<F>(
+    roots: &BTreeSet<String>,
+    name: &str,
+    fetch: F,
+) -> Option<serde_json::Value>
+where
+    F: std::future::Future<Output = Result<serde_json::Value>>,
+{
+    if !roots.contains(name) {
+        return None;
+    }
+    Some(match fetch.await {
+        Ok(value) => value,
+        Err(error) => serde_json::json!({
+            "available": false,
+            "error": format!("{error:#}"),
+        }),
+    })
+}
+
+async fn fetch_soma(mut atlas: AtlasClient, consumer_id: &str) -> Result<serde_json::Value> {
+    let (channel_id, _, channel) = tokio::time::timeout(
+        ATLAS_CONTROL_TIMEOUT,
+        atlas_client::connect_to_capability(&mut atlas, consumer_id, SOMA_GET_HEALTH),
+    )
+    .await
+    .context("connect to Soma get_health timed out")?
+    .context("connect to Soma get_health")?;
+    let result = match tokio::time::timeout(SNAPSHOT_TIMEOUT, async {
+        let response = RobonixSystemSomaGetHealthClient::new(channel)
+            .get_health(GetHealthRequest {})
+            .await
+            .context("call Soma get_health")?
+            .into_inner();
+        let snapshot = response
+            .snapshot
+            .context("Soma has not published a health snapshot")?;
+        Ok(soma_json(snapshot))
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => Err(anyhow::anyhow!(
+            "Soma snapshot timed out after {} ms",
+            SNAPSHOT_TIMEOUT.as_millis()
+        )),
+    };
+    disconnect_bounded(&mut atlas, &channel_id).await;
+    result
+}
+
+fn soma_json(snapshot: SomaHealthSnapshot) -> serde_json::Value {
+    let fresh = snapshot_is_fresh(snapshot.soma_ts_ns, snapshot.ttl_ms);
+    let metadata = serde_json::json!({
+        "available": true,
+        "fresh": fresh,
+        "source_ts_ns": snapshot.source_ts_ns,
+        "soma_ts_ns": snapshot.soma_ts_ns,
+        "ttl_ms": snapshot.ttl_ms,
+    });
+    if !fresh {
+        return metadata;
+    }
+
+    let components = snapshot
+        .components
+        .into_iter()
+        .map(|component| {
+            let id = component.id.clone();
+            (
+                id,
+                serde_json::json!({
+                    "parent_id": component.parent_id,
+                    "kind": component.kind,
+                    "name": component.name,
+                    "frame_id": component.frame_id,
+                    "model": component.model,
+                    "health": component.health,
+                    "operational_state": component.operational_state,
+                    "present": component.present,
+                    "online": component.online,
+                    "detail": component.detail,
+                }),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let actuators = snapshot
+        .actuators
+        .into_iter()
+        .map(|actuator| {
+            let id = actuator.component_id.clone();
+            (
+                id,
+                serde_json::json!({
+                    "joint_name": actuator.joint_name,
+                    "position": actuator.position.map(scalar_json),
+                    "velocity": actuator.velocity.map(scalar_json),
+                    "effort": actuator.effort.map(scalar_json),
+                    "current": actuator.current.map(scalar_json),
+                    "voltage": actuator.voltage.map(scalar_json),
+                    "motor_temp": actuator.motor_temp.map(scalar_json),
+                    "driver_temp": actuator.driver_temp.map(scalar_json),
+                    "torque_enabled": actuator.torque_enabled,
+                    "brake_engaged": actuator.brake_engaged,
+                    "communication_ok": actuator.communication_ok,
+                    "vendor_mode": actuator.vendor_mode,
+                    "vendor_error_code": actuator.vendor_error_code,
+                    "status_flags": actuator.status_flags,
+                }),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let mut metrics = BTreeMap::<String, BTreeMap<String, serde_json::Value>>::new();
+    for metric in snapshot.metrics {
+        let value = metric.value.map(scalar_json);
+        metrics.entry(metric.component_id).or_default().insert(
+            metric.name,
+            serde_json::json!({"value": value, "source_key": metric.source_key}),
+        );
+    }
+    let safety = snapshot.safety.map(|safety| {
+        serde_json::json!({
+            "motion_allowed": safety.motion_allowed,
+            "motor_power_allowed": safety.motor_power_allowed,
+            "aggregate_state": safety.aggregate_state,
+            "detail": safety.detail,
+        })
+    });
+    let mut output = metadata.as_object().cloned().unwrap_or_default();
+    output.insert(
+        "data".to_owned(),
+        serde_json::json!({
+            "schema_version": snapshot.schema_version,
+            "body_id": snapshot.body_id,
+            "seq": snapshot.seq,
+            "components": components,
+            "actuators": actuators,
+            "metrics": metrics,
+            "safety": safety,
+        }),
+    );
+    serde_json::Value::Object(output)
+}
+
+fn scalar_json(value: Scalar) -> serde_json::Value {
+    serde_json::json!({
+        "value": value.value,
+        "unit": value.unit,
+        "quality": value.quality,
+    })
+}
+
+fn snapshot_is_fresh(timestamp_ns: i64, ttl_ms: u32) -> bool {
+    if timestamp_ns <= 0 || ttl_ms == 0 {
+        return false;
+    }
+    let Ok(now) = SystemTime::now().duration_since(UNIX_EPOCH) else {
+        return false;
+    };
+    let now_ns = i128::try_from(now.as_nanos()).unwrap_or(i128::MAX);
+    let timestamp_ns = i128::from(timestamp_ns);
+    let age_ns = now_ns.saturating_sub(timestamp_ns);
+    age_ns >= 0 && age_ns <= i128::from(ttl_ms) * 1_000_000
+}
+
+async fn fetch_vitals(mut atlas: AtlasClient, consumer_id: &str) -> Result<serde_json::Value> {
+    let (channel_id, _, channel) = tokio::time::timeout(
+        ATLAS_CONTROL_TIMEOUT,
+        atlas_client::connect_to_capability(&mut atlas, consumer_id, VITALS_GET),
+    )
+    .await
+    .context("connect to Vitals get timed out")?
+    .context("connect to Vitals get")?;
+    let result = match tokio::time::timeout(SNAPSHOT_TIMEOUT, async {
+        let response = RobonixSystemVitalsGetClient::new(channel)
+            .get_vitals(GetVitalsRequest {})
+            .await
+            .context("call Vitals get")?
+            .into_inner();
+        let snapshot = response.snapshot.context("Vitals returned no snapshot")?;
+        Ok(vitals_json(snapshot))
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => Err(anyhow::anyhow!(
+            "Vitals snapshot timed out after {} ms",
+            SNAPSHOT_TIMEOUT.as_millis()
+        )),
+    };
+    disconnect_bounded(&mut atlas, &channel_id).await;
+    result
+}
+
+fn vitals_json(snapshot: VitalsSnapshot) -> serde_json::Value {
+    let power = snapshot.power.map(|power| {
+        serde_json::json!({
+            "battery_percent": power.battery_percent,
+            "voltage": power.voltage,
+            "charging": power.charging,
+            "remaining_s": power.remaining_s,
+        })
+    });
+    let components = snapshot
+        .components
+        .into_iter()
+        .map(|component| {
+            let name = component.name.clone();
+            (
+                name,
+                serde_json::json!({
+                    "health": component.health,
+                    "detail": component.detail,
+                    "value": component.value,
+                    "threshold": component.threshold,
+                }),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let bodies = snapshot
+        .bodies
+        .into_iter()
+        .map(|body| {
+            let key = body.body_type.clone();
+            let body_components = body
+                .components
+                .into_iter()
+                .map(|component| {
+                    let component_key = if component.id.is_empty() {
+                        component.name.clone()
+                    } else {
+                        component.id.clone()
+                    };
+                    (
+                        component_key,
+                        serde_json::json!({
+                            "name": component.name,
+                            "kind": component.kind,
+                            "temperature": component.temperature,
+                            "error_code": component.error_code,
+                            "enabled": component.enabled,
+                            "parent_id": component.parent_id,
+                            "model": component.model,
+                        }),
+                    )
+                })
+                .collect::<BTreeMap<_, _>>();
+            (
+                key,
+                serde_json::json!({
+                    "model": body.model,
+                    "state": body.state,
+                    "message": body.message,
+                    "components": body_components,
+                }),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    serde_json::json!({
+        "available": true,
+        "data": {
+            "ts_ns": snapshot.ts_ns,
+            "power": power,
+            "components": components,
+            "bodies": bodies,
+        }
+    })
+}
+
+async fn fetch_scene(mut atlas: AtlasClient, consumer_id: &str) -> Result<serde_json::Value> {
+    let (channel_id, _, channel) = tokio::time::timeout(
+        ATLAS_CONTROL_TIMEOUT,
+        atlas_client::connect_to_capability(&mut atlas, consumer_id, SCENE_GET_ROBOT_CONTEXT),
+    )
+    .await
+    .context("connect to Scene get_robot_context timed out")?
+    .context("connect to Scene get_robot_context")?;
+    let result = match tokio::time::timeout(SNAPSHOT_TIMEOUT, async {
+        let response = RobonixSystemSceneGetRobotContextClient::new(channel)
+            .get_robot_context(GetRobotContextRequest {})
+            .await
+            .context("call Scene get_robot_context")?
+            .into_inner();
+        let fresh = response.pose_known && !response.stale;
+        let mut output = serde_json::json!({
+            "available": true,
+            "fresh": fresh,
+            "reason": response.reason,
+            "observed_at_unix": response.observed_at_unix,
+            "snapshot_at_unix": response.snapshot_at_unix,
+        });
+        if fresh {
+            output.as_object_mut().unwrap().insert("data".to_owned(), serde_json::json!({
+                "map_id": response.map_id,
+                "pose": {"x": response.x, "y": response.y, "z": response.z, "yaw": response.yaw},
+                "room_id": response.room_id,
+                "room_name": response.room_name,
+                "containing_area_ids": response.containing_area_ids,
+                "containing_area_names": response.containing_area_names,
+            }));
+        }
+        Ok(output)
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => Err(anyhow::anyhow!(
+            "Scene snapshot timed out after {} ms",
+            SNAPSHOT_TIMEOUT.as_millis()
+        )),
+    };
+    disconnect_bounded(&mut atlas, &channel_id).await;
+    result
+}
+
+async fn disconnect_bounded(atlas: &mut AtlasClient, channel_id: &str) {
+    let _ = tokio::time::timeout(
+        ATLAS_CONTROL_TIMEOUT,
+        atlas.disconnect_capability(channel_id),
+    )
+    .await;
+}
+
+/// Resolve one opaque Keystone session into canonical identity. Caller-provided
+/// user IDs or roles are never inputs to this operation.
+pub(crate) async fn resolve_session_identity(
+    atlas: &AtlasClient,
+    provider_id: &str,
+    token: &str,
+) -> Result<SentinelIdentity, Status> {
+    if token.is_empty() {
+        return Err(Status::unauthenticated("login session is required"));
+    }
+    let mut atlas = atlas.clone();
+    let (channel_id, _, channel) = tokio::time::timeout(
+        ATLAS_CONTROL_TIMEOUT,
+        atlas_client::connect_to_capability(&mut atlas, provider_id, KEYSTONE_GET_PROFILE),
+    )
+    .await
+    .map_err(|_| Status::deadline_exceeded("resolve Keystone timed out"))?
+    .map_err(|error| Status::unavailable(format!("resolve Keystone: {error:#}")))?;
+    let response = match tokio::time::timeout(
+        ADMIN_RPC_TIMEOUT,
+        RobonixSystemKeystoneGetProfileClient::new(channel).get_profile(GetProfileRequest {
+            session_token: token.to_owned(),
+        }),
+    )
+    .await
+    {
+        Ok(result) => result.map(|response| response.into_inner()),
+        Err(_) => Err(Status::deadline_exceeded(
+            "Keystone profile lookup timed out",
+        )),
+    };
+    disconnect_bounded(&mut atlas, &channel_id).await;
+    let response = response?;
+    let user = response
+        .user
+        .ok_or_else(|| Status::internal("Keystone returned an empty profile"))?;
+    Ok(SentinelIdentity {
+        known: true,
+        user_id: user.user_id,
+        roles: user.roles,
+    })
+}
+
+/// Resolve the Keystone session on every admin request; UI role checks are not trusted.
+async fn require_admin(atlas: &AtlasClient, provider_id: &str, token: &str) -> Result<(), Status> {
+    let identity = resolve_session_identity(atlas, provider_id, token).await?;
+    if !identity.roles.iter().any(|role| role == "admin") {
+        return Err(Status::permission_denied("administrator role is required"));
+    }
+    Ok(())
+}
+
+#[tonic::async_trait]
+impl RobonixSystemSentinelListRules for ExecutorServiceImpl {
+    async fn list_rules(
+        &self,
+        request: Request<ListRulesRequest>,
+    ) -> Result<Response<ListRulesResponse>, Status> {
+        let input = request.into_inner();
+        require_admin(&self.atlas, SENTINEL_PROVIDER_ID, &input.session_token).await?;
+        let rules_json = self
+            .sentinel
+            .rules_json()
+            .await
+            .map_err(|error| Status::internal(format!("read Sentinel rules: {error:#}")))?;
+        Ok(Response::new(ListRulesResponse { rules_json }))
+    }
+}
+
+#[tonic::async_trait]
+impl RobonixSystemSentinelReplaceRules for ExecutorServiceImpl {
+    async fn replace_rules(
+        &self,
+        request: Request<ReplaceRulesRequest>,
+    ) -> Result<Response<ReplaceRulesResponse>, Status> {
+        let input = request.into_inner();
+        require_admin(&self.atlas, SENTINEL_PROVIDER_ID, &input.session_token).await?;
+        let rules_json = self
+            .sentinel
+            .replace_rules(&input.rules_json)
+            .await
+            .map_err(|error| {
+                Status::invalid_argument(format!("invalid Sentinel rules: {error:#}"))
+            })?;
+        Ok(Response::new(ReplaceRulesResponse { rules_json }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn malformed_capability_args_fail_closed_instead_of_becoming_empty_object() {
+        let decision = parse_capability_args("{not-json").unwrap_err();
+        assert!(!decision.allow);
+        assert!(decision.indeterminate);
+        assert_eq!(decision.rule_id, "invalid_args_json");
+        assert!(decision.reason.contains("not valid JSON"));
+    }
+
+    #[test]
+    fn fresh_soma_snapshot_preserves_boolean_false_as_typed_state() {
+        let now_ns = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos() as i64;
+        let value = soma_json(SomaHealthSnapshot {
+            source_ts_ns: now_ns,
+            soma_ts_ns: now_ns,
+            ttl_ms: 2_000,
+            safety: Some(crate::pb::soma::SafetyState {
+                motion_allowed: false,
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+
+        assert_eq!(
+            value.pointer("/fresh").and_then(serde_json::Value::as_bool),
+            Some(true)
+        );
+        assert_eq!(
+            value
+                .pointer("/data/safety/motion_allowed")
+                .and_then(serde_json::Value::as_bool),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn stale_soma_snapshot_does_not_publish_policy_data() {
+        let value = soma_json(SomaHealthSnapshot {
+            source_ts_ns: 1,
+            soma_ts_ns: 1,
+            ttl_ms: 1,
+            ..Default::default()
+        });
+
+        assert_eq!(
+            value.pointer("/fresh").and_then(serde_json::Value::as_bool),
+            Some(false)
+        );
+        assert!(value.pointer("/data").is_none());
+    }
+}

--- a/system/executor/src/service.rs
+++ b/system/executor/src/service.rs
@@ -19,6 +19,9 @@ use crate::pb::pilot::rtdl_node_state::RtdlNodeStateEnum;
 use crate::pb::pilot::{CapabilityCall, CapabilityCallResult, Plan};
 use crate::plan_runtime::{PlanRuntime, StopWhen};
 use crate::rtdl_wire::{self, NodeEventContext};
+use crate::sentinel_runtime::{
+    SENTINEL_PROVIDER_ID, SentinelIdentity, SentinelRuntime, resolve_session_identity,
+};
 use robonix_atlas::client::AtlasClient;
 use robonix_scribe::{info, warn};
 use std::collections::HashSet;
@@ -40,23 +43,25 @@ const MODULE_HEALTH_TTL_MS: u32 = 5000;
 /// dispatch runs without serialising on a single mutex.
 #[derive(Clone)]
 pub struct ExecutorServiceImpl {
-    atlas: AtlasClient,
+    pub(crate) atlas: AtlasClient,
     /// Executor's own provider_id. Two roles:
     ///   1. consumer_id passed to atlas on every ConnectCapability so the
     ///      channel record reflects who is using each downstream provider.
     ///   2. self-detection: when a CapabilityCall in the plan targets this
     ///      provider_id, dispatch short-circuits to the in-process builtin
     ///      handlers instead of going through MCP loopback.
-    provider_id: String,
+    pub(crate) provider_id: String,
     runtime: PlanRuntime,
+    pub(crate) sentinel: SentinelRuntime,
 }
 
 impl ExecutorServiceImpl {
-    pub fn new(atlas: AtlasClient, provider_id: String) -> Self {
+    pub fn new(atlas: AtlasClient, provider_id: String, sentinel: SentinelRuntime) -> Self {
         Self {
             atlas,
             provider_id,
             runtime: PlanRuntime::default(),
+            sentinel,
         }
     }
 }
@@ -69,12 +74,28 @@ impl RobonixSystemExecutorExecute for ExecutorServiceImpl {
         &self,
         request: Request<Plan>,
     ) -> Result<Response<Self::ExecuteStream>, Status> {
-        let plan = request.into_inner();
+        let mut plan = request.into_inner();
         validate_plan(&plan).map_err(Status::invalid_argument)?;
+        // An empty credential preserves non-Keystone/local deployments, but it
+        // never makes caller-supplied identity trusted. Subject-scoped rules
+        // therefore fail closed for direct Pilot/Executor callers. A supplied
+        // credential must resolve successfully before PlanStarted is emitted.
+        let identity = if plan.auth_session_token.is_empty() {
+            SentinelIdentity::default()
+        } else {
+            resolve_session_identity(&self.atlas, &self.provider_id, &plan.auth_session_token)
+                .await?
+        };
+        plan.auth_session_token.clear();
         let (tx, rx) = tokio::sync::mpsc::channel(64);
-        let atlas = self.atlas.clone();
-        let provider_id = self.provider_id.clone();
         let runtime = self.runtime.clone();
+        let context = ExecutionContext {
+            atlas: self.atlas.clone(),
+            provider_id: self.provider_id.clone(),
+            runtime: runtime.clone(),
+            sentinel: self.sentinel.clone(),
+            identity,
+        };
 
         tokio::spawn(async move {
             let plan_id = plan.plan_id.clone();
@@ -86,9 +107,7 @@ impl RobonixSystemExecutorExecute for ExecutorServiceImpl {
                 Arc::clone(&plan),
                 plan.root_index as usize,
                 tx.clone(),
-                atlas,
-                provider_id,
-                runtime.clone(),
+                context,
             )
             .await;
             let cancelled = runtime.is_cancelled(&plan_id).await;
@@ -112,11 +131,11 @@ fn execute_node(
     plan: Arc<Plan>,
     node_index: usize,
     tx: Sender<Result<RtdlEvent, Status>>,
-    atlas: AtlasClient,
-    provider_id: String,
-    runtime: PlanRuntime,
+    context: ExecutionContext,
 ) -> ExecuteNodeFuture {
     Box::pin(async move {
+        let runtime = context.runtime.clone();
+        let provider_id = context.provider_id.clone();
         let node = &plan.nodes[node_index];
         let node_ctx = node_event_context(&plan, node_index);
         let op_id = node.op_id.clone();
@@ -137,14 +156,14 @@ fn execute_node(
             .should_stop_at(&plan.plan_id, &op_id, StopWhen::OnEnter)
             .await
         {
-            let mut atlas = atlas;
+            let mut atlas = context.atlas.clone();
             runtime
                 .trigger_stop(&plan.plan_id, &provider_id, &mut atlas)
                 .await;
             send_stop_on_enter(&tx, &node_ctx, &runtime).await;
             return true;
         }
-        let mut atlas_after = atlas.clone();
+        let mut atlas_after = context.atlas.clone();
         let failed = match node.node_kind {
             RTDL_SEQUENCE => {
                 let mut any_failed = false;
@@ -159,9 +178,7 @@ fn execute_node(
                         Arc::clone(&plan),
                         *child as usize,
                         tx.clone(),
-                        atlas.clone(),
-                        provider_id.clone(),
-                        runtime.clone(),
+                        context.clone(),
                     )
                     .await;
                     if any_failed {
@@ -191,20 +208,10 @@ fn execute_node(
                 for child in &node.children {
                     let child_plan = Arc::clone(&plan);
                     let child_tx = tx.clone();
-                    let child_atlas = atlas.clone();
-                    let child_provider_id = provider_id.clone();
-                    let child_runtime = runtime.clone();
+                    let child_context = context.clone();
                     let child_index = *child as usize;
                     handles.push(tokio::spawn(async move {
-                        execute_node(
-                            child_plan,
-                            child_index,
-                            child_tx,
-                            child_atlas,
-                            child_provider_id,
-                            child_runtime,
-                        )
-                        .await
+                        execute_node(child_plan, child_index, child_tx, child_context).await
                     }));
                 }
                 let mut any_failed = false;
@@ -240,15 +247,7 @@ fn execute_node(
                     .call
                     .as_ref()
                     .expect("validated do node must contain call");
-                execute_call(
-                    call,
-                    node_ctx,
-                    tx,
-                    atlas,
-                    provider_id.clone(),
-                    runtime.clone(),
-                )
-                .await
+                execute_call(call, node_ctx, tx, context).await
             }
             _ => {
                 warn!(
@@ -360,15 +359,68 @@ async fn send_operator_terminal(
         .await;
 }
 
+/// Per-plan dependencies and canonical identity shared by every tree node.
+#[derive(Clone)]
+struct ExecutionContext {
+    atlas: AtlasClient,
+    provider_id: String,
+    runtime: PlanRuntime,
+    sentinel: SentinelRuntime,
+    identity: SentinelIdentity,
+}
+
 /// Dispatch one RTDL `do` node and stream node_state events.
 async fn execute_call(
     call: &CapabilityCall,
     node: NodeEventContext,
     tx: Sender<Result<RtdlEvent, Status>>,
-    mut atlas: AtlasClient,
-    provider_id: String,
-    runtime: PlanRuntime,
+    context: ExecutionContext,
 ) -> bool {
+    let ExecutionContext {
+        mut atlas,
+        provider_id,
+        runtime,
+        sentinel,
+        identity,
+    } = context;
+    let decision = sentinel
+        .check(
+            &atlas,
+            SENTINEL_PROVIDER_ID,
+            &call.contract_id,
+            &call.args_json,
+            &identity,
+        )
+        .await;
+    if !decision.allow {
+        let result = CapabilityCallResult {
+            call_id: call.call_id.clone(),
+            provider_id: call.provider_id.clone(),
+            contract_id: call.contract_id.clone(),
+            success: false,
+            output: String::new(),
+            error: format!(
+                "Sentinel denied capability call by rule '{}': {}",
+                decision.rule_id, decision.reason
+            ),
+        };
+        warn!(
+            "[sentinel] denied call_id={} contract='{}' rule='{}': {}",
+            call.call_id, call.contract_id, decision.rule_id, decision.reason
+        );
+        runtime
+            .record_op_state(&node.plan_id, &node.op_id, RtdlNodeStateEnum::Failed as u32)
+            .await;
+        let _ = tx
+            .send(Ok(rtdl_wire::node_state_from_result(
+                &node,
+                result,
+                RtdlNodeStateEnum::Failed as u32,
+            )))
+            .await;
+        return true;
+    }
+
     // Log the args too (bounded) so the log shows what each call requested —
     // essential for debugging plan-control builtins (stop_plan_at / cancel_plan)
     // and any cap call. Truncated to keep large payloads (images, file content)
@@ -781,6 +833,7 @@ mod tests {
             round: 0,
             nodes,
             root_index,
+            auth_session_token: String::new(),
         }
     }
 

--- a/system/liaison/README.md
+++ b/system/liaison/README.md
@@ -65,7 +65,10 @@ forwarding work. Client-supplied `user_id`, display name, and roles are never
 authorization inputs.
 
 Accepted Pilot tasks contain canonical `user_id`, `username`, `display_name`,
-and `roles`. The session token itself is removed before forwarding to Pilot.
+and `roles` for conversational context. Liaison moves the validated session
+token into a typed internal field; Pilot does not parse it and redacts it from
+client events, while Executor uses it once to resolve canonical Sentinel
+identity directly from Keystone before dispatch.
 
 Text turns require a valid account session and never require Voiceprint. For
 voice turns:

--- a/system/liaison/src/main.rs
+++ b/system/liaison/src/main.rs
@@ -48,6 +48,7 @@ use pb::contracts::{
     },
     robonix_system_pilot_client::RobonixSystemPilotClient,
 };
+use pb::keystone::User;
 use pb::liaison::{
     GetHandsfreeStatusRequest, GetHandsfreeStatusResponse, SetHandsfreeRequest,
     SetHandsfreeResponse, StartVoiceSessionRequest, VoiceEvent, WatchHandsfreeEventsRequest,
@@ -191,7 +192,7 @@ impl LiaisonPipeline {
 }
 
 /// Resolve the login token, replace caller-supplied identity with Keystone's
-/// canonical account, and remove the secret before forwarding to Pilot.
+/// canonical account, and move the secret into the typed internal-only field.
 async fn authenticate_task(
     keystone: &keystone_gateway::KeystoneGateway,
     task: &mut Task,
@@ -207,6 +208,18 @@ async fn authenticate_task(
         .filter(|value| !value.is_empty())
         .ok_or_else(|| Status::unauthenticated("login session is required"))?;
     let user = keystone.resolve_session(&token).await?;
+    install_authenticated_identity(task, context, token, user)
+}
+
+fn install_authenticated_identity(
+    task: &mut Task,
+    mut context: serde_json::Value,
+    token: String,
+    user: User,
+) -> Result<(), Status> {
+    let object = context
+        .as_object_mut()
+        .ok_or_else(|| Status::invalid_argument("Task.context_json must be a JSON object"))?;
     object.insert("user_id".to_string(), serde_json::json!(user.user_id));
     object.insert("username".to_string(), serde_json::json!(user.username));
     object.insert(
@@ -216,6 +229,9 @@ async fn authenticate_task(
     object.insert("roles".to_string(), serde_json::json!(user.roles));
     task.context_json =
         serde_json::to_string(&context).map_err(|error| Status::internal(error.to_string()))?;
+    // Never trust a caller-supplied typed value. Only the credential that was
+    // successfully resolved above may cross the Liaison -> Pilot boundary.
+    task.auth_session_token = token;
     Ok(())
 }
 
@@ -443,6 +459,7 @@ async fn drain_session_end(pipeline: &LiaisonPipeline, session_id: &str) {
         audio_data: vec![],
         context_json: r#"{"session_end":true}"#.to_string(),
         timestamp_ms: now_ms(),
+        auth_session_token: String::new(),
     };
     match pipeline.handle_intent(task).await {
         Ok(rx) => {
@@ -483,6 +500,7 @@ async fn run_text_loop(pipeline: Arc<LiaisonPipeline>) -> Result<()> {
             audio_data: vec![],
             context_json: String::new(),
             timestamp_ms: now_ms(),
+            auth_session_token: String::new(),
         };
 
         match pipeline.handle_intent(task).await {
@@ -880,6 +898,7 @@ mod tests {
             audio_data: vec![],
             context_json: String::new(),
             timestamp_ms: 0,
+            auth_session_token: String::new(),
         };
         ensure_user_id(&mut t);
         let v: serde_json::Value = serde_json::from_str(&t.context_json).unwrap();
@@ -898,6 +917,7 @@ mod tests {
             audio_data: vec![],
             context_json: r#"{"foo":"bar","user_id":"voice:alice"}"#.into(),
             timestamp_ms: 0,
+            auth_session_token: String::new(),
         };
         ensure_user_id(&mut t);
         let v: serde_json::Value = serde_json::from_str(&t.context_json).unwrap();
@@ -916,7 +936,33 @@ mod tests {
             audio_data: vec![],
             context_json: r#"{"user_id":"local:alice"}"#.into(),
             timestamp_ms: 0,
+            auth_session_token: String::new(),
         };
         assert_eq!(task_user_id(&t), "local:alice");
+    }
+
+    #[test]
+    fn authenticated_identity_overwrites_caller_claims_and_typed_secret() {
+        let mut task = Task {
+            context_json: r#"{"user_id":"forged","roles":["admin"]}"#.into(),
+            auth_session_token: "caller-supplied-secret".into(),
+            ..Default::default()
+        };
+        let context: serde_json::Value = serde_json::from_str(&task.context_json).unwrap();
+        let user = User {
+            user_id: "canonical-user".into(),
+            username: "canonical".into(),
+            display_name: "Canonical User".into(),
+            roles: vec!["user".into()],
+            ..Default::default()
+        };
+
+        install_authenticated_identity(&mut task, context, "validated-session".into(), user)
+            .unwrap();
+
+        let context: serde_json::Value = serde_json::from_str(&task.context_json).unwrap();
+        assert_eq!(context["user_id"], "canonical-user");
+        assert_eq!(context["roles"], serde_json::json!(["user"]));
+        assert_eq!(task.auth_session_token, "validated-session");
     }
 }

--- a/system/liaison/src/voice.rs
+++ b/system/liaison/src/voice.rs
@@ -302,6 +302,10 @@ async fn run_session(
     } else {
         None
     };
+    let auth_session_token = keystone_account
+        .as_ref()
+        .map(|_| req.session_token.clone())
+        .unwrap_or_default();
     // `record_seconds` is now a hard-stop ceiling on streaming capture
     // (FunASR's VAD ends the turn under most conditions; this just
     // protects against a sensor that never goes silent). 0 / unset →
@@ -500,6 +504,7 @@ async fn run_session(
         &principal,
         &audio_pcm,
         &req.context_json,
+        &auth_session_token,
     );
 
     let mut accumulated_text = String::new();
@@ -1158,6 +1163,7 @@ fn build_task(
     principal: &VoicePrincipal,
     audio_pcm: &[u8],
     extra_context_json: &str,
+    auth_session_token: &str,
 ) -> Task {
     let mut ctx: serde_json::Value = if extra_context_json.trim().is_empty() {
         serde_json::json!({})
@@ -1204,6 +1210,7 @@ fn build_task(
         audio_data: audio_pcm.to_vec(),
         context_json: ctx.to_string(),
         timestamp_ms: now_ms(),
+        auth_session_token: auth_session_token.to_string(),
     }
 }
 
@@ -1427,6 +1434,7 @@ mod tests {
             },
             &[],
             r#"{"foo":"bar"}"#,
+            "validated-session",
         );
         let v: serde_json::Value = serde_json::from_str(&task.context_json).unwrap();
         assert_eq!(v["user_id"], "user-alice");
@@ -1437,6 +1445,7 @@ mod tests {
         assert_eq!(v["access"]["allowed"], true);
         assert_eq!(v["access"]["method"], "voiceprint");
         assert_eq!(v["foo"], "bar");
+        assert_eq!(task.auth_session_token, "validated-session");
     }
 
     #[test]

--- a/system/pilot/src/memory.rs
+++ b/system/pilot/src/memory.rs
@@ -41,6 +41,7 @@ fn single_call_plan(plan_id: String, session_id: String, round: u32, call: Capab
             },
         ],
         root_index: 0,
+        auth_session_token: String::new(),
     }
 }
 

--- a/system/pilot/src/planner.rs
+++ b/system/pilot/src/planner.rs
@@ -140,6 +140,14 @@ fn task_modality(task: &Task) -> Option<String> {
         })
 }
 
+/// Build the user-visible Plan event without exposing the reusable Keystone
+/// credential carried by the internal Executor copy.
+fn public_plan(plan: &Plan) -> Plan {
+    let mut public = plan.clone();
+    public.auth_session_token.clear();
+    public
+}
+
 /// Skip vector memory prefetch for trivial chit-chat (saves latency and noise).
 fn skip_memory_prefetch(user_text: &str) -> bool {
     let t = user_text.trim();
@@ -1567,7 +1575,8 @@ pub async fn run_turn(
             continue 'supervisor;
         }
 
-        let graph = graph.expect("non-meta RTDL response must carry a graph");
+        let mut graph = graph.expect("non-meta RTDL response must carry a graph");
+        graph.auth_session_token = task.auth_session_token.clone();
 
         let calls = plan_call_count(&graph);
         let call_signatures = plan_call_signatures(&graph);
@@ -1712,7 +1721,7 @@ pub async fn run_turn(
         let _ = tx
             .send(Ok(service::pack(
                 &session_id,
-                PilotStreamBody::Plan(graph.clone()),
+                PilotStreamBody::Plan(public_plan(&graph)),
             )))
             .await;
         cancel_requested.extend(cancel_targets);
@@ -2081,6 +2090,7 @@ fn empty_sequence_plan(plan_id: String, session_id: String, round: u32) -> Plan 
             description: "recovery: no valid plan produced".to_string(),
         }],
         root_index: 0,
+        auth_session_token: String::new(),
     }
 }
 
@@ -2128,6 +2138,7 @@ fn expand_rtdl_to_plan(
         round,
         nodes,
         root_index,
+        auth_session_token: String::new(),
     })
 }
 
@@ -2812,7 +2823,7 @@ mod tests {
         extract_json_object, feed_results_into_history, format_plan_summary, invalid_cancel_target,
         is_control_only, is_legacy_plan_control_contract, mixes_control_inspection_with_action,
         parse_meta_plan_op, parse_rtdl_assistant_response, parse_task_update, plan_call_signatures,
-        rtdl_node_kind_name, rtdl_recovery_final_text, rtdl_state_name,
+        public_plan, rtdl_node_kind_name, rtdl_recovery_final_text, rtdl_state_name,
         should_replan_after_plan_done, skip_memory_prefetch, start_or_resume_task,
         task_is_session_end,
     };
@@ -3280,6 +3291,7 @@ mod tests {
             audio_data: Vec::new(),
             context_json: ctx.into(),
             timestamp_ms: 0,
+            auth_session_token: String::new(),
         }
     }
 
@@ -3303,6 +3315,16 @@ mod tests {
     }
 
     #[test]
+    fn public_plan_redacts_internal_auth_credential() {
+        let mut internal = single_do_plan("robonix/test/run");
+        internal.auth_session_token = "reusable-secret".into();
+
+        let public = public_plan(&internal);
+        assert!(public.auth_session_token.is_empty());
+        assert_eq!(internal.auth_session_token, "reusable-secret");
+    }
+
+    #[test]
     fn skip_prefetch_chitchat() {
         assert!(skip_memory_prefetch("hi"));
         assert!(skip_memory_prefetch("Hello"));
@@ -3320,6 +3342,7 @@ mod tests {
             session_id: "s".into(),
             round: 0,
             root_index: 0,
+            auth_session_token: String::new(),
             nodes: vec![RtdlNode {
                 node_kind: RTDL_DO,
                 children: vec![],

--- a/system/pilot/src/service.rs
+++ b/system/pilot/src/service.rs
@@ -590,6 +590,7 @@ mod tests {
             audio_data: Vec::new(),
             context_json: ctx.into(),
             timestamp_ms: 0,
+            auth_session_token: String::new(),
         }
     }
 

--- a/system/pilot/src/state_context.rs
+++ b/system/pilot/src/state_context.rs
@@ -91,6 +91,7 @@ async fn query_scene(
             description: "Read Scene spatial context before planning".into(),
         }],
         root_index: 0,
+        auth_session_token: String::new(),
     };
     let query = async {
         let mut stream = graph

--- a/system/sentinel/Cargo.toml
+++ b/system/sentinel/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "robonix-sentinel"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Robonix Sentinel capability-call policy core"
+
+[lib]
+name = "robonix_sentinel"
+path = "src/lib.rs"
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true

--- a/system/sentinel/README.md
+++ b/system/sentinel/README.md
@@ -1,36 +1,46 @@
-# Sentinel - safety supervision
+# Sentinel - capability-call policy
 
-Sentinel is the planned Robonix safety-supervision component. Its job is to
-decide whether a requested capability call is allowed under the current robot
-state, operator identity, scene context, and policy.
+Sentinel is the robot-wide policy engine served from the Executor process for
+the v0.1 runtime. It registers as its own Atlas provider, and Executor evaluates
+each capability call immediately before dispatch.
 
-## Current status
+Rules can match a contract wildcard, exact Keystone users or roles, local-time
+windows, typed call arguments, and typed robot context. The context is fetched
+by Sentinel from Soma, Vitals, and Scene; Client and Task metadata are never
+trusted as robot state. The highest-priority matching rule wins. Calls are
+allowed when no rule applies, while a candidate rule with missing, stale, or
+wrongly typed trusted data fails closed.
 
-Sentinel is not implemented on `dev` yet. There is no `robonix-sentinel`
-binary, no `system/executor/src/dispatch/sentinel.rs`, and no `sentinel.yaml`
-rule loader in Executor.
+Predicates use an RFC 6901 JSON Pointer and an explicit `boolean`, `string`,
+`integer`, or `float` type. Boolean and string predicates support `eq`/`ne`;
+numeric predicates additionally support `lt`/`le`/`gt`/`ge` and ranges with
+independently inclusive bounds. No string/number/boolean coercion is performed.
+For example, one deployment can define "left gripper is closed" using its
+actual calibrated Soma position interval rather than a Sentinel-wide
+`gripper_open` enum:
 
-Executor currently dispatches validated RTDL `do` nodes directly through Atlas
-to the selected primitive, service, or skill provider. The only safety-related
-controls in the current path are local to the components that already exist,
-for example:
+```json
+{
+  "path": "/soma/data/actuators/body~1arm~1left_piper~1gripper/position/value",
+  "kind": "float",
+  "operator": "range",
+  "min": 0.0,
+  "max": 0.01,
+  "min_inclusive": true,
+  "max_inclusive": true
+}
+```
 
-- Executor plan cancellation and stop points (`cancel_plan`, `stop_plan_at`,
-  `cancel_all_plans`).
-- Liaison access control for text/API users and voiceprint-verified speakers
-  before work enters Pilot/TTS.
-- Provider-side validation in individual primitives and services.
+The `~1` escape is the JSON Pointer representation of `/` inside a component
+ID. Argument predicates use the same schema but address the capability's
+`args_json` root directly.
 
-Do not rely on this directory for runtime enforcement today.
+Administrators manage the complete rule set through the Sentinel `list_rules`
+and `replace_rules` contracts. Executor verifies the supplied Keystone session
+before reading or replacing the robot-local policy file.
 
-## Intended role
+Run the policy-core tests with:
 
-When Sentinel lands, it should sit on the capability-call path before Executor
-dispatches side-effecting work. The policy decision should be based on:
-
-- the requested contract and arguments,
-- the operator identity and permissions from [keystone](../keystone/),
-- current robot/body health from [vitals](../vitals/),
-- current environment state from [scene](../scene/),
-- explicit safety policy such as allow/deny lists, rate limits, workspace
-  limits, stop windows, and emergency-stop state.
+```bash
+cargo test -p robonix-sentinel
+```

--- a/system/sentinel/src/lib.rs
+++ b/system/sentinel/src/lib.rs
@@ -1,0 +1,918 @@
+// SPDX-License-Identifier: MulanPSL-2.0
+
+//! Transport-independent policy evaluation for capability calls.
+
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use thiserror::Error;
+
+/// Effect applied when a rule matches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Effect {
+    Allow,
+    Deny,
+}
+
+/// Local-time window. Weekdays use ISO Monday=1 through Sunday=7.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TimeWindow {
+    #[serde(default)]
+    pub days: Vec<u8>,
+    pub start: String,
+    pub end: String,
+}
+
+/// The exact JSON type expected at a predicate path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ValueKind {
+    Boolean,
+    String,
+    Integer,
+    Float,
+}
+
+/// Operators supported by the deliberately small v0.1 predicate language.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Operator {
+    Eq,
+    Ne,
+    Lt,
+    Le,
+    Gt,
+    Ge,
+    Range,
+}
+
+const fn default_true() -> bool {
+    true
+}
+
+/// One typed comparison against an RFC 6901 JSON Pointer.
+///
+/// `range` uses `min` and `max`; every other operator uses `value`. Boolean and
+/// string predicates only accept `eq` and `ne`. No type coercion is performed.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Predicate {
+    pub path: String,
+    pub kind: ValueKind,
+    pub operator: Operator,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max: Option<Value>,
+    #[serde(default = "default_true")]
+    pub min_inclusive: bool,
+    #[serde(default = "default_true")]
+    pub max_inclusive: bool,
+}
+
+/// Conditions in one rule. Every configured category and predicate must match.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct Conditions {
+    /// Capability contract pattern. `*` is the only wildcard.
+    pub contract: String,
+    /// Exact Keystone user IDs. Empty means any user.
+    pub users: Vec<String>,
+    /// At least one exact Keystone role must match. Empty means any role.
+    pub roles: Vec<String>,
+    /// Any one time window may match. Empty means any time.
+    pub time: Vec<TimeWindow>,
+    /// Predicates over Executor-owned call arguments.
+    pub args: Vec<Predicate>,
+    /// Predicates over trusted robot snapshots collected by Sentinel.
+    pub context: Vec<Predicate>,
+}
+
+/// One robot-wide Sentinel policy rule.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Rule {
+    pub id: String,
+    pub effect: Effect,
+    #[serde(default)]
+    pub priority: i32,
+    #[serde(default)]
+    pub conditions: Conditions,
+    #[serde(default)]
+    pub reason: String,
+}
+
+/// Trusted inputs to a policy decision.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EvaluationContext {
+    /// Distinguishes a known anonymous/role-less identity from unavailable data.
+    pub identity_known: bool,
+    pub user_id: Option<String>,
+    pub roles: Vec<String>,
+    /// Root object populated by trusted Sentinel state adapters only.
+    pub state: Value,
+    pub weekday: u8,
+    pub minute_of_day: u16,
+}
+
+impl Default for EvaluationContext {
+    fn default() -> Self {
+        Self {
+            identity_known: false,
+            user_id: None,
+            roles: Vec::new(),
+            state: Value::Object(Default::default()),
+            weekday: 0,
+            minute_of_day: 0,
+        }
+    }
+}
+
+/// Result of checking one capability call.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Decision {
+    pub allow: bool,
+    pub indeterminate: bool,
+    pub rule_id: String,
+    pub reason: String,
+}
+
+/// Invalid rule-set errors returned before rules become active.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum RuleError {
+    #[error("rule ID must not be empty")]
+    EmptyRuleId,
+    #[error("duplicate rule ID '{0}'")]
+    DuplicateRuleId(String),
+    #[error("weekday must be between 1 and 7, got {0}")]
+    InvalidWeekday(u8),
+    #[error("invalid time '{0}', expected HH:MM")]
+    InvalidTime(String),
+    #[error("time window start and end must differ")]
+    EmptyTimeWindow,
+    #[error("invalid predicate path '{0}', expected an RFC 6901 JSON Pointer")]
+    InvalidPredicatePath(String),
+    #[error("operator '{operator:?}' is invalid for {kind:?} predicate '{path}'")]
+    InvalidPredicateOperator {
+        path: String,
+        kind: ValueKind,
+        operator: Operator,
+    },
+    #[error("predicate '{path}' has an invalid {field}; expected {kind:?}")]
+    InvalidPredicateValue {
+        path: String,
+        field: &'static str,
+        kind: ValueKind,
+    },
+    #[error("predicate '{0}' must use value or min/max exclusively")]
+    InvalidPredicateShape(String),
+    #[error("predicate '{0}' has an empty or reversed range")]
+    InvalidPredicateRange(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum MatchOutcome {
+    Match,
+    NoMatch,
+    Indeterminate(String),
+}
+
+/// Ordered in-memory Sentinel rule set.
+#[derive(Debug, Clone, Default)]
+pub struct Sentinel {
+    rules: Vec<Rule>,
+}
+
+impl Sentinel {
+    /// Construct Sentinel with a validated initial rule set.
+    pub fn new(rules: Vec<Rule>) -> Result<Self, RuleError> {
+        validate_rules(&rules)?;
+        Ok(Self { rules })
+    }
+
+    /// Return active rules in their configured order.
+    pub fn list_rules(&self) -> &[Rule] {
+        &self.rules
+    }
+
+    /// Atomically replace all active rules after validating every entry.
+    pub fn set_rules(&mut self, rules: Vec<Rule>) -> Result<(), RuleError> {
+        validate_rules(&rules)?;
+        self.rules = rules;
+        Ok(())
+    }
+
+    /// Return trusted snapshot roots referenced by active rules.
+    pub fn required_context_roots(&self) -> BTreeSet<String> {
+        self.rules
+            .iter()
+            .flat_map(|rule| &rule.conditions.context)
+            .filter_map(|predicate| {
+                predicate
+                    .path
+                    .strip_prefix('/')
+                    .and_then(|rest| rest.split('/').next())
+                    .filter(|root| !root.is_empty())
+                    .map(str::to_owned)
+            })
+            .collect()
+    }
+
+    /// Evaluate a call. Highest priority wins; configured order breaks ties.
+    ///
+    /// Sentinel is an overlay policy and therefore allows calls for which no
+    /// rule applies. A candidate rule whose trusted inputs are unavailable is
+    /// fail-closed and produces an indeterminate denial.
+    pub fn check(
+        &self,
+        contract_id: &str,
+        args_json: &Value,
+        context: &EvaluationContext,
+    ) -> Decision {
+        let selected = self
+            .rules
+            .iter()
+            .filter_map(
+                |rule| match rule_matches(rule, contract_id, args_json, context) {
+                    MatchOutcome::NoMatch => None,
+                    outcome => Some((rule, outcome)),
+                },
+            )
+            .fold(
+                None,
+                |selected: Option<(&Rule, MatchOutcome)>, candidate| match selected {
+                    Some((current, _)) if current.priority >= candidate.0.priority => selected,
+                    _ => Some(candidate),
+                },
+            );
+
+        let Some((rule, outcome)) = selected else {
+            return Decision {
+                allow: true,
+                indeterminate: false,
+                rule_id: String::new(),
+                reason: "no Sentinel rule matched".to_owned(),
+            };
+        };
+        if let MatchOutcome::Indeterminate(reason) = outcome {
+            return Decision {
+                allow: false,
+                indeterminate: true,
+                rule_id: rule.id.clone(),
+                reason: format!(
+                    "Sentinel rule '{}' could not be evaluated: {reason}",
+                    rule.id
+                ),
+            };
+        }
+
+        let allow = rule.effect == Effect::Allow;
+        Decision {
+            allow,
+            indeterminate: false,
+            rule_id: rule.id.clone(),
+            reason: if rule.reason.trim().is_empty() {
+                format!(
+                    "{} by Sentinel rule '{}'",
+                    if allow { "allowed" } else { "denied" },
+                    rule.id
+                )
+            } else {
+                rule.reason.clone()
+            },
+        }
+    }
+}
+
+/// Validate all rules before a replacement becomes visible to dispatch.
+fn validate_rules(rules: &[Rule]) -> Result<(), RuleError> {
+    let mut ids = BTreeSet::new();
+    for rule in rules {
+        if rule.id.trim().is_empty() {
+            return Err(RuleError::EmptyRuleId);
+        }
+        if !ids.insert(rule.id.as_str()) {
+            return Err(RuleError::DuplicateRuleId(rule.id.clone()));
+        }
+        for window in &rule.conditions.time {
+            validate_time_window(window)?;
+        }
+        for predicate in rule.conditions.args.iter().chain(&rule.conditions.context) {
+            validate_predicate(predicate)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_predicate(predicate: &Predicate) -> Result<(), RuleError> {
+    if predicate.path.is_empty()
+        || !predicate.path.starts_with('/')
+        || predicate.path.contains("//")
+    {
+        return Err(RuleError::InvalidPredicatePath(predicate.path.clone()));
+    }
+    if matches!(predicate.kind, ValueKind::Boolean | ValueKind::String)
+        && !matches!(predicate.operator, Operator::Eq | Operator::Ne)
+    {
+        return Err(RuleError::InvalidPredicateOperator {
+            path: predicate.path.clone(),
+            kind: predicate.kind,
+            operator: predicate.operator,
+        });
+    }
+
+    if predicate.operator == Operator::Range {
+        if predicate.value.is_some() || predicate.min.is_none() || predicate.max.is_none() {
+            return Err(RuleError::InvalidPredicateShape(predicate.path.clone()));
+        }
+        validate_typed_value(predicate, predicate.min.as_ref(), "min")?;
+        validate_typed_value(predicate, predicate.max.as_ref(), "max")?;
+        if !range_is_nonempty(predicate) {
+            return Err(RuleError::InvalidPredicateRange(predicate.path.clone()));
+        }
+    } else {
+        if predicate.value.is_none() || predicate.min.is_some() || predicate.max.is_some() {
+            return Err(RuleError::InvalidPredicateShape(predicate.path.clone()));
+        }
+        validate_typed_value(predicate, predicate.value.as_ref(), "value")?;
+    }
+    Ok(())
+}
+
+fn validate_typed_value(
+    predicate: &Predicate,
+    value: Option<&Value>,
+    field: &'static str,
+) -> Result<(), RuleError> {
+    if value.is_some_and(|value| expected_matches_kind(value, predicate.kind)) {
+        Ok(())
+    } else {
+        Err(RuleError::InvalidPredicateValue {
+            path: predicate.path.clone(),
+            field,
+            kind: predicate.kind,
+        })
+    }
+}
+
+fn expected_matches_kind(value: &Value, kind: ValueKind) -> bool {
+    match kind {
+        // `kind` supplies the numeric semantic type. JSON writers are allowed
+        // to serialize an integral float bound as `1` rather than `1.0`.
+        ValueKind::Float => value.is_number(),
+        _ => value_matches_kind(value, kind),
+    }
+}
+
+fn value_matches_kind(value: &Value, kind: ValueKind) -> bool {
+    match kind {
+        ValueKind::Boolean => value.is_boolean(),
+        ValueKind::String => value.is_string(),
+        ValueKind::Integer => value.as_i64().is_some(),
+        ValueKind::Float => {
+            value.as_f64().is_some() && value.as_i64().is_none() && value.as_u64().is_none()
+        }
+    }
+}
+
+fn range_is_nonempty(predicate: &Predicate) -> bool {
+    let order = match predicate.kind {
+        ValueKind::Integer => predicate
+            .min
+            .as_ref()
+            .and_then(Value::as_i64)
+            .zip(predicate.max.as_ref().and_then(Value::as_i64))
+            .map(|(min, max)| min.partial_cmp(&max)),
+        ValueKind::Float => predicate
+            .min
+            .as_ref()
+            .and_then(Value::as_f64)
+            .zip(predicate.max.as_ref().and_then(Value::as_f64))
+            .map(|(min, max)| min.partial_cmp(&max)),
+        _ => None,
+    }
+    .flatten();
+    match order {
+        Some(std::cmp::Ordering::Less) => true,
+        Some(std::cmp::Ordering::Equal) => predicate.min_inclusive && predicate.max_inclusive,
+        _ => false,
+    }
+}
+
+/// Return whether every configured condition matches the current call.
+fn rule_matches(
+    rule: &Rule,
+    contract_id: &str,
+    args_json: &Value,
+    context: &EvaluationContext,
+) -> MatchOutcome {
+    let conditions = &rule.conditions;
+    let mut outcomes = vec![if conditions.contract.trim().is_empty()
+        || wildcard_matches(&conditions.contract, contract_id)
+    {
+        MatchOutcome::Match
+    } else {
+        MatchOutcome::NoMatch
+    }];
+
+    outcomes.push(identity_matches(conditions, context));
+    outcomes.push(
+        if conditions.time.is_empty()
+            || conditions
+                .time
+                .iter()
+                .any(|window| time_matches(window, context.weekday, context.minute_of_day))
+        {
+            MatchOutcome::Match
+        } else {
+            MatchOutcome::NoMatch
+        },
+    );
+    outcomes.extend(
+        conditions
+            .args
+            .iter()
+            .map(|predicate| predicate_matches(predicate, args_json, "argument")),
+    );
+    outcomes.extend(
+        conditions
+            .context
+            .iter()
+            .map(|predicate| predicate_matches(predicate, &context.state, "context")),
+    );
+
+    combine_outcomes(outcomes)
+}
+
+fn identity_matches(conditions: &Conditions, context: &EvaluationContext) -> MatchOutcome {
+    if conditions.users.is_empty() && conditions.roles.is_empty() {
+        return MatchOutcome::Match;
+    }
+    if !context.identity_known {
+        return MatchOutcome::Indeterminate("Keystone identity is unavailable".to_owned());
+    }
+    if !conditions.users.is_empty()
+        && !context
+            .user_id
+            .as_ref()
+            .is_some_and(|user| conditions.users.contains(user))
+    {
+        return MatchOutcome::NoMatch;
+    }
+    if !conditions.roles.is_empty()
+        && !context
+            .roles
+            .iter()
+            .any(|role| conditions.roles.contains(role))
+    {
+        return MatchOutcome::NoMatch;
+    }
+    MatchOutcome::Match
+}
+
+fn combine_outcomes(outcomes: Vec<MatchOutcome>) -> MatchOutcome {
+    let mut indeterminate = None;
+    for outcome in outcomes {
+        match outcome {
+            MatchOutcome::NoMatch => return MatchOutcome::NoMatch,
+            MatchOutcome::Indeterminate(reason) if indeterminate.is_none() => {
+                indeterminate = Some(reason);
+            }
+            MatchOutcome::Match | MatchOutcome::Indeterminate(_) => {}
+        }
+    }
+    indeterminate.map_or(MatchOutcome::Match, MatchOutcome::Indeterminate)
+}
+
+fn predicate_matches(predicate: &Predicate, root: &Value, source: &str) -> MatchOutcome {
+    let Some(actual) = root.pointer(&predicate.path) else {
+        return MatchOutcome::Indeterminate(format!(
+            "{source} path '{}' is unavailable",
+            predicate.path
+        ));
+    };
+    if !value_matches_kind(actual, predicate.kind) {
+        return MatchOutcome::Indeterminate(format!(
+            "{source} path '{}' is not a {:?}",
+            predicate.path, predicate.kind
+        ));
+    }
+    if compare_predicate(predicate, actual) {
+        MatchOutcome::Match
+    } else {
+        MatchOutcome::NoMatch
+    }
+}
+
+fn compare_predicate(predicate: &Predicate, actual: &Value) -> bool {
+    if predicate.operator == Operator::Range {
+        return match predicate.kind {
+            ValueKind::Integer => in_range(
+                actual.as_i64().unwrap(),
+                predicate.min.as_ref().and_then(Value::as_i64).unwrap(),
+                predicate.max.as_ref().and_then(Value::as_i64).unwrap(),
+                predicate.min_inclusive,
+                predicate.max_inclusive,
+            ),
+            ValueKind::Float => in_range(
+                actual.as_f64().unwrap(),
+                predicate.min.as_ref().and_then(Value::as_f64).unwrap(),
+                predicate.max.as_ref().and_then(Value::as_f64).unwrap(),
+                predicate.min_inclusive,
+                predicate.max_inclusive,
+            ),
+            _ => false,
+        };
+    }
+
+    let expected = predicate.value.as_ref().unwrap();
+    match predicate.kind {
+        ValueKind::Boolean => compare_ordered(
+            actual.as_bool().unwrap(),
+            expected.as_bool().unwrap(),
+            predicate.operator,
+        ),
+        ValueKind::String => compare_ordered(
+            actual.as_str().unwrap(),
+            expected.as_str().unwrap(),
+            predicate.operator,
+        ),
+        ValueKind::Integer => compare_ordered(
+            actual.as_i64().unwrap(),
+            expected.as_i64().unwrap(),
+            predicate.operator,
+        ),
+        ValueKind::Float => compare_ordered(
+            actual.as_f64().unwrap(),
+            expected.as_f64().unwrap(),
+            predicate.operator,
+        ),
+    }
+}
+
+fn compare_ordered<T: PartialOrd + PartialEq>(actual: T, expected: T, operator: Operator) -> bool {
+    match operator {
+        Operator::Eq => actual == expected,
+        Operator::Ne => actual != expected,
+        Operator::Lt => actual < expected,
+        Operator::Le => actual <= expected,
+        Operator::Gt => actual > expected,
+        Operator::Ge => actual >= expected,
+        Operator::Range => false,
+    }
+}
+
+fn in_range<T: PartialOrd>(
+    actual: T,
+    min: T,
+    max: T,
+    min_inclusive: bool,
+    max_inclusive: bool,
+) -> bool {
+    (if min_inclusive {
+        actual >= min
+    } else {
+        actual > min
+    }) && (if max_inclusive {
+        actual <= max
+    } else {
+        actual < max
+    })
+}
+
+/// Match `*` wildcards without treating any other character specially.
+fn wildcard_matches(pattern: &str, value: &str) -> bool {
+    let (mut pattern_index, mut value_index) = (0usize, 0usize);
+    let (mut star_index, mut star_value_index) = (None, 0usize);
+    let pattern = pattern.as_bytes();
+    let value = value.as_bytes();
+    while value_index < value.len() {
+        if pattern_index < pattern.len() && pattern[pattern_index] == value[value_index] {
+            pattern_index += 1;
+            value_index += 1;
+        } else if pattern_index < pattern.len() && pattern[pattern_index] == b'*' {
+            star_index = Some(pattern_index);
+            pattern_index += 1;
+            star_value_index = value_index;
+        } else if let Some(star) = star_index {
+            pattern_index = star + 1;
+            star_value_index += 1;
+            value_index = star_value_index;
+        } else {
+            return false;
+        }
+    }
+    while pattern_index < pattern.len() && pattern[pattern_index] == b'*' {
+        pattern_index += 1;
+    }
+    pattern_index == pattern.len()
+}
+
+fn validate_time_window(window: &TimeWindow) -> Result<(), RuleError> {
+    for day in &window.days {
+        if !(1..=7).contains(day) {
+            return Err(RuleError::InvalidWeekday(*day));
+        }
+    }
+    let start = parse_time(&window.start)?;
+    let end = parse_time(&window.end)?;
+    if start == end {
+        return Err(RuleError::EmptyTimeWindow);
+    }
+    Ok(())
+}
+
+/// Match a local time window, including windows that cross midnight.
+fn time_matches(window: &TimeWindow, weekday: u8, minute_of_day: u16) -> bool {
+    if !(1..=7).contains(&weekday) || minute_of_day >= 24 * 60 {
+        return false;
+    }
+    let (Ok(start), Ok(end)) = (parse_time(&window.start), parse_time(&window.end)) else {
+        return false;
+    };
+    if start < end {
+        day_matches(&window.days, weekday) && (start..end).contains(&minute_of_day)
+    } else if minute_of_day >= start {
+        day_matches(&window.days, weekday)
+    } else if minute_of_day < end {
+        day_matches(&window.days, if weekday == 1 { 7 } else { weekday - 1 })
+    } else {
+        false
+    }
+}
+
+fn day_matches(days: &[u8], weekday: u8) -> bool {
+    days.is_empty() || days.contains(&weekday)
+}
+
+fn parse_time(value: &str) -> Result<u16, RuleError> {
+    let Some((hour, minute)) = value.split_once(':') else {
+        return Err(RuleError::InvalidTime(value.to_owned()));
+    };
+    if hour.len() != 2 || minute.len() != 2 {
+        return Err(RuleError::InvalidTime(value.to_owned()));
+    }
+    let (Ok(hour), Ok(minute)) = (hour.parse::<u16>(), minute.parse::<u16>()) else {
+        return Err(RuleError::InvalidTime(value.to_owned()));
+    };
+    if hour >= 24 || minute >= 60 {
+        return Err(RuleError::InvalidTime(value.to_owned()));
+    }
+    Ok(hour * 60 + minute)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn rule(id: &str, effect: Effect, priority: i32, conditions: Conditions) -> Rule {
+        Rule {
+            id: id.to_owned(),
+            effect,
+            priority,
+            conditions,
+            reason: format!("matched {id}"),
+        }
+    }
+
+    fn predicate(path: &str, kind: ValueKind, operator: Operator, value: Value) -> Predicate {
+        Predicate {
+            path: path.to_owned(),
+            kind,
+            operator,
+            value: Some(value),
+            min: None,
+            max: None,
+            min_inclusive: true,
+            max_inclusive: true,
+        }
+    }
+
+    fn range(path: &str, kind: ValueKind, min: Value, max: Value) -> Predicate {
+        Predicate {
+            path: path.to_owned(),
+            kind,
+            operator: Operator::Range,
+            value: None,
+            min: Some(min),
+            max: Some(max),
+            min_inclusive: true,
+            max_inclusive: true,
+        }
+    }
+
+    fn known_context(state: Value) -> EvaluationContext {
+        EvaluationContext {
+            identity_known: true,
+            user_id: Some("u1".to_owned()),
+            roles: vec!["user".to_owned()],
+            state,
+            weekday: 1,
+            minute_of_day: 12 * 60,
+        }
+    }
+
+    #[test]
+    fn contract_and_role_rule_denies_matching_call() {
+        let sentinel = Sentinel::new(vec![rule(
+            "deny-guest-motion",
+            Effect::Deny,
+            10,
+            Conditions {
+                contract: "robonix/*/navigation/*".to_owned(),
+                roles: vec!["guest".to_owned()],
+                ..Conditions::default()
+            },
+        )])
+        .unwrap();
+        let mut context = known_context(json!({}));
+        context.roles = vec!["guest".to_owned()];
+
+        let decision = sentinel.check("robonix/service/navigation/navigate", &json!({}), &context);
+
+        assert!(!decision.allow);
+        assert!(!decision.indeterminate);
+        assert_eq!(decision.rule_id, "deny-guest-motion");
+    }
+
+    #[test]
+    fn boolean_false_is_a_real_condition_not_missing_state() {
+        let sentinel = Sentinel::new(vec![rule(
+            "deny-when-motion-disabled",
+            Effect::Deny,
+            10,
+            Conditions {
+                context: vec![predicate(
+                    "/soma/safety/motion_allowed",
+                    ValueKind::Boolean,
+                    Operator::Eq,
+                    json!(false),
+                )],
+                ..Conditions::default()
+            },
+        )])
+        .unwrap();
+
+        let decision = sentinel.check(
+            "navigate",
+            &json!({}),
+            &known_context(json!({"soma":{"safety":{"motion_allowed":false}}})),
+        );
+
+        assert!(!decision.allow);
+        assert!(!decision.indeterminate);
+    }
+
+    #[test]
+    fn integer_and_float_ranges_are_strictly_typed() {
+        let sentinel = Sentinel::new(vec![rule(
+            "deny-risk-envelope",
+            Effect::Deny,
+            10,
+            Conditions {
+                args: vec![range(
+                    "/waypoints",
+                    ValueKind::Integer,
+                    json!(33),
+                    json!(64),
+                )],
+                context: vec![range(
+                    "/soma/grippers/left/position_m",
+                    ValueKind::Float,
+                    json!(0.0),
+                    json!(0.01),
+                )],
+                ..Conditions::default()
+            },
+        )])
+        .unwrap();
+        let context = known_context(json!({
+            "soma":{"grippers":{"left":{"position_m":0.005}}}
+        }));
+
+        assert!(
+            !sentinel
+                .check("trajectory", &json!({"waypoints":40}), &context)
+                .allow
+        );
+        assert!(
+            sentinel
+                .check("trajectory", &json!({"waypoints":10}), &context)
+                .allow
+        );
+    }
+
+    #[test]
+    fn explicit_float_kind_accepts_integral_json_bounds_from_web_clients() {
+        let sentinel = Sentinel::new(vec![rule(
+            "float-range",
+            Effect::Deny,
+            10,
+            Conditions {
+                context: vec![range("/temperature", ValueKind::Float, json!(0), json!(1))],
+                ..Conditions::default()
+            },
+        )])
+        .unwrap();
+
+        assert!(
+            !sentinel
+                .check(
+                    "thermal",
+                    &json!({}),
+                    &known_context(json!({"temperature":0.5})),
+                )
+                .allow
+        );
+        assert!(
+            sentinel
+                .check(
+                    "thermal",
+                    &json!({}),
+                    &known_context(json!({"temperature":0})),
+                )
+                .indeterminate
+        );
+    }
+
+    #[test]
+    fn missing_or_wrongly_typed_candidate_context_fails_closed() {
+        let sentinel = Sentinel::new(vec![rule(
+            "deny-closed-gripper-operation",
+            Effect::Deny,
+            10,
+            Conditions {
+                contract: "gripper/*".to_owned(),
+                context: vec![range(
+                    "/soma/grippers/left/position_m",
+                    ValueKind::Float,
+                    json!(0.0),
+                    json!(0.01),
+                )],
+                ..Conditions::default()
+            },
+        )])
+        .unwrap();
+
+        for state in [
+            json!({}),
+            json!({"soma":{"grippers":{"left":{"position_m":"closed"}}}}),
+        ] {
+            let decision = sentinel.check("gripper/move", &json!({}), &known_context(state));
+            assert!(!decision.allow);
+            assert!(decision.indeterminate);
+        }
+        assert!(
+            sentinel
+                .check("navigation/move", &json!({}), &known_context(json!({})))
+                .allow
+        );
+    }
+
+    #[test]
+    fn higher_priority_allow_overrides_general_deny() {
+        let sentinel = Sentinel::new(vec![
+            rule("deny", Effect::Deny, 10, Conditions::default()),
+            rule("allow-admin", Effect::Allow, 20, Conditions::default()),
+        ])
+        .unwrap();
+
+        assert!(
+            sentinel
+                .check("any", &json!({}), &known_context(json!({})))
+                .allow
+        );
+    }
+
+    #[test]
+    fn invalid_replacement_leaves_existing_rules_active() {
+        let mut sentinel = Sentinel::new(vec![rule(
+            "existing",
+            Effect::Deny,
+            1,
+            Conditions::default(),
+        )])
+        .unwrap();
+        let invalid = rule(
+            "invalid",
+            Effect::Allow,
+            2,
+            Conditions {
+                context: vec![predicate(
+                    "not-a-pointer",
+                    ValueKind::Boolean,
+                    Operator::Eq,
+                    json!(true),
+                )],
+                ..Conditions::default()
+            },
+        );
+
+        assert!(sentinel.set_rules(vec![invalid]).is_err());
+        assert_eq!(sentinel.list_rules()[0].id, "existing");
+    }
+}

--- a/tools/rbnx/src/cmd/ask.rs
+++ b/tools/rbnx/src/cmd/ask.rs
@@ -57,6 +57,7 @@ pub async fn execute(server: &str, prompt: &str, json: bool) -> Result<()> {
         audio_data: vec![],
         context_json: String::new(),
         timestamp_ms: now_ms(),
+        auth_session_token: String::new(),
     };
     let mut stream = client
         .submit_task(Request::new(task))

--- a/tools/rbnx/src/cmd/chat.rs
+++ b/tools/rbnx/src/cmd/chat.rs
@@ -1693,6 +1693,7 @@ fn build_text_task(session_id: &str, user_id: &str, text: &str) -> crate::pb::pi
         })
         .to_string(),
         timestamp_ms: now_ms(),
+        auth_session_token: String::new(),
     }
 }
 
@@ -1718,6 +1719,7 @@ fn build_control_task(
         audio_data: vec![],
         context_json: ctx.to_string(),
         timestamp_ms: now_ms(),
+        auth_session_token: String::new(),
     }
 }
 

--- a/tools/rbnx/src/cmd/deploy.rs
+++ b/tools/rbnx/src/cmd/deploy.rs
@@ -64,6 +64,7 @@ const DRIVER_REGISTER_TIMEOUT: Duration = Duration::from_secs(60);
 // exceed 90s on a cold self-hosted runner.
 const DEFAULT_DRIVER_INIT_TIMEOUT: Duration = Duration::from_secs(90);
 const DEPLOY_CONSUMER_ID: &str = "rbnx-cli/deploy";
+const DEFAULT_EXECUTOR_LISTEN: &str = "127.0.0.1:50061";
 
 fn driver_init_timeout() -> Duration {
     std::env::var("ROBONIX_DRIVER_INIT_TIMEOUT_S")
@@ -251,6 +252,174 @@ keystone_endpoint: 127.0.0.1:50095
             .map(|pair| pair[1].as_str());
 
         assert_eq!(endpoint, Some("127.0.0.1:50095"));
+    }
+
+    #[test]
+    fn executor_receives_sentinel_deployment_config_without_flattening() {
+        let cfg: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+listen: 127.0.0.1:50061
+sentinel_listen: 0.0.0.0:50062
+sentinel_rules: /home/robot/.robonix/data/sentinel-rules.json
+sentinel_rules_seed: /opt/robonix/examples/webots/sentinel-rules.v1.json
+"#,
+        )
+        .expect("executor config");
+
+        let args = system_cli_args("executor", Some(&cfg), Some("0.0.0.0:50051"));
+        let config_json = args
+            .windows(2)
+            .find(|pair| pair[0] == "--config-json")
+            .map(|pair| pair[1].as_str())
+            .expect("--config-json");
+        let forwarded: serde_json::Value =
+            serde_json::from_str(config_json).expect("forwarded Executor config JSON");
+
+        assert_eq!(forwarded["listen"], "127.0.0.1:50061");
+        assert_eq!(forwarded["sentinel_listen"], "0.0.0.0:50062");
+        assert_eq!(
+            forwarded["sentinel_rules"],
+            "/home/robot/.robonix/data/sentinel-rules.json"
+        );
+        assert_eq!(
+            forwarded["sentinel_rules_seed"],
+            "/opt/robonix/examples/webots/sentinel-rules.v1.json"
+        );
+        assert_eq!(
+            system_listens("executor", Some(&cfg))
+                .expect("Executor listen plan")
+                .into_iter()
+                .map(|listen| listen.address)
+                .collect::<Vec<_>>(),
+            ["127.0.0.1:50061", "0.0.0.0:50062"]
+        );
+    }
+
+    #[test]
+    fn executor_preflight_includes_derived_sentinel_listen() {
+        let cfg: serde_yaml::Value =
+            serde_yaml::from_str("listen: 127.0.0.1:51061").expect("executor config");
+
+        let listens = system_listens("executor", Some(&cfg)).expect("Executor listen plan");
+        assert_eq!(listens[0].field, "listen");
+        assert_eq!(listens[0].address, "127.0.0.1:51061");
+        assert_eq!(listens[1].field, "sentinel_listen (derived)");
+        assert_eq!(listens[1].address, "127.0.0.1:51062");
+    }
+
+    #[test]
+    fn executor_preflight_rejects_adjacent_port_overflow() {
+        let cfg: serde_yaml::Value =
+            serde_yaml::from_str("listen: 127.0.0.1:65535").expect("executor config");
+
+        let error = system_listens("executor", Some(&cfg)).expect_err("port overflow");
+        assert!(error.to_string().contains("port 65535"), "{error:#}");
+    }
+
+    #[test]
+    fn executor_preflight_rejects_explicit_listen_collision() {
+        let executor: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+listen: 127.0.0.1:50061
+sentinel_listen: 0.0.0.0:50061
+"#,
+        )
+        .expect("executor config");
+        let deploy = DeployManifest {
+            system: HashMap::from([("executor".to_owned(), executor)]),
+            ..Default::default()
+        };
+
+        let error = validate_system_listen_plan(&deploy).expect_err("explicit collision");
+        assert!(error.to_string().contains("sentinel_listen"), "{error:#}");
+        assert!(error.to_string().contains("conflicts"), "{error:#}");
+    }
+
+    #[test]
+    fn executor_preflight_rejects_exact_duplicate_listens() {
+        let executor: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+listen: 127.0.0.1:50061
+sentinel_listen: 127.0.0.1:50061
+"#,
+        )
+        .expect("executor config");
+        let deploy = DeployManifest {
+            system: HashMap::from([("executor".to_owned(), executor)]),
+            ..Default::default()
+        };
+
+        let error = validate_system_listen_plan(&deploy).expect_err("duplicate listen");
+        assert!(error.to_string().contains("sentinel_listen"), "{error:#}");
+        assert!(error.to_string().contains("127.0.0.1:50061"), "{error:#}");
+    }
+
+    #[test]
+    fn executor_preflight_rejects_derived_cross_system_collision() {
+        let atlas: serde_yaml::Value =
+            serde_yaml::from_str("listen: 0.0.0.0:50062").expect("atlas config");
+        let executor: serde_yaml::Value =
+            serde_yaml::from_str("listen: 127.0.0.1:50061").expect("executor config");
+        let deploy = DeployManifest {
+            system: HashMap::from([
+                ("atlas".to_owned(), atlas),
+                ("executor".to_owned(), executor),
+            ]),
+            ..Default::default()
+        };
+
+        let error = validate_system_listen_plan(&deploy).expect_err("derived collision");
+        assert!(
+            error.to_string().contains("sentinel_listen (derived)"),
+            "{error:#}"
+        );
+        assert!(
+            error.to_string().contains("system/atlas.listen"),
+            "{error:#}"
+        );
+    }
+
+    #[test]
+    fn fresh_webots_sentinel_manifest_resolves_versioned_seed_and_forwards_it() {
+        let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../examples/webots")
+            .canonicalize()
+            .expect("Webots example directory");
+        let manifest_path = manifest_dir.join("robonix_manifest.sentinel-demo.yaml");
+        let raw = std::fs::read_to_string(&manifest_path).expect("Sentinel demo manifest");
+        let root: serde_yaml::Value = serde_yaml::from_str(&raw).expect("parse demo manifest");
+        let root = prepare_manifest(root, None).expect("prepare demo manifest");
+        let mut deploy: DeployManifest =
+            serde_yaml::from_value(root).expect("decode demo manifest");
+
+        resolve_executor_rule_paths(&mut deploy.system, &manifest_dir);
+        let cfg = deploy.system.get("executor").expect("Executor block");
+        let args = system_cli_args("executor", Some(cfg), Some("0.0.0.0:50051"));
+        let config_json = args
+            .windows(2)
+            .find(|pair| pair[0] == "--config-json")
+            .map(|pair| pair[1].as_str())
+            .expect("--config-json");
+        let forwarded: serde_json::Value =
+            serde_json::from_str(config_json).expect("forwarded Executor config JSON");
+        let expected_seed = manifest_dir.join("sentinel-rules.v1.json");
+        let expected_rules = PathBuf::from(std::env::var_os("HOME").expect("HOME"))
+            .join(".robonix/data/sentinel-rules.json");
+
+        assert_eq!(forwarded["listen"], "127.0.0.1:50061");
+        assert_eq!(forwarded["sentinel_listen"], "0.0.0.0:50062");
+        assert_eq!(
+            forwarded["sentinel_rules"].as_str(),
+            Some(expected_rules.to_string_lossy().as_ref())
+        );
+        assert_eq!(
+            forwarded["sentinel_rules_seed"].as_str(),
+            Some(expected_seed.to_string_lossy().as_ref())
+        );
+        assert!(
+            expected_seed.is_file(),
+            "versioned seed must ship with demo"
+        );
     }
 }
 
@@ -505,6 +674,41 @@ fn ensure_soma_defaults(
         }
         let joined = manifest_dir.join(p);
         *v = Value::String(joined.to_string_lossy().into_owned());
+    }
+}
+
+/// Resolve Executor-owned rule paths relative to the selected deployment.
+///
+/// The active policy normally lives at an absolute robot-local data path, while
+/// a versioned first-run seed can live beside the manifest. Resolve both keys
+/// consistently before forwarding the untouched config block to Executor.
+fn resolve_executor_rule_paths(
+    system: &mut HashMap<String, serde_yaml::Value>,
+    manifest_dir: &Path,
+) {
+    let Some(executor) = system
+        .get_mut("executor")
+        .and_then(serde_yaml::Value::as_mapping_mut)
+    else {
+        return;
+    };
+    for key in ["sentinel_rules", "sentinel_rules_seed"] {
+        let yaml_key = serde_yaml::Value::String(key.to_owned());
+        let Some(path) = executor
+            .get(&yaml_key)
+            .and_then(serde_yaml::Value::as_str)
+            .map(str::trim)
+            .filter(|path| !path.is_empty())
+            .map(PathBuf::from)
+        else {
+            continue;
+        };
+        if path.is_relative() {
+            executor.insert(
+                yaml_key,
+                serde_yaml::Value::String(manifest_dir.join(path).to_string_lossy().into_owned()),
+            );
+        }
     }
 }
 
@@ -997,6 +1201,10 @@ pub async fn execute(
     if (soma_declared || soma_implied) && !skip_system {
         ensure_soma_defaults(&mut deploy.system, &manifest_dir, &manifest_path);
     }
+    if !skip_system {
+        resolve_executor_rule_paths(&mut deploy.system, &manifest_dir);
+        validate_system_listen_plan(&deploy).context("invalid system listen plan")?;
+    }
 
     let log_dir = log_dir.unwrap_or_else(|| manifest_dir.join("rbnx-boot").join("logs"));
     // The CLI prepares and clears this directory before Scribe's first log
@@ -1154,21 +1362,24 @@ pub async fn execute(
                 // run). The fallout is mysterious: register_capability hits an
                 // atlas that doesn't have your takeover/state-push fixes,
                 // endpoints route to dead orphan gRPC servers, …
-                if let Some(listen) = system_listen(name, deploy.system.get(*name))
-                    && let Err(e) = port_is_free(&listen)
-                {
-                    output::boot_fail(
-                        name,
-                        &format!(
-                            "listen address '{listen}' is taken: {e:#}. \
-                                  Stop the running process (try `bash sim/stop.sh` \
-                                  or `pkill -f robonix-{name}`) and retry."
-                        ),
-                    );
-                    anyhow::bail!(
-                        "system/{name}: listen address '{listen}' is already in use; \
-                         refusing to spawn (would shadow the existing process)"
-                    );
+                for listen in system_listens(name, deploy.system.get(*name))? {
+                    if let Err(e) = port_is_free(&listen.address) {
+                        output::boot_fail(
+                            name,
+                            &format!(
+                                "listen address '{}' is taken: {e:#}. \
+                                      Stop the running process (try `bash sim/stop.sh` \
+                                      or `pkill -f robonix-{name}`) and retry.",
+                                listen.address
+                            ),
+                        );
+                        anyhow::bail!(
+                            "system/{name}.{}: listen address '{}' is already in use; \
+                             refusing to spawn (would shadow the existing process)",
+                            listen.field,
+                            listen.address,
+                        );
+                    }
                 }
 
                 // Required-arg validation before spawn. Without this, an empty
@@ -1652,25 +1863,141 @@ fn system_boot_detail(name: &str, args: &[String]) -> String {
 /// elsewhere). Consumers that don't carry their own `atlas:` field inherit
 /// from this so the manifest doesn't have to repeat the address. An
 /// explicit per-block `atlas:` still wins.
-/// Extract the `host:port` string each system binary will try to bind.
-/// Used by the pre-spawn port-availability check. Returns None for
-/// services we don't gate on (or whose listen field is absent — caller
-/// then doesn't pre-check).
-fn system_listen(name: &str, cfg: Option<&serde_yaml::Value>) -> Option<String> {
-    let map = cfg?.as_mapping()?;
-    let s = map
-        .get(serde_yaml::Value::String("listen".into()))?
-        .as_str()?;
-    let trimmed = s.trim();
-    if trimmed.is_empty()
-        || !matches!(
-            name,
-            "atlas" | "keystone" | "executor" | "pilot" | "liaison" | "soma"
-        )
-    {
-        return None;
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SystemListen {
+    field: &'static str,
+    address: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PlannedSystemListen {
+    component: &'static str,
+    field: &'static str,
+    address: String,
+}
+
+/// Extract every effective `host:port` a system binary will try to bind.
+/// Executor owns both its execution and Sentinel management endpoints; when
+/// `sentinel_listen` is omitted, Executor derives it from `listen + 1`.
+/// Services we do not gate, and absent listen fields, return an empty list.
+fn system_listens(name: &str, cfg: Option<&serde_yaml::Value>) -> Result<Vec<SystemListen>> {
+    if !matches!(
+        name,
+        "atlas" | "keystone" | "executor" | "pilot" | "liaison" | "soma"
+    ) {
+        return Ok(Vec::new());
     }
-    Some(trimmed.to_string())
+    let map = cfg.and_then(serde_yaml::Value::as_mapping);
+    let mut listens = Vec::new();
+    let configured_primary = map
+        .and_then(|map| map.get(serde_yaml::Value::String("listen".into())))
+        .and_then(serde_yaml::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let effective_primary = if name == "executor" {
+        Some(configured_primary.unwrap_or(DEFAULT_EXECUTOR_LISTEN))
+    } else {
+        configured_primary
+    };
+    if let Some(primary) = effective_primary {
+        listens.push(SystemListen {
+            field: "listen",
+            address: primary.to_owned(),
+        });
+    }
+
+    if name == "executor" {
+        let configured_sentinel = map
+            .and_then(|map| map.get(serde_yaml::Value::String("sentinel_listen".into())))
+            .and_then(serde_yaml::Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+        let (field, address) = match configured_sentinel {
+            Some(sentinel) => ("sentinel_listen", sentinel.to_owned()),
+            None => (
+                "sentinel_listen (derived)",
+                adjacent_executor_listen(
+                    effective_primary.expect("Executor always has an effective listen"),
+                )?,
+            ),
+        };
+        listens.push(SystemListen { field, address });
+    }
+    Ok(listens)
+}
+
+fn adjacent_executor_listen(listen: &str) -> Result<String> {
+    let mut address: std::net::SocketAddr = listen
+        .parse()
+        .with_context(|| format!("invalid Executor listen address '{listen}'"))?;
+    let port = address.port().checked_add(1).with_context(|| {
+        format!(
+            "cannot derive Executor sentinel_listen from listen port {}",
+            address.port()
+        )
+    })?;
+    address.set_port(port);
+    Ok(address.to_string())
+}
+
+/// Validate the whole built-in system listen plan before spawning anything.
+/// Checking ports one component at a time cannot catch two currently-free
+/// addresses that overlap each other, especially Executor's derived endpoint.
+fn validate_system_listen_plan(deploy: &DeployManifest) -> Result<Vec<PlannedSystemListen>> {
+    const BUILTIN_ORDER: [&str; 6] = ["atlas", "executor", "keystone", "soma", "pilot", "liaison"];
+    let mut planned: Vec<PlannedSystemListen> = Vec::new();
+    for component in BUILTIN_ORDER {
+        if !deploy.system.contains_key(component) {
+            continue;
+        }
+        for listen in system_listens(component, deploy.system.get(component))? {
+            let candidate = PlannedSystemListen {
+                component,
+                field: listen.field,
+                address: listen.address,
+            };
+            for existing in &planned {
+                if listen_addresses_conflict(&existing.address, &candidate.address)? {
+                    anyhow::bail!(
+                        "system/{}.{} listen address '{}' conflicts with system/{}.{} '{}'",
+                        candidate.component,
+                        candidate.field,
+                        candidate.address,
+                        existing.component,
+                        existing.field,
+                        existing.address,
+                    );
+                }
+            }
+            planned.push(candidate);
+        }
+    }
+    Ok(planned)
+}
+
+fn listen_addresses_conflict(left: &str, right: &str) -> Result<bool> {
+    use std::net::ToSocketAddrs;
+
+    let resolve = |listen: &str| -> Result<Vec<std::net::SocketAddr>> {
+        let addresses = listen
+            .to_socket_addrs()
+            .with_context(|| format!("parse listen address '{listen}'"))?
+            .collect::<Vec<_>>();
+        if addresses.is_empty() {
+            anyhow::bail!("listen address '{listen}' resolved to no socket addresses");
+        }
+        Ok(addresses)
+    };
+    let left = resolve(left)?;
+    let right = resolve(right)?;
+    Ok(left.iter().any(|left| {
+        right.iter().any(|right| {
+            left.port() == right.port()
+                && (left.ip() == right.ip()
+                    || left.ip().is_unspecified()
+                    || right.ip().is_unspecified())
+        })
+    }))
 }
 
 /// Probe a host:port. Returns `Ok(())` when nothing is listening (we can


### PR DESCRIPTION
## What changed

- add a typed Sentinel rule engine and `ListRules` / `ReplaceRules` management contracts
- carry a Keystone-validated session on the internal Liaison -> Pilot -> Executor path, redact it from public Plan events, and re-resolve identity before execution
- enforce robot-level rules immediately before capability dispatch using typed RFC 6901 state paths, user/role, capability, time, and region inputs
- require an authenticated Keystone admin for rule management
- advertise the Sentinel provider, validate explicit and derived listen-port collisions, and bootstrap a versioned Webots demo policy only on first run

## Why

This provides the minimum end-to-end Sentinel loop for the Keystone demo branch without hard-coding robot predicates such as `moving` or `gripper_open`. Robot state remains generic and typed, so deployments can address boolean, integer-range, and float-range conditions through stable state paths.

## Security properties

- caller-supplied identity is overwritten after Keystone resolution
- Executor derives canonical identity from Keystone instead of trusting Plan user/role fields
- the reusable session token is cleared from client-visible Plan events
- malformed capability arguments and missing/wrongly typed policy state fail closed
- only Keystone admins can list or replace rules

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p robonix-sentinel -p robonix-executor -p robonix-cli` (7 Sentinel, 44 Executor, 32 CLI tests)
- `cargo clippy -p robonix-sentinel -p robonix-executor -p robonix-cli --all-targets -- -D warnings`
- `python3 -m unittest scripts/tests/test_check_commit_authorship.py`
- `python3 scripts/check_commit_authorship.py --base origin/dev-keystone --head HEAD`
- `git diff --check`

## Companion change

The admin rule-management page is being published separately from the robonix-client Keystone branch.

This PR intentionally targets `dev-keystone`; it does not change `dev` or `dev-next`.