### PR TITLE
fix(speech): split long Tencent TTS input

### DIFF
--- a/services/speech/README.md
+++ b/services/speech/README.md
@@ -45,7 +45,20 @@ Do not commit Tencent credentials. Put them in the operator shell, a local
 ignored env file, or a machine-local boot wrapper. The AppID and non-secret
 backend settings belong in the deployment manifest. Useful optional knobs:
 `TENCENT_ASR_ENGINE` (default `16k_zh`), `TENCENT_TTS_VOICE_TYPE` (default
-`1001`), and `TENCENT_TTS_REGION` (default `ap-guangzhou`).
+`1001`), `TENCENT_TTS_REGION` (default `ap-guangzhou`),
+`TENCENT_TTS_MAX_CHARS` (default `140`), and
+`TENCENT_TTS_MAX_TOTAL_CHARS` (default `5000`). The per-request setting accepts
+1–150 characters, using Tencent's Chinese limit as a conservative ceiling for
+mixed text. Long input is split at sentence punctuation, commas or whitespace,
+and finally a hard boundary, with its PCM segments returned in order. The
+service rejects input above the configured total limit, input requiring more
+than 40 provider requests, and separator runs that cannot be sent without a
+punctuation-only request. The Speech contract requires
+`TENCENT_TTS_CODEC=pcm`; encoded formats such as WAV or MP3 are rejected because
+their independently wrapped segments cannot be exposed as one `pcm_s16le`
+response. One-shot synthesis and `speech/speak` also stop below 4 MiB of decoded
+PCM so the result fits the core client's default gRPC receive limit; use the
+streaming TTS capability for larger output.
 
 With `SPEECH_BACKEND=tencent`, the build installs only the cloud client and
 audio adaptation dependencies. It does not install or warm FunASR, Whisper,

--- a/services/speech/docs/speech_service.proto.ref
+++ b/services/speech/docs/speech_service.proto.ref
@@ -4,7 +4,7 @@
 // Architecture position: robonix/service/speech (service layer)
 //   - Receives audio from lower-layer primitive drivers (e.g. audio_driver)
 //   - Auto-adapts any input sample_rate / channels / encoding to 16kHz mono s16le
-//   - Outputs synthesized audio (MP3) for downstream playback
+//   - Outputs 16 kHz mono pcm_s16le audio for downstream playback
 //
 // Self-contained: all message types are inlined (no external proto imports).
 // Build: scripts/build.sh generates *_pb2.py / *_pb2_grpc.py into proto_gen/
@@ -99,9 +99,9 @@ message SynthesizeRequest {
 }
 
 message SynthesizeResponse {
-  bytes audio_data = 1;      // synthesized audio (MP3 format)
-  string encoding = 2;       // always "mp3" for Edge TTS
-  uint32 sample_rate_hz = 3; // always 24000 for Edge TTS
+  bytes audio_data = 1;      // synthesized 16-bit PCM audio
+  string encoding = 2;       // "pcm_s16le"
+  uint32 sample_rate_hz = 3; // 16000
   string error = 4;          // non-empty on failure
 }
 
@@ -115,19 +115,19 @@ message SynthesizeStreamRequest {
 }
 
 message SynthesizeStreamResponse {
-  bytes audio_data = 1;      // one MP3 audio chunk
-  string encoding = 2;       // "mp3"
-  uint32 sample_rate_hz = 3; // 24000
+  bytes audio_data = 1;      // one 16-bit PCM audio chunk
+  string encoding = 2;       // "pcm_s16le"
+  uint32 sample_rate_hz = 3; // 16000
   bool is_final = 4;         // true on last chunk (audio_data empty)
 }
 
 // TTS service: two synthesis modes.
 service SpeechTts {
-  // Unary: send text, get complete MP3 audio.
-  // Backend: Edge TTS (Microsoft Cognitive Services, free tier).
+  // Unary: send text, get complete PCM audio.
+  // Backend: configured local or cloud TTS implementation.
   rpc Synthesize (SynthesizeRequest) returns (SynthesizeResponse);
 
-  // Server streaming: send text, receive MP3 chunks as they're generated.
+  // Server streaming: send text, receive PCM chunks as they're generated.
   rpc SynthesizeStream (SynthesizeStreamRequest) returns (stream SynthesizeStreamResponse);
 }
 

--- a/services/speech/package_manifest.yaml
+++ b/services/speech/package_manifest.yaml
@@ -23,8 +23,10 @@
 #   tencent_tts_voice_type: int — default 1001
 #   tencent_tts_region: str — default ap-guangzhou
 #   tencent_tts_model_type: int — default 1
-#   tencent_tts_sample_rate: int — default 16000
-#   tencent_tts_codec: str — default pcm
+#   tencent_tts_sample_rate: int — required 16000
+#   tencent_tts_codec: str — required pcm
+#   tencent_tts_max_chars: int — default 140; accepted 1..150
+#   tencent_tts_max_total_chars: int — default 5000; accepted 1..6000
 #   tencent_tts_primary_language: int — optional 1=Chinese, 2=English;
 #       omit for automatic Chinese/English selection per utterance
 #   log:               str   — log level (default: info)

--- a/services/speech/speech_service/service.py
+++ b/services/speech/speech_service/service.py
@@ -1276,7 +1276,7 @@ def list_speakers(req: ListSpeakers_Request) -> ListSpeakers_Response:
 
 
 @speech.mcp("robonix/service/speech/speak")
-def speak(req: Speak_Request) -> Speak_Response:
+async def speak(req: Speak_Request) -> Speak_Response:
     """Synthesize `text` to speech and play it out loud on a speaker. `target`
     is the speaker primitive's provider_id (from list_speakers). When it is
     empty, the configured default_speaker_provider_id is used; without a
@@ -1301,42 +1301,92 @@ def speak(req: Speak_Request) -> Speak_Response:
     speaker_lock = _speaker_lock(cap.provider_id)
     if speaker_lock.locked():
         log.info("speech/speak queued for busy speaker %s", cap.provider_id)
-    with speaker_lock:
+
+    # Poll so a busy speaker only suspends this await, and so cancellation
+    # cannot race a blocking acquire that would otherwise leak the lock.
+    while not speaker_lock.acquire(blocking=False):
+        await asyncio.sleep(0.01)
+    try:
         tts_backend = _tts_servicer.tts_backend
         if tts_backend is None:
-            log.warning("speech/speak called before Driver(INIT) installed a TTS backend; using direct Edge TTS fallback")
+            log.warning(
+                "speech/speak called before Driver(INIT) installed a TTS "
+                "backend; using direct Edge TTS fallback"
+            )
         if tts_backend is None and _speak_tts is None:
             _speak_tts = EdgeTTSBackend()
         if tts_backend is None:
             tts_backend = _speak_tts
-        # MCP handlers run inside FastMCP's event loop, so asyncio.run() here
-        # would error ("loop already running"). Synthesize on a worker thread
-        # that owns its own loop.
-        import asyncio
-        import concurrent.futures
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
-            pcm = ex.submit(lambda: asyncio.run(tts_backend.synthesize(text))).result()
+
+        # FastMCP's async shim awaits this coroutine. Keep synthesis on a
+        # worker thread (backends may call asyncio.run) and bind a liveness
+        # flag so multi-segment Tencent fan-out stops after cancellation.
+        active = threading.Event()
+        active.set()
+
+        def is_active() -> bool:
+            return active.is_set()
+
+        def _synthesize() -> bytes:
+            token = bind_tts_request_active(is_active)
+            try:
+                return asyncio.run(tts_backend.synthesize(text))
+            finally:
+                reset_tts_request_active(token)
+
+        loop = asyncio.get_running_loop()
+        synth_future = loop.run_in_executor(None, _synthesize)
+        try:
+            pcm = await synth_future
+        except asyncio.CancelledError:
+            active.clear()
+            try:
+                await synth_future
+            except Exception as exc:
+                log.info("speech/speak synthesis stopped after cancel: %s", exc)
+            raise
+
         if not pcm:
             raise RuntimeError("TTS backend returned no PCM audio")
-        log.info("speech/speak synthesized %d PCM bytes for %d chars", len(pcm), len(text))
+        log.info(
+            "speech/speak synthesized %d PCM bytes for %d chars", len(pcm), len(text)
+        )
 
-        with (
-            speech.connect_capability(cap, _SPEAKER_CONTRACT, Transport.GRPC) as ch,
-            grpc.insecure_channel(ch.endpoint) as speaker_channel,
-        ):
-            stub = contracts_grpc.RobonixPrimitiveAudioSpeakerStub(speaker_channel)
+        def _play() -> None:
+            with (
+                speech.connect_capability(cap, _SPEAKER_CONTRACT, Transport.GRPC) as ch,
+                grpc.insecure_channel(ch.endpoint) as speaker_channel,
+            ):
+                stub = contracts_grpc.RobonixPrimitiveAudioSpeakerStub(speaker_channel)
 
-            def frames():
-                frame_bytes = 9600 * 2  # 600 ms s16le frames
-                seq = 0
-                for i in range(0, len(pcm), frame_bytes):
-                    seq += 1
-                    yield audio_pb2.AudioChunk(
-                        data=pcm[i:i + frame_bytes], timestamp_ns=0,
-                        sequence=seq, duration_s=0.0,
-                    )
+                def frames():
+                    frame_bytes = 9600 * 2  # 600 ms s16le frames
+                    seq = 0
+                    for i in range(0, len(pcm), frame_bytes):
+                        if not active.is_set():
+                            return
+                        seq += 1
+                        yield audio_pb2.AudioChunk(
+                            data=pcm[i : i + frame_bytes],
+                            timestamp_ns=0,
+                            sequence=seq,
+                            duration_s=0.0,
+                        )
 
-            stub.Speaker(frames())
+                stub.Speaker(frames())
+
+        play_future = loop.run_in_executor(None, _play)
+        try:
+            await play_future
+        except asyncio.CancelledError:
+            active.clear()
+            try:
+                await play_future
+            except Exception as exc:
+                log.info("speech/speak playback stopped after cancel: %s", exc)
+            raise
+    finally:
+        speaker_lock.release()
 
     return Speak_Response(ok=True, detail=f"spoke {len(text)} chars on {cap.provider_id}")
 

--- a/services/speech/speech_service/service.py
+++ b/services/speech/speech_service/service.py
@@ -4,7 +4,7 @@
 Architecture position: robonix/service/speech
   - Consumes the audio_driver primitive; consumed in turn by skills / pilot
   - Receives raw audio from audio_driver via gRPC, returns transcriptions
-  - Receives text from applications, returns synthesized audio (MP3)
+  - Receives text from applications, returns synthesized 16 kHz PCM audio
 
 Provides 5 RPCs across 5 gRPC service contracts (from robonix_contracts.proto):
 
@@ -15,10 +15,10 @@ Provides 5 RPCs across 5 gRPC service contracts (from robonix_contracts.proto):
     Stream(stream) -> stream   -- real-time chunk-by-chunk transcription
 
   SystemSpeechTts (Text-to-Speech -- one-shot):
-    Call(req) -> resp          -- returns complete MP3 audio
+    Call(req) -> resp          -- returns complete PCM audio
 
   SystemSpeechTtsStream (Streaming TTS):
-    Stream(req) -> stream      -- yields MP3 chunks as generated
+    Stream(req) -> stream      -- yields PCM chunks as generated
 
   SystemSpeechDialog (Voice Dialog Session):
     Stream(req) -> stream      -- managed session with state transitions
@@ -26,7 +26,7 @@ Provides 5 RPCs across 5 gRPC service contracts (from robonix_contracts.proto):
 Backend engines:
   - Whisper (transformers pipeline)  -- one-shot ASR, GPU FP16, high accuracy
   - FunASR Paraformer-zh-streaming   -- streaming ASR, 600ms granularity
-  - Edge TTS (Microsoft, free)       -- TTS synthesis, zh-CN-XiaoxiaoNeural
+  - Configured local/cloud backend   -- TTS synthesis, 16 kHz mono pcm_s16le
 
 Audio adaptation:
   The service auto-adapts any input format (sample_rate, channels, encoding)
@@ -69,6 +69,12 @@ import importlib
 from concurrent import futures
 from pathlib import Path
 from typing import Iterable, Iterator, Optional, Protocol
+
+from speech_service.tts_errors import TTSInputError
+from speech_service.tts_runtime import (
+    bind_tts_request_active,
+    reset_tts_request_active,
+)
 
 # Route all stdlib logging (this module + transitive deps) through Scribe so
 # `rbnx logs -t speech` sees everything and the package owns no log file or
@@ -912,14 +918,29 @@ class SpeechWakeWordServicer(SpeechWakeWordBase):
             return speech_pb2.DetectWakeWord_Response(error=str(exc))
 
 
+_TTS_CACHE_MAX_ENTRIES = 16
+_TTS_CACHE_MAX_BYTES = 64 * 1024 * 1024
+
+
+def _tts_response_metadata() -> tuple[str, int]:
+    """Read and validate TTS response metadata before backend work starts."""
+    encoding = os.environ.get("SPEECH_TTS_OUTPUT_ENCODING", "pcm_s16le").strip()
+    if encoding != "pcm_s16le":
+        raise ValueError("SPEECH_TTS_OUTPUT_ENCODING must be pcm_s16le")
+    sample_rate_hz = int(os.environ.get("SPEECH_TTS_OUTPUT_SAMPLE_RATE", "16000"))
+    if sample_rate_hz != 16000:
+        raise ValueError("SPEECH_TTS_OUTPUT_SAMPLE_RATE must be 16000")
+    return encoding, sample_rate_hz
+
+
 class SpeechTtsServicer(SpeechTtsBase):
     """TTS gRPC servicer -- handles the Call RPC for one-shot text-to-speech.
 
-    Delegates to EdgeTTSBackend for audio generation.
-    Output format: MP3 at 24kHz (fixed by Edge TTS).
+    Delegates to the configured TTS backend for audio generation.
+    Output format: 16 kHz mono pcm_s16le.
 
-    Note: Edge TTS uses asyncio internally, but gRPC servicers are sync.
-    Call uses asyncio.run().
+    TTS backends are asynchronous, but gRPC servicers are synchronous. Call
+    uses asyncio.run().
     """
 
     def __init__(self, tts_backend):
@@ -932,16 +953,29 @@ class SpeechTtsServicer(SpeechTtsBase):
             self.tts_backend = tts_backend
             self._cache.clear()
 
-    def _synthesize_cached(self, text: str, voice: str, speed: float) -> bytes:
+    def _synthesize_cached(
+        self, text: str, voice: str, speed: float, is_active=None
+    ) -> bytes:
+        """Return cached audio while bounding this servicer's TTS cache."""
         key = (text, voice, speed)
         with self._cache_lock:
             cached = self._cache.get(key)
         if cached is not None:
             return cached
-        audio_data = asyncio.run(self.tts_backend.synthesize(text, voice, speed))
+        active_token = bind_tts_request_active(is_active)
+        try:
+            audio_data = asyncio.run(self.tts_backend.synthesize(text, voice, speed))
+        finally:
+            reset_tts_request_active(active_token)
+        if len(audio_data) > _TTS_CACHE_MAX_BYTES:
+            return audio_data
         with self._cache_lock:
             self._cache[key] = audio_data
-            while len(self._cache) > 16:
+            while self._cache and (
+                len(self._cache) > _TTS_CACHE_MAX_ENTRIES
+                or sum(len(value) for value in self._cache.values())
+                > _TTS_CACHE_MAX_BYTES
+            ):
                 self._cache.pop(next(iter(self._cache)))
         return audio_data
 
@@ -959,7 +993,7 @@ class SpeechTtsServicer(SpeechTtsBase):
                 log.exception("TTS cache prewarm failed for %d-character prompt", len(text))
 
     def Synthesize(self, request, context):
-        """Handle one-shot TTS: receive text, return complete MP3 audio.
+        """Handle one-shot TTS: receive text, return complete PCM audio.
 
         Request fields (from tts.proto Synthesize_Request):
             text     -- text to synthesize
@@ -973,8 +1007,8 @@ class SpeechTtsServicer(SpeechTtsBase):
             context.set_code(grpc.StatusCode.UNAVAILABLE)
             context.set_details(
                 "TTS backend not available. "
-                "Edge TTS requires network access to Microsoft Cognitive Services. "
-                "Check network/model access or set SPEECH_BACKEND=mock for local mock testing."
+                "Check backend configuration and network access, or set "
+                "SPEECH_BACKEND=mock for local mock testing."
             )
             return tts_pb2.Synthesize_Response()
 
@@ -983,13 +1017,19 @@ class SpeechTtsServicer(SpeechTtsBase):
         speed = request.speed or 1.0
 
         try:
-            audio_data = self._synthesize_cached(text, voice, speed)
+            encoding, sample_rate_hz = _tts_response_metadata()
+            audio_data = self._synthesize_cached(
+                text, voice, speed, is_active=context.is_active
+            )
             return tts_pb2.Synthesize_Response(
                 audio_data=audio_data,
-                encoding=os.environ.get("SPEECH_TTS_OUTPUT_ENCODING", "pcm_s16le"),
-                sample_rate_hz=int(os.environ.get("SPEECH_TTS_OUTPUT_SAMPLE_RATE", "16000")),
+                encoding=encoding,
+                sample_rate_hz=sample_rate_hz,
                 error="",
             )
+        except TTSInputError as e:
+            log.warning("TTS synthesize rejected invalid input: %s", e)
+            return tts_pb2.Synthesize_Response(audio_data=b"", error=str(e))
         except Exception as e:
             log.exception("TTS synthesize failed")
             return tts_pb2.Synthesize_Response(audio_data=b"", error=str(e))
@@ -999,21 +1039,21 @@ class SpeechTtsStreamServicer(SpeechTtsStreamBase):
     """Streaming TTS gRPC servicer -- handles the Stream RPC for chunk-by-chunk
     text-to-speech synthesis.
 
-    Delegates to EdgeTTSBackend for audio generation.
-    Output format: MP3 at 24kHz (fixed by Edge TTS).
+    Delegates to the configured TTS backend for audio generation.
+    Output format: 16 kHz mono pcm_s16le.
 
     This is a server stream: unary request with text/voice/speed,
     streams back tts_pb2.SynthesizeAudioChunk messages.
 
-    Note: Edge TTS uses asyncio internally. A dedicated event loop is
-    created per call to avoid "cannot run from running loop" conflicts.
+    TTS backends are asynchronous. A dedicated event loop is created per call
+    to avoid "cannot run from running loop" conflicts.
     """
 
     def __init__(self, tts_backend):
         self.tts_backend = tts_backend
 
     def SynthesizeStream(self, request, context):
-        """Handle streaming TTS: receive text, yield MP3 audio chunks.
+        """Handle streaming TTS: receive text, yield PCM audio chunks.
 
         Request fields (from tts.proto SynthesizeStream_Request):
             text        -- text to synthesize
@@ -1028,7 +1068,7 @@ class SpeechTtsStreamServicer(SpeechTtsStreamBase):
             context.set_code(grpc.StatusCode.UNAVAILABLE)
             context.set_details(
                 "TTS backend not available. "
-                "Edge TTS requires network access to Microsoft Cognitive Services."
+                "Check backend configuration and network access."
             )
             return
 
@@ -1036,36 +1076,52 @@ class SpeechTtsStreamServicer(SpeechTtsStreamBase):
         voice = request.voice
         speed = request.speed or 1.0
 
+        loop = asyncio.new_event_loop()
+        async_gen = None
         try:
-            loop = asyncio.new_event_loop()
+            encoding, sample_rate_hz = _tts_response_metadata()
             async_gen = self.tts_backend.synthesize_stream(text, voice, speed)
             seq = 0
             while True:
                 try:
+                    if not context.is_active():
+                        return
                     chunk_data = loop.run_until_complete(async_gen.__anext__())
                     yield tts_pb2.SynthesizeAudioChunk(
                         chunk=audio_pb2.AudioChunk(
                             data=chunk_data,
                             sequence=seq,
                         ),
-                        encoding=os.environ.get("SPEECH_TTS_OUTPUT_ENCODING", "pcm_s16le"),
-                        sample_rate_hz=int(os.environ.get("SPEECH_TTS_OUTPUT_SAMPLE_RATE", "16000")),
+                        encoding=encoding,
+                        sample_rate_hz=sample_rate_hz,
                         is_final=False,
                     )
                     seq += 1
                 except StopAsyncIteration:
                     yield tts_pb2.SynthesizeAudioChunk(
                         chunk=audio_pb2.AudioChunk(data=b""),
-                        encoding=os.environ.get("SPEECH_TTS_OUTPUT_ENCODING", "pcm_s16le"),
-                        sample_rate_hz=int(os.environ.get("SPEECH_TTS_OUTPUT_SAMPLE_RATE", "16000")),
+                        encoding=encoding,
+                        sample_rate_hz=sample_rate_hz,
                         is_final=True,
                     )
                     break
-            loop.close()
+        except TTSInputError as e:
+            log.warning("TTS stream rejected invalid input: %s", e)
+            context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
+            context.set_details(str(e))
         except Exception as e:
             log.exception("TTS stream synthesize failed")
             context.set_code(grpc.StatusCode.INTERNAL)
             context.set_details(str(e))
+        finally:
+            try:
+                close_generator = getattr(async_gen, "aclose", None)
+                if close_generator is not None:
+                    loop.run_until_complete(close_generator())
+            except Exception:
+                log.exception("TTS stream generator cleanup failed")
+            finally:
+                loop.close()
 
 
 class SpeechDialogServicer(SpeechDialogBase):
@@ -1264,10 +1320,11 @@ def speak(req: Speak_Request) -> Speak_Response:
             raise RuntimeError("TTS backend returned no PCM audio")
         log.info("speech/speak synthesized %d PCM bytes for %d chars", len(pcm), len(text))
 
-        with speech.connect_capability(cap, _SPEAKER_CONTRACT, Transport.GRPC) as ch:
-            stub = contracts_grpc.RobonixPrimitiveAudioSpeakerStub(
-                grpc.insecure_channel(ch.endpoint)
-            )
+        with (
+            speech.connect_capability(cap, _SPEAKER_CONTRACT, Transport.GRPC) as ch,
+            grpc.insecure_channel(ch.endpoint) as speaker_channel,
+        ):
+            stub = contracts_grpc.RobonixPrimitiveAudioSpeakerStub(speaker_channel)
 
             def frames():
                 frame_bytes = 9600 * 2  # 600 ms s16le frames
@@ -1306,6 +1363,8 @@ _CFG_ENV_MAP = {
     "tencent_tts_model_type": "TENCENT_TTS_MODEL_TYPE",
     "tencent_tts_sample_rate": "TENCENT_TTS_SAMPLE_RATE",
     "tencent_tts_codec": "TENCENT_TTS_CODEC",
+    "tencent_tts_max_chars": "TENCENT_TTS_MAX_CHARS",
+    "tencent_tts_max_total_chars": "TENCENT_TTS_MAX_TOTAL_CHARS",
     "tencent_tts_primary_language": "TENCENT_TTS_PRIMARY_LANGUAGE",
     "speech_asr_backend_class": "SPEECH_ASR_BACKEND_CLASS",
     "speech_asr_stream_backend_class": "SPEECH_ASR_STREAM_BACKEND_CLASS",

--- a/services/speech/speech_service/tencent_cloud.py
+++ b/services/speech/speech_service/tencent_cloud.py
@@ -16,6 +16,7 @@ import logging
 import os
 import random
 import time
+import unicodedata
 import uuid
 from dataclasses import dataclass
 from typing import Iterator
@@ -24,7 +25,27 @@ from urllib.parse import quote, urlencode
 import requests
 from websockets.sync.client import connect
 
+from speech_service.tts_errors import TTSInputError
+from speech_service.tts_runtime import tts_request_is_active
+
 log = logging.getLogger(__name__)
+
+_TTS_DEFAULT_MAX_CHARS = 140
+_TTS_PROVIDER_MAX_CHARS = 150
+_TTS_DEFAULT_MAX_TOTAL_CHARS = 5_000
+_TTS_MAX_SEGMENTS = 40
+_TTS_MAX_TOTAL_CHARS = _TTS_PROVIDER_MAX_CHARS * _TTS_MAX_SEGMENTS
+_TTS_MAX_ONE_SHOT_PCM_BYTES = 4 * 1024 * 1024 - 64 * 1024
+_TTS_MAX_SEGMENT_PCM_BYTES = _TTS_MAX_ONE_SHOT_PCM_BYTES
+_TTS_MAX_TOTAL_PCM_BYTES = _TTS_MAX_ONE_SHOT_PCM_BYTES
+_TTS_SENTENCE_BREAKS = frozenset(
+    "\N{IDEOGRAPHIC FULL STOP}"
+    "\N{FULLWIDTH EXCLAMATION MARK}"
+    "\N{FULLWIDTH QUESTION MARK}"
+    "\N{FULLWIDTH SEMICOLON}"
+    ".!?;\n"
+)
+_TTS_CLAUSE_BREAKS = frozenset("\N{FULLWIDTH COMMA}, \t")
 
 
 def _env_first(*names: str, default: str = "") -> str:
@@ -41,6 +62,56 @@ def _require_env(*names: str) -> str:
         return value
     joined = " / ".join(names)
     raise RuntimeError(f"missing Tencent Cloud credential env: {joined}")
+
+
+def _split_tts_text(text: str, max_chars: int) -> list[str]:
+    """Split text into provider-safe chunks without dropping any characters.
+
+    Prefer the last sentence boundary within each limit-sized window, then a
+    comma or whitespace, and finally the hard boundary. Short input is returned
+    unchanged so the existing single-request behavior remains intact.
+    """
+    if max_chars <= 0:
+        raise ValueError("Tencent TTS max chars must be greater than zero")
+    if len(text) <= max_chars:
+        return [text]
+
+    segments: list[str] = []
+    remaining = text
+    while len(remaining) > max_chars:
+        window = remaining[:max_chars]
+        split_at = (
+            max((window.rfind(mark) for mark in _TTS_SENTENCE_BREAKS), default=-1) + 1
+        )
+        if split_at and not _has_tts_content(window[:split_at]):
+            split_at = 0
+        if split_at == 0:
+            split_at = (
+                max((window.rfind(mark) for mark in _TTS_CLAUSE_BREAKS), default=-1) + 1
+            )
+        if split_at and not _has_tts_content(window[:split_at]):
+            split_at = 0
+        if split_at == 0:
+            split_at = max_chars
+
+        # A hard cut immediately before trailing punctuation would create a
+        # punctuation-only provider request (for example 140 Han characters
+        # followed by an ideographic full stop). Move enough preceding text
+        # to keep both requests meaningful without exceeding the limit.
+        tail = remaining[split_at:]
+        while tail and len(tail) < max_chars and not _has_tts_content(tail):
+            split_at -= 1
+            tail = remaining[split_at:]
+        segments.append(remaining[:split_at])
+        remaining = remaining[split_at:]
+    if remaining:
+        segments.append(remaining)
+    return segments
+
+
+def _has_tts_content(text: str) -> bool:
+    """Return whether text contains something beyond punctuation/spacing."""
+    return any(unicodedata.category(char)[0] not in {"P", "Z", "C"} for char in text)
 
 
 @dataclass(frozen=True)
@@ -264,52 +335,205 @@ class TencentTTSBackend:
     action = "TextToVoice"
 
     def __init__(self):
+        """Load and validate the Tencent settings used by every TTS request."""
         self.secret_id = _require_env("TENCENTCLOUD_SECRET_ID", "TENCENT_SECRET_ID")
         self.secret_key = _require_env("TENCENTCLOUD_SECRET_KEY", "TENCENT_SECRET_KEY")
         self.region = os.environ.get("TENCENT_TTS_REGION", "ap-guangzhou")
         self.voice_type = int(os.environ.get("TENCENT_TTS_VOICE_TYPE", "1001"))
         self.model_type = int(os.environ.get("TENCENT_TTS_MODEL_TYPE", "1"))
         self.sample_rate = int(os.environ.get("TENCENT_TTS_SAMPLE_RATE", "16000"))
-        self.codec = os.environ.get("TENCENT_TTS_CODEC", "pcm")
-        self.primary_language = int(os.environ.get("TENCENT_TTS_PRIMARY_LANGUAGE", "1"))
+        if self.sample_rate != 16000:
+            raise ValueError(
+                "Tencent TTS requires TENCENT_TTS_SAMPLE_RATE=16000 for the "
+                "speech service and speaker PCM contract"
+            )
+        self.codec = os.environ.get("TENCENT_TTS_CODEC", "pcm").strip().lower()
+        if self.codec != "pcm":
+            raise ValueError(
+                "Tencent TTS requires TENCENT_TTS_CODEC=pcm for the speech "
+                "service pcm_s16le contract"
+            )
+        language_override = os.environ.get("TENCENT_TTS_PRIMARY_LANGUAGE", "").strip()
+        try:
+            self.primary_language = (
+                int(language_override) if language_override else None
+            )
+        except ValueError as exc:
+            raise ValueError("TENCENT_TTS_PRIMARY_LANGUAGE must be an integer") from exc
+        if self.primary_language not in {None, 1, 2}:
+            raise ValueError("TENCENT_TTS_PRIMARY_LANGUAGE must be 1 or 2")
+        try:
+            self.max_text_chars = int(
+                os.environ.get("TENCENT_TTS_MAX_CHARS", str(_TTS_DEFAULT_MAX_CHARS))
+            )
+        except ValueError as exc:
+            raise ValueError("TENCENT_TTS_MAX_CHARS must be an integer") from exc
+        if not 1 <= self.max_text_chars <= _TTS_PROVIDER_MAX_CHARS:
+            raise ValueError(
+                f"TENCENT_TTS_MAX_CHARS must be between 1 and {_TTS_PROVIDER_MAX_CHARS}"
+            )
+        try:
+            self.max_total_text_chars = int(
+                os.environ.get(
+                    "TENCENT_TTS_MAX_TOTAL_CHARS",
+                    str(_TTS_DEFAULT_MAX_TOTAL_CHARS),
+                )
+            )
+        except ValueError as exc:
+            raise ValueError("TENCENT_TTS_MAX_TOTAL_CHARS must be an integer") from exc
+        if not 1 <= self.max_total_text_chars <= _TTS_MAX_TOTAL_CHARS:
+            raise ValueError(
+                "TENCENT_TTS_MAX_TOTAL_CHARS must be between "
+                f"1 and {_TTS_MAX_TOTAL_CHARS}"
+            )
         log.info(
-            "Tencent TTS initialized (voice_type=%s, sample_rate=%s, codec=%s)",
+            "Tencent TTS initialized (voice_type=%s, sample_rate=%s, "
+            "codec=%s, max_chars=%s, max_total_chars=%s)",
             self.voice_type,
             self.sample_rate,
             self.codec,
+            self.max_text_chars,
+            self.max_total_text_chars,
         )
 
     async def synthesize(self, text: str, voice: str = "", speed: float = 1.0) -> bytes:
+        """Synthesize all safe text segments and concatenate their PCM audio."""
+        segments = self._segments_for_provider(text)
         primary_language = self._primary_language_for_text(text)
-        payload = {
-            "Text": text,
-            "SessionId": str(uuid.uuid4()),
-            "Volume": 0,
-            "Speed": self._speed_to_tencent(speed),
-            "ProjectId": 0,
-            "ModelType": self.model_type,
-            "VoiceType": int(voice) if voice else self.voice_type,
-            "PrimaryLanguage": primary_language,
-            "SampleRate": self.sample_rate,
-            "Codec": self.codec,
-            "EnableSubtitle": False,
-        }
-        log.info("Tencent TTS request: voice_type=%s primary_language=%s text_len=%s", payload["VoiceType"], primary_language, len(text or ""))
-        response = await asyncio.to_thread(self._post_json, payload)
-        audio_b64 = response.get("Audio", "")
-        if not audio_b64:
-            raise RuntimeError(f"Tencent TTS returned no audio: {response}")
-        return base64.b64decode(audio_b64)
+        if len(segments) > 1:
+            log.info(
+                "Tencent TTS split %d chars into %d requests",
+                len(text),
+                len(segments),
+            )
+        audio = []
+        audio_size = 0
+        for index, segment in enumerate(segments, start=1):
+            if not tts_request_is_active():
+                raise RuntimeError(
+                    f"Tencent TTS synthesis cancelled before segment "
+                    f"{index}/{len(segments)}"
+                )
+            segment_audio = await self._synthesize_segment(
+                segment,
+                voice,
+                speed,
+                primary_language=primary_language,
+                index=index,
+                total=len(segments),
+            )
+            audio_size += len(segment_audio)
+            if audio_size > _TTS_MAX_TOTAL_PCM_BYTES:
+                raise RuntimeError(
+                    "Tencent TTS synthesized PCM exceeds the one-shot safety "
+                    "limit; use streaming TTS for larger output"
+                )
+            audio.append(segment_audio)
+        return b"".join(audio)
+
+    async def _synthesize_segment(
+        self,
+        text: str,
+        voice: str,
+        speed: float,
+        *,
+        primary_language: int,
+        index: int,
+        total: int,
+    ) -> bytes:
+        """Send one bounded TextToVoice request and identify failures by segment."""
+        try:
+            payload = {
+                "Text": text,
+                "SessionId": str(uuid.uuid4()),
+                "Volume": 0,
+                "Speed": self._speed_to_tencent(speed),
+                "ProjectId": 0,
+                "ModelType": self.model_type,
+                "VoiceType": int(voice) if voice else self.voice_type,
+                "PrimaryLanguage": primary_language,
+                "SampleRate": self.sample_rate,
+                "Codec": self.codec,
+                "EnableSubtitle": False,
+            }
+            log.info(
+                "Tencent TTS request: segment=%d/%d voice_type=%s "
+                "primary_language=%s text_len=%s",
+                index,
+                total,
+                payload["VoiceType"],
+                primary_language,
+                len(text or ""),
+            )
+            response = await asyncio.to_thread(self._post_json, payload)
+            audio_b64 = response.get("Audio", "")
+            if not audio_b64:
+                raise RuntimeError(f"Tencent TTS returned no audio: {response}")
+            max_encoded_length = 4 * ((_TTS_MAX_SEGMENT_PCM_BYTES + 2) // 3)
+            if len(audio_b64) > max_encoded_length:
+                raise RuntimeError(
+                    "Tencent TTS encoded audio exceeds the segment safety limit"
+                )
+            audio = base64.b64decode(audio_b64, validate=True)
+            if not audio:
+                raise RuntimeError("Tencent TTS decoded to empty PCM audio")
+            if len(audio) % 2:
+                raise RuntimeError(
+                    f"Tencent TTS returned odd-length pcm_s16le audio: {len(audio)} bytes"
+                )
+            if len(audio) > _TTS_MAX_SEGMENT_PCM_BYTES:
+                raise RuntimeError("Tencent TTS segment PCM exceeds its safety limit")
+            return audio
+        except Exception as exc:
+            raise RuntimeError(
+                f"Tencent TTS segment {index}/{total} failed "
+                f"(text_len={len(text)}): {exc}"
+            ) from exc
 
     async def synthesize_stream(self, text: str, voice: str = "", speed: float = 1.0):
-        data = await self.synthesize(text, voice, speed)
-        for i in range(0, len(data), 4096):
-            yield data[i : i + 4096]
+        """Synthesize and yield each safe segment before requesting the next one."""
+        segments = self._segments_for_provider(text)
+        primary_language = self._primary_language_for_text(text)
+        for index, segment in enumerate(segments, start=1):
+            data = await self._synthesize_segment(
+                segment,
+                voice,
+                speed,
+                primary_language=primary_language,
+                index=index,
+                total=len(segments),
+            )
+            for offset in range(0, len(data), 4096):
+                yield data[offset : offset + 4096]
+
+    def _segments_for_provider(self, text: str) -> list[str]:
+        """Validate and split text without dropping provider-visible input."""
+        if not text:
+            raise TTSInputError("Tencent TTS text must not be empty")
+        if not _has_tts_content(text):
+            raise TTSInputError("Tencent TTS text must contain speakable content")
+        if len(text) > self.max_total_text_chars:
+            raise TTSInputError(
+                f"Tencent TTS text length {len(text)} exceeds the configured "
+                f"maximum of {self.max_total_text_chars} characters"
+            )
+        segments = _split_tts_text(text, self.max_text_chars)
+        if len(segments) > _TTS_MAX_SEGMENTS:
+            raise TTSInputError(
+                f"Tencent TTS text requires {len(segments)} requests; "
+                f"the safety limit is {_TTS_MAX_SEGMENTS}"
+            )
+        if any(not _has_tts_content(segment) for segment in segments):
+            raise TTSInputError(
+                "Tencent TTS text cannot be split without a punctuation- or "
+                "whitespace-only provider request; shorten consecutive separators"
+            )
+        return segments
 
     def _primary_language_for_text(self, text: str) -> int:
-        override = os.environ.get("TENCENT_TTS_PRIMARY_LANGUAGE", "").strip()
-        if override:
-            return int(override)
+        """Use the configured language or infer one once for the full utterance."""
+        if self.primary_language is not None:
+            return self.primary_language
         letters = sum(1 for ch in text if ("A" <= ch <= "Z") or ("a" <= ch <= "z"))
         cjk = sum(1 for ch in text if "\u4e00" <= ch <= "\u9fff")
         # Tencent TextToVoice exposes 1=Chinese, 2=English. Use English only
@@ -334,22 +558,32 @@ class TencentTTSBackend:
         return min(6, round((speed - 1.0) * 2))
 
     def _post_json(self, payload: dict) -> dict:
+        """Post one signed request and retain Tencent's request ID on errors."""
         body = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
         timestamp = int(time.time())
         headers = self._headers(body, timestamp)
-        resp = requests.post(self.endpoint, data=body.encode("utf-8"), headers=headers, timeout=10)
+        resp = requests.post(
+            self.endpoint, data=body.encode("utf-8"), headers=headers, timeout=10
+        )
         resp.raise_for_status()
         data = resp.json()
         response = data.get("Response", {})
         if "Error" in response:
             err = response["Error"]
-            raise RuntimeError(f"Tencent TTS {err.get('Code')}: {err.get('Message')}")
+            request_id = response.get("RequestId", "")
+            request_suffix = f" (request_id={request_id})" if request_id else ""
+            raise RuntimeError(
+                f"Tencent TTS {err.get('Code')}: {err.get('Message')}{request_suffix}"
+            )
         return response
 
     def _headers(self, body: str, timestamp: int) -> dict:
+        """Build Tencent TC3-HMAC-SHA256 headers for one request body."""
         date = time.strftime("%Y-%m-%d", time.gmtime(timestamp))
         hashed_request_payload = hashlib.sha256(body.encode("utf-8")).hexdigest()
-        canonical_headers = f"content-type:application/json; charset=utf-8\nhost:{self.host}\n"
+        canonical_headers = (
+            f"content-type:application/json; charset=utf-8\nhost:{self.host}\n"
+        )
         signed_headers = "content-type;host"
         canonical_request = "\n".join(
             [

--- a/services/speech/speech_service/tencent_cloud.py
+++ b/services/speech/speech_service/tencent_cloud.py
@@ -64,17 +64,64 @@ def _require_env(*names: str) -> str:
     raise RuntimeError(f"missing Tencent Cloud credential env: {joined}")
 
 
+def _has_tts_content(text: str) -> bool:
+    """Return whether text contains something beyond punctuation/spacing."""
+    return any(unicodedata.category(char)[0] not in {"P", "Z", "C"} for char in text)
+
+
+def _attach_trailing_separators(remaining: str, split_at: int, max_chars: int) -> int:
+    """Keep trailing punctuation with speakable text after a candidate cut."""
+    # A hard cut immediately before trailing punctuation would create a
+    # punctuation-only provider request (for example 140 Han characters
+    # followed by an ideographic full stop). Move enough preceding text
+    # to keep both requests meaningful without exceeding the limit.
+    tail = remaining[split_at:]
+    while tail and len(tail) < max_chars and not _has_tts_content(tail):
+        split_at -= 1
+        tail = remaining[split_at:]
+    return split_at
+
+
+def _hard_split_tts_text(text: str, max_chars: int) -> list[str]:
+    """Split only on the character budget, preserving every input character."""
+    if len(text) <= max_chars:
+        return [text]
+
+    segments: list[str] = []
+    remaining = text
+    while len(remaining) > max_chars:
+        split_at = _attach_trailing_separators(remaining, max_chars, max_chars)
+        if split_at <= 0:
+            split_at = max_chars
+        segments.append(remaining[:split_at])
+        remaining = remaining[split_at:]
+    if remaining:
+        segments.append(remaining)
+    return segments
+
+
 def _split_tts_text(text: str, max_chars: int) -> list[str]:
     """Split text into provider-safe chunks without dropping any characters.
 
     Prefer the last sentence boundary within each limit-sized window, then a
     comma or whitespace, and finally the hard boundary. Short input is returned
     unchanged so the existing single-request behavior remains intact.
+
+    Natural boundaries that leave only a tiny head fragment are ignored when
+    more than one additional full window remains; otherwise dense punctuation
+    near a previous hard cut can alternate short/long segments and exhaust the
+    request budget on otherwise valid input.
     """
     if max_chars <= 0:
         raise ValueError("Tencent TTS max chars must be greater than zero")
     if len(text) <= max_chars:
         return [text]
+
+    # Ignore early natural breaks that carve off a tiny head while a large
+    # remainder still needs multiple requests. A quarter-window floor keeps
+    # ordinary sentence splits (for example "Hello!") while rejecting the
+    # 2-character leftovers that inflate ("a"*141+".")*N into 2N segments.
+    min_natural_chars = max(1, max_chars // 4)
 
     segments: list[str] = []
     remaining = text
@@ -85,33 +132,35 @@ def _split_tts_text(text: str, max_chars: int) -> list[str]:
         )
         if split_at and not _has_tts_content(window[:split_at]):
             split_at = 0
+        if (
+            split_at
+            and split_at < min_natural_chars
+            and len(remaining) - split_at >= max_chars
+        ):
+            split_at = 0
         if split_at == 0:
             split_at = (
                 max((window.rfind(mark) for mark in _TTS_CLAUSE_BREAKS), default=-1) + 1
             )
         if split_at and not _has_tts_content(window[:split_at]):
             split_at = 0
+        if (
+            split_at
+            and split_at < min_natural_chars
+            and len(remaining) - split_at >= max_chars
+        ):
+            split_at = 0
         if split_at == 0:
             split_at = max_chars
 
-        # A hard cut immediately before trailing punctuation would create a
-        # punctuation-only provider request (for example 140 Han characters
-        # followed by an ideographic full stop). Move enough preceding text
-        # to keep both requests meaningful without exceeding the limit.
-        tail = remaining[split_at:]
-        while tail and len(tail) < max_chars and not _has_tts_content(tail):
-            split_at -= 1
-            tail = remaining[split_at:]
+        split_at = _attach_trailing_separators(remaining, split_at, max_chars)
+        if split_at <= 0:
+            split_at = max_chars
         segments.append(remaining[:split_at])
         remaining = remaining[split_at:]
     if remaining:
         segments.append(remaining)
     return segments
-
-
-def _has_tts_content(text: str) -> bool:
-    """Return whether text contains something beyond punctuation/spacing."""
-    return any(unicodedata.category(char)[0] not in {"P", "Z", "C"} for char in text)
 
 
 @dataclass(frozen=True)
@@ -409,11 +458,7 @@ class TencentTTSBackend:
         audio = []
         audio_size = 0
         for index, segment in enumerate(segments, start=1):
-            if not tts_request_is_active():
-                raise RuntimeError(
-                    f"Tencent TTS synthesis cancelled before segment "
-                    f"{index}/{len(segments)}"
-                )
+            self._ensure_tts_request_active(index, len(segments))
             segment_audio = await self._synthesize_segment(
                 segment,
                 voice,
@@ -495,6 +540,7 @@ class TencentTTSBackend:
         segments = self._segments_for_provider(text)
         primary_language = self._primary_language_for_text(text)
         for index, segment in enumerate(segments, start=1):
+            self._ensure_tts_request_active(index, len(segments))
             data = await self._synthesize_segment(
                 segment,
                 voice,
@@ -505,6 +551,14 @@ class TencentTTSBackend:
             )
             for offset in range(0, len(data), 4096):
                 yield data[offset : offset + 4096]
+
+    @staticmethod
+    def _ensure_tts_request_active(index: int, total: int) -> None:
+        """Stop paid fan-out when the bound transport/request is no longer live."""
+        if not tts_request_is_active():
+            raise RuntimeError(
+                f"Tencent TTS synthesis cancelled before segment {index}/{total}"
+            )
 
     def _segments_for_provider(self, text: str) -> list[str]:
         """Validate and split text without dropping provider-visible input."""
@@ -518,6 +572,11 @@ class TencentTTSBackend:
                 f"maximum of {self.max_total_text_chars} characters"
             )
         segments = _split_tts_text(text, self.max_text_chars)
+        if len(segments) > _TTS_MAX_SEGMENTS:
+            # Natural punctuation can carve tiny follow-up fragments (for
+            # example 140/2 alternating cuts) that exceed the request cap even
+            # when a plain budget split fits. Prefer the bounded split then.
+            segments = _hard_split_tts_text(text, self.max_text_chars)
         if len(segments) > _TTS_MAX_SEGMENTS:
             raise TTSInputError(
                 f"Tencent TTS text requires {len(segments)} requests; "

--- a/services/speech/speech_service/tts_errors.py
+++ b/services/speech/speech_service/tts_errors.py
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+
+
+class TTSInputError(ValueError):
+    """Report text that a TTS backend cannot safely send to its provider."""

--- a/services/speech/speech_service/tts_runtime.py
+++ b/services/speech/speech_service/tts_runtime.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+
+from collections.abc import Callable
+from contextvars import ContextVar
+
+_tts_request_active: ContextVar[Callable[[], bool] | None] = ContextVar(
+    "tts_request_active", default=None
+)
+
+
+def bind_tts_request_active(callback: Callable[[], bool] | None):
+    """Bind an optional transport-liveness callback to the current synthesis."""
+    return _tts_request_active.set(callback)
+
+
+def reset_tts_request_active(token) -> None:
+    """Restore the liveness callback that preceded this synthesis."""
+    _tts_request_active.reset(token)
+
+
+def tts_request_is_active() -> bool:
+    """Return true outside an RPC or while its transport remains active."""
+    callback = _tts_request_active.get()
+    return callback is None or callback()

--- a/services/speech/tests/test_speak_queue.py
+++ b/services/speech/tests/test_speak_queue.py
@@ -1,8 +1,18 @@
 # SPDX-License-Identifier: MulanPSL-2.0
+import base64
+import os
 import threading
 import unittest
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock, patch
 
-from speech_service.service import _speaker_lock
+from speech_service import service as service_module
+from speech_service.service import _speaker_lock, speak
+from speech_service.tencent_cloud import TencentTTSBackend
+
+_HAN_CHAR = "\N{CJK UNIFIED IDEOGRAPH-7532}"
+_SHORT_CJK_TEXT = _HAN_CHAR * 6
 
 
 class SpeakerQueueTest(unittest.TestCase):
@@ -29,6 +39,85 @@ class SpeakerQueueTest(unittest.TestCase):
         with first:
             self.assertTrue(second.acquire(blocking=False))
             second.release()
+
+
+class SpeakTencentTest(unittest.TestCase):
+    def _run_speak(self, text):
+        """Run speech/speak through Tencent TTS and capture provider/playback data."""
+        provider_payloads = []
+        played_frames = []
+        environment = {
+            "TENCENTCLOUD_SECRET_ID": "test-id",
+            "TENCENTCLOUD_SECRET_KEY": "test-key",
+            "TENCENT_TTS_MAX_CHARS": "140",
+        }
+
+        def provider_response(payload):
+            if len(payload["Text"]) > 140:
+                raise RuntimeError("UnsupportedOperation.TextTooLong")
+            provider_payloads.append(payload)
+            pcm = b"\x00\x00" * len(payload["Text"])
+            return {"Audio": base64.b64encode(pcm).decode("ascii")}
+
+        speaker_stub = Mock()
+        speaker_stub.Speaker.side_effect = lambda frames: played_frames.extend(frames)
+        speaker_channel = MagicMock()
+        capability = SimpleNamespace(provider_id="test-speaker")
+        connection = nullcontext(SimpleNamespace(endpoint="test-endpoint"))
+
+        with patch.dict(os.environ, environment, clear=True):
+            backend = TencentTTSBackend()
+            backend._post_json = provider_response
+            with (
+                patch.object(
+                    service_module.ATLAS, "find_capability", return_value=[capability]
+                ),
+                patch.object(service_module._tts_servicer, "tts_backend", backend),
+                patch.object(
+                    service_module.speech, "connect_capability", return_value=connection
+                ),
+                patch.object(
+                    service_module.grpc,
+                    "insecure_channel",
+                    return_value=speaker_channel,
+                ),
+                patch.object(
+                    service_module.contracts_grpc,
+                    "RobonixPrimitiveAudioSpeakerStub",
+                    return_value=speaker_stub,
+                ),
+            ):
+                response = speak(SimpleNamespace(text=text, target="test-speaker"))
+
+        speaker_channel.__enter__.assert_called_once_with()
+        speaker_channel.__exit__.assert_called_once()
+
+        return provider_payloads, played_frames, response
+
+    def test_speak_plays_every_long_text_segment_in_order(self):
+        """speech/speak forwards complete PCM joined from safe Tencent requests."""
+        text = _HAN_CHAR * 244
+        provider_payloads, played_frames, response = self._run_speak(text)
+
+        sent = [payload["Text"] for payload in provider_payloads]
+        self.assertEqual([len(segment) for segment in sent], [140, 104])
+        self.assertEqual("".join(sent), text)
+        self.assertEqual(
+            b"".join(frame.data for frame in played_frames), b"\x00\x00" * 244
+        )
+        self.assertTrue(response.ok)
+
+    def test_speak_keeps_short_text_single_request_behavior(self):
+        """speech/speak still sends a short utterance once and plays it fully."""
+        text = _SHORT_CJK_TEXT
+        provider_payloads, played_frames, response = self._run_speak(text)
+
+        self.assertEqual([payload["Text"] for payload in provider_payloads], [text])
+        self.assertEqual(
+            b"".join(frame.data for frame in played_frames),
+            b"\x00\x00" * len(text),
+        )
+        self.assertTrue(response.ok)
 
 
 if __name__ == "__main__":

--- a/services/speech/tests/test_speak_queue.py
+++ b/services/speech/tests/test_speak_queue.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: MulanPSL-2.0
+import asyncio
 import base64
 import os
 import threading
@@ -41,8 +42,8 @@ class SpeakerQueueTest(unittest.TestCase):
             second.release()
 
 
-class SpeakTencentTest(unittest.TestCase):
-    def _run_speak(self, text):
+class SpeakTencentTest(unittest.IsolatedAsyncioTestCase):
+    async def _run_speak(self, text):
         """Run speech/speak through Tencent TTS and capture provider/playback data."""
         provider_payloads = []
         played_frames = []
@@ -87,17 +88,17 @@ class SpeakTencentTest(unittest.TestCase):
                     return_value=speaker_stub,
                 ),
             ):
-                response = speak(SimpleNamespace(text=text, target="test-speaker"))
+                response = await speak(SimpleNamespace(text=text, target="test-speaker"))
 
         speaker_channel.__enter__.assert_called_once_with()
         speaker_channel.__exit__.assert_called_once()
 
         return provider_payloads, played_frames, response
 
-    def test_speak_plays_every_long_text_segment_in_order(self):
+    async def test_speak_plays_every_long_text_segment_in_order(self):
         """speech/speak forwards complete PCM joined from safe Tencent requests."""
         text = _HAN_CHAR * 244
-        provider_payloads, played_frames, response = self._run_speak(text)
+        provider_payloads, played_frames, response = await self._run_speak(text)
 
         sent = [payload["Text"] for payload in provider_payloads]
         self.assertEqual([len(segment) for segment in sent], [140, 104])
@@ -107,10 +108,10 @@ class SpeakTencentTest(unittest.TestCase):
         )
         self.assertTrue(response.ok)
 
-    def test_speak_keeps_short_text_single_request_behavior(self):
+    async def test_speak_keeps_short_text_single_request_behavior(self):
         """speech/speak still sends a short utterance once and plays it fully."""
         text = _SHORT_CJK_TEXT
-        provider_payloads, played_frames, response = self._run_speak(text)
+        provider_payloads, played_frames, response = await self._run_speak(text)
 
         self.assertEqual([payload["Text"] for payload in provider_payloads], [text])
         self.assertEqual(
@@ -118,6 +119,71 @@ class SpeakTencentTest(unittest.TestCase):
             b"\x00\x00" * len(text),
         )
         self.assertTrue(response.ok)
+
+    async def test_speak_cancellation_stops_after_first_segment(self):
+        """Cancelled MCP speak must not request later Tencent segments or play."""
+        text = _HAN_CHAR * 244
+        first_started = threading.Event()
+        release_first = threading.Event()
+        provider_payloads = []
+
+        def provider_response(payload):
+            provider_payloads.append(payload)
+            if len(provider_payloads) == 1:
+                first_started.set()
+                self.assertTrue(release_first.wait(2.0))
+            pcm = b"\x00\x00" * len(payload["Text"])
+            return {"Audio": base64.b64encode(pcm).decode("ascii")}
+
+        played_frames = []
+        speaker_stub = Mock()
+        speaker_stub.Speaker.side_effect = lambda frames: played_frames.extend(
+            list(frames)
+        )
+        speaker_channel = MagicMock()
+        capability = SimpleNamespace(provider_id="test-speaker")
+        connection = nullcontext(SimpleNamespace(endpoint="test-endpoint"))
+        environment = {
+            "TENCENTCLOUD_SECRET_ID": "test-id",
+            "TENCENTCLOUD_SECRET_KEY": "test-key",
+            "TENCENT_TTS_MAX_CHARS": "140",
+        }
+
+        with patch.dict(os.environ, environment, clear=True):
+            backend = TencentTTSBackend()
+            backend._post_json = provider_response
+            with (
+                patch.object(
+                    service_module.ATLAS, "find_capability", return_value=[capability]
+                ),
+                patch.object(service_module._tts_servicer, "tts_backend", backend),
+                patch.object(
+                    service_module.speech, "connect_capability", return_value=connection
+                ),
+                patch.object(
+                    service_module.grpc,
+                    "insecure_channel",
+                    return_value=speaker_channel,
+                ),
+                patch.object(
+                    service_module.contracts_grpc,
+                    "RobonixPrimitiveAudioSpeakerStub",
+                    return_value=speaker_stub,
+                ),
+            ):
+                task = asyncio.create_task(
+                    speak(SimpleNamespace(text=text, target="test-speaker"))
+                )
+                self.assertTrue(await asyncio.to_thread(first_started.wait, 2.0))
+                task.cancel()
+                release_first.set()
+                with self.assertRaises(asyncio.CancelledError):
+                    await task
+
+        self.assertEqual(len(provider_payloads), 1)
+        self.assertEqual(provider_payloads[0]["Text"], _HAN_CHAR * 140)
+        speaker_stub.Speaker.assert_not_called()
+        self.assertEqual(played_frames, [])
 
 
 if __name__ == "__main__":

--- a/services/speech/tests/test_tencent_cloud.py
+++ b/services/speech/tests/test_tencent_cloud.py
@@ -1,6 +1,50 @@
+import base64
+import binascii
+import os
 import unittest
+from unittest.mock import Mock, patch
 
-from speech_service.tencent_cloud import TencentRealtimeASRBackend
+from speech_service.tencent_cloud import (
+    TencentRealtimeASRBackend,
+    TencentTTSBackend,
+    _split_tts_text,
+)
+from speech_service.tts_errors import TTSInputError
+
+_BASE_ENV = {
+    "TENCENTCLOUD_SECRET_ID": "test-id",
+    "TENCENTCLOUD_SECRET_KEY": "test-key",
+}
+
+_HAN_A = "\N{CJK UNIFIED IDEOGRAPH-7532}"
+_HAN_B = "\N{CJK UNIFIED IDEOGRAPH-4E59}"
+_CJK_FULL_STOP = "\N{IDEOGRAPHIC FULL STOP}"
+_CJK_COMMA = "\N{FULLWIDTH COMMA}"
+_CJK_EXCLAMATION = "\N{FULLWIDTH EXCLAMATION MARK}"
+_MIXED_TEXT = (
+    f"{_HAN_A}{_HAN_B}{_CJK_COMMA}Robot status. "
+    f"{_HAN_B}{_HAN_A}{_CJK_EXCLAMATION}Task execution continues."
+)
+_STREAM_TEXT = (
+    f"{_HAN_A}{_HAN_B}{_CJK_FULL_STOP}"
+    f"{_HAN_B}{_HAN_A}{_CJK_COMMA}"
+    f"{_HAN_A}{_HAN_B}{_CJK_FULL_STOP}"
+    f"{_HAN_B}{_HAN_A}{_CJK_FULL_STOP}"
+)
+_SHORT_CJK_TEXT = f"{_HAN_A}{_HAN_B}{_HAN_A}{_HAN_B}"
+_SENTENCE_CASE = (
+    f"{_HAN_A}{_HAN_B}{_CJK_FULL_STOP}"
+    f"{_HAN_A}{_HAN_B}{_HAN_A}{_HAN_B}{_CJK_COMMA}{_HAN_A}{_HAN_B}"
+)
+_CLAUSE_CASE = (
+    f"{_HAN_A}{_HAN_B}{_HAN_A}{_HAN_B}{_CJK_COMMA}"
+    f"{_HAN_B}{_HAN_A}{_HAN_B}{_HAN_A}{_HAN_B}{_HAN_A}{_HAN_B}"
+)
+
+
+def _fake_pcm(text: str) -> bytes:
+    raw = text.encode("utf-8")
+    return raw if len(raw) % 2 == 0 else raw + b"\x00"
 
 
 class TencentStreamingTranscriptTest(unittest.TestCase):
@@ -26,6 +70,394 @@ class TencentStreamingTranscriptTest(unittest.TestCase):
         )
         self.assertIsNone(event)
         self.assertEqual(last, "still there")
+
+
+class TencentTTSChunkingTest(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        """Create a Tencent backend with fake credentials and a small limit."""
+        self._env = patch.dict(
+            os.environ,
+            {
+                "TENCENTCLOUD_SECRET_ID": "test-id",
+                "TENCENTCLOUD_SECRET_KEY": "test-key",
+                "TENCENT_TTS_MAX_CHARS": "10",
+            },
+            clear=True,
+        )
+        self._env.start()
+        self.addCleanup(self._env.stop)
+        self.backend = TencentTTSBackend()
+
+    def _install_echo_response(self):
+        """Return request text as audio bytes and record each provider payload."""
+        payloads = []
+
+        def echo(payload):
+            if len(payload["Text"]) > self.backend.max_text_chars:
+                raise RuntimeError("UnsupportedOperation.TextTooLong")
+            payloads.append(payload)
+            audio = base64.b64encode(_fake_pcm(payload["Text"])).decode("ascii")
+            return {"Audio": audio}
+
+        self.backend._post_json = echo
+        return payloads
+
+    async def test_text_around_boundary_uses_expected_request_count(self):
+        """N-1/N/N+1 inputs use one, one, and two provider requests."""
+        for length, request_count in ((9, 1), (10, 1), (11, 2)):
+            with self.subTest(length=length):
+                text = _HAN_A * length
+                payloads = self._install_echo_response()
+                audio = await self.backend.synthesize(text)
+                sent = [payload["Text"] for payload in payloads]
+                self.assertEqual(len(sent), request_count)
+                self.assertEqual("".join(sent), text)
+                self.assertEqual(audio, b"".join(_fake_pcm(part) for part in sent))
+
+    async def test_long_chinese_and_mixed_text_are_complete_and_bounded(self):
+        """Long Chinese and mixed input reaches the provider in bounded order."""
+        for text in (
+            _HAN_A * 244,
+            _MIXED_TEXT,
+        ):
+            with self.subTest(text=text):
+                payloads = self._install_echo_response()
+                audio = await self.backend.synthesize(text)
+                sent = [payload["Text"] for payload in payloads]
+                self.assertEqual("".join(sent), text)
+                self.assertTrue(all(0 < len(segment) <= 10 for segment in sent))
+                self.assertEqual(audio, b"".join(_fake_pcm(part) for part in sent))
+                self.assertTrue(
+                    all(payload["PrimaryLanguage"] == 1 for payload in payloads)
+                )
+
+    async def test_stream_yields_first_segment_before_requesting_the_next(self):
+        """Streaming emits a segment before starting the following request."""
+        text = _STREAM_TEXT
+        expected = _split_tts_text(text, 10)
+        payloads = self._install_echo_response()
+        stream = self.backend.synthesize_stream(text)
+
+        first = await anext(stream)
+        self.assertEqual(first, _fake_pcm(expected[0]))
+        self.assertEqual([payload["Text"] for payload in payloads], expected[:1])
+
+        remaining = [chunk async for chunk in stream]
+        self.assertEqual(
+            b"".join([first, *remaining]),
+            b"".join(_fake_pcm(part) for part in expected),
+        )
+        self.assertEqual([payload["Text"] for payload in payloads], expected)
+
+    async def test_short_stream_uses_one_request_and_yields_complete_audio(self):
+        """Tencent streaming keeps short input in one complete request."""
+        text = _SHORT_CJK_TEXT
+        payloads = self._install_echo_response()
+
+        audio = b"".join(
+            [chunk async for chunk in self.backend.synthesize_stream(text)]
+        )
+
+        self.assertEqual([payload["Text"] for payload in payloads], [text])
+        self.assertEqual(audio, _fake_pcm(text))
+
+    async def test_stream_drains_large_segment_before_requesting_next(self):
+        """All 4096-byte chunks for one segment precede the next request."""
+        payloads = []
+
+        def large_response(payload):
+            payloads.append(payload)
+            return {"Audio": base64.b64encode(b"\x00\x00" * 4097).decode("ascii")}
+
+        self.backend._post_json = large_response
+        stream = self.backend.synthesize_stream(_HAN_A * 11)
+        first_segment = [await anext(stream) for _ in range(3)]
+
+        self.assertEqual([len(chunk) for chunk in first_segment], [4096, 4096, 2])
+        self.assertEqual([payload["Text"] for payload in payloads], [_HAN_A * 10])
+
+        self.assertEqual(len(await anext(stream)), 4096)
+        self.assertEqual(
+            [payload["Text"] for payload in payloads],
+            [_HAN_A * 10, _HAN_A],
+        )
+        await stream.aclose()
+
+    async def test_failure_identifies_segment_and_keeps_original_exception(self):
+        """A failed provider request names its segment and retains its cause."""
+        provider_error = ValueError("provider failed")
+        calls = []
+
+        def fail_second(payload):
+            calls.append(payload)
+            if len(calls) == 2:
+                raise provider_error
+            return {"Audio": base64.b64encode(b"\x00\x00").decode("ascii")}
+
+        self.backend._post_json = fail_second
+        with self.assertRaisesRegex(RuntimeError, r"segment 2/3 failed") as raised:
+            await self.backend.synthesize(_HAN_A * 21)
+        self.assertIs(raised.exception.__cause__, provider_error)
+
+    async def test_stream_failure_identifies_later_segment(self):
+        """Streaming preserves context after yielding an earlier segment."""
+        provider_error = RuntimeError("stream provider failed")
+        calls = []
+
+        def fail_second(payload):
+            calls.append(payload)
+            if len(calls) == 2:
+                raise provider_error
+            return {"Audio": base64.b64encode(b"\x00\x00").decode("ascii")}
+
+        self.backend._post_json = fail_second
+        stream = self.backend.synthesize_stream(_HAN_A * 21)
+        self.assertEqual(await anext(stream), b"\x00\x00")
+        with self.assertRaisesRegex(RuntimeError, r"segment 2/3 failed") as raised:
+            await anext(stream)
+        self.assertIs(raised.exception.__cause__, provider_error)
+
+    async def test_rejects_malformed_or_invalid_pcm_audio(self):
+        """Malformed Base64 and odd pcm_s16le payloads fail explicitly."""
+        cases = (
+            ("%%%%", "base64", binascii.Error),
+            ("YQ==", "odd-length", RuntimeError),
+        )
+        for encoded, detail, cause_type in cases:
+            with self.subTest(encoded=encoded):
+                self.backend._post_json = lambda _payload, audio=encoded: {
+                    "Audio": audio
+                }
+                with self.assertRaisesRegex(
+                    RuntimeError, r"segment 1/1 failed"
+                ) as raised:
+                    await self.backend.synthesize("short")
+                self.assertIsInstance(raised.exception.__cause__, cause_type)
+                self.assertIn(detail, str(raised.exception.__cause__).lower())
+
+    async def test_invalid_or_unsafe_text_is_rejected_before_provider_calls(self):
+        """Never drop or send contentless text merely to satisfy a tiny limit."""
+        self.backend.max_text_chars = 1
+        payloads = self._install_echo_response()
+
+        cases = (
+            (_HAN_A + _CJK_FULL_STOP, "punctuation- or whitespace-only"),
+            (_CJK_FULL_STOP * 2, "speakable content"),
+            ("", "must not be empty"),
+        )
+        for text, detail in cases:
+            with self.subTest(text=text), self.assertRaisesRegex(ValueError, detail):
+                await self.backend.synthesize(text)
+
+        self.assertEqual(payloads, [])
+
+    async def test_total_text_and_request_limits_prevent_provider_fanout(self):
+        """Bound request cost before starting any partial synthesis."""
+        payloads = self._install_echo_response()
+        self.backend.max_total_text_chars = 20
+
+        with self.assertRaisesRegex(TTSInputError, "exceeds.*20"):
+            await self.backend.synthesize(_HAN_A * 21)
+
+        self.backend.max_total_text_chars = 5_000
+        self.backend.max_text_chars = 1
+        with self.assertRaisesRegex(TTSInputError, "requires 41 requests"):
+            await self.backend.synthesize(_HAN_A * 41)
+        self.assertEqual(payloads, [])
+
+    async def test_pcm_limits_bound_one_shot_and_segment_memory(self):
+        """Reject unexpectedly large decoded audio before it grows unbounded."""
+        payloads = self._install_echo_response()
+        with (
+            patch("speech_service.tencent_cloud._TTS_MAX_TOTAL_PCM_BYTES", 32),
+            self.assertRaisesRegex(RuntimeError, "one-shot safety limit"),
+        ):
+            await self.backend.synthesize(_HAN_A * 11)
+        self.assertEqual(len(payloads), 2)
+
+        payloads.clear()
+        with (
+            patch("speech_service.tencent_cloud._TTS_MAX_SEGMENT_PCM_BYTES", 2),
+            patch("speech_service.tencent_cloud.base64.b64decode") as decode,
+        ):
+            stream = self.backend.synthesize_stream(_HAN_A)
+            with self.assertRaisesRegex(RuntimeError, "encoded audio exceeds"):
+                await anext(stream)
+        decode.assert_not_called()
+        self.assertEqual(len(payloads), 1)
+
+
+class TencentTTSTextSplitterTest(unittest.TestCase):
+    def test_boundary_and_hard_split(self):
+        self.assertEqual(_split_tts_text(_HAN_A * 10, 10), [_HAN_A * 10])
+        self.assertEqual(_split_tts_text(_HAN_A * 11, 10), [_HAN_A * 10, _HAN_A])
+
+    def test_default_safe_limit_splits_reported_chinese_response(self):
+        text = _HAN_A * 244
+        segments = _split_tts_text(text, 140)
+        self.assertEqual([len(segment) for segment in segments], [140, 104])
+        self.assertEqual("".join(segments), text)
+
+    def test_sentence_break_precedes_later_comma(self):
+        """Sentence punctuation wins over a later comma in the same window."""
+        text = _SENTENCE_CASE
+        segments = _split_tts_text(text, 8)
+        self.assertEqual(segments[0], _HAN_A + _HAN_B + _CJK_FULL_STOP)
+        self.assertEqual("".join(segments), text)
+        self.assertTrue(all(len(segment) <= 8 for segment in segments))
+
+    def test_english_punctuation_newline_comma_and_word_boundaries(self):
+        """Natural mixed-language boundaries are preferred before hard cuts."""
+        cases = (
+            ("Hello!World?", 7, ["Hello!", "World?"]),
+            ("abc\ndefghijk", 6, ["abc\n", "defghi", "jk"]),
+            (
+                _CLAUSE_CASE,
+                6,
+                [
+                    _HAN_A + _HAN_B + _HAN_A + _HAN_B + _CJK_COMMA,
+                    _HAN_B + _HAN_A + _HAN_B + _HAN_A + _HAN_B + _HAN_A,
+                    _HAN_B,
+                ],
+            ),
+            ("Robot status.", 10, ["Robot ", "status."]),
+        )
+        for text, limit, expected in cases:
+            with self.subTest(text=text):
+                self.assertEqual(_split_tts_text(text, limit), expected)
+
+    def test_trailing_punctuation_is_not_isolated_after_hard_cut(self):
+        text = _HAN_A * 10 + _CJK_FULL_STOP
+        segments = _split_tts_text(text, 10)
+        self.assertEqual(segments, [_HAN_A * 9, _HAN_A + _CJK_FULL_STOP])
+        self.assertTrue(all(any(char.isalnum() for char in part) for part in segments))
+
+    def test_rejects_non_positive_limit(self):
+        with self.assertRaisesRegex(ValueError, "greater than zero"):
+            _split_tts_text("text", 0)
+
+
+class TencentTTSConfigTest(unittest.TestCase):
+    def test_defaults_to_provider_safe_limit_and_pcm(self):
+        with patch.dict(os.environ, _BASE_ENV, clear=True):
+            backend = TencentTTSBackend()
+        self.assertEqual(backend.max_text_chars, 140)
+        self.assertEqual(backend.max_total_text_chars, 5_000)
+        self.assertEqual(backend.codec, "pcm")
+        self.assertIsNone(backend.primary_language)
+
+    def test_rejects_limit_outside_provider_safe_range(self):
+        """Invalid or unsafe limits fail during backend initialization."""
+        cases = (
+            ("0", "between 1 and 150"),
+            ("151", "between 1 and 150"),
+            ("x", "integer"),
+        )
+        for value, detail in cases:
+            with (
+                self.subTest(value=value),
+                patch.dict(
+                    os.environ,
+                    {**_BASE_ENV, "TENCENT_TTS_MAX_CHARS": value},
+                    clear=True,
+                ),
+                self.assertRaisesRegex(ValueError, detail),
+            ):
+                TencentTTSBackend()
+
+    def test_rejects_invalid_total_text_limit(self):
+        """The utterance-wide bound stays finite and configurable."""
+        cases = (
+            ("0", "between 1 and 6000"),
+            ("6001", "between 1 and 6000"),
+            ("x", "integer"),
+        )
+        for value, detail in cases:
+            with (
+                self.subTest(value=value),
+                patch.dict(
+                    os.environ,
+                    {**_BASE_ENV, "TENCENT_TTS_MAX_TOTAL_CHARS": value},
+                    clear=True,
+                ),
+                self.assertRaisesRegex(ValueError, detail),
+            ):
+                TencentTTSBackend()
+
+    def test_rejects_invalid_primary_language_override(self):
+        """Only Tencent's documented Chinese and English selectors are valid."""
+        for value, detail in (("0", "1 or 2"), ("3", "1 or 2"), ("x", "integer")):
+            with (
+                self.subTest(value=value),
+                patch.dict(
+                    os.environ,
+                    {**_BASE_ENV, "TENCENT_TTS_PRIMARY_LANGUAGE": value},
+                    clear=True,
+                ),
+                self.assertRaisesRegex(ValueError, detail),
+            ):
+                TencentTTSBackend()
+
+    def test_primary_language_auto_detection_and_valid_overrides(self):
+        """Automatic and explicit language selection use one validated value."""
+        cases = (
+            ({}, "Robot status.", 2),
+            ({}, _SHORT_CJK_TEXT, 1),
+            ({"TENCENT_TTS_PRIMARY_LANGUAGE": "1"}, "Robot status.", 1),
+            ({"TENCENT_TTS_PRIMARY_LANGUAGE": "2"}, _SHORT_CJK_TEXT, 2),
+        )
+        for extra_env, text, expected in cases:
+            with (
+                self.subTest(extra_env=extra_env, text=text),
+                patch.dict(os.environ, {**_BASE_ENV, **extra_env}, clear=True),
+            ):
+                backend = TencentTTSBackend()
+                self.assertEqual(backend._primary_language_for_text(text), expected)
+
+    def test_rejects_non_pcm_codec(self):
+        """Encoded Tencent output cannot satisfy the service's PCM contract."""
+        with (
+            patch.dict(
+                os.environ,
+                {**_BASE_ENV, "TENCENT_TTS_CODEC": "wav"},
+                clear=True,
+            ),
+            self.assertRaisesRegex(ValueError, "requires.*pcm"),
+        ):
+            TencentTTSBackend()
+
+    def test_rejects_non_16khz_sample_rate(self):
+        """Speaker-bound raw PCM must use the service's fixed sample rate."""
+        with (
+            patch.dict(
+                os.environ,
+                {**_BASE_ENV, "TENCENT_TTS_SAMPLE_RATE": "8000"},
+                clear=True,
+            ),
+            self.assertRaisesRegex(ValueError, "requires.*16000"),
+        ):
+            TencentTTSBackend()
+
+    def test_provider_error_includes_request_id(self):
+        """Tencent diagnostics retain the request identifier for operations."""
+        provider_response = Mock()
+        provider_response.raise_for_status.return_value = None
+        provider_response.json.return_value = {
+            "Response": {
+                "Error": {"Code": "InvalidText", "Message": "bad text"},
+                "RequestId": "request-211",
+            }
+        }
+        with (
+            patch.dict(os.environ, _BASE_ENV, clear=True),
+            patch(
+                "speech_service.tencent_cloud.requests.post",
+                return_value=provider_response,
+            ),
+        ):
+            backend = TencentTTSBackend()
+            with self.assertRaisesRegex(RuntimeError, "request_id=request-211"):
+                backend._post_json({"Text": "bad"})
 
 
 if __name__ == "__main__":

--- a/services/speech/tests/test_tencent_cloud.py
+++ b/services/speech/tests/test_tencent_cloud.py
@@ -7,9 +7,15 @@ from unittest.mock import Mock, patch
 from speech_service.tencent_cloud import (
     TencentRealtimeASRBackend,
     TencentTTSBackend,
+    _TTS_MAX_SEGMENTS,
+    _hard_split_tts_text,
     _split_tts_text,
 )
 from speech_service.tts_errors import TTSInputError
+from speech_service.tts_runtime import (
+    bind_tts_request_active,
+    reset_tts_request_active,
+)
 
 _BASE_ENV = {
     "TENCENTCLOUD_SECRET_ID": "test-id",
@@ -265,6 +271,81 @@ class TencentTTSChunkingTest(unittest.IsolatedAsyncioTestCase):
             await self.backend.synthesize(_HAN_A * 41)
         self.assertEqual(payloads, [])
 
+    async def test_dense_sentence_punctuation_stays_within_request_budget(self):
+        """Valid long text must not be rejected for inefficient natural splits."""
+        # Reviewer fixture: naive sentence cuts previously alternated 140/2 and
+        # produced 70 segments, tripping _TTS_MAX_SEGMENTS even though length
+        # is under 5000 and a hard budget split needs only 36 requests.
+        text = ("a" * 141 + ".") * 35
+        self.assertLessEqual(len(text), 5_000)
+        natural = _split_tts_text(text, 140)
+        hard = _hard_split_tts_text(text, 140)
+        self.assertLessEqual(len(natural), _TTS_MAX_SEGMENTS)
+        self.assertLessEqual(len(hard), _TTS_MAX_SEGMENTS)
+        self.assertEqual("".join(natural), text)
+        self.assertEqual("".join(hard), text)
+
+        with patch.dict(
+            os.environ,
+            {
+                "TENCENTCLOUD_SECRET_ID": "test-id",
+                "TENCENTCLOUD_SECRET_KEY": "test-key",
+                "TENCENT_TTS_MAX_CHARS": "140",
+                "TENCENT_TTS_MAX_TOTAL_CHARS": "5000",
+            },
+            clear=True,
+        ):
+            backend = TencentTTSBackend()
+        payloads = []
+
+        def echo(payload):
+            payloads.append(payload)
+            return {
+                "Audio": base64.b64encode(_fake_pcm(payload["Text"])).decode("ascii")
+            }
+
+        backend._post_json = echo
+        audio = await backend.synthesize(text)
+        sent = [payload["Text"] for payload in payloads]
+        self.assertEqual("".join(sent), text)
+        self.assertLessEqual(len(sent), _TTS_MAX_SEGMENTS)
+        self.assertEqual(audio, b"".join(_fake_pcm(part) for part in sent))
+
+    async def test_request_budget_falls_back_to_hard_split(self):
+        """If natural splits exceed the cap, reuse a bounded hard split."""
+        text = _HAN_A * 50
+        with patch.dict(os.environ, _BASE_ENV, clear=True):
+            backend = TencentTTSBackend()
+        backend.max_text_chars = 10
+        bloated = [text[i : i + 1] for i in range(len(text))]
+        self.assertGreater(len(bloated), _TTS_MAX_SEGMENTS)
+        with patch(
+            "speech_service.tencent_cloud._split_tts_text", return_value=bloated
+        ):
+            segments = backend._segments_for_provider(text)
+        self.assertEqual(segments, _hard_split_tts_text(text, 10))
+        self.assertLessEqual(len(segments), _TTS_MAX_SEGMENTS)
+        self.assertEqual("".join(segments), text)
+
+    async def test_cancellation_stops_before_later_stream_segments(self):
+        """Streaming honors the same liveness gate as one-shot synthesis."""
+        payloads = self._install_echo_response()
+        active = True
+
+        def is_active():
+            return active
+
+        token = bind_tts_request_active(is_active)
+        try:
+            stream = self.backend.synthesize_stream(_HAN_A * 21)
+            self.assertEqual(await anext(stream), _fake_pcm(_HAN_A * 10))
+            active = False
+            with self.assertRaisesRegex(RuntimeError, r"cancelled before segment 2/3"):
+                await anext(stream)
+        finally:
+            reset_tts_request_active(token)
+        self.assertEqual([payload["Text"] for payload in payloads], [_HAN_A * 10])
+
     async def test_pcm_limits_bound_one_shot_and_segment_memory(self):
         """Reject unexpectedly large decoded audio before it grows unbounded."""
         payloads = self._install_echo_response()
@@ -335,6 +416,18 @@ class TencentTTSTextSplitterTest(unittest.TestCase):
     def test_rejects_non_positive_limit(self):
         with self.assertRaisesRegex(ValueError, "greater than zero"):
             _split_tts_text("text", 0)
+
+    def test_ignores_tiny_follow_up_sentence_fragments_on_long_remainder(self):
+        """Avoid 140/2 alternation when a later hard cut stays within budget."""
+        text = ("a" * 141 + ".") * 35
+        segments = _split_tts_text(text, 140)
+        self.assertEqual("".join(segments), text)
+        self.assertLessEqual(len(segments), _TTS_MAX_SEGMENTS)
+        self.assertTrue(all(len(segment) <= 140 for segment in segments))
+        # The previous bug emitted a two-character leftover after nearly every
+        # hard cut (~70 segments). Keep that explosion from returning.
+        tiny = [segment for segment in segments if len(segment) <= 2]
+        self.assertLessEqual(len(tiny), 1)
 
 
 class TencentTTSConfigTest(unittest.TestCase):

--- a/services/speech/tests/test_tts_servicers.py
+++ b/services/speech/tests/test_tts_servicers.py
@@ -1,0 +1,299 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+import base64
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import grpc
+from speech_service import service as service_module
+from speech_service.service import (
+    SpeechTtsServicer,
+    SpeechTtsStreamServicer,
+    _apply_cfg_to_env,
+)
+from speech_service.tencent_cloud import TencentTTSBackend
+from speech_service.tts_errors import TTSInputError
+
+_HAN_CHAR = "\N{CJK UNIFIED IDEOGRAPH-7532}"
+
+
+class _OneShotBackend:
+    def __init__(self, audio=b"\x00\x00", error=None):
+        self.calls = []
+        self.audio = audio
+        self.error = error
+
+    async def synthesize(self, text, voice="", speed=1.0):
+        self.calls.append((text, voice, speed))
+        if self.error is not None:
+            raise self.error
+        return self.audio
+
+
+class _RejectingBackend:
+    async def synthesize(self, text, voice="", speed=1.0):
+        raise TTSInputError("invalid TTS text")
+
+    async def synthesize_stream(self, text, voice="", speed=1.0):
+        if text:
+            raise TTSInputError("invalid TTS text")
+        yield b""
+
+
+class _UnexpectedValueErrorBackend:
+    async def synthesize_stream(self, text, voice="", speed=1.0):
+        if text:
+            raise ValueError("backend configuration is invalid")
+        yield b""
+
+
+class _StreamingBackend:
+    def __init__(self, *, fail_after_first=False):
+        self.calls = []
+        self.closed = False
+        self.fail_after_first = fail_after_first
+
+    async def synthesize_stream(self, text, voice="", speed=1.0):
+        """Yield fixture PCM and record closure even after failure/cancellation."""
+        self.calls.append((text, voice, speed))
+        try:
+            yield b"\x00\x00"
+            if self.fail_after_first:
+                raise RuntimeError("Tencent TTS segment 2/2 failed")
+            yield b"\x01\x00"
+        finally:
+            self.closed = True
+
+
+def _request(text="short text"):
+    return SimpleNamespace(text=text, voice="", speed=0.0)
+
+
+class SpeechTtsServicerTest(unittest.TestCase):
+    def setUp(self):
+        """Isolate TTS response metadata from the operator environment."""
+        self._env = patch.dict(
+            os.environ,
+            {
+                "SPEECH_TTS_OUTPUT_ENCODING": "pcm_s16le",
+                "SPEECH_TTS_OUTPUT_SAMPLE_RATE": "16000",
+            },
+            clear=False,
+        )
+        self._env.start()
+        self.addCleanup(self._env.stop)
+
+    def test_runtime_config_applies_tencent_text_limits(self):
+        """Driver config exports both limits consumed by Tencent TTS."""
+        with patch.dict(os.environ, {}, clear=True):
+            _apply_cfg_to_env(
+                {
+                    "tencent_tts_max_chars": 123,
+                    "tencent_tts_max_total_chars": 4_567,
+                }
+            )
+            self.assertEqual(os.environ["TENCENT_TTS_MAX_CHARS"], "123")
+            self.assertEqual(os.environ["TENCENT_TTS_MAX_TOTAL_CHARS"], "4567")
+
+    def test_one_shot_short_text_is_forwarded_unchanged(self):
+        """The unary RPC keeps existing short-text and PCM metadata behavior."""
+        backend = _OneShotBackend()
+        response = SpeechTtsServicer(backend).Synthesize(_request(), Mock())
+
+        self.assertEqual(backend.calls, [("short text", "", 1.0)])
+        self.assertEqual(response.audio_data, b"\x00\x00")
+        self.assertEqual(response.encoding, "pcm_s16le")
+        self.assertEqual(response.sample_rate_hz, 16000)
+        self.assertEqual(response.error, "")
+
+    def test_oversized_audio_is_not_retained_in_cache(self):
+        """A single large provider response cannot pin the TTS cache budget."""
+        backend = _OneShotBackend()
+        servicer = SpeechTtsServicer(backend)
+        with patch.object(service_module, "_TTS_CACHE_MAX_BYTES", 1):
+            servicer.Synthesize(_request(), Mock())
+            servicer.Synthesize(_request(), Mock())
+
+        self.assertEqual(len(backend.calls), 2)
+
+    def test_cache_evicts_oldest_audio_to_stay_within_byte_budget(self):
+        """Several small entries cannot collectively exceed the cache budget."""
+        backend = _OneShotBackend()
+        servicer = SpeechTtsServicer(backend)
+        with patch.object(service_module, "_TTS_CACHE_MAX_BYTES", 3):
+            servicer.Synthesize(_request("first"), Mock())
+            servicer.Synthesize(_request("second"), Mock())
+            servicer.Synthesize(_request("first"), Mock())
+
+        self.assertEqual(len(backend.calls), 3)
+
+    def test_invalid_metadata_fails_before_one_shot_backend_work(self):
+        """Local response configuration is checked before provider work."""
+        cases = (
+            ({"SPEECH_TTS_OUTPUT_SAMPLE_RATE": "invalid"}, "invalid literal"),
+            ({"SPEECH_TTS_OUTPUT_SAMPLE_RATE": "8000"}, "must be 16000"),
+            ({"SPEECH_TTS_OUTPUT_ENCODING": "mp3"}, "must be pcm_s16le"),
+            ({"SPEECH_TTS_OUTPUT_ENCODING": ""}, "must be pcm_s16le"),
+        )
+        for environment, detail in cases:
+            with self.subTest(environment=environment):
+                backend = _OneShotBackend()
+                context = Mock()
+                with patch.dict(os.environ, environment, clear=False):
+                    response = SpeechTtsServicer(backend).Synthesize(
+                        _request(), context
+                    )
+
+                self.assertEqual(backend.calls, [])
+                self.assertIn(detail, response.error)
+                context.set_code.assert_not_called()
+
+    def test_one_shot_invalid_input_uses_contract_error_field(self):
+        """Unary input errors retain the response-level failure contract."""
+        context = Mock()
+        response = SpeechTtsServicer(_RejectingBackend()).Synthesize(
+            _request(), context
+        )
+
+        context.set_code.assert_not_called()
+        context.set_details.assert_not_called()
+        self.assertEqual(response.audio_data, b"")
+        self.assertEqual(response.error, "invalid TTS text")
+
+    def test_one_shot_provider_failure_uses_contract_error_field(self):
+        """Unary provider failures retain the response-level failure contract."""
+        context = Mock()
+        response = SpeechTtsServicer(
+            _OneShotBackend(error=RuntimeError("provider unavailable"))
+        ).Synthesize(_request(), context)
+
+        context.set_code.assert_not_called()
+        context.set_details.assert_not_called()
+        self.assertEqual(response.audio_data, b"")
+        self.assertEqual(response.error, "provider unavailable")
+
+    def test_one_shot_cancellation_stops_tencent_segment_fanout(self):
+        """An inactive unary transport prevents the next paid provider request."""
+        provider_payloads = []
+        environment = {
+            "TENCENTCLOUD_SECRET_ID": "test-id",
+            "TENCENTCLOUD_SECRET_KEY": "test-key",
+            "TENCENT_TTS_MAX_CHARS": "1",
+        }
+        with patch.dict(os.environ, environment, clear=True):
+            backend = TencentTTSBackend()
+        backend._post_json = lambda payload: (
+            provider_payloads.append(payload)
+            or {"Audio": base64.b64encode(b"\x00\x00").decode("ascii")}
+        )
+        context = Mock()
+        context.is_active.side_effect = (True, False)
+
+        response = SpeechTtsServicer(backend).Synthesize(
+            _request(_HAN_CHAR * 3), context
+        )
+
+        self.assertEqual(len(provider_payloads), 1)
+        self.assertIn("cancelled before segment 2/3", response.error)
+
+    def test_stream_short_text_emits_audio_then_one_final_chunk(self):
+        """A successful stream preserves chunk order and terminates explicitly."""
+        backend = _StreamingBackend()
+        context = Mock()
+        responses = list(
+            SpeechTtsStreamServicer(backend).SynthesizeStream(_request(), context)
+        )
+
+        self.assertEqual(backend.calls, [("short text", "", 1.0)])
+        self.assertEqual(
+            [response.chunk.data for response in responses[:-1]],
+            [b"\x00\x00", b"\x01\x00"],
+        )
+        self.assertFalse(any(response.is_final for response in responses[:-1]))
+        self.assertTrue(responses[-1].is_final)
+        self.assertTrue(backend.closed)
+        context.set_code.assert_not_called()
+
+    def test_stream_failure_sets_rpc_error_without_false_final_chunk(self):
+        """A later segment failure keeps earlier audio but never reports success."""
+        backend = _StreamingBackend(fail_after_first=True)
+        context = Mock()
+        responses = list(
+            SpeechTtsStreamServicer(backend).SynthesizeStream(_request(), context)
+        )
+
+        self.assertEqual([response.chunk.data for response in responses], [b"\x00\x00"])
+        self.assertFalse(any(response.is_final for response in responses))
+        context.set_code.assert_called_once_with(grpc.StatusCode.INTERNAL)
+        context.set_details.assert_called_once_with("Tencent TTS segment 2/2 failed")
+        self.assertTrue(backend.closed)
+
+    def test_stream_invalid_input_sets_invalid_argument(self):
+        """Streaming input errors use an explicit client-facing gRPC status."""
+        context = Mock()
+        responses = list(
+            SpeechTtsStreamServicer(_RejectingBackend()).SynthesizeStream(
+                _request(), context
+            )
+        )
+
+        self.assertEqual(responses, [])
+        context.set_code.assert_called_once_with(grpc.StatusCode.INVALID_ARGUMENT)
+        context.set_details.assert_called_once_with("invalid TTS text")
+
+    def test_stream_unexpected_value_error_sets_internal(self):
+        """Backend ValueError does not mislabel an internal fault as bad input."""
+        context = Mock()
+        responses = list(
+            SpeechTtsStreamServicer(_UnexpectedValueErrorBackend()).SynthesizeStream(
+                _request(), context
+            )
+        )
+
+        self.assertEqual(responses, [])
+        context.set_code.assert_called_once_with(grpc.StatusCode.INTERNAL)
+        context.set_details.assert_called_once_with("backend configuration is invalid")
+
+    def test_invalid_metadata_fails_before_stream_backend_work(self):
+        """Streaming validates local response metadata before provider work."""
+        backend = _StreamingBackend()
+        context = Mock()
+        with patch.dict(
+            os.environ, {"SPEECH_TTS_OUTPUT_SAMPLE_RATE": "invalid"}, clear=False
+        ):
+            responses = list(
+                SpeechTtsStreamServicer(backend).SynthesizeStream(_request(), context)
+            )
+
+        self.assertEqual(responses, [])
+        self.assertEqual(backend.calls, [])
+        context.set_code.assert_called_once_with(grpc.StatusCode.INTERNAL)
+
+    def test_client_cancellation_closes_backend_generator(self):
+        """Closing the synchronous RPC iterator releases its async generator."""
+        backend = _StreamingBackend()
+        responses = SpeechTtsStreamServicer(backend).SynthesizeStream(
+            _request(), Mock()
+        )
+        first = next(responses)
+        self.assertEqual(first.chunk.data, b"\x00\x00")
+        responses.close()
+        self.assertTrue(backend.closed)
+
+    def test_inactive_context_stops_before_requesting_another_chunk(self):
+        """Server-side cancellation does not start additional backend work."""
+        backend = _StreamingBackend()
+        context = Mock()
+        context.is_active.side_effect = (True, False)
+        responses = list(
+            SpeechTtsStreamServicer(backend).SynthesizeStream(_request(), context)
+        )
+
+        self.assertEqual([response.chunk.data for response in responses], [b"\x00\x00"])
+        self.assertFalse(any(response.is_final for response in responses))
+        self.assertTrue(backend.closed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Tencent TextToVoice rejects long Chinese input with
`UnsupportedOperation.TextTooLong`. This prevents longer utterances from being
returned or played completely through unary TTS, streaming TTS, and
`speech/speak`.

## Changes

- Split Tencent TTS input into provider-safe segments.
- Prefer sentence punctuation, then clause or whitespace boundaries, and
  finally bounded hard splits.
- Preserve every accepted input character and synthesize segments in order.
- Keep short-text behavior as a single provider request.
- Use one primary language selection for the complete utterance.
- Add total-character, request-count, decoded-PCM, and cache limits.
- Stop requesting later segments after unary or streaming cancellation.
- Validate PCM/Base64 responses and retain Tencent request IDs in errors.
- Preserve unary response error semantics and explicit streaming gRPC errors.
- Document Tencent TTS configuration and limits.

## Compatibility

- No capability contract or generated-code changes.
- No migration is required.
- Tencent output remains 16 kHz mono `pcm_s16le`.
- `TENCENT_TTS_CODEC` must remain `pcm`.
- Added configurable per-request and total-text limits.

## Validation

- Speech service tests: 47 passed.
- Tencent TTS tests on Python 3.10: 27 passed.
- Tencent TTS tests on Python 3.11: 27 passed.
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --tests -- -D warnings`
- `cargo build --workspace`
- `cargo test --workspace --all-targets`: 251 passed.
- Runtime portability, Webots smoke, LaserScan regression, documentation, Ruff,
  and commit-authorship checks passed.

No screenshots are applicable because this is a backend-only change.

Closes #211