### PR TITLE
fix(scene): survive malformed upstream messages and keep the web UI local

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,17 @@ jobs:
           system/scene/tests/test_perception_vlm_geometry.py
           system/scene/tests/test_image_relations.py
 
+      # The goal planner and the message-shape rule are pure and import neither
+      # robonix_api nor the generated MCP types, so they run under the same
+      # lightweight dependency set. Without them here nothing on a pull request
+      # exercises the guards against a malformed occupancy grid, which is how
+      # those guards came to be missing in the first place.
+      - name: Test Scene goal planning and upstream message validation
+        run: >-
+          python3 -m pytest -q
+          system/scene/tests/test_goal_planner.py
+          system/scene/tests/test_malformed_grid_inputs.py
+
   check:
     name: Rust (fmt + clippy + build + tests)
     runs-on: ubuntu-22.04

--- a/system/scene/scene_service/goal_planner.py
+++ b/system/scene/scene_service/goal_planner.py
@@ -7,6 +7,7 @@ import math
 from collections.abc import Iterable, Sequence
 
 from .geometry import point_in_polygon, polygon_centroid
+from .message_shape import occupancy_grid_is_well_formed
 from .robot_geometry import RobotFootprint
 
 Point = tuple[float, float]
@@ -157,7 +158,7 @@ def _grid_array(grid_msg, *, width: int, height: int):
         grid = np.frombuffer(data, dtype=np.int8)
     else:
         grid = np.asarray(data, dtype=np.int8)
-    if grid.size != width * height:
+    if not occupancy_grid_is_well_formed(width, height, grid.size):
         raise ValueError(
             f"occupancy grid contains {grid.size} cells; expected {width * height}"
         )

--- a/system/scene/scene_service/message_shape.py
+++ b/system/scene/scene_service/message_shape.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+"""What makes an upstream image or occupancy grid well formed.
+
+ROS 2 does not check that a message is self-consistent. An `OccupancyGrid`
+whose `data` is shorter than `width * height`, or an `Image` whose buffer does
+not match its declared size and encoding, is type-valid and will be delivered
+to every subscriber. Both then reach code that reshapes the buffer, and
+`reshape` raises.
+
+That mattered because the raising happened inside request handlers: the Scene
+debug UI answered 500 on `/api/state` and `/api/camera` for as long as the
+malformed message stayed the latest one, and the `goal_near` capability failed
+the same way through the MCP path. Anyone able to publish on `/map` could hold
+the interface down.
+
+The rule belongs in one place rather than at each decode site, so it cannot be
+applied at one and forgotten at another. These functions are pure and import
+nothing, so they can be tested without a ROS or robonix runtime.
+
+Reported as issues #226 and #227.
+"""
+
+from __future__ import annotations
+
+# Bytes per pixel for the encodings Scene decodes. An encoding that is absent
+# is one Scene does not render, and its buffer length is not this module's
+# business.
+_BYTES_PER_PIXEL = {
+    "rgb8": 3,
+    "bgr8": 3,
+    "rgba8": 4,
+    "bgra8": 4,
+    "mono8": 1,
+    "32fc1": 4,
+    "16uc1": 2,
+}
+
+
+def occupancy_cells_expected(width: int, height: int) -> int:
+    """How many cells a grid of this size must carry."""
+    return int(width) * int(height)
+
+
+def occupancy_grid_is_well_formed(width: int, height: int, data_len: int) -> bool:
+    """Whether a grid can be reshaped to its declared size.
+
+    A zero dimension is rejected too: it is not decodable, and treating it as
+    "empty but fine" pushes an empty array into code that assumes cells exist.
+    """
+    if int(width) <= 0 or int(height) <= 0:
+        return False
+    return int(data_len) == occupancy_cells_expected(width, height)
+
+
+def image_bytes_expected(width: int, height: int, encoding: str) -> int | None:
+    """How many bytes an image of this size and encoding must carry.
+
+    `None` for an encoding Scene does not decode — the caller rejects those on
+    their own grounds, and guessing a size for them would be inventing one.
+    """
+    per_pixel = _BYTES_PER_PIXEL.get((encoding or "").lower())
+    if per_pixel is None:
+        return None
+    return int(width) * int(height) * per_pixel
+
+
+def image_is_well_formed(
+    width: int, height: int, encoding: str, data_len: int
+) -> bool:
+    """Whether an image buffer matches its declared size and encoding.
+
+    An unsupported encoding returns True: this function answers "is the buffer
+    the right length", and for an encoding with no defined length that question
+    does not apply. The decoder still rejects it.
+    """
+    if int(width) <= 0 or int(height) <= 0:
+        return False
+    expected = image_bytes_expected(width, height, encoding)
+    if expected is None:
+        return True
+    return int(data_len) == expected

--- a/system/scene/scene_service/service.py
+++ b/system/scene/scene_service/service.py
@@ -1791,6 +1791,19 @@ async def _run_active(config: dict) -> None:
         web_server = uvicorn.Server(web_uv)
         web_task = asyncio.create_task(web_server.serve(), name="scene-web-http")
         log.info("web UI on http://%s:%d", web_host, web_port)
+        # This surface carries no authentication — it is a debug and operator
+        # UI, and its annotation endpoints read and write map data. That is
+        # tenable on loopback and is a decision on any other address, so an
+        # operator who did not make that decision deliberately should be told
+        # they have. `web_host: 127.0.0.1` in the Scene config, or
+        # SCENE_WEB_HOST, keeps it local.
+        if web_host not in ("127.0.0.1", "::1", "localhost"):
+            log.warning(
+                "web UI is bound to %s and has no authentication: anyone who "
+                "can reach %s:%d may read and modify map annotations. Set "
+                "web_host: 127.0.0.1 (or SCENE_WEB_HOST) to keep it local.",
+                web_host, web_host, web_port,
+            )
 
     log.info(
         "scene up; cap=%s mcp=%s observations=%d",

--- a/system/scene/scene_service/service.py
+++ b/system/scene/scene_service/service.py
@@ -1758,8 +1758,8 @@ async def _run_active(config: dict) -> None:
     )
     mcp_tools.attach_object_mutations(object_mutations)
 
-    # SCENE_WEB_HOST are environment fallbacks; an explicit Scene config file
-    # can set web_host: 127.0.0.1 to keep this operator surface local-only.
+    # SCENE_WEB_HOST is the environment fallback; an explicit Scene config file
+    # can set web_host. Both default to loopback — see web_binding.
     web_port = int(
         int(config.get("web_port") or "0")
         if config.get("web_port") is not None and config.get("web_port") != ""
@@ -1791,17 +1791,15 @@ async def _run_active(config: dict) -> None:
         web_server = uvicorn.Server(web_uv)
         web_task = asyncio.create_task(web_server.serve(), name="scene-web-http")
         log.info("web UI on http://%s:%d", web_host, web_port)
-        # This surface carries no authentication — it is a debug and operator
-        # UI, and its annotation endpoints read and write map data. That is
-        # tenable on loopback and is a decision on any other address, so an
-        # operator who did not make that decision deliberately should be told
-        # they have. `web_host: 127.0.0.1` in the Scene config, or
-        # SCENE_WEB_HOST, keeps it local.
+        # Loopback is the default. Anything else was asked for, and is worth
+        # one line in the log because this surface has no authentication and
+        # its annotation endpoints write map data — whoever reaches it can
+        # change what the robot believes about its world.
         if web_host not in ("127.0.0.1", "::1", "localhost"):
             log.warning(
-                "web UI is bound to %s and has no authentication: anyone who "
-                "can reach %s:%d may read and modify map annotations. Set "
-                "web_host: 127.0.0.1 (or SCENE_WEB_HOST) to keep it local.",
+                "web UI is bound to %s, not loopback, and has no "
+                "authentication: anyone who can reach %s:%d may read and "
+                "modify map annotations.",
                 web_host, web_host, web_port,
             )
 

--- a/system/scene/scene_service/web.py
+++ b/system/scene/scene_service/web.py
@@ -32,6 +32,8 @@ from starlette.routing import Route
 
 from robonix_api import ATLAS
 
+from .message_shape import image_is_well_formed, occupancy_grid_is_well_formed
+
 from .annotations import validate_annotation_fields
 from .map_binding import sanitize_map_id as _sanitize_map_id
 from .map_meta import make_meta
@@ -325,7 +327,18 @@ def _occupancy_payload(hub: Any) -> Optional[dict]:
         return None
     info = msg.info
     w, h = int(info.width), int(info.height)
-    if w == 0 or h == 0:
+    # A publisher is not required to be honest. `data` is sized by whoever
+    # published it, and a grid whose length disagrees with width * height is
+    # type-valid ROS 2 — nothing upstream rejects it. Reshaping it raises, and
+    # an exception here becomes a 500 on /api/state for as long as that message
+    # stays the latest one, which takes the whole debug UI down. Dropping the
+    # frame keeps the rest of the page working and lets the next well-formed
+    # grid recover it.
+    if not occupancy_grid_is_well_formed(w, h, len(msg.data)):
+        log.warning(
+            "occupancy_grid dropped: %d cells for a %dx%d grid",
+            len(msg.data), w, h,
+        )
         return None
     # nav_msgs/OccupancyGrid data is row-major bottom-up int8 in
     # [-1, 100]: -1 unknown, 0 free, 100 occupied. Render as grayscale:
@@ -366,9 +379,16 @@ def _image_to_png_b64(msg: Any, *, kind: str) -> Optional[dict]:
     except ImportError:
         return None
     h, w = int(msg.height), int(msg.width)
-    if h == 0 or w == 0:
-        return None
     enc = (msg.encoding or "").lower()
+    # Same reasoning as the occupancy grid above: the buffer is sized by the
+    # publisher, and one that disagrees with the declared size makes reshape
+    # raise, which surfaces as a 500 on /api/camera.
+    if not image_is_well_formed(w, h, enc, len(msg.data)):
+        log.warning(
+            "%s image dropped: %d bytes for a %dx%d %s frame",
+            kind, len(msg.data), w, h, enc,
+        )
+        return None
     arr: Any = None
     out_mode = "RGB"
     if kind == "rgb":

--- a/system/scene/scene_service/web_binding.py
+++ b/system/scene/scene_service/web_binding.py
@@ -1,9 +1,14 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 """Resolve the Scene debug UI bind address.
 
-The port is already deployment-configurable.  Keep the historical all-interface
-default for existing deployments, while allowing safety-sensitive robot
-profiles to bind the UI to loopback explicitly.
+The UI carries no authentication and its annotation endpoints read and write
+map data, so reaching it is enough to alter what the robot believes about its
+world. The default is therefore loopback: exposing that surface to a network
+is a decision, and a decision should be made rather than inherited.
+
+`web_host` in the Scene config, or SCENE_WEB_HOST, opens it deliberately —
+a deployment whose operator UI is reached from another machine sets one of
+them, and the service says at startup when it is bound wide.
 """
 
 from __future__ import annotations
@@ -24,7 +29,7 @@ def resolve_web_host(
     raw = (
         config["web_host"]
         if "web_host" in config
-        else env.get("SCENE_WEB_HOST", "0.0.0.0")
+        else env.get("SCENE_WEB_HOST", "127.0.0.1")
     )
     if not isinstance(raw, str):
         raise ValueError("Scene web_host/SCENE_WEB_HOST must be a string")

--- a/system/scene/scripts/start.sh
+++ b/system/scene/scripts/start.sh
@@ -168,6 +168,10 @@ if [[ "${ROBONIX_FORCE_CPU:-0}" != "1" ]]; then
     fi
 fi
 
+# SCENE_WEB_HOST below defaults to loopback. The container runs with
+# --network host, so what the service binds is what the host exposes, and the
+# web UI has no authentication while its annotation endpoints write map data.
+# Set SCENE_WEB_HOST=0.0.0.0 to reach it from another machine.
 exec docker run --rm \
     --name "$CT" \
     --entrypoint /scene/docker/entrypoint.sh \
@@ -180,7 +184,7 @@ exec docker run --rm \
     -e ROBONIX_CAPABILITY_ID="${ROBONIX_CAPABILITY_ID:-com.robonix.system.scene}" \
     -e ROBONIX_PKG_HOST_DIR="$(pwd)" \
     -e SCENE_WEB_PORT="${SCENE_WEB_PORT:-50107}" \
-    -e SCENE_WEB_HOST="${SCENE_WEB_HOST-0.0.0.0}" \
+    -e SCENE_WEB_HOST="${SCENE_WEB_HOST-127.0.0.1}" \
     -e SCENE_LOG_LEVEL="${SCENE_LOG_LEVEL:-INFO}" \
     -e SCENE_CG_FORCE_CPU="${SCENE_CG_FORCE_CPU:-}" \
     -e SCENE_CG_OBJ_MIN_POINTS="${SCENE_CG_OBJ_MIN_POINTS:-}" \

--- a/system/scene/scripts/start_native.sh
+++ b/system/scene/scripts/start_native.sh
@@ -66,7 +66,10 @@ mkdir -p "$SCENE_ANNOTATIONS_DIR"
 
 # Service knobs (same defaults the docker run wires via -e).
 export SCENE_WEB_PORT="${SCENE_WEB_PORT:-50107}"
-export SCENE_WEB_HOST="${SCENE_WEB_HOST-0.0.0.0}"
+# Loopback by default: the web UI has no authentication and its annotation
+# endpoints write map data. Set SCENE_WEB_HOST=0.0.0.0 to reach it from another
+# machine.
+export SCENE_WEB_HOST="${SCENE_WEB_HOST-127.0.0.1}"
 export SCENE_LOG_LEVEL="${SCENE_LOG_LEVEL:-INFO}"
 
 echo "[scene/native] python=$PY ros=$ROS_DISTRO rmw=${RMW_IMPLEMENTATION:-<default>} web=$SCENE_WEB_HOST:$SCENE_WEB_PORT"

--- a/system/scene/tests/conftest.py
+++ b/system/scene/tests/conftest.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+"""Put the Scene package root on sys.path for every test in this directory.
+
+pytest prepends the directory that holds a test file, not the package root, so
+`from scene_service import ...` only resolves when pytest is run from
+system/scene. The older tests each carry their own sys.path.insert; the ones
+that do not import nothing when CI runs pytest from the repository root, which
+is how test_goal_planner.py could sit in the tree unexercised. Doing it once
+here means a new test does not have to remember.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/system/scene/tests/test_malformed_grid_inputs.py
+++ b/system/scene/tests/test_malformed_grid_inputs.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: MulanPSL-2.0
+"""Scene must survive a structurally inconsistent upstream message.
+
+Nothing in ROS 2 rejects an `OccupancyGrid` whose `data` length disagrees with
+`width * height`, or an `Image` whose buffer does not match its declared size
+and encoding. Both are type-valid and are delivered to every subscriber. Both
+used to reach code that reshaped the buffer, and `reshape` raises.
+
+The raising happened inside request handlers, which is what made it matter: the
+debug UI answered 500 on `/api/state` and `/api/camera` for as long as the bad
+message stayed the latest one, and `goal_near` failed the same way through the
+MCP path. Anyone able to publish on `/map` could hold the interface down.
+
+Both entry points now ask `message_shape` the same question, so these tests
+cover the rule itself and the fact that each caller applies it.
+
+Reported as issues #226 and #227.
+"""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from scene_service import goal_planner
+from scene_service.message_shape import (
+    image_bytes_expected,
+    image_is_well_formed,
+    occupancy_grid_is_well_formed,
+)
+
+
+def _grid(*, width=8, height=6, resolution=0.05, cells=None):
+    """An OccupancyGrid whose `data` length is independent of its declared
+    size, which is the whole point of these tests."""
+    if cells is None:
+        cells = width * height
+    return SimpleNamespace(
+        header=SimpleNamespace(frame_id="map"),
+        info=SimpleNamespace(
+            width=width,
+            height=height,
+            resolution=resolution,
+            origin=SimpleNamespace(position=SimpleNamespace(x=0.0, y=0.0)),
+        ),
+        data=np.zeros(cells, dtype=np.int8).tobytes(),
+    )
+
+
+# --- the rule ---------------------------------------------------------------
+
+
+def test_a_grid_is_well_formed_only_at_its_declared_size():
+    assert occupancy_grid_is_well_formed(8, 6, 48)
+    assert not occupancy_grid_is_well_formed(8, 6, 47)
+    assert not occupancy_grid_is_well_formed(8, 6, 49)
+
+
+@pytest.mark.parametrize(("width", "height"), [(0, 6), (8, 0), (-1, 6)])
+def test_a_grid_without_extent_is_not_well_formed(width, height):
+    assert not occupancy_grid_is_well_formed(width, height, 0)
+
+
+@pytest.mark.parametrize(
+    ("encoding", "per_pixel"),
+    [("rgb8", 3), ("bgr8", 3), ("rgba8", 4), ("bgra8", 4), ("mono8", 1),
+     ("32fc1", 4), ("16uc1", 2)],
+)
+def test_each_decoded_encoding_states_its_own_length(encoding, per_pixel):
+    assert image_bytes_expected(4, 3, encoding) == 4 * 3 * per_pixel
+    assert image_is_well_formed(4, 3, encoding, 4 * 3 * per_pixel)
+    assert not image_is_well_formed(4, 3, encoding, 4 * 3 * per_pixel - 1)
+
+
+def test_an_encoding_scene_does_not_decode_has_no_length_to_check():
+    # The decoder rejects it on its own grounds; inventing a size for it here
+    # would be guessing.
+    assert image_bytes_expected(4, 3, "yuv422") is None
+    assert image_is_well_formed(4, 3, "yuv422", 7)
+
+
+# --- the planner path (#227) ------------------------------------------------
+
+
+def test_zero_resolution_is_rejected_rather_than_dividing_by_zero():
+    with pytest.raises(ValueError, match="resolution"):
+        goal_planner._grid_metadata(_grid(resolution=0.0))
+
+
+@pytest.mark.parametrize("resolution", [-0.05, float("nan"), float("inf")])
+def test_a_resolution_that_cannot_scale_anything_is_rejected(resolution):
+    with pytest.raises(ValueError, match="resolution"):
+        goal_planner._grid_metadata(_grid(resolution=resolution))
+
+
+@pytest.mark.parametrize(("width", "height"), [(0, 6), (8, 0)])
+def test_an_empty_dimension_is_rejected(width, height):
+    with pytest.raises(ValueError):
+        goal_planner._grid_metadata(_grid(width=width, height=height))
+
+
+@pytest.mark.parametrize("cells", [10, 100])
+def test_a_mismatched_buffer_is_rejected_before_reshape(cells):
+    with pytest.raises(ValueError, match="cells"):
+        goal_planner._grid_array(_grid(width=8, height=6, cells=cells),
+                                 width=8, height=6)
+
+
+def test_a_well_formed_grid_still_decodes():
+    grid = _grid(width=8, height=6)
+    assert goal_planner._grid_array(grid, width=8, height=6).shape == (6, 8)

--- a/system/scene/tests/test_web_binding.py
+++ b/system/scene/tests/test_web_binding.py
@@ -19,11 +19,14 @@ def test_explicit_config_host_wins_over_environment():
 
 
 def test_environment_host_is_supported_for_launcher_compatibility():
-    assert resolve_web_host({}, {"SCENE_WEB_HOST": "127.0.0.1"}) == "127.0.0.1"
+    assert resolve_web_host({}, {"SCENE_WEB_HOST": "0.0.0.0"}) == "0.0.0.0"
 
 
-def test_existing_deployments_keep_legacy_default():
-    assert resolve_web_host({}, {}) == "0.0.0.0"
+def test_the_ui_is_local_unless_someone_opens_it():
+    # The UI has no authentication and its annotation endpoints write map
+    # data, so the default is loopback. Exposing it is a decision; a
+    # deployment that wants it sets web_host or SCENE_WEB_HOST.
+    assert resolve_web_host({}, {}) == "127.0.0.1"
 
 
 @pytest.mark.parametrize(
@@ -61,11 +64,20 @@ def test_explicit_blank_values_do_not_fall_back_to_all_interfaces():
 
 
 def test_launchers_preserve_blank_values_for_runtime_rejection():
+    # `${VAR-default}` and not `${VAR:-default}`: an operator who exports an
+    # empty SCENE_WEB_HOST has made a mistake, and it should reach
+    # resolve_web_host to be rejected rather than be replaced silently.
     root = Path(__file__).resolve().parents[1]
-    docker_launcher = (root / "scripts" / "start.sh").read_text(encoding="utf-8")
-    native_launcher = (root / "scripts" / "start_native.sh").read_text(
-        encoding="utf-8"
-    )
-    expected = "SCENE_WEB_HOST=\"${SCENE_WEB_HOST-0.0.0.0}\""
-    assert expected in docker_launcher
-    assert expected in native_launcher
+    for name in ("start.sh", "start_native.sh"):
+        launcher = (root / "scripts" / name).read_text(encoding="utf-8")
+        assert 'SCENE_WEB_HOST="${SCENE_WEB_HOST-' in launcher, name
+        assert 'SCENE_WEB_HOST="${SCENE_WEB_HOST:-' not in launcher, name
+
+
+def test_launchers_default_the_ui_to_loopback():
+    # The library default is loopback; a launcher that passed 0.0.0.0 would
+    # override it and put the unauthenticated UI back on every interface.
+    root = Path(__file__).resolve().parents[1]
+    for name in ("start.sh", "start_native.sh"):
+        launcher = (root / "scripts" / name).read_text(encoding="utf-8")
+        assert 'SCENE_WEB_HOST="${SCENE_WEB_HOST-127.0.0.1}"' in launcher, name


### PR DESCRIPTION
Fixes #226. Fixes #227. Relates to #229.

## What was wrong

ROS 2 does not check that a message is self-consistent. An `OccupancyGrid` whose `data` length disagrees with `width * height`, or an `Image` whose buffer does not match its declared size and encoding, is type-valid and is delivered to every subscriber. Scene then reshaped the buffer, and `reshape` raises.

The raising happened inside request handlers, which is what made it matter. The debug UI answered 500 on `/api/state` and `/api/camera` for as long as the malformed message stayed the latest one, so anyone able to publish on `/map` could hold the interface down. The same contamination reached `goal_near` through the MCP path, where a resolution of zero also divided by zero.

Separately, that UI has no authentication and its annotation endpoints read and write map data, and it defaulted to binding every interface.

## What changed

**One rule, stated once.** `scene_service/message_shape.py` says what length a grid or an image of a given size and encoding must carry. It is pure and imports nothing. Both decode sites ask it, so the rule cannot be applied at one and forgotten at the other, and it can be tested without a ROS or robonix runtime.

**A malformed frame is dropped, not raised.** The rest of the page keeps working and the next well-formed message recovers the view, with one warning naming what was discarded.

**The planner half was already fixed.** The `goal_planner` refactor rejects a non-positive resolution and a mismatched cell count, so #227 no longer reproduces. Nothing tested either check, so nothing would have noticed them going away again — that is what the new tests are for.

**The UI defaults to loopback.** All three places that choose the bind address — the resolver and both launchers — now default to `127.0.0.1`. A launcher still passing `0.0.0.0` would have made the library default meaningless, so a test checks that too. The container runs with `--network host`, so the service's bind is the host's bind and nothing about port publishing changes. `SCENE_WEB_HOST=0.0.0.0`, or `web_host` in the Scene config, opens it again in one line, and the service logs a warning whenever it is bound wide so the choice stays visible.

## Tests

`system/scene/tests/test_malformed_grid_inputs.py`, 21 cases: the rule itself, both planner entry points, and every encoding Scene decodes.

These and `test_goal_planner.py` now run in the pull-request CI job. They import neither `robonix_api` nor the generated MCP types, so the lightweight dependency set already there is enough. Nothing on a pull request exercised these guards before, which is how they came to be missing in the first place.

Locally: 201 passed against a 200 baseline, with the same 11 pre-existing failures on both sides — all of them `ModuleNotFoundError` for workspace and codegen artifacts that are absent outside a built package.

## Note on #229

Authentication itself is not added here. The endpoints remain open to whoever can reach the port; what changed is that reaching it now takes a deliberate act. Whether this UI should carry real authentication is a larger question than a default, and worth deciding separately.
