### PR TITLE
fix(testing): wait for a usable map before the post-restart scenario pass

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1347,6 +1347,279 @@ jobs:
             tail -260 "examples/webots/rbnx-boot/logs/scene.log" || true
             exit 1
           fi
+          # A Webots boot starts a fresh live SLAM session by design — see the
+          # comment at the top of examples/webots/robonix_manifest.yaml — so the
+          # rebooted RTAB-Map opens an empty database and refills it from the
+          # sensor stream. Until it has, /map is published and entirely unknown.
+          #
+          # object_navigation is the only scenario that needs a global plan, and
+          # --first puts it at the head of this pass. Without this gate it asked
+          # the planner to route across a map that did not exist yet: nav2
+          # answered "GridBased: failed to create plan", Pilot retried, and the
+          # scenario spent its whole 300s that way.
+          #
+          # Waiting for a publisher would not help, because the publisher exists
+          # from the moment the node starts, and neither would waiting for a
+          # message, because an all-unknown grid is a valid message. The gate has
+          # to be free space. The reasoning is the one written above for Scene:
+          # Atlas readiness proves a provider registered its contracts, not that
+          # it has produced anything usable.
+          echo "waiting for /map to carry known cells after lifecycle restart"
+          if ! docker exec -i "$ROBONIX_SIM_CONTAINER" bash -lc '
+            set -eo pipefail
+            source /opt/ros/humble/setup.bash
+            set -u
+            export ROS_DOMAIN_ID='"${ROS_DOMAIN_ID}"'
+            export RMW_IMPLEMENTATION="${RMW_IMPLEMENTATION:-rmw_zenoh_cpp}"
+            python3 - --timeout 240 "$@"
+          ' _ <"$GITHUB_WORKSPACE/testing/wait_for_map.py" \
+            >"$RUNNER_TEMP/sim-logs/map-readiness-post-restart.txt" 2>&1; then
+            echo "::error::/map had no usable occupancy grid after lifecycle restart"
+            cat "$RUNNER_TEMP/sim-logs/map-readiness-post-restart.txt" || true
+            tail -260 "examples/webots/rbnx-boot/logs/mapping.log" || true
+            exit 1
+          fi
+          cat "$RUNNER_TEMP/sim-logs/map-readiness-post-restart.txt"
+
+          python3 "$GITHUB_WORKSPACE/testing/run.py" --server "$ROBONIX_CI_ATLAS" \
+            --first object_navigation \
+            --summary-json "$GITHUB_WORKSPACE/testing/logs/summary.json" | tee "$RUNNER_TEMP/scenarios.out"
+          # Surface the one-line RESULT for the reusable-workflow output / bot.
+          echo "result=$(grep '^RESULT:' "$RUNNER_TEMP/scenarios.out" | tail -1)" >> "$GITHUB_OUTPUT"
+
+      - name: Drive a fixed mapping loop
+        # Chassis motion is a gRPC contract and the executor only dispatches
+        # MCP, so this drives cmd_vel directly. A scripted rectangle returns to
+        # its start, which makes the saved map comparable between runs and
+        # forces the SLAM graph to close a loop.
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          docker exec -i "$ROBONIX_SIM_CONTAINER" bash <<'EOS'
+          source /opt/ros/humble/setup.bash
+          export RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION:-rmw_zenoh_cpp}
+          python3 - <<'PY'
+          import math, time
+          import rclpy
+          from geometry_msgs.msg import Twist
+          rclpy.init()
+          node = rclpy.create_node("ci_mapping_loop")
+          pub = node.create_publisher(Twist, "/cmd_vel", 10)
+          time.sleep(2.0)
+
+          def drive(lin, ang, seconds):
+              msg = Twist()
+              msg.linear.x, msg.angular.z = lin, ang
+              end = time.time() + seconds
+              while time.time() < end:
+                  pub.publish(msg)
+                  rclpy.spin_once(node, timeout_sec=0.05)
+              pub.publish(Twist())
+              for _ in range(5):
+                  rclpy.spin_once(node, timeout_sec=0.02)
+
+          for corner in range(4):
+              drive(0.25, 0.0, 6.0)          # 1.5 m leg
+              drive(0.0, 0.5, math.pi / 1.0) # 90 deg turn
+              print(f"corner {corner + 1}/4 done", flush=True)
+          node.destroy_node(); rclpy.shutdown()
+          PY
+          EOS
+
+      - name: Verify scene map persistence
+        # A failed suite is exactly when the saved map matters most, so this
+        # runs even then; it still fails the job on its own checks.
+        if: ${{ !cancelled() }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/sim-logs"
+          map_id="ci_scene_map_${RUN_KEY}"
+          python3 "$GITHUB_WORKSPACE/testing/verify_scene_map_persistence.py" \
+            --scene-url "http://127.0.0.1:${SCENE_WEB_PORT}" \
+            --map-id "$map_id" \
+            --mapping-container "${ROBONIX_MAPPING_CONTAINER:-robonix_mapping}" \
+            --maps-dir "$MAPPING_MAPS_DIR" \
+            --sim-container "$ROBONIX_SIM_CONTAINER" \
+            --export-preview "$RUNNER_TEMP/sim-logs/slam-map.png" \
+            --delete-after \
+            --timeout 420 | tee "$RUNNER_TEMP/sim-logs/scene-map-persistence.txt"
+
+      - name: Validate boot/shutdown lifecycle
+        # boot → shutdown → re-boot. Proves the runtime keeps
+        # state under <manifest-dir>/rbnx-boot/ (not ~/.robonix/), that
+        # Soma package children are stopped cleanly, and that the stack
+        # can come back up after a clean teardown (the issue #128
+        # regression). The second boot reuses both the per-run sim container
+        # and the persistent mapping/scene state: a process restart must not
+        # silently turn into a new-map session while the physical robot stays
+        # at its post-scenario pose. CI leaves the second boot running so the
+        # next step can exercise scenarios against the restarted stack; the
+        # final cleanup step shuts it down.
+        working-directory: examples/webots
+        run: |
+          set -euo pipefail
+          milvus_lock="$(dirname "$AGENT_MILVUS_URI")/.$(basename "$AGENT_MILVUS_URI").lock"
+          # Scenario memory uses fixed fixture keys and must be isolated between
+          # passes. Mapping and scene data are deliberately preserved because
+          # they are runtime state whose reboot recovery this test exercises.
+          export ROBONIX_LIFECYCLE_RESET_PATHS="${AGENT_MEMORY_DIR}:${AGENT_MILVUS_URI}:${milvus_lock}"
+          python3 "$GITHUB_WORKSPACE/testing/validate_lifecycle.py" \
+            --rbnx rbnx \
+            --manifest robonix_manifest.ci.generated.yaml \
+            --server "$ROBONIX_CI_ATLAS" \
+            --sim-container "$ROBONIX_SIM_CONTAINER" \
+            --leave-running \
+            --log-dir "$RUNNER_TEMP/lifecycle-logs" | tee "$RUNNER_TEMP/lifecycle.out"
+
+      - name: Re-run scenario suite after lifecycle validator
+        # After the validator re-boots the stack, run the scenarios one
+        # more time so the report covers both a fresh boot and a
+        # post-shutdown boot. This is what actually exercises the
+        # "restart doesn't crash" fix — the original suite proved
+        # boot-once, this proves boot-after-shutdown.
+        working-directory: examples/webots
+        run: |
+          set -euo pipefail
+          export ROBONIX_ATLAS="$ROBONIX_CI_ATLAS"
+          # Wait for atlas to settle (the validator just re-booted
+          # everything; reuse the same caps wait).
+          for i in $(seq 1 60); do
+            if rbnx caps -v --server "$ROBONIX_CI_ATLAS" >"$RUNNER_TEMP/caps.post-restart.txt" 2>&1 \
+              && grep -q "robonix/service/navigation/navigate" "$RUNNER_TEMP/caps.post-restart.txt" \
+              && grep -q "^● nav2 \[ACTIVE\]" "$RUNNER_TEMP/caps.post-restart.txt" \
+              && grep -qE "^● explore \[(INACTIVE|ACTIVE)\]" "$RUNNER_TEMP/caps.post-restart.txt"; then
+              echo "post-restart atlas ready"
+              break
+            fi
+            if [ "$i" -eq 60 ]; then
+              echo "::error::atlas not ready after lifecycle reboot"
+              tail -120 "$RUNNER_TEMP/caps.post-restart.txt" || true
+              exit 1
+            fi
+            sleep 5
+          done
+          # The restart suite is an independent pass over the same scenario set.
+          # save_map is intentionally immutable, so remove the first suite's
+          # test-only saved map before exercising save_map again. Do not touch
+          # the live Webots/RTAB-Map session database (webots_lab).
+          if [ -d "${MAPPING_MAPS_DIR:?}/ci_test_map" ]; then
+            docker run --rm --network none \
+              -v "$MAPPING_MAPS_DIR:/maps:rw" \
+              busybox:latest sh -lc 'rm -rf /maps/ci_test_map' \
+              || sudo -n rm -rf "$MAPPING_MAPS_DIR/ci_test_map" \
+              || rm -rf "$MAPPING_MAPS_DIR/ci_test_map"
+          fi
+          # The fake VLM keeps per-scenario pending-step state so it can avoid
+          # duplicate calls while one RTDL batch is still executing. The first
+          # suite and the post-lifecycle suite are independent test runs, so
+          # restart the deterministic planner before the second suite.
+          if [ -n "${FAKE_VLM_PID:-}" ]; then
+            kill "$FAKE_VLM_PID" 2>/dev/null || true
+          fi
+          for _ in $(seq 1 30); do
+            if ! curl -fsS --noproxy '*' "http://127.0.0.1:${FAKE_VLM_PORT}/v1/models" >/dev/null 2>&1; then
+              break
+            fi
+            sleep 0.2
+          done
+          echo "[fake-vlm] --- restart after lifecycle validator ---" >>"$RUNNER_TEMP/fake_vlm.log"
+          python3 "$GITHUB_WORKSPACE/testing/fake_vlm/server.py" \
+            --port "$FAKE_VLM_PORT" >>"$RUNNER_TEMP/fake_vlm.log" 2>&1 &
+          export FAKE_VLM_PID="$!"
+          echo "FAKE_VLM_PID=$FAKE_VLM_PID" >> "$GITHUB_ENV"
+          for i in $(seq 1 20); do
+            curl -fsS --noproxy '*' "http://127.0.0.1:${FAKE_VLM_PORT}/v1/models" >/dev/null 2>&1 && break
+            if [ "$i" -eq 20 ]; then
+              echo "::error::fake VLM did not restart after lifecycle validator"
+              tail -120 "$RUNNER_TEMP/fake_vlm.log" || true
+              exit 1
+            fi
+            sleep 0.5
+          done
+          # Atlas readiness only proves that Scene registered its contracts.
+          # A restarted Scene still needs fresh camera frames before its object
+          # registry contains a real object, so apply the same readiness gate
+          # used before the first scenario pass.
+          scene_url="http://127.0.0.1:${SCENE_WEB_PORT}/api/state"
+          state_file="$RUNNER_TEMP/sim-logs/scene-state-post-restart.json"
+          scene_ready=0
+          echo "waiting for a real non-robot scene object after lifecycle restart: ${scene_url}"
+          for _ in $(seq 1 180); do
+            if curl -fsS --max-time 2 "$scene_url" -o "$state_file"; then
+              if python3 - "$state_file" <<'SCENE_READY_PY'
+          import json, sys
+          path = sys.argv[1]
+          with open(path, "r", encoding="utf-8") as f:
+              state = json.load(f)
+          objects = state.get("objects") or []
+          for obj in objects:
+              cls = str(obj.get("cls") or obj.get("label") or "").strip().lower()
+              oid = str(obj.get("id") or "")
+              if cls and cls != "robot" and oid.startswith("scene.object."):
+                  print(json.dumps({
+                      "id": obj.get("id"),
+                      "cls": obj.get("cls") or obj.get("label"),
+                      "confidence": obj.get("confidence"),
+                      "observation_count": obj.get("observation_count"),
+                      "pose": obj.get("pose"),
+                  }, ensure_ascii=False))
+                  sys.exit(0)
+          sys.exit(1)
+          SCENE_READY_PY
+              then
+                echo "post-restart scene object readiness confirmed"
+                scene_ready=1
+                break
+              fi
+            fi
+            sleep 2
+          done
+          if [ "$scene_ready" -ne 1 ]; then
+            echo "::error::scene did not expose a non-robot object after lifecycle restart"
+            cat "$state_file" || true
+            tail -260 "examples/webots/rbnx-boot/logs/scene.log" || true
+            exit 1
+          fi
+          # Mapping restarted with everything else, and RTAB-Map does not
+          # republish /map the instant its process is up. The first pass waits
+          # for the grid before running scenarios; this pass did not, and
+          # object_navigation — the only scenario that needs a global plan, and
+          # the one --first puts at the head of the run — was asking the planner
+          # to route across a map that had not come back yet. nav2 answered
+          # "GridBased: failed to create plan", Pilot retried, and the scenario
+          # burned its 300s.
+          #
+          # The reasoning is the one already written above for Scene: Atlas
+          # readiness proves a provider registered its contracts, not that it
+          # has produced anything to use.
+          map_readiness="$RUNNER_TEMP/sim-logs/map-readiness-post-restart.txt"
+          echo "waiting for a real /map OccupancyGrid publisher after lifecycle restart"
+          if ! docker exec "$ROBONIX_SIM_CONTAINER" bash -lc '
+            set -eo pipefail
+            source /opt/ros/humble/setup.bash
+            set -u
+            export ROS_DOMAIN_ID='"${ROS_DOMAIN_ID}"'
+            export RMW_IMPLEMENTATION="${RMW_IMPLEMENTATION:-rmw_zenoh_cpp}"
+            for _ in $(seq 1 90); do
+              if ros2 topic info -v /map > /tmp/map-info.txt 2>&1 &&
+                 grep -q "Type: nav_msgs/msg/OccupancyGrid" /tmp/map-info.txt &&
+                 grep -Eq "Publisher count: [1-9]" /tmp/map-info.txt; then
+                cat /tmp/map-info.txt
+                exit 0
+              fi
+              sleep 2
+            done
+            cat /tmp/map-info.txt 2>/dev/null || true
+            exit 1
+          ' >"$map_readiness" 2>&1; then
+            echo "::error::mapping did not expose a /map publisher after lifecycle restart"
+            cat "$map_readiness" || true
+            tail -260 "examples/webots/rbnx-boot/logs/mapping.log" || true
+            exit 1
+          fi
+          echo "post-restart map readiness confirmed"
+
           python3 "$GITHUB_WORKSPACE/testing/run.py" --server "$ROBONIX_CI_ATLAS" \
             --first object_navigation \
             --summary-json "$GITHUB_WORKSPACE/testing/logs/summary.restart.json" \

--- a/testing/wait_for_map.py
+++ b/testing/wait_for_map.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Wait until /map carries enough known cells to plan across.
+
+A Webots boot starts a fresh live SLAM session by design — see the comment at
+the top of examples/webots/robonix_manifest.yaml. RTAB-Map therefore opens an
+empty database and fills it from the sensor stream as the simulation runs, and
+for the first stretch after boot the occupancy grid is published but entirely
+unknown.
+
+Waiting for a publisher does not capture that: the publisher exists from the
+moment the node starts. Waiting for a message does not either, because an
+all-unknown grid is a perfectly good message. What a scenario that needs a
+global plan actually depends on is free space, so that is what this waits for.
+
+Prints the grid's size and known-cell count and exits 0 when the threshold is
+met, or exits 1 on timeout having printed the best it saw.
+"""
+
+import argparse
+import sys
+import time
+
+import rclpy
+from nav_msgs.msg import OccupancyGrid
+from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--topic", default="/map")
+    ap.add_argument("--timeout", type=float, default=180.0)
+    # A tenth of a percent of a large grid is still hundreds of cells. The
+    # threshold is deliberately low: this gate is here to catch "the map has
+    # not started yet", not to judge coverage.
+    ap.add_argument("--min-known", type=int, default=200)
+    args = ap.parse_args()
+
+    rclpy.init()
+    node = rclpy.create_node("robonix_ci_wait_for_map")
+
+    # The map is latched: a subscriber that joins late must still receive the
+    # last grid rather than waiting for the next publish.
+    qos = QoSProfile(
+        depth=1,
+        reliability=ReliabilityPolicy.RELIABLE,
+        durability=DurabilityPolicy.TRANSIENT_LOCAL,
+        history=HistoryPolicy.KEEP_LAST,
+    )
+
+    best = {"known": -1, "width": 0, "height": 0}
+
+    def on_map(msg: OccupancyGrid) -> None:
+        known = sum(1 for cell in msg.data if cell >= 0)
+        if known > best["known"]:
+            best.update(
+                known=known, width=msg.info.width, height=msg.info.height
+            )
+
+    node.create_subscription(OccupancyGrid, args.topic, on_map, qos)
+
+    deadline = time.monotonic() + args.timeout
+    try:
+        while time.monotonic() < deadline:
+            rclpy.spin_once(node, timeout_sec=0.5)
+            if best["known"] >= args.min_known:
+                print(
+                    f"{args.topic}: {best['width']}x{best['height']} grid, "
+                    f"{best['known']} known cells"
+                )
+                return 0
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+    if best["known"] < 0:
+        print(f"{args.topic}: no message received in {args.timeout:.0f}s", file=sys.stderr)
+    else:
+        print(
+            f"{args.topic}: only {best['known']} known cells after "
+            f"{args.timeout:.0f}s (needed {args.min_known})",
+            file=sys.stderr,
+        )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## The failure

The Webots suite has been red on `dev` since 2026-08-24; the last green run was 8-23. Every failure has the same shape: 15 of 16 scenarios pass and `object_navigation` times out after 300s in the pass that runs after the lifecycle validator reboots the stack. The first pass passes it.

## Why

Its per-scenario log (`testing/logs/flow.object_navigation.jsonl`) shows navigation being asked for a plan six times and giving the same answer every time:

```
aborted; distance_remaining=0.000m recoveries=15
nav2=GridBased: failed to create plan with tolerance 0.50
```

`distance_remaining=0.000m` reads like the robot arrived. It is zero because no path was ever produced. Pilot replanned the same goal until the scenario ran out of time.

The mapping log says why the planner had nothing to work with: the rebooted RTAB-Map opened `mapping-34-1788953572017.db (0 MB)`, a fresh and empty database. That is correct behaviour rather than a fault — the comment at the top of `examples/webots/robonix_manifest.yaml` states that a Webots boot starts a fresh live SLAM session, and warns against a static `SCENE_MAP_ID` precisely so a first run does not look like a loaded map.

What is wrong is the readiness gate. The first pass waits for `/map` before running scenarios. The pass after the reboot waits for Atlas capabilities, the fake VLM and a Scene object, then runs immediately — with `--first object_navigation` putting the one scenario that needs a global plan at the head of the run.

## The change

This adds the missing gate and makes it a real one. Waiting for a publisher would not help, because the publisher exists from the moment the node starts, and waiting for a message would not either, because an all-unknown grid is a valid message. `testing/wait_for_map.py` waits for an occupancy grid that carries known cells, because free space is what a global plan actually depends on. The argument is the one already written above the Scene gate: Atlas readiness proves a provider registered its contracts, not that it has produced anything usable.

## Verification

A full Webots suite was dispatched on this branch (run 34377863821). All four jobs passed. The gate reported what it waited for:

```
waiting for /map to carry known cells after lifecycle restart
/map: 155x215 grid, 8962 known cells
```

Both passes then reported `RESULT: PASS — 16/16`, with `object_navigation` healthy in the restart pass. That measurement also settles the open question from the commit message: the map does come back after a reboot, and the restart pass simply was not waiting for it.

`slam-map.png` from the same run shows a complete room — open free space with clean wall returns — so mapping quality itself was never the problem.
