### PR TITLE
fix(ci): stop the Webots suite failing on a flaky route to GitHub

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -530,6 +530,17 @@ jobs:
           # developer workstation, so CI must not mutate ~/.gitconfig.
           git_config="$RUNNER_TEMP/robonix-ci-gitconfig"
           : > "$git_config"
+          # The runner service inherited HTTP_PROXY=127.0.0.1:9981 from a
+          # macOS-forwarding config that was disabled on 2026-08-10. The
+          # listener is still up but forwards nothing, so every clone since has
+          # died with `GnuTLS, handshake failed` — an error that names TLS and
+          # hides the fact that the proxy is a dead end. Drop the inherited
+          # values for this job so the routing decided below is the one that
+          # applies.
+          for stale in HTTP_PROXY HTTPS_PROXY ALL_PROXY http_proxy https_proxy all_proxy; do
+            printf '%s=\n' "$stale" >> "$GITHUB_ENV"
+          done
+          unset HTTP_PROXY HTTPS_PROXY ALL_PROXY http_proxy https_proxy all_proxy
           if timeout 15s git ls-remote --exit-code \
               "https://ghfast.top/https://github.com/syswonder/robonix.git" \
               HEAD >/dev/null 2>&1; then

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -537,11 +537,22 @@ jobs:
               url."https://ghfast.top/https://github.com/".insteadOf \
               "https://github.com/"
             echo "Using ghfast.top for GitHub clones"
-          else
+          elif timeout 5s bash -c '</dev/tcp/127.0.0.1/7897' 2>/dev/null &&
+               timeout 20s git -c 'http.https://github.com/.proxy=http://127.0.0.1:7897' \
+                 ls-remote --exit-code "https://github.com/syswonder/robonix.git" \
+                 HEAD >/dev/null 2>&1; then
             git config --file "$git_config" \
               'http.https://github.com/.proxy' \
               'http://127.0.0.1:7897'
             echo "ghfast.top unavailable; using GitHub through Clash at 127.0.0.1:7897"
+          else
+            # Both routes are gone. Pointing git at a proxy that is not
+            # listening is worse than not setting one: every clone dies with a
+            # GnuTLS handshake failure against a closed port, which reads like
+            # a TLS problem rather than a missing proxy. Leave git alone and
+            # let it reach github.com directly; if that also fails the error
+            # will at least name the real cause.
+            echo "ghfast.top unavailable and no proxy on 127.0.0.1:7897; going direct"
           fi
           echo "GIT_CONFIG_GLOBAL=$git_config" >> "$GITHUB_ENV"
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1253,7 +1253,8 @@ jobs:
           for i in $(seq 1 60); do
             if rbnx caps -v --server "$ROBONIX_CI_ATLAS" >"$RUNNER_TEMP/caps.post-restart.txt" 2>&1 \
               && grep -q "robonix/service/navigation/navigate" "$RUNNER_TEMP/caps.post-restart.txt" \
-              && grep -q "^● nav2 \[ACTIVE\]" "$RUNNER_TEMP/caps.post-restart.txt"; then
+              && grep -q "^● nav2 \[ACTIVE\]" "$RUNNER_TEMP/caps.post-restart.txt" \
+              && grep -qE "^● explore \[(INACTIVE|ACTIVE)\]" "$RUNNER_TEMP/caps.post-restart.txt"; then
               echo "post-restart atlas ready"
               break
             fi

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -548,10 +548,22 @@ jobs:
               url."https://ghfast.top/https://github.com/".insteadOf \
               "https://github.com/"
             echo "Using ghfast.top for GitHub clones"
-          elif timeout 5s bash -c '</dev/tcp/127.0.0.1/7897' 2>/dev/null &&
-               timeout 20s git -c 'http.https://github.com/.proxy=http://127.0.0.1:7897' \
-                 ls-remote --exit-code "https://github.com/syswonder/robonix.git" \
-                 HEAD >/dev/null 2>&1; then
+          elif proxy_ok=0
+               # Clash on this runner drops out for stretches at a time. Both
+               # other routes are hard-blocked here — a direct clone and
+               # ghfast.top both come back "Connection reset by peer" — so the
+               # proxy is the only way out and a single failed probe is worth
+               # waiting on rather than treating as absent.
+               for attempt in 1 2 3 4 5 6; do
+                 if timeout 20s git -c 'http.https://github.com/.proxy=http://127.0.0.1:7897' \
+                      ls-remote --exit-code "https://github.com/syswonder/robonix.git" \
+                      HEAD >/dev/null 2>&1; then
+                   proxy_ok=1; break
+                 fi
+                 echo "Clash probe $attempt/6 failed; retrying in 10s"
+                 sleep 10
+               done
+               [ "$proxy_ok" = 1 ]; then
             git config --file "$git_config" \
               'http.https://github.com/.proxy' \
               'http://127.0.0.1:7897'

--- a/testing/validate_lifecycle.py
+++ b/testing/validate_lifecycle.py
@@ -77,6 +77,11 @@ REQUIRED_ACTIVE = [
     "scene", "tiago_camera", "tiago_lidar", "audio_driver",
     "mapping", "nav2", "memory", "speech", "voiceprint",
 ]
+# Skills idle in INACTIVE until a consumer activates them, so "boot done"
+# for a skill means rbnx has driven it out of REGISTERED (CMD_INIT accepted).
+# Capability declaration alone races the executor: it refuses to auto-activate
+# a skill that is still REGISTERED, and it never retries.
+REQUIRED_INITIALIZED = ["explore"]
 
 # Runtime processes that the user has called out by name in the issue.
 # `pgrep -f` matches the wrapper command; the `rbnx start` form is
@@ -338,6 +343,10 @@ def wait_for_boot(
             caps.returncode == 0
             and all(c in out for c in REQUIRED_CAPS)
             and all(f"● {p} [ACTIVE]" in out for p in REQUIRED_ACTIVE)
+            and all(
+                any(f"● {p} [{state}]" in out for state in ("INACTIVE", "ACTIVE"))
+                for p in REQUIRED_INITIALIZED
+            )
         )
         if ok:
             log(f"{label}: all required providers ACTIVE")

--- a/tools/rbnx/src/cmd/deploy.rs
+++ b/tools/rbnx/src/cmd/deploy.rs
@@ -443,18 +443,7 @@ fn check_prerequisites(
         ));
         let dest = cache_root.join(repo_dir_name(url));
         std::fs::create_dir_all(cache_root)?;
-        let mut clone = std::process::Command::new("git");
-        clone.arg("clone").arg("--depth").arg("1");
-        if let Some(b) = branch {
-            clone.arg("--branch").arg(b);
-        }
-        clone.arg(url).arg(&dest);
-        let status = clone
-            .status()
-            .with_context(|| format!("git clone {url} failed to spawn"))?;
-        if !status.success() {
-            anyhow::bail!("git clone {url} exited with {:?}", status.code());
-        }
+        super::run_package::git_clone_with_retry(url, branch.as_deref(), &dest)?;
         // Newly-cloned package needs a build too.
         let stamp = dest.join("rbnx-build").join(".rbnx-built");
         if !stamp.exists() {

--- a/tools/rbnx/src/cmd/run_package.rs
+++ b/tools/rbnx/src/cmd/run_package.rs
@@ -240,10 +240,13 @@ pub(super) fn git_clone_with_retry(
 
     let mut last_code: Option<i32> = None;
     for attempt in 1..=ATTEMPTS {
-        if dest.exists() {
+        if attempt > 1 && dest.exists() {
             // A failed clone can leave a partial tree; git will not clone into
             // it, so the retry would fail for a different reason than the one
-            // we are retrying.
+            // we are retrying. Only ever remove what a previous *attempt of
+            // this call* created — every caller already guarantees the
+            // destination is absent, and a helper that deletes whatever it
+            // finds there would be a trap for the next one that does not.
             let _ = std::fs::remove_dir_all(dest);
         }
         let mut clone = std::process::Command::new("git");

--- a/tools/rbnx/src/cmd/run_package.rs
+++ b/tools/rbnx/src/cmd/run_package.rs
@@ -214,6 +214,63 @@ pub async fn execute_build(
 /// "fetch → build" be a controlled offline step the user can run
 /// when they have network / time, then `rbnx boot` is a fast,
 /// online-optional bring-up.
+/// `git clone --depth 1` with bounded retries.
+///
+/// Clones the repo into `dest`, retrying transient failures. Between attempts
+/// it removes any partial checkout git left behind, because git refuses to
+/// clone into a non-empty directory and a half-written tree would otherwise
+/// turn one flaky network moment into a permanent failure.
+///
+/// Retries exist because a deployment build clones several remotes over
+/// several minutes, and any one of them dying takes the whole build with it.
+/// On a runner whose only route to GitHub is a proxy that drops for stretches
+/// at a time, a single `GnuTLS, handshake failed` mid-build was enough to fail
+/// a run whose next attempt seconds later would have succeeded.
+///
+/// The last attempt's exit status is what the error reports. Returns `Err`
+/// only after every attempt has failed, or if git could not be spawned at all
+/// — a missing git binary is not transient, so that is not retried.
+pub(super) fn git_clone_with_retry(
+    url: &str,
+    branch: Option<&str>,
+    dest: &std::path::Path,
+) -> Result<()> {
+    const ATTEMPTS: u32 = 3;
+    const BACKOFF: std::time::Duration = std::time::Duration::from_secs(5);
+
+    let mut last_code: Option<i32> = None;
+    for attempt in 1..=ATTEMPTS {
+        if dest.exists() {
+            // A failed clone can leave a partial tree; git will not clone into
+            // it, so the retry would fail for a different reason than the one
+            // we are retrying.
+            let _ = std::fs::remove_dir_all(dest);
+        }
+        let mut clone = std::process::Command::new("git");
+        clone.arg("clone").arg("--depth").arg("1");
+        if let Some(b) = branch {
+            clone.arg("--branch").arg(b);
+        }
+        clone.arg(url).arg(dest);
+        let status = clone
+            .status()
+            .with_context(|| format!("git clone {url} failed to spawn"))?;
+        if status.success() {
+            return Ok(());
+        }
+        last_code = status.code();
+        if attempt < ATTEMPTS {
+            output::warning(&format!(
+                "git clone {url} failed (attempt {attempt}/{ATTEMPTS}); \
+                 retrying in {}s",
+                BACKOFF.as_secs()
+            ));
+            std::thread::sleep(BACKOFF);
+        }
+    }
+    anyhow::bail!("git clone {url} exited with {last_code:?} after {ATTEMPTS} attempts")
+}
+
 fn build_deploy_manifest(
     manifest_path: &Path,
     config: &Config,
@@ -351,18 +408,7 @@ fn build_deploy_manifest(
         for r in &to_clone {
             let (url, branch) = r.url_to_clone.as_ref().unwrap();
             output::sub_step(&format!("git clone {url} -> {}", r.pkg_dir.display()));
-            let mut clone = std::process::Command::new("git");
-            clone.arg("clone").arg("--depth").arg("1");
-            if let Some(b) = branch {
-                clone.arg("--branch").arg(b);
-            }
-            clone.arg(url).arg(&r.pkg_dir);
-            let status = clone
-                .status()
-                .with_context(|| format!("git clone {url} failed to spawn"))?;
-            if !status.success() {
-                anyhow::bail!("git clone {url} exited with {:?}", status.code());
-            }
+            git_clone_with_retry(url, branch.as_deref(), &r.pkg_dir)?;
         }
     }
 
@@ -1039,6 +1085,35 @@ mod tests {
     use super::*;
     use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    /// A failing clone must exhaust its attempts, name the exit status, and
+    /// leave no partial checkout behind. The stale directory seeded here
+    /// stands in for the tree a network-interrupted clone leaves: without the
+    /// cleanup between attempts, git refuses to clone into a non-empty
+    /// directory and every retry fails for the wrong reason.
+    ///
+    /// The URL is a local path that does not exist, so git fails immediately
+    /// and the test needs no network.
+    #[test]
+    fn git_clone_with_retry_cleans_partial_checkouts_and_reports_the_last_status() {
+        let root = temp_root("clone-retry");
+        let dest = root.join("pkg");
+        fs::create_dir_all(&dest).expect("dest");
+        fs::write(dest.join("leftover.txt"), b"partial clone").expect("seed leftover");
+
+        let missing = root.join("no-such-repo.git");
+        let err = git_clone_with_retry(&missing.to_string_lossy(), None, &dest)
+            .expect_err("clone of a nonexistent repo must fail");
+
+        let msg = format!("{err:#}");
+        assert!(msg.contains("after 3 attempts"), "unexpected error: {msg}");
+        assert!(
+            !dest.exists(),
+            "a failed clone must not leave a partial checkout at {}",
+            dest.display()
+        );
+        let _ = fs::remove_dir_all(&root);
+    }
 
     fn temp_root(label: &str) -> PathBuf {
         let nonce = SystemTime::now()


### PR DESCRIPTION
The Webots integration suite has been failing on `dev` because git could not reach GitHub, not because anything in the deployment was wrong. Two distinct causes, both fixed here, plus a third failure that surfaced once the network ones were gone.

**A dead proxy the route decision could not see.** The runner service inherited `HTTP_PROXY=127.0.0.1:9981` from a macOS-forwarding config that was disabled on 2026-08-10. The listener is still up but forwards nothing, so clones died with `GnuTLS, handshake failed` — an error that names TLS and hides the fact that the proxy is a dead end. The mirror step now clears the inherited values for the job, probes each candidate route for real with `git ls-remote`, and when no route answers leaves git alone to go direct rather than pointing it at a closed port. Clash on this runner drops out for stretches at a time and is the only way out when ghfast.top is blocked, so its probe retries six times at ten-second intervals instead of treating one failure as absence.

**A route decided once, then trusted for twenty minutes.** Even a correct decision at job start does not survive Clash dropping midway through `rbnx build`, which clones several remotes over several minutes. Both clone sites gave up after a single attempt, so one handshake failure partway through the fetch phase failed a run that would have succeeded seconds later — this is what killed run 33527386073. Clones now go through a shared helper that retries three times with a 5s backoff, removing any partial checkout between attempts, since git refuses to clone into a non-empty directory and a half-written tree would otherwise turn one flaky moment into a permanent failure.

**A skill call racing its own CMD_INIT after the lifecycle reboot.** Run 33506916121 (dev at 750cc58f) got past the network and failed only the post-restart pass of `object_navigation`: `skill explore is REGISTERED; automatic activation is only valid from INACTIVE`. The atlas log shows the window: the explore container declared its capabilities at 11:41:24.5, the restart suite dispatched its first explore call at 11:41:25.48, and rbnx boot sent CMD_INIT (REGISTERED → INACTIVE) at 11:41:25.74. Both readiness checks let the suite start inside those 260 ms: the lifecycle validator only required the explore contracts to be declared and the service providers to be ACTIVE, and the workflow's post-restart gate only looked at nav2. Both waits now treat a skill as booted only once it has left REGISTERED (INACTIVE or ACTIVE). The executor deliberately never retries activation, so the fix belongs in the readiness checks, not in the executor.

## Validation

- `cargo fmt --all -- --check` and `cargo clippy -p robonix-cli --all-targets -- -D warnings` clean.
- `cargo test -p robonix-cli git_clone_with_retry` — new test seeds a partial checkout, clones a nonexistent repo, and asserts all three attempts ran and the partial tree was removed.
- The retry helper's behaviour was confirmed from the test output: three `fatal: repository ... does not exist` lines for one call.

The clone retry is a behaviour change for every `rbnx build`, not just CI: a genuinely bad URL now costs 10s of backoff before failing. That trade buys not losing a twenty-minute deployment build to one dropped packet.
- Webots suite dispatched on this branch after the readiness fix: https://github.com/syswonder/robonix/actions/runs/33770928429 (result to be recorded when it finishes).
