### PR TITLE
docs: point published URLs at the robonix.ai domains

### DIFF
--- a/.github/workflows/ci-bot.yml
+++ b/.github/workflows/ci-bot.yml
@@ -185,7 +185,7 @@ jobs:
       REPORT_SITE_DIR: /tmp/robonix-report-site-${{ github.run_id }}
       REPORTS_REPOSITORY: syswonder/robonix-ci-reports
       REPORTS_BRANCH: main
-      REPORT_BASE_URL: https://syswonder.github.io/robonix-ci-reports
+      REPORT_BASE_URL: https://ci-reports.robonix.ai
     steps:
       - name: Checkout trusted report generator
         uses: actions/checkout@v4

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1712,7 +1712,7 @@ jobs:
       REPORT_SITE_DIR: /tmp/robonix-report-site-${{ github.run_id }}
       REPORTS_REPOSITORY: syswonder/robonix-ci-reports
       REPORTS_BRANCH: main
-      REPORT_BASE_URL: https://syswonder.github.io/robonix-ci-reports
+      REPORT_BASE_URL: https://ci-reports.robonix.ai
       PUBLISH_REPORT_SITE: >-
         ${{ inputs.authorized == true ||
             github.event_name == 'push' ||

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,7 +5,7 @@ Each maintainer is written `Name (@github, email)` so the contact stays bound to
 the person; components with two owners separate them with `;`. A public email is
 shown only where the person publishes one on their GitHub profile.
 
-- Project: <https://robonix.syswonder.org>
+- Project: <https://book.robonix.ai>
 - Mailing list: robotos@syswonder.org
 - Contributor roster: <https://www.syswonder.org>
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <img src="https://img.shields.io/github/languages/code-size/syswonder/robonix?color=green&style=flat-square" alt="Code size" />
   <img src="https://img.shields.io/github/repo-size/syswonder/robonix?color=lightgray&style=flat-square" alt="Repo size" />
   <img src="https://img.shields.io/github/languages/top/syswonder/robonix?color=orange&style=flat-square" alt="Top language" />
-  <a href="https://syswonder.github.io/robonix-package-catalog/packages/"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fsyswonder.github.io%2Frobonix-package-catalog%2Fapi%2Fv1%2Fpackages&query=%24.packages.length&label=Robonix%20packages&color=0f766e&style=flat-square" alt="Robonix packages" /></a>
+  <a href="https://packages.robonix.ai/packages/"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fsyswonder.github.io%2Frobonix-package-catalog%2Fapi%2Fv1%2Fpackages&query=%24.packages.length&label=Robonix%20packages&color=0f766e&style=flat-square" alt="Robonix packages" /></a>
   <a href="#supported-robots"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fsyswonder.github.io%2Frobonix-package-catalog%2Fapi%2Fv1%2Frobots&query=%24.robots.length&label=Robot%20deployments&color=2563eb&style=flat-square" alt="Published robot deployments" /></a>
 </p>
 
@@ -41,19 +41,19 @@ capabilities. The long-term goal is simple: **train once, deploy on any robot**.
 
 | Robot | Integrated hardware | Maintained by | Deployment | Catalog |
 | --- | --- | --- | --- | --- |
-| AgileX Ranger Mini v3 | Ranger Mini v3 chassis; Livox MID-360 lidar and IMU; Intel RealSense D435i RGB-D camera; optional AgileX Piper arm; audio | syswonder | [link](https://github.com/syswonder/robot-agilex-ranger_mini_v3) | [link](https://syswonder.github.io/robonix-package-catalog/robots/robonix.robot.agilex.ranger_mini_v3/) |
-| DEEP Robotics Lite3 | Lite3 quadruped chassis; Livox MID-360 lidar and IMU; Orbbec Gemini 330-series RGB-D camera | [Bunnycxk](https://github.com/Bunnycxk) | [link](https://github.com/syswonder/robot-deep_robotics-lite3) | [link](https://syswonder.github.io/robonix-package-catalog/robots/robonix.robot.deep_robotics.lite3/) |
-| WHEELTEC R550 mini_tank | R550 tracked chassis and IMU; LSLIDAR N10P; Orbbec Astra S RGB-D camera | [sherry-part](https://github.com/sherry-part) | [link](https://github.com/syswonder/robot-wheeltec-r550) | [link](https://syswonder.github.io/robonix-package-catalog/robots/robonix.robot.wheeltec.r550/) |
-| Unitree Go2 | Go2 quadruped chassis; onboard lidar, camera, and IMU; audio bridge | [Origamii520](https://github.com/Origamii520) | [link](https://github.com/syswonder/robot-unitree-go2) | [link](https://syswonder.github.io/robonix-package-catalog/robots/robonix.robot.unitree.go2/) |
-| WowRobo Roboarm | Five-axis LeRobot Koch arm; Orbbec Gemini 215 RGB-D camera; audio | [gaoyz1235](https://github.com/gaoyz1235) | [link](https://github.com/syswonder/robot-wowrobo-roboarm) | [link](https://syswonder.github.io/robonix-package-catalog/robots/robonix.robot.wowrobo.roboarm/) |
+| AgileX Ranger Mini v3 | Ranger Mini v3 chassis; Livox MID-360 lidar and IMU; Intel RealSense D435i RGB-D camera; optional AgileX Piper arm; audio | syswonder | [link](https://github.com/syswonder/robot-agilex-ranger_mini_v3) | [link](https://packages.robonix.ai/robots/robonix.robot.agilex.ranger_mini_v3/) |
+| DEEP Robotics Lite3 | Lite3 quadruped chassis; Livox MID-360 lidar and IMU; Orbbec Gemini 330-series RGB-D camera | [Bunnycxk](https://github.com/Bunnycxk) | [link](https://github.com/syswonder/robot-deep_robotics-lite3) | [link](https://packages.robonix.ai/robots/robonix.robot.deep_robotics.lite3/) |
+| WHEELTEC R550 mini_tank | R550 tracked chassis and IMU; LSLIDAR N10P; Orbbec Astra S RGB-D camera | [sherry-part](https://github.com/sherry-part) | [link](https://github.com/syswonder/robot-wheeltec-r550) | [link](https://packages.robonix.ai/robots/robonix.robot.wheeltec.r550/) |
+| Unitree Go2 | Go2 quadruped chassis; onboard lidar, camera, and IMU; audio bridge | [Origamii520](https://github.com/Origamii520) | [link](https://github.com/syswonder/robot-unitree-go2) | [link](https://packages.robonix.ai/robots/robonix.robot.unitree.go2/) |
+| WowRobo Roboarm | Five-axis LeRobot Koch arm; Orbbec Gemini 215 RGB-D camera; audio | [gaoyz1235](https://github.com/gaoyz1235) | [link](https://github.com/syswonder/robot-wowrobo-roboarm) | [link](https://packages.robonix.ai/robots/robonix.robot.wowrobo.roboarm/) |
 | Webots TIAGo Lite (simulation) | Simulated differential-drive chassis; head RGB-D camera; Hokuyo planar lidar; audio | syswonder | [link](examples/webots/) | — |
-| Minecraft Bot (simulation) | Minecraft player body; camera, chassis, world-state, inventory, navigation, and exploration providers | [ZZJJWarth](https://github.com/ZZJJWarth) | [link](https://github.com/syswonder/robot-syswonder-minecraft_bot) | [link](https://syswonder.github.io/robonix-package-catalog/robots/robonix.robot.syswonder.minecraft_bot/) |
+| Minecraft Bot (simulation) | Minecraft player body; camera, chassis, world-state, inventory, navigation, and exploration providers | [ZZJJWarth](https://github.com/ZZJJWarth) | [link](https://github.com/syswonder/robot-syswonder-minecraft_bot) | [link](https://packages.robonix.ai/robots/robonix.robot.syswonder.minecraft_bot/) |
 
 Each deployment links the complete robot manifest and its primitive, service,
 and skill dependencies. Published deployment metadata does not replace the
 hardware-specific safety, commissioning, and acceptance gates documented by
 each repository. See the
-[robot catalog](https://syswonder.github.io/robonix-package-catalog/robots/)
+[robot catalog](https://packages.robonix.ai/robots/)
 for published integrations.
 
 ## Quick Start
@@ -121,9 +121,9 @@ Services and skills declare capabilities through Atlas. Pilot can select those
 capabilities while planning, and Executor dispatches the resulting RTDL nodes
 while preserving per-task state, concurrency, and cancellation. Browse current
 drivers, services, and skills in the
-[package catalog](https://syswonder.github.io/robonix-package-catalog/packages/).
+[package catalog](https://packages.robonix.ai/packages/).
 The package badge above is updated from the
-[catalog API](https://syswonder.github.io/robonix-package-catalog/api/v1/packages).
+[catalog API](https://packages.robonix.ai/api/v1/packages).
 
 ### Hardware and robot deployments
 
@@ -133,7 +133,7 @@ deployment repository assembles these primitives with the complete body
 description, selected services and skills, and runtime configuration for one
 platform. This gives models and skills one consistent view of each robot.
 Browse complete integrations in the
-[robot catalog](https://syswonder.github.io/robonix-package-catalog/robots/).
+[robot catalog](https://packages.robonix.ai/robots/).
 
 ### Build services and skills
 
@@ -316,7 +316,7 @@ definitions are documented in the
 
 This repository contains Robonix system components, built-in reference services, and
 examples such as Webots/Tiago. Reusable community packages are indexed by the
-[Robonix Package Catalog](https://syswonder.github.io/robonix-package-catalog/);
+[Robonix Package Catalog](https://packages.robonix.ai/);
 their source stays in separate package repositories instead of being duplicated
 here.
 
@@ -333,20 +333,20 @@ here.
 
 ### External packages
 
-Use the [Robonix Package Catalog](https://syswonder.github.io/robonix-package-catalog/)
+Use the [Robonix Package Catalog](https://packages.robonix.ai/)
 to find reusable primitive, service, and skill packages maintained outside this
 repository. The catalog also exposes a machine-readable static JSON API:
 
 | Method | Path | Parameters |
 | --- | --- | --- |
-| `GET` | `https://syswonder.github.io/robonix-package-catalog/api/v1/packages` | none |
-| `GET` | `https://syswonder.github.io/robonix-package-catalog/api/v1/search` | none; filter client-side |
-| `GET` | `https://syswonder.github.io/robonix-package-catalog/api/v1/package/<package-name>` | `package-name` is the exact `package.name`, URL-encoded |
+| `GET` | `https://packages.robonix.ai/api/v1/packages` | none |
+| `GET` | `https://packages.robonix.ai/api/v1/search` | none; filter client-side |
+| `GET` | `https://packages.robonix.ai/api/v1/package/<package-name>` | `package-name` is the exact `package.name`, URL-encoded |
 
 Example:
 
 ```js
-const base = 'https://syswonder.github.io/robonix-package-catalog/api/v1';
+const base = 'https://packages.robonix.ai/api/v1';
 const catalog = await fetch(`${base}/packages`).then(r => r.json());
 const mapping = await fetch(`${base}/package/${encodeURIComponent('robonix.service.mapping')}`)
   .then(r => r.json());

--- a/system/vitals/README.md
+++ b/system/vitals/README.md
@@ -27,7 +27,7 @@ Piper CAN0 → health_piper (Python Primitive, robonix_api)
 
 The `health_piper` primitive implements `robonix/primitive/health/stream` and
 wraps `piper_sdk`. It is **not** part of the Robonix source tree — create it in your
-deployment's `primitives/` directory following the [vendor onboarding guide](https://robonix.syswonder.org/integration-guide/vendor-onboarding.html).
+deployment's `primitives/` directory following the [vendor onboarding guide](https://book.robonix.ai/integration-guide/vendor-onboarding.html).
 
 ### Mock SOMA path (no SOMA needed)
 
@@ -165,7 +165,7 @@ cargo test --workspace --all-targets
 
 Prerequisites: Piper arm connected via CAN0, `~/roboarm/.venv` with `piper-sdk>=0.6.1`,
 and a `health_piper` primitive package created in your deployment per the
-[vendor onboarding guide](https://robonix.syswonder.org/integration-guide/vendor-onboarding.html).
+[vendor onboarding guide](https://book.robonix.ai/integration-guide/vendor-onboarding.html).
 
 **Step 1: Create the primitive** in your deployment directory (e.g. `~/roboarm/robonix/primitives/health_piper/`), then run `rbnx codegen -p .` inside it.
 


### PR DESCRIPTION
The project moved to `robonix.ai`. Each published site now lives on a subdomain that drops the `robonix-` prefix it used to carry inside the path.

## Rewrites

| Old base | New base | Occurrences |
|---|---|---|
| `syswonder.github.io/robonix-package-catalog` | `packages.robonix.ai` | 18 |
| `syswonder.github.io/robonix-ci-reports` | `ci-reports.robonix.ai` | 2 |
| `robonix.syswonder.org` | `book.robonix.ai` | 2 |

Files touched: `README.md`, `MAINTAINERS.md`, `system/vitals/README.md`, `.github/workflows/ci-bot.yml`, `.github/workflows/testing.yml`.

## Left alone

`REPORTS_REPOSITORY: syswonder/robonix-ci-reports` and the `--arg env "robonix-ci-reports"` deployment-environment name still carry the prefix. Those name GitHub resources rather than the published site, so renaming them here would break the report publisher.

## Validation

All four target hosts serve over HTTPS and are configured as GitHub Pages custom domains on their respective repositories:

```
robonix.ai              A     -> GitHub Pages
book.robonix.ai         CNAME -> syswonder.github.io
packages.robonix.ai     CNAME -> syswonder.github.io
ci-reports.robonix.ai   CNAME -> syswonder.github.io
```

Every rewritten URL was fetched: 16 distinct URLs, all 200. Three initially looked like failures and were checked individually — `<https://book.robonix.ai>` is a markdown autolink whose closing `>` my extraction swallowed, `…/api/v1` is the base-path constant in the example snippet rather than an endpoint, and `…/api/v1/package/<package-name>` is a documented placeholder. Substituting a real package name (`robonix.skill.explore`) returns 200, as do `/api/v1/packages`, `/api/v1/search`, and `/api/v1/robots`.

The old `robonix.syswonder.org` no longer resolves, so the `system/vitals` links were dead before this change; `book.robonix.ai/integration-guide/vendor-onboarding.html` serves that page today.