### PR TITLE
fix(scribe): reorder ts_parse secs binding for non-Unix builds

### DIFF
--- a/system/scribe/src/lib.rs
+++ b/system/scribe/src/lib.rs
@@ -170,7 +170,6 @@ pub fn ts_parse(s: &str) -> Option<u64> {
             t as u64
         }
     };
-    let ts_ns = secs.checked_mul(1_000_000_000)?.checked_add(nsec as u64)?;
     #[cfg(not(unix))]
     let secs = {
         let days_before_month: [u32; 12] = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334];
@@ -184,6 +183,7 @@ pub fn ts_parse(s: &str) -> Option<u64> {
             - 1;
         days as u64 * 86400 + hour as u64 * 3600 + min as u64 * 60 + sec as u64
     };
+    let ts_ns = secs.checked_mul(1_000_000_000)?.checked_add(nsec as u64)?;
     Some(ts_ns)
 }
 


### PR DESCRIPTION
Fixes #233: `ts_parse` in `system/scribe/src/lib.rs` fails to compile on non-Unix targets with `error[E0425]: cannot find value 'secs' in this scope`.

## Root cause

The `secs` binding is split across two `#[cfg]` blocks — `#[cfg(unix)]` before the use site and `#[cfg(not(unix))]` after it. On non-Unix targets the first block is stripped by `cfg`, leaving only the second binding, which is declared *after* the `let ts_ns = secs...` line that uses it. Rust only allows a binding to be used after its declaration, hence E0425.

## Fix

Move the `let ts_ns = ...` line below the `#[cfg(not(unix))]` block so `secs` is declared before use on both targets. Pure reorder, no logic change.

## Validation

- `cargo check -p robonix-scribe` — clean (Unix)
- `cargo fmt -p robonix-scribe -- --check` — clean
