### PR TITLE
chore: report production languages accurately

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,22 @@
-robonix/** linguist-vendored
-rust/examples/** linguist-vendored
-rust/tools/** linguist-vendored
-rust/_deprecated/** linguist-vendored
+# GitHub Linguist reports Robonix product code in every implementation language,
+# including Rust, Python, shell scripts, and frontend code.  Only non-product
+# material is excluded from the language bar; all files remain reviewable.
+
+# Tests and evaluation infrastructure.
+**/tests/** linguist-detectable=false
+**/test/** linguist-detectable=false
+**/__tests__/** linguist-detectable=false
+**/test_*.* linguist-detectable=false
+**/*_test.* linguist-detectable=false
+**/*.test.* linguist-detectable=false
+**/*.spec.* linguist-detectable=false
+testing/** linguist-detectable=false
+**/benchmarks/** linguist-detectable=false
+**/benchmark/** linguist-detectable=false
+
+# Examples, fixtures, generated outputs, and local build artifacts.
+examples/** linguist-detectable=false
+**/fixtures/** linguist-detectable=false
+**/generated/** linguist-detectable=false
+**/proto_gen/** linguist-detectable=false
+**/rbnx-build/** linguist-detectable=false


### PR DESCRIPTION
## Summary

Make GitHub's language bar describe Robonix product code rather than its test and experiment volume.

## What changed

- Keep every production implementation language detectable, including Rust, Python, shell scripts, and frontend code.
- Exclude test directories and test-name patterns across languages.
- Exclude benchmark/evaluation infrastructure, examples, fixtures, generated artifacts, and local build outputs.
- Replace obsolete rules for the former `rust/` and `robonix/` directory layout.

This changes only GitHub Linguist metadata. Files remain tracked, visible, and reviewable.

## Validation

- Audited every tracked file with `git check-attr linguist-detectable`.
- Confirmed production Rust, Scene Python, and `system/scene/scripts/build.sh` use normal Linguist detection.
- Confirmed all 54 tracked files matching the test-name patterns resolve to `linguist-detectable=false`.
- Confirmed 16 tracked non-test shell scripts remain detectable; test/example shell files stay excluded.
- `git diff --check` passed.
- Commit authorship policy passed for the introduced commit.

GitHub refreshes repository language statistics after the change reaches the default branch.
