### PR TITLE
fix: build on LoongArch64 by honoring a system protoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,10 @@ Browse them in the [package catalog](https://packages.robonix.ai/packages/), or 
 | x86\_64 | Ubuntu 22.04                                       | ✅ Tested  |
 | x86\_64 | Debian 13                                          | ✅ Tested  |
 | arm64   | NVIDIA Jetson — JetPack 6.2 (L4T 36.4.3, Ubuntu 22.04) | ✅ Tested  |
+| LoongArch64 | Loongson 3A6000 + AMD Radeon 7900 XTX — Loong ArchLinux 2026.08.07 | ✅ Tested |
 | x86\_64 / arm64 | Ubuntu 24.04 and newer                     | 🚧 Planned |
+
+> **Note (LoongArch64):** Robonix itself runs on the Loongson 3A6000 host, while the simulation platform (Webots) runs on a separate x86\_64 machine with Ubuntu 22.04. The two machines are connected over Ethernet on the same LAN.
 
 "Tested" means the full Robonix pipeline runs end-to-end on that platform — in simulation or on a real robot: voice & interaction, task execution, body movement, scene & mapping (semantic map + spatial map), navigation, and skill execution. Other Linux distributions will likely work but are not regularly verified.
 

--- a/system/atlas/build.rs
+++ b/system/atlas/build.rs
@@ -7,7 +7,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("cargo:rerun-if-changed={}", atlas_proto.display());
 
-    let protoc = protoc_bin_vendored::protoc_bin_path()?;
+    // Prefer a system protoc when present (needed on architectures like
+    // LoongArch where protoc-bin-vendored does not ship a binary).
+    let protoc = std::env::var_os("PROTOC")
+        .map(PathBuf::from)
+        .map(Ok)
+        .unwrap_or_else(protoc_bin_vendored::protoc_bin_path)?;
     // SAFETY: build.rs is single-threaded.
     unsafe {
         std::env::set_var("PROTOC", protoc);

--- a/system/executor/build.rs
+++ b/system/executor/build.rs
@@ -43,7 +43,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         false,
     )?;
 
-    let protoc = protoc_bin_vendored::protoc_bin_path()?;
+    // Prefer a system protoc when present (needed on architectures like
+    // LoongArch where protoc-bin-vendored does not ship a binary).
+    let protoc = std::env::var_os("PROTOC")
+        .map(PathBuf::from)
+        .map(Ok)
+        .unwrap_or_else(protoc_bin_vendored::protoc_bin_path)?;
     // SAFETY: build.rs is single-threaded.
     unsafe {
         std::env::set_var("PROTOC", protoc);

--- a/system/liaison/build.rs
+++ b/system/liaison/build.rs
@@ -42,7 +42,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         false,
     )?;
 
-    let protoc = protoc_bin_vendored::protoc_bin_path()?;
+    // Prefer a system protoc when present (needed on architectures like
+    // LoongArch where protoc-bin-vendored does not ship a binary).
+    let protoc = std::env::var_os("PROTOC")
+        .map(PathBuf::from)
+        .map(Ok)
+        .unwrap_or_else(protoc_bin_vendored::protoc_bin_path)?;
     // SAFETY: build.rs is single-threaded.
     unsafe {
         std::env::set_var("PROTOC", protoc);

--- a/system/pilot/build.rs
+++ b/system/pilot/build.rs
@@ -45,7 +45,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     // 2. Compile every emitted .proto with tonic-prost-build (server+client).
-    let protoc = protoc_bin_vendored::protoc_bin_path()?;
+    // Prefer a system protoc when present (needed on architectures like
+    // LoongArch where protoc-bin-vendored does not ship a binary).
+    let protoc = std::env::var_os("PROTOC")
+        .map(PathBuf::from)
+        .map(Ok)
+        .unwrap_or_else(protoc_bin_vendored::protoc_bin_path)?;
     // SAFETY: build.rs is single-threaded.
     unsafe {
         std::env::set_var("PROTOC", protoc);

--- a/system/soma/build.rs
+++ b/system/soma/build.rs
@@ -65,7 +65,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         false,
     )?;
 
-    let protoc = protoc_bin_vendored::protoc_bin_path()?;
+    // Prefer a system protoc when present (needed on architectures like
+    // LoongArch where protoc-bin-vendored does not ship a binary).
+    let protoc = std::env::var_os("PROTOC")
+        .map(PathBuf::from)
+        .map(Ok)
+        .unwrap_or_else(protoc_bin_vendored::protoc_bin_path)?;
     // SAFETY: build.rs is single-threaded.
     unsafe {
         std::env::set_var("PROTOC", protoc);

--- a/system/vitals/build.rs
+++ b/system/vitals/build.rs
@@ -41,7 +41,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         false,
     )?;
 
-    let protoc = protoc_bin_vendored::protoc_bin_path()?;
+    // Prefer a system protoc when present (needed on architectures like
+    // LoongArch where protoc-bin-vendored does not ship a binary).
+    let protoc = std::env::var_os("PROTOC")
+        .map(PathBuf::from)
+        .map(Ok)
+        .unwrap_or_else(protoc_bin_vendored::protoc_bin_path)?;
     // SAFETY: build.rs is single-threaded.
     unsafe {
         std::env::set_var("PROTOC", protoc);

--- a/tools/rbnx/build.rs
+++ b/tools/rbnx/build.rs
@@ -42,7 +42,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         false,
     )?;
 
-    let protoc = protoc_bin_vendored::protoc_bin_path()?;
+    // Prefer a system protoc when present (needed on architectures like
+    // LoongArch where protoc-bin-vendored does not ship a binary).
+    let protoc = std::env::var_os("PROTOC")
+        .map(PathBuf::from)
+        .map(Ok)
+        .unwrap_or_else(protoc_bin_vendored::protoc_bin_path)?;
     // SAFETY: build.rs is single-threaded.
     unsafe {
         std::env::set_var("PROTOC", protoc);


### PR DESCRIPTION
## Behavior

`protoc-bin-vendored` ships no loongarch64 binary, so every crate with a
`build.rs` that compiles `.proto` files failed to configure on LoongArch64.
Each of the seven build scripts now prefers `$PROTOC` when it is set, and falls
back to the vendored binary exactly as before.

Affected build scripts: `system/{atlas,executor,liaison,pilot,soma,vitals}` and
`tools/rbnx`.

## Configuration requirement

On LoongArch64, export a system protoc before building:

    export PROTOC=/usr/bin/protoc   # pacman -S protobuf
    make install

On x86_64 and arm64 nothing changes: with `PROTOC` unset the vendored binary is
used, so no existing workflow or CI job needs an update.

## Also in this branch

- `README.md`: adds the LoongArch64 host platform row (Loongson 3A6000 + AMD
  Radeon 7900 XTX, Loong ArchLinux 2026.08.07) and the note that the Webots
  simulation runs on a separate x86_64 Ubuntu 22.04 machine on the same LAN.
- `examples/ollama_chat/robonix_manifest.yaml`: manifest for the brain-only
  deployment used by that topology.

No capability contract, IDL, or generated code changes.

## Validation

    $ cargo fmt --all -- --check
    FMT CLEAN

    $ PROTOC=/usr/local/protobuf-21.12/bin/protoc \
        cargo clippy --workspace --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 35.49s

    $ env -u PROTOC cargo check -p robonix-atlas -p robonix-cli
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 22.53s

The LoongArch64 build itself was run on the 3A6000 host (`make install` with
`PROTOC` set, then `rbnx boot`); the x86_64 checks above confirm the fallback
path is unchanged.

## Notes

- Cross-process behavior (atlas wire, driver lifecycle) is untouched by this
  change; the end-to-end run is the two-machine topology described in
  `README.md`.
- The end-to-end deployment write-up lives in the handbook repository
  (syswonder/robonix-book), in a separate PR; this branch does not bump the
  `docs` submodule pointer.