### PR TITLE
fix(webots): give the registered depth the optical frame it is registered to

### DIFF
--- a/examples/webots/sim/ros_ws/src/eaios_webots/resource/tiago_full_webots.urdf
+++ b/examples/webots/sim/ros_ws/src/eaios_webots/resource/tiago_full_webots.urdf
@@ -1759,7 +1759,19 @@
         <imageSuffix>/image_raw</imageSuffix>
         <pointCloudSuffix>/points</pointCloudSuffix>
         <alwaysOn>true</alwaysOn>
-        <frameName>head_front_camera_depth_optical_frame</frameName>
+        <!-- The topic is depth_registered: the depth is registered to the
+             colour camera, so its frame IS the RGB optical frame. Naming a
+             separate depth frame here made the driver publish
+             head_front_camera_depth_optical_frame with identity rotation,
+             while the URDF's own optical joint for it never reached the TF
+             tree. Consumers that read the frame from the image header then
+             projected with the optical convention (Z forward) against a
+             body-oriented transform, so forward distance landed on Y and the
+             height difference became the reported "depth". That is why the benchmark
+             found 48 of 51 objects "out of range". Both frames already
+             resolve to the same translation, so this only supplies the
+             rotation that was missing. -->
+        <frameName>head_front_camera_rgb_optical_frame</frameName>
       </ros>
     </device>
     <plugin type="webots_ros2_control::Ros2Control" />

--- a/examples/webots/sim/ros_ws/src/eaios_webots/resource/tiago_webots.urdf
+++ b/examples/webots/sim/ros_ws/src/eaios_webots/resource/tiago_webots.urdf
@@ -1252,7 +1252,19 @@
         <imageSuffix>/image_raw</imageSuffix>
         <pointCloudSuffix>/points</pointCloudSuffix>
         <alwaysOn>true</alwaysOn>
-        <frameName>head_front_camera_depth_optical_frame</frameName>
+        <!-- The topic is depth_registered: the depth is registered to the
+             colour camera, so its frame IS the RGB optical frame. Naming a
+             separate depth frame here made the driver publish
+             head_front_camera_depth_optical_frame with identity rotation,
+             while the URDF's own optical joint for it never reached the TF
+             tree. Consumers that read the frame from the image header then
+             projected with the optical convention (Z forward) against a
+             body-oriented transform, so forward distance landed on Y and the
+             height difference became the reported "depth". That is why the benchmark
+             found 48 of 51 objects "out of range". Both frames already
+             resolve to the same translation, so this only supplies the
+             rotation that was missing. -->
+        <frameName>head_front_camera_rgb_optical_frame</frameName>
       </ros>
     </device>
     <plugin type="webots_ros2_control::Ros2Control" />


### PR DESCRIPTION
The RangeFinder declared its own frame name, so webots_ros2_driver published `head_front_camera_depth_optical_frame` with identity rotation while the URDF's own optical joint for it never reached the TF tree at all. Measured on a live deployment:

```
head_front_camera_rgb_optical_frame     rpy = (-1.5708, 0, -1.5708)   xyz = (0.2390, 0.0200, 1.0652)
head_front_camera_depth_optical_frame   rpy = ( 0,      0,  0      )   xyz = (0.2390, 0.0200, 1.0652)
head_front_camera_depth_frame           absent from the TF tree
```

Byte-identical translations, and only one of them carries the optical convention. A consumer that reads the frame from the depth image header and projects with the optical convention then applies a body-oriented transform: forward distance lands on Y and the height difference becomes the reported depth.

The topic is `depth_registered`, so its frame is the colour camera's optical frame by definition. Pointing `<frameName>` there supplies the rotation that was missing and changes nothing positionally.

## What this was breaking

The Scene benchmark placed 48 of 51 ground-truth objects "out of range". The only three it could project were cabinet(3) at z=2.02 and two windows at z=1.70 — the three tallest, hence the only ones above the 1.065 m camera and the only ones whose "depth" came out positive. A potted plant 1.55 m directly ahead of the robot never once reached the projection stage across 153 visibility samples.

Visible ground-truth objects per run, same world and harness:

| | path travelled | visible |
|---|---|---|
| before | 4.1 – 12.5 m over five runs | 0 – 1 of 51 |
| after | 4 – 18 m over ten runs | 22 – 34 of 51 |

Scene itself was never affected: it selects the RGB optical frame explicitly, and its potted plant lands 8 cm from the WBT truth.

## Validation

Webots Integration Tests pass end to end on a branch carrying this commit — run [33556140209](https://github.com/syswonder/robonix/actions/runs/33556140209), every step green including `Build Webots deployment`, `Run scenario suite`, `Drive a fixed mapping loop` and `Verify scene map persistence`.

That last one matters here: mapping consumes `rgbd` and lists `depth` among its occupancy sources, so this commit changes what the depth camera contributes to the costmap. The suite passing with it is the evidence that the change is safe for navigation and mapping, not just for the benchmark.