### PR TITLE
fix(ci): close a TOCTOU window and declare least-privilege permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [main, dev, dev-next, dev/**]
 
+# Least privilege: every job here only reads the checked-out tree.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     branches: [main, dev, dev-next, dev/**]
 
+# Least privilege: every job here only reads the checked-out tree.
+permissions:
+  contents: read
+
 jobs:
   docs:
     name: Docs check (English-only)

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -187,8 +187,13 @@ jobs:
         id: pr_review
         uses: actions/github-script@v7
         env:
-          PR_NUMBER: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.number || '' }}
-          PR_HEAD_SHA: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
+          # ChatOps (`workflow_call`) already resolved and froze the PR head at
+          # its own authorization gate; reuse that value instead of re-reading
+          # the live head here. Re-reading would reopen a time-of-check /
+          # time-of-use window in which the PR author can push a new commit
+          # between authorization and the approval match below.
+          PR_NUMBER: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.number || inputs.pr_number || '' }}
+          PR_HEAD_SHA: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || inputs.pr_head_sha || '' }}
         with:
           script: |
             const prNumber = process.env.PR_NUMBER;


### PR DESCRIPTION
Addresses the open code-scanning alerts on the workflows.

## What CodeQL flagged

11 open alerts, of which 10 sit in workflow files:

| Rule | Count | File |
|---|---|---|
| `actions/untrusted-checkout-toctou` | 7 critical | `testing.yml` |
| `actions/untrusted-checkout` | 1 high | `testing.yml` |
| `actions/missing-workflow-permissions` | 2 medium | `ci.yml`, `docs-check.yml` |

## The real defect

`testing.yml` is reachable from `issue_comment` through `ci-bot.yml` → `workflow_call`. That path is already gated: only `admin`/`maintain` may invoke it, a `safe-to-test` label is required, and the approval check demands `r.commit_id === headSha` so an approval only counts for the exact commit it was given for.

The gap is where `headSha` comes from. `ci-bot.yml` resolves and freezes the PR head at its authorization gate and passes it down as `pr_head_sha`, but the approval gate in `testing.yml` only read `github.event.pull_request.head.sha`, which is empty on the `workflow_call` path. It then fell back to fetching the *live* head. An author could push a new commit between authorization and that fetch, and the approval match would run against the newly pushed head.

This change consumes the frozen `pr_head_sha` (and `pr_number`) on the `workflow_call` path. The `pull_request_target` path is unchanged — its event payload is already fixed for the run.

## Least privilege

`ci.yml` and `docs-check.yml` declared no `permissions:` block and ran with the repository default token scope. Both only read the checked-out tree, so they are pinned to `contents: read`.

## Not changed

`py/bind-socket-all-network-interfaces` in `pylib/robonix-api/robonix_api/capability.py` is a false positive for this architecture: a capability provider must be reachable across the deployment network, and the bind host is already configurable through `ROBONIX_PROVIDER_BIND_HOST` (documented in the same file). Dismissed as `won't fix` rather than changed.

## Validation

All three workflows re-parse as valid YAML. No behavioural change on the `push` / `pull_request_target` / `workflow_dispatch` paths.